### PR TITLE
Referential transparency support and better precondition errors

### DIFF
--- a/LedgerSMB.pm
+++ b/LedgerSMB.pm
@@ -493,15 +493,19 @@ sub _error {
     #Carp::confess();
     if ( $ENV{GATEWAY_INTERFACE} ) {
 
+        my $status = 500;
+        my $status = $msg->{status} if ref $msg;
+        my $msg = $msg->{error} if ref $msg;
         $self->{msg}    = $msg;
         $self->{format} = "html";
+        
         $logger->error($msg);
         $logger->error("dbversion: $self->{dbversion}, company: $self->{company}");
 
         delete $self->{pre};
 
-        
-        print qq|Status: 500 ISE\nContent-Type: text/html; charset=utf-8\n\n|;
+                
+        print qq|Status: $status ISE\nContent-Type: text/html; charset=utf-8\n\n|;
         print "<head><link rel='stylesheet' href='css/$self->{_user}->{stylesheet}' type='text/css'></head>";
         $self->{msg} =~ s/\n/<br \/>\n/;
         print

--- a/LedgerSMB/Request.pm
+++ b/LedgerSMB/Request.pm
@@ -76,7 +76,9 @@ sub requires_series {
     my $start = shift @_;
     my $end  = shift @_;
     for my $att (@_){
-        $self->requires("${att}_$_") for ($start .. $stop);
+    $self->requires(map { $att = $_; 
+                          map { "${att}_$_" } ($start .. $stop) 
+                        } @_ );
     }
 }
 
@@ -94,9 +96,8 @@ sub requires_from {
     eval { $meta = $class->meta } 
          or Carp::croak 
             "Could not get meta object.  Is $class a valid Moose class?";
-    for my $att($meta->get_attibute_list){
-        $self->require($att) if $meta->get_attribute($_)->is_required;
-    }
+    $self->require(grep { $meta->get_attribute($_)->is_required }
+                   ($meta->get_attribute_list));
 }
 
 =head2 numbers(@attnames)
@@ -125,7 +126,7 @@ sub numbers_series {
     my $start = shift @_;
     my $end  = shift @_;
     for my $att (@_){
-        $self->numbers("${att}_$_") for ($start .. $stop);
+        $self->numbers( map { "${att}_$_" } ($start .. $stop));
     }
 }
 

--- a/LedgerSMB/Request.pm
+++ b/LedgerSMB/Request.pm
@@ -48,7 +48,7 @@ in the current hash or an empty string.  '0' does pass however.
 sub requires {
     my $self = shift @_;
     for (@_){
-        Carp::croak(LedgerSMB::App_State->Locale->text("Required attribute not provided: [_1]", $_))
+        Carp::croak({ status => 422 error => LedgerSMB::App_State->Locale->text("Required attribute not provided: [_1]", $_) } )
               unless $self->{$_} or $self->{$_} eq '0';
     }
 }

--- a/LedgerSMB/Request.pm
+++ b/LedgerSMB/Request.pm
@@ -54,13 +54,14 @@ sub requires {
                      grep {not ($self->{$_} or $self->{$_})} @_;
     # todo, allow error list to be returned
     die LedgerSMB::Request::Error(status => 422,
-                                     msg => [join "\n"
-                                              map {$_->msg} @error_list ]) 
+                                     msg => [join "\n",
+                                              (map {$_->msg} @error_list) ]) 
     if @error_list and not $return_errors;
     return {missing => [map {$_->field } @error_list ],
             error => LedgerSMB::Request::Error(status => 422,
-                                     msg => [join "\n"
-                                              map {$_->msg} @error_list ])
+                                     msg => [join "\n",
+                                              (map {$_->msg} @error_list) ])
+           };
 }
 
 =head2 requries_series($start, $stop, @attnames)

--- a/LedgerSMB/Request/Error.pm
+++ b/LedgerSMB/Request/Error.pm
@@ -1,0 +1,72 @@
+=head1 NAME
+
+LedgerSMB::Request::Error - HTTP Request error handling for LedgerSMB
+
+=head1 SYNOPSIS
+
+ die LedgerSMB::Request::Error->new(msg => 'something went wrong');
+
+or
+
+ die LedgerSMB::Request::Error->new(status => 422, msg => "you forgot to fill in country code");
+
+=head1 PROPERTIES
+
+=cut
+
+package LedgerSMB::Request::Error;
+use LedgerSMB::App_State;
+use Moose;
+
+=head2 status (default 500)
+
+HTTP status to send
+
+=cut
+
+has status => (is => 'ro', isa => 'Int', default => '500');
+
+=head2 msg
+
+String to send as error message
+
+=cut
+
+has msg => (is => 'ro', isa => 'Str', required => 1);
+
+=head1 METHODS
+
+=head2 http_response($additional_html)
+
+Generates full http response based on error.  Does NOT exit
+
+=cut
+
+sub http_response {
+    my ($self, $additional_html) = @_;
+
+    my $status = $self->status;
+    my $msg = $self->msg;
+    $msg =~ s/\n/<br \/>\n/;
+    my $user = LedgerSMB::App_State::User;
+
+    return qq|Status: $status ISE\nContent-Type: text/html; charset=utf-8\n\n|
+           . "<head><link rel='stylesheet' href='css/$user->{stylesheet}' type='text/css'></head>"
+           . qq|<body><h2 class="error">Error!</h2> <p><b>$msg</b></p>
+         $additional_html
+         </body>|;
+}
+
+=head2 throw
+
+Dies with the status as return code after displaying error.
+
+=cut
+
+sub throw {
+    my ($self) = @_;
+    warn $self->msg;
+    exit $self->status;
+}
+
+__PACKAGE__->meta->make_immutable;


### PR DESCRIPTION
This provides basic referential transparency support for LedgerSMB::Request validation, and provides better errors by checking all requested params before raising any.  This allows  additionally one to check every required tfield on a form before raising an error and specifying all missing fields in the error.

Also improved:  Moose integration.