### PR TITLE
1.3 Possible fix for #1139 - Let's discuss it before merging

### DIFF
--- a/LedgerSMB/Form.pm
+++ b/LedgerSMB/Form.pm
@@ -2793,11 +2793,16 @@ sub lastname_used {
     $vc ||= $self->{vc};    # add default to correct for improper passing
     my $arap;
     my $where;
+    my $eclass;   # we have to use a criteria to find only vendors or customers
+                  # otherwise we can get vendor by default in sales order on creating a new sales order
+                  # it would be nice to test this function later in other --PI
     if ($vc eq 'customer') {
         $arap = 'ar';
+        $eclass = 2;
     } else {
         $arap = 'ap';
         $vc = 'vendor';
+        $eclass = 1;
     }
     my $sth;
 
@@ -2821,7 +2826,8 @@ sub lastname_used {
 			ct.curr AS currency
 		FROM entity_credit_account ct
 		JOIN entity ON (ct.entity_id = entity.id)
-		WHERE entity.id = (select entity_id from $arap 
+		WHERE entity.entity_class = $eclass AND 
+                      entity.id = (select entity_id from $arap 
 		                    where entity_id IS NOT NULL $where 
                                  order by id DESC limit 1)|;
 


### PR DESCRIPTION
When I creating a new sales or purchase orders, I always get a specific vendor by default as vendor or customer. It is strange, because that vendor is not a customer.
As I dig deeper, I found the code, where this vendor appears.
I found that, in the Form.pm -> lastname_used() function there was no selector for separating vendor and customers.
Due to that and the content of my oe table (activity) that vendor appeared always, independently of vendor/customer forms.
I fixed it by using a criteria, now I get this default vendor only in purchase order.
Is it a feature or bug to get a default customer/vendor in creating a very new order? Any possible sideffect limiting results?

Anyway, is it a good idea in general to pick up a "random" customer or vendor as default? My opinion it is not.
