### PR TITLE
Fix for bug #1139 : port from 1.3 :)

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -110,6 +110,7 @@ Supported Presently
 Changelog for 1.3.40
 * Updated nginx configuration (Pongracz I)
 * GL account search now will search within descriptions for matches (Chris T)
+* Fixed #1139 (Vendor can show up as default customer in sales order, confusing...) (Pongracz I)
 
 Changelog for 1.3.39
 * Fixed Internal Server Error clicking through ar/ap report (Chris T, 1022)

--- a/LedgerSMB/Form.pm
+++ b/LedgerSMB/Form.pm
@@ -2529,11 +2529,15 @@ sub lastname_used {
     $vc ||= $self->{vc};    # add default to correct for improper passing
     my $arap;
     my $where;
+    my $eclass;   # we have to use a criteria to find only vendors or customers
+                  # otherwise we can get vendor by default in sales order on creating a new sales order -- PI
     if ($vc eq 'customer') {
         $arap = 'ar';
+        $eclass = 2;
     } else {
         $arap = 'ap';
         $vc = 'vendor';
+        $eclass = 1;
     }
     my $sth;
 
@@ -2557,7 +2561,8 @@ sub lastname_used {
 			ct.curr AS currency
 		FROM entity_credit_account ct
 		JOIN entity ON (ct.entity_id = entity.id)
-		WHERE entity.id = (select entity_id from $arap 
+		WHERE entity.entity_class = $eclass AND
+                      entity.id = (select entity_id from $arap 
 		                    where entity_id IS NOT NULL $where 
                                  order by id DESC limit 1)|;
 


### PR DESCRIPTION
In creating new sales/purchase orders I got a specific vendor by default. This fix also set the criteria to search only for vendor (purchase) or customer (sales) orders.
