### PR TITLE
User id not required

### DIFF
--- a/LedgerSMB/Entity/User.pm
+++ b/LedgerSMB/Entity/User.pm
@@ -34,7 +34,7 @@ This is the integer id of the user
 
 =cut 
 
-has id => (is => 'ro', isa => 'Int', required => 1);
+has id => (is => 'ro', isa => 'Int');
 
 =item entity_id
 


### PR DESCRIPTION
To silence setup.pm's log output (which is very chatty and looks like it's not working at all).