### PR TITLE
Fix SF bug 1339 - Missing file error after saving bank reconciliation

### DIFF
--- a/LedgerSMB/Scripts/recon.pm
+++ b/LedgerSMB/Scripts/recon.pm
@@ -140,21 +140,15 @@ Saves the reconciliation set for later use.
 =cut
 
 sub save_recon_set {
-    my ($request) = shift;
+    my ($request) = @_;
     my $recon = LedgerSMB::DBObject::Reconciliation->new(base => $request);
     if ($recon->close_form){
         $recon->save();
+        return search($request);
     } else {
         $recon->{notice} = $recon->{_locale}->text('Data not saved.  Please update again.');
+        return _display_report($recon);
     }
-    my $template = LedgerSMB::Template->new( 
-            user => $request->{_user}, 
-    	    template => 'reconciliation/search', 
-            locale => $request->{_locale},
-            format => 'HTML',
-            path=>"UI");
-    return $template->render($recon);
-    
 }
 
 =item get_results


### PR DESCRIPTION
Prior to this patch, code was pointing to a non-existent template file,
and doing this regardless of whether the requested save was valid.

If the save is not valid, we should display the reconciliation report
once again, as the error message suggests 'please update again'.

If the save is valid, we should return to the "Search Reconciliation
Reports" form. This is already in place and working as a separate
function in the module, so we can simply call that, rather than
coding a separate template.