### PR TITLE
Resolve fallout from earlier fixes

### DIFF
--- a/LedgerSMB.pm
+++ b/LedgerSMB.pm
@@ -159,8 +159,6 @@ use strict;
 use utf8;
 
 
-use Carp::Always;
-
 $CGI::Simple::POST_MAX = -1;
 
 package LedgerSMB;

--- a/LedgerSMB.pm
+++ b/LedgerSMB.pm
@@ -158,6 +158,9 @@ use Carp;
 use strict;
 use utf8;
 
+
+use Carp::Always;
+
 $CGI::Simple::POST_MAX = -1;
 
 package LedgerSMB;
@@ -488,30 +491,6 @@ sub error {
     Carp::croak $msg;
 }
 
-sub _error {
-
-    my ( $self, $msg ) = @_;
-    my $error;
-    if (eval { $msg->isa('LedgerSMB::Request::Error') }){
-        $error = $msg;
-    } else {
-        $error = LedgerSMB::Request::Error->new(msg => "$msg");
-    }
-    
-    if ( $ENV{GATEWAY_INTERFACE} ) {
-
-        delete $self->{pre};
-        print $error->http_response("<p>dbversion: $self->{dbversion}, company: $self->{company}</p>");
-
-    }
-    else {
-
-        if ( $ENV{error_function} ) {
-            &{ $ENV{error_function} }($msg);
-        }
-        $error->throw;
-    }
-}
 # Database routines used throughout
 
 sub _db_init {

--- a/LedgerSMB/Form.pm
+++ b/LedgerSMB/Form.pm
@@ -422,31 +422,6 @@ sub error {
     Carp::croak $msg;
 }
 
-sub _error {
-
-    my ( $self, $msg ) = @_;
-    my $error;
-    if (eval { $msg->isa('LedgerSMB::Request::Error') }){
-        $error = $msg;
-    } else {
-        $error = LedgerSMB::Request::Error->new(msg => "$msg");
-    }
-    
-    if ( $ENV{GATEWAY_INTERFACE} ) {
-
-        delete $self->{pre};
-        print $error->http_response("<p>dbversion: $self->{dbversion}, company: $self->{company}</p>");
-
-    }
-    else {
-
-        if ( $ENV{error_function} ) {
-            &{ $ENV{error_function} }($msg);
-        }
-        $error->throw;
-    }
-}
-
 =item $form->finalize_request();
 
 Stops further processing, allowing post-request cleanup on intermediate
@@ -458,6 +433,7 @@ This function replaces explicit 'exit()' calls.
 
 sub finalize_request {
     LedgerSMB::finalize_request();
+    die;
 }
 
 


### PR DESCRIPTION
Fixes to stop Starman from reporting each early-exit or error as an Internal Server Error (instead of with the error's nice error message).
