### PR TITLE
Fix SF Bug 1337 - Cannot post AP transactions

### DIFF
--- a/bin/aa.pl
+++ b/bin/aa.pl
@@ -227,8 +227,7 @@ sub create_links {
     $form->{duedate}     = $duedate     if $duedate;
     $form->{crdate}      = $crdate      if $crdate;
 
-    $form->{"old$form->{vc}"} =
-      qq|$form->{$form->{vc}}--$form->{"$form->{vc}_id"}|;
+    $form->{"old$form->{vc}"} = $form->{$form->{vc}};
     $form->{oldtransdate} = $form->{transdate};
 
     # customers/vendors


### PR DESCRIPTION
Code was appending the account number to $form->{oldvendor}, even
though this was already done. Doing it twice broke later comparisons
between $form->{vendor} and $form->{oldvendor}.