### PR TITLE
Urgent fix for null dates in COGS

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -16,6 +16,7 @@ Changelog for 1.4.1
 * Fixed bug 1204, Unable to select blank salutation (Chris T)
 * Fixed bug 1198, incorrect rewrite rule on Apache 2.4 (Chris T)
 * Fixed bug 1217, Link to business units on Business_Unit report was hardcoded (Pongracz I)
+* Fixed bug causing COGS dates to be set null (Chris T)
 
 Chris T is Chris Travers
 Erik H is Erik Huelsmann

--- a/sql/modules/Fixes.sql
+++ b/sql/modules/Fixes.sql
@@ -86,3 +86,21 @@ COMMIT;
 
 -- Fixes after 1.4.0 below this point.  Fixes above to be deleted after 1.4.10
 -- Fixes below not to be deleted
+
+BEGIN;
+update acc_trans 
+   set transdate = (select transdate 
+                      from (select id, transdate from ar
+                             union
+                            select id, transdate from ap
+                             union
+                            select id, transdate from gl
+                            ) gl 
+                     where gl.id = acc_trans.trans_id
+                           and not exists (select 1 from account_checkpoint cp
+                                             where end_date > gl.transdate)
+                   ) 
+ where transdate is null;
+COMMIT;
+
+


### PR DESCRIPTION
This prevents null dates from being entered in COGS.  Previously for books without checkpoints, null dates would be entered which is bad.

Please review in particular the change to the Fixes.sql
