### PR TITLE
Fix for bug #1133 : Exchange rate issue when 1.000,00 format used. Descr...

### DIFF
--- a/bin/io.pl
+++ b/bin/io.pl
@@ -578,6 +578,9 @@ sub select_item {
 
     $exchangerate = ( $form->{exchangerate} ) ? $form->{exchangerate} : 1;
 
+    $form->{exchangerate} =
+        $form->format_amount( \%myconfig, $form->{exchangerate} );
+
     # list items with radio button on a form
     $form->header;
 


### PR DESCRIPTION
...iption: ->{exchangerate} converted to float to be able to calculate prices for select items in foreign currency, but did not set back to user defined format, so, for example it changed from 223,43 into 22.343

(grafted from 98f267aad2fd2e5c9053ed6382211645476d4ace)

--HG--
extra : source : 98f267aad2fd2e5c9053ed6382211645476d4ace
