### PR TITLE
Fix for bug #1078 : It have to set an initial value for the project_id, ...

### DIFF
--- a/LedgerSMB/OE.pm
+++ b/LedgerSMB/OE.pm
@@ -547,6 +547,8 @@ sub save {
 
             $netamount += $form->{"sellprice_$i"} * $form->{"qty_$i"};
 
+            $project_id = "0";
+
             if ( $form->{"projectnumber_$i"} ne "" ) {
                 ( $null, $project_id ) = split /--/,
                   $form->{"projectnumber_$i"};


### PR DESCRIPTION
...otherwise on empty project in the form cause that, the last of the previously set project number will remain. So, set to zero before it will be untouched or set to the selected projectnumber.
