### PR TITLE
Resolve fallout from earlier 1.4 fixes

### DIFF
--- a/LedgerSMB.pm
+++ b/LedgerSMB.pm
@@ -172,8 +172,6 @@ use Carp;
 use strict;
 use utf8;
 
-use Carp::Always;
-
 $CGI::Simple::POST_MAX = -1;
 
 package LedgerSMB;

--- a/LedgerSMB.pm
+++ b/LedgerSMB.pm
@@ -172,6 +172,8 @@ use Carp;
 use strict;
 use utf8;
 
+use Carp::Always;
+
 $CGI::Simple::POST_MAX = -1;
 
 package LedgerSMB;
@@ -637,39 +639,6 @@ sub error {
     Carp::croak $msg;
 }
 
-sub _error {
-
-    my ( $self, $msg ) = @_;
-    #Carp::confess();
-    if ( $ENV{GATEWAY_INTERFACE} ) {
-
-        $self->{msg}    = $msg;
-        $self->{format} = "html";
-        $logger->error($msg);
-        $logger->error("dbversion: $self->{dbversion}, company: $self->{company}");
-
-        delete $self->{pre};
-
-        
-        print qq|Content-Type: text/html; charset=utf-8\n\n|;
-        print "<head><link rel='stylesheet' href='css/$self->{_user}->{stylesheet}' type='text/css'></head>";
-        $self->{msg} =~ s/\n/<br \/>\n/;
-        print
-          qq|<body><h2 class="error">Error!</h2> <p><b>$self->{msg}</b></p>
-             <p>dbversion: $self->{dbversion}, company: $self->{company}</p>
-             </body>|;
-
-        $self->finalize_request;
-
-    }
-    else {
-
-        if ( $ENV{error_function} ) {
-            &{ $ENV{error_function} }($msg);
-        }
-        die "Error: $msg\n";
-    }
-}
 # Database routines used throughout
 
 sub _db_init {

--- a/LedgerSMB.pm
+++ b/LedgerSMB.pm
@@ -629,6 +629,7 @@ sub is_allowed_role {
 
 sub finalize_request {
     LedgerSMB::App_State->cleanup();
+    die "exit";
 }
 
 # To be replaced with a generic interface to an Error class

--- a/LedgerSMB/Form.pm
+++ b/LedgerSMB/Form.pm
@@ -419,42 +419,6 @@ sub error {
     Carp::croak $msg;
 }
 
-sub _error {
-
-    my ( $self, $msg ) = @_;
-
-    if ( $ENV{GATEWAY_INTERFACE} ) {
-
-        $self->{msg}    = $msg;
-        $self->{format} = "html";
-        $self->format_string('msg');
-
-        delete $self->{pre};
-
-        if ( !$self->{header} ) {
-            $self->header;
-        }
-        $logger->error($msg);
-        $logger->error("dbversion: $self->{dbversion}, company: $self->{company}");
-
-        print
-          qq|<body><h2 class="error">Error!</h2> <p><b>$self->{msg}</b>
-             <p>dbversion: $self->{dbversion}, company: $self->{company}</p>
-             </body>|;
-
-        $self->finalize_request();
-
-    }
-    else {
-
-        if ( $ENV{error_function} ) {
-            __PACKAGE__->can($ENV{error_function})->($msg);
-        }
-        die "Error: $msg\n";
-    }
-    die;
-}
-
 =item $form->finalize_request();
 
 Stops further processing, allowing post-request cleanup on intermediate
@@ -466,6 +430,7 @@ This function replaces explicit 'exit()' calls.
 
 sub finalize_request {
     LedgerSMB::finalize_request();
+    die;
 }
 
 

--- a/lsmb-request.pl
+++ b/lsmb-request.pl
@@ -34,6 +34,44 @@ use LedgerSMB::Locale;
 use Data::Dumper;
 use Log::Log4perl;
 use strict;
+
+
+sub _error {
+
+    my ( $self, $msg ) = @_;
+    #Carp::confess();
+    if ( $ENV{GATEWAY_INTERFACE} ) {
+
+        $self->{msg}    = $msg;
+        $self->{format} = "html";
+        $logger->error($msg);
+        $logger->error("dbversion: $self->{dbversion}, company: $self->{company}");
+
+        delete $self->{pre};
+
+        
+        print qq|Content-Type: text/html; charset=utf-8\n\n|;
+        print "<head><link rel='stylesheet' href='css/$self->{_user}->{stylesheet}' type='text/css'></head>";
+        $self->{msg} =~ s/\n/<br \/>\n/;
+        print
+          qq|<body><h2 class="error">Error!</h2> <p><b>$self->{msg}</b></p>
+             <p>dbversion: $self->{dbversion}, company: $self->{company}</p>
+             </body>|;
+
+        $self->finalize_request;
+
+    }
+    else {
+
+        if ( $ENV{error_function} ) {
+            &{ $ENV{error_function} }($msg);
+        }
+        die "Error: $msg\n";
+    }
+}
+
+
+
 binmode STDIN, ':bytes' if (defined $ENV{REQUEST_METHOD}) and ($ENV{REQUEST_METHOD} eq 'POST');
 binmode STDOUT, ':utf8';
 

--- a/lsmb-request.pl
+++ b/lsmb-request.pl
@@ -39,7 +39,6 @@ use strict;
 sub _error {
 
     my ( $self, $msg ) = @_;
-    #Carp::confess();
     if ( $ENV{GATEWAY_INTERFACE} ) {
 
         $self->{msg}    = $msg;
@@ -58,15 +57,12 @@ sub _error {
              <p>dbversion: $self->{dbversion}, company: $self->{company}</p>
              </body>|;
 
-        $self->finalize_request;
-
     }
     else {
 
         if ( $ENV{error_function} ) {
             &{ $ENV{error_function} }($msg);
         }
-        die "Error: $msg\n";
     }
 }
 

--- a/lsmb-request.pl
+++ b/lsmb-request.pl
@@ -36,38 +36,6 @@ use Log::Log4perl;
 use strict;
 
 
-sub _error {
-
-    my ( $self, $msg ) = @_;
-    if ( $ENV{GATEWAY_INTERFACE} ) {
-
-        $self->{msg}    = $msg;
-        $self->{format} = "html";
-        $logger->error($msg);
-        $logger->error("dbversion: $self->{dbversion}, company: $self->{company}");
-
-        delete $self->{pre};
-
-        
-        print qq|Content-Type: text/html; charset=utf-8\n\n|;
-        print "<head><link rel='stylesheet' href='css/$self->{_user}->{stylesheet}' type='text/css'></head>";
-        $self->{msg} =~ s/\n/<br \/>\n/;
-        print
-          qq|<body><h2 class="error">Error!</h2> <p><b>$self->{msg}</b></p>
-             <p>dbversion: $self->{dbversion}, company: $self->{company}</p>
-             </body>|;
-
-    }
-    else {
-
-        if ( $ENV{error_function} ) {
-            &{ $ENV{error_function} }($msg);
-        }
-    }
-}
-
-
-
 binmode STDIN, ':bytes' if (defined $ENV{REQUEST_METHOD}) and ($ENV{REQUEST_METHOD} eq 'POST');
 binmode STDOUT, ':utf8';
 
@@ -126,6 +94,36 @@ $request->{dbh}->disconnect()
     if defined $request->{dbh};
 $logger->debug("End");
 
+sub _error {
+
+    my ( $self, $msg ) = @_;
+    if ( $ENV{GATEWAY_INTERFACE} ) {
+
+        $self->{msg}    = $msg;
+        $self->{format} = "html";
+        $logger->error($msg);
+        $logger->error("dbversion: $self->{dbversion}, company: $self->{company}");
+
+        delete $self->{pre};
+
+        
+        print qq|Content-Type: text/html; charset=utf-8\n\n|;
+        print "<head><link rel='stylesheet' href='css/$self->{_user}->{stylesheet}' type='text/css'></head>";
+        $self->{msg} =~ s/\n/<br \/>\n/;
+        print
+          qq|<body><h2 class="error">Error!</h2> <p><b>$self->{msg}</b></p>
+             <p>dbversion: $self->{dbversion}, company: $self->{company}</p>
+             </body>|;
+
+    }
+    else {
+
+        if ( $ENV{error_function} ) {
+            &{ $ENV{error_function} }($msg);
+        }
+    }
+}
+
 sub call_script {
   my $script = shift @_;
   my $request = shift @_;
@@ -152,7 +150,7 @@ sub call_script {
       # -- CT
      $LedgerSMB::App_State::DBH->rollback if ($LedgerSMB::App_State::DBH and $_ eq 'Died');
      LedgerSMB::App_State->cleanup();
-     $request->_error($_) unless $_ =~ /^Died at/;
+     &_error($request, $_) unless $_ =~ /^Died at/;
   };
 }
 1;

--- a/old-handler.pl
+++ b/old-handler.pl
@@ -83,10 +83,44 @@ use LedgerSMB::Session;
 use LedgerSMB::App_State;
 use Data::Dumper;
 
-#our $logger=Log::Log4perl->get_logger('old-handler-chain');#make logger available to other old programs
-#Log::Log4perl::init(\$LedgerSMB::Sysconfig::log4perl_config);
 
-#sleep 10000;
+sub _error {
+
+    my ( $self, $msg ) = @_;
+
+    if ( $ENV{GATEWAY_INTERFACE} ) {
+
+        $self->{msg}    = $msg;
+        $self->{format} = "html";
+        $self->format_string('msg');
+
+        delete $self->{pre};
+
+        if ( !$self->{header} ) {
+            $self->header;
+        }
+        $logger->error($msg);
+        $logger->error("dbversion: $self->{dbversion}, company: $self->{company}");
+
+        print
+          qq|<body><h2 class="error">Error!</h2> <p><b>$self->{msg}</b>
+             <p>dbversion: $self->{dbversion}, company: $self->{company}</p>
+             </body>|;
+
+        $self->finalize_request();
+
+    }
+    else {
+
+        if ( $ENV{error_function} ) {
+            __PACKAGE__->can($ENV{error_function})->($msg);
+        }
+        die "Error: $msg\n";
+    }
+    die;
+}
+
+
 
 use Data::Dumper;
 require "common.pl";

--- a/old-handler.pl
+++ b/old-handler.pl
@@ -203,7 +203,7 @@ map { $form->{$_} = $myconfig{$_} } qw(stylesheet timeout)
 
 if ($myconfig{language}){
     $locale   = LedgerSMB::Locale->get_handle( $myconfig{language} )
-      or $form->_error( __FILE__ . ':' . __LINE__ . ": Locale not loaded: $!\n" );
+      or &_error( $form, __FILE__ . ':' . __LINE__ . ": Locale not loaded: $!\n" );
 }
 
 $LedgerSMB::App_State::Locale = $locale;
@@ -250,7 +250,7 @@ $LedgerSMB::App_State::Locale = $locale;
   # -- CT
   $form->{_error} = 1;
   $LedgerSMB::App_State::DBH = undef;
-  $form->_error("'$_'") unless $_ =~ /^Died/i or $_ =~ /^exit at Ledger/; 
+  &_error($form, "'$_'") unless $_ =~ /^Died/i or $_ =~ /^exit at Ledger/; 
 } 
 ;
 

--- a/old-handler.pl
+++ b/old-handler.pl
@@ -107,17 +107,13 @@ sub _error {
              <p>dbversion: $self->{dbversion}, company: $self->{company}</p>
              </body>|;
 
-        $self->finalize_request();
-
     }
     else {
 
         if ( $ENV{error_function} ) {
             __PACKAGE__->can($ENV{error_function})->($msg);
         }
-        die "Error: $msg\n";
     }
-    die;
 }
 
 


### PR DESCRIPTION
Fixes to stop Starman from reporting each early-exit or error as an Internal Server Error (instead of with the error's nice error message).
