### PR TITLE
Fix for Cash -> Payments error reported by RamJett:

### DIFF
--- a/LedgerSMB/DBObject/Payment.pm
+++ b/LedgerSMB/DBObject/Payment.pm
@@ -794,7 +794,7 @@ sub post_payment {
    $self->error($self->{_locale}->text("Exchange rate inconsistency with database.  Got [_1], expected [_2]", $self->{exrate}, $db_exchangerate));
    }
  }
- for (@{$self->{amount}}){
+ for ($self->_parse_array($self->{amount})){
     $_ = $_->bstr if ref $_;
  }
  my @TMParray = $self->exec_method(funcname => 'payment_post');


### PR DESCRIPTION
Trying to make a payment. Log error is : Can't use string ("{209.99}")
as an ARRAY ref while "strict refs" in use at LedgerSMB/DBObject/Payment.pm line 797
