### PR TITLE
Removing file_links dropping

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -113,6 +113,8 @@ Changelog for 1.3.42
 * Fix doubled email addresses when emailing invoice (1186, Pongracz I)
 * Hungarian translation changes (Pongracz I)
 * Fix for inactive customers showing up on receipt search (1095, Chris T)
+* Hungarian translation changes (Pongracz I)
+* View file_links is no longer dropped before rebuild (Chris T, 1099)
 
 Chris T is Chris Travers
 Pongracz I is Pongracz Istvan

--- a/sql/modules/Files.sql
+++ b/sql/modules/Files.sql
@@ -326,9 +326,6 @@ $$ language sql;
 COMMENT ON FUNCTION file__get(in_id int, in_file_class int) IS
 $$ Retrieves the file information specified including content.$$;
 
-DROP VIEW IF EXISTS file_order_links CASCADE;
-DROP VIEW IF EXISTS file_tx_links CASCADE;
-DROP VIEW IF EXISTS file_links CASCADE;
 DELETE FROM file_view_catalog WHERE file_class in (1, 2);
 
 CREATE OR REPLACE view file_tx_links AS


### PR DESCRIPTION
This corrects cases where custom file permissions are lost when rebuilding file_links.
