### PR TITLE
Fix #1144: Contact 'Save as new' broken (action not defined).

### DIFF
--- a/LedgerSMB/Scripts/contact.pm
+++ b/LedgerSMB/Scripts/contact.pm
@@ -631,7 +631,21 @@ sub save_contact {
     delete $request->{description};
     delete $request->{contact};
     get($request);
-} 
+}
+
+=item save_contact_new
+
+Saves the specified contact info as an additional item
+
+=cut
+
+sub save_contact_new {
+    my ($request) = @_;
+    delete $request->{contact_id};
+    delete $request->{old_contact};
+    
+    save_contact($request);
+}
 
 =item delete_contact
 


### PR DESCRIPTION
(grafted from 37ca311c046b2399c56e5d974fe53c0ce6f8fe8b)

--HG--
extra : source : 37ca311c046b2399c56e5d974fe53c0ce6f8fe8b
