### PR TITLE
Changes in invoice number handling on printing

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -110,6 +110,7 @@ Supported Presently
 Changelog for 1.3.40
 * Updated nginx configuration (Pongracz I)
 * GL account search now will search within descriptions for matches (Chris T)
+* Printing without an invoice number now errors instead of increments (Chris T)
 
 Changelog for 1.3.39
 * Fixed Internal Server Error clicking through ar/ap report (Chris T, 1022)

--- a/bin/io.pl
+++ b/bin/io.pl
@@ -1713,14 +1713,10 @@ sub print_form {
     $form->isblank( "${inv}date",
         $locale->text( $form->{label} . ' Date missing!' ) );
 
-    # get next number
+    # We used to increment the number but we no longer allow printing before
+    # posting, so the safe thing to do is just to display an error.  --Chris T
     if ( !$form->{"${inv}number"} and $inv) {
-        $form->{"${inv}number"} =
-          $form->update_defaults( \%myconfig, $numberfld );
-        if ( $form->{media} eq 'screen' ) {
-            &update;
-            $form->finalize_request();
-        }
+        $form->error($locale->text('Reference Number Missing'));
     }
 
     # $locale->text('Invoice Number missing!')


### PR DESCRIPTION
this prevents incrementing the invoice, and thus setting the invoice number to one higher than the saved one on the printed invoice.
