### PR TITLE
initial change for 1.4.13, fixing account_edit permissions

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,6 +1,11 @@
 Changelog for 1.4 Series
 Released 2014-09-15
 
+Changelog for 1.4.13
+* Account edit group can checkboxes and mark acocunts obsolete (Chris T)
+
+Chris T is Chris Travers
+
 Changelog for 1.4.12
 * Updated German translation by Adrian v. Meibom <meibomberlin@googlemail.com>
 * Fixed printing of purchase order due to SQL error (bug 1359) (Erik H)

--- a/sql/modules/Roles.sql
+++ b/sql/modules/Roles.sql
@@ -948,6 +948,7 @@ SELECT lsmb__grant_perms('account_edit', obj, perm)
   FROM unnest(array['account'::text, 'account_heading', 'account_link', 
                     'cr_coa_to_account', 'tax']) obj
  CROSS JOIN unnest(array['SELECT'::text, 'INSERT', 'UPDATE']) perm;
+SELECT lsmb__grant_perms('account_edit', 'account_link', 'DELETE')
 
 SELECT lsmb__create_role('account_delete');
 SELECT lsmb__grant_perms('account_delete', obj, 'DELETE')


### PR DESCRIPTION
This ensures that account_edit can edit checkboxes and mark accounts obsolete.