### PR TITLE
* Fix order entry breaking on attached-file-lookup

### DIFF
--- a/LedgerSMB/OE.pm
+++ b/LedgerSMB/OE.pm
@@ -58,7 +58,7 @@ rewritten
 sub get_files {
      my ($self, $form, $locale) = @_;
      return if !$form->{id};
-     my $file = LedgerSMB::File->new(%$form);
+     my $file = LedgerSMB::File->new;
      @{$form->{files}} = $file->list({ref_key => $form->{id}, file_class => 2});
      @{$form->{file_links}} = $file->list_links(
                   {ref_key => $form->{id}, file_class => 2}


### PR DESCRIPTION
@freelock fixes this paste:

````
Error!'Attribute (description) does not pass the type constraint because: Validation failed for 'Maybe[Str]' with value [ "Hours - with qualifying maintenance plan" ] at constructor LedgerSMB::File::new (defined at LedgerSMB/File.pm line 348) line 52
LedgerSMB::File::new('LedgerSMB::File', 'reqdate_2', '', 'meta_number', 373, 'PRINTERS', 'ARRAY(0x56fd818)', 'oldtotalpaid', '', 'onhand_1', 'Math::BigFloat=HASH(0x56c48f0)', 'partnumber_2', '', 'email', 'ejanssen@pencol.edu', 'entity_class', 2, 'tel', '206-577-0540', 'business', undef, ...) called at LedgerSMB/OE.pm line 61
OE::get_files('OE', 'Form=HASH(0x94f058)', 'LedgerSMB::Locale::en=HASH(0x2455590)') called at bin/oe.pl line 955
lsmb_legacy::form_footer called at bin/io.pl line 963
lsmb_legacy::display_form called at bin/oe.pl line 111
lsmb_legacy::edit() called at bin/io.pl line 2035
lsmb_legacy::print_form('Form=HASH(0x56be170)') called at bin/io.pl line 1359
lsmb_legacy::send_email called at old-handler.pl line 206
lsmb_legacy::__ANON__() called at /usr/share/perl5/Try/Tiny.pm line 76
eval {...} called at /usr/share/perl5/Try/Tiny.pm line 67
Try::Tiny::try('CODE(0xa6ba68)', 'Try::Tiny::Catch=REF(0x4fd1920)') called at old-handler.pl line 225
require old-handler.pl called at /usr/local/ledger/ledgersmb/oe.pl line 7
````