### PR TITLE
Clarification and update to INSTALL file

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -139,7 +139,9 @@ password expiration, so don't do that outside of testing/recovery
 scenarios.
 
 3)  The postgres user or other db superuser must be given access via
-the web app in order to create databases.
+the web app in order to create databases.  A password must be set for
+this user, if not previously set, if you wish to use the setup.pl web
+management console to configure LedgerSMB company databases.
 
 A typical pg_hba.conf entry might be:
 
@@ -148,6 +150,12 @@ host   all   all   127.0.0.1/32    md5
 If you want to lock this down, you can lock it down further by:
 host   lsmbdb  all  127.0.0.1/32    md5
 host  postgres postgres  127.0.0.1/32    md5
+
+A typical command to set a password using the psql command line
+might be:
+
+ $ psql -c "ALTER USER postgres WITH PASSWORD 'My-Password'"
+
 
 As of 1.4, connections to template1 are no longer required for the db setup 
 process.
@@ -312,9 +320,14 @@ upgrade script at http://localhost/ledgersmb/setup.pl.  This is very different
 from the approaches taken by LedgerSMB 1.2.x and earlier and SQL-Ledger, but
 rather forms a wizard to walk you through the process.
 
+The setup.pl wizard will prompt for a super-user login and password. This is
+the database superuser mentioned above (often 'postgres').  It will also ask
+for a database name.  If the database name you provide does not yet exist,
+the process of creating a new company database will be started.
+
 Please note that the setup.pl file assumes that LedgerSMB is already configured 
 to be able to access the database and locate the relevant PostgreSQL contrib 
-scripts.  In particular, you must have the  contrib_dir directive set to point
+scripts.  In particular, you must have the contrib_dir directive set to point
 to those scripts properly in your ledgersmb.conf before you begin.
 
 If you are upgrading from 1.2, your 1.2 tables will be moved to schema lsmb12.

--- a/INSTALL
+++ b/INSTALL
@@ -104,7 +104,7 @@ Installing PostgreSQL
 
 On Debian and its derivatives installing PostgreSQL works with:
 
- $ apt-get install postgresql-server postgresql-client postgresql-contrib
+ $ apt-get install postgresql postgresql-client postgresql-contrib
 
 On Fedora and its derivatives this command does the same:
 
@@ -184,6 +184,8 @@ LedgerSMB depends on these additional modules (not listing core modules):
   Number::Format
   DateTime::Format::Strptime
   Moose
+  namespace::autoclean
+  Carp::Always
 
 and these optional ones:
 
@@ -246,7 +248,8 @@ following command:
    libfile-mimeinfo-perl libtemplate-plugin-number-format-perl \
    libdatetime-format-strptime-perl libconfig-general-perl \
    libdatetime-format-strptime-perl libio-stringy-perl libmoose-perl \
-   libconfig-inifiles-perl
+   libconfig-inifiles-perl libnamespace-autoclean-perl \
+   libcarp-always-perl
 
 
 This installs the required modules available from the Wheezy repository.
@@ -257,6 +260,11 @@ following packages by executing this command:
  $ aptitude install libtemplate-plugin-latex-perl \
       libtex-encode-perl texlive-latex-recommended
 
+To install the optional module for size detection of images for embedding
+in LaTeX, execute:
+
+ $ aptitude install libimage-size-perl
+
 The credit card processing support for TrustCommerce is available
 from the Wheezy repository through:
 
@@ -265,8 +273,12 @@ from the Wheezy repository through:
 The Open Office output option is available from the Wheezy repository
 as well through the command:
 
- $ aptitude install libxml-twig-perl
+ $ aptitude install libxml-twig-perl libopenoffice-oodoc-perl
 
+To use the Starman perl-based web server install the required perl modules
+by executing:
+
+ $ aptitude install starman libcgi-emulate-psgi-perl libplack-perl
 
 (@@@ ADD info about xelatex @@@)
 http://ledgersmb.org/faq/localization/im-using-non-ascii-unicode-characters-why-cant-i-generate-pdf-output
@@ -283,8 +295,8 @@ Install rpm or look at dists/rpm/ledgersmb.spec for perl module dependencies
 Initializing a company database
 ===============================
 
-LedgerSMB 1.3 stores data for each company in a separate "database".  A
-database is a PostgreSQL concept for grouping tables, indexes, etc.
+LedgerSMB 1.3 and higher stores data for each company in a separate "database".
+A database is a PostgreSQL concept for grouping tables, indexes, etc.
 
 Each company database must be named.  This name is essentially the system
 identifier within PostgreSQL for the company's dataset.  The name for the

--- a/bin/aa.pl
+++ b/bin/aa.pl
@@ -680,15 +680,15 @@ $form->open_status_div . qq|
 	      </tr>
               <tr>
                 <th align=right nowrap>| . $locale->text('Invoice Created') . qq|</th>
-                <td><input name=crdate size=11 title="($myconfig{'dateformat'})" value=$form->{crdate}></td>
+                <td><input class="date" name=crdate size=11 title="($myconfig{'dateformat'})" value=$form->{crdate}></td>
               </tr>
 	      <tr>
 		<th align=right nowrap>| . $locale->text('Invoice Date') . qq|</th>
-		<td><input name=transdate id=transdate size=11 title="($myconfig{'dateformat'})" value=$form->{transdate}></td>
+		<td><input class="date" name=transdate id=transdate size=11 title="($myconfig{'dateformat'})" value=$form->{transdate}></td>
 	      </tr>
 	      <tr>
 		<th align=right nowrap>| . $locale->text('Due Date') . qq|</th>
-		<td><input name=duedate id=duedate size=11 title="$myconfig{'dateformat'}" value=$form->{duedate}></td>
+		<td><input class="date" name=duedate id=duedate size=11 title="$myconfig{'dateformat'}" value=$form->{duedate}></td>
 	      </tr>
 	      <tr>
 		<th align=right nowrap>| . $locale->text('PO Number') . qq|</th>


### PR DESCRIPTION
In following the INSTALL instruction for 1.4.10.1 on a clean Debian Wheezy machine, I hit a couple of problems. These patches clarify those points.

* Missing perl dependencies
* An outdated Debian package name
* Clarification on setting a db superuser password and use with setup.pl

As ever, comments/criticism welcome. Happy to change and resubmit.


