### PR TITLE
Minor tweak to .travis.yml to try to fix bad cpan modules for 1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ before_install:
    - "cpanm Encode"
    - "cpanm Time::Local"
    - "cpanm Cwd"
+   - "cpanm --force Class::Std"
    - "cpanm Config::Std"
    - "cpanm Mojo::Base"
    - "cpanm MIME::Lite"


### PR DESCRIPTION
travis-ci is now usually passing (if class::std installs, which it doesn't always).
