### PR TITLE
Partially fix (aging) statement printing (first part).

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -159,6 +159,7 @@ and these optional ones:
   Locale::Country    [Developer tool dependencies]
   Locale::Language   [Developer tool dependencies]
   Template::Plugin::Latex [Support for Postscript and PDF output]
+  TeX::Encode             [Support for Postscript and PDF output]
   XML::Twig               [Support for OpenOffice output]
   OpenOffice::OODoc       [Support for OpenOffice output]
 
@@ -216,7 +217,8 @@ This installs the required modules available from the Wheezy repository.
 To install the (optional) PDF/Postscript output module, install the
 following packages by executing this command:
 
- $ aptitude install libtemplate-plugin-latex-perl texlive-latex-recommended
+ $ aptitude install libtemplate-plugin-latex-perl \
+      libtex-encode-perl texlive-latex-recommended
 
 The credit card processing support for TrustCommerce is available
 from the Wheezy repository through:

--- a/UI/Reports/aging_report.html
+++ b/UI/Reports/aging_report.html
@@ -57,13 +57,14 @@ PROCESS button element_data = {
 };
 PROCESS select element_data = {
     name = 'print_template'
- options = [{text = 'Statement', value = 'Statement'}]
+ options = [{text = 'Statement', value = 'statement'}]
    class = 'print_template'
 };
 
 PRINTERS.push({text = text('Email'), value = 'email' });
 
-PFORMATS = [];
+PFORMATS = [ {text = 'PDF', value = 'pdf'},
+             {text = 'HTML', value = 'html'} ];
 
 FOREACH F IN STDFORMATS;
   PFORMATS.push({text = F, value = F});


### PR DESCRIPTION
  Note: (aging) statements now show output formats, but don't
    consult the value $LedgerSMB::Sysconfig::have_latex yet (which it
    should). Also, the downloadable statements are still empty.
