### PR TITLE
* Depend on the cookie to indicate login state

### DIFF
--- a/LedgerSMB.pm
+++ b/LedgerSMB.pm
@@ -429,7 +429,7 @@ sub _process_cookies {
     $self->{cookie} = $cookie{$LedgerSMB::Sysconfig::cookie_name};
 
 
-    if (! $self->{company} && $self->is_run_mode('cgi', 'mod_perl')){
+    if (! $self->{company} && $self->{cookie}) {
         my $ccookie = $self->{cookie};
         $ccookie =~ s/.*:([^:]*)$/$1/;
         $self->{company} = $ccookie

--- a/LedgerSMB/DBH.pm
+++ b/LedgerSMB/DBH.pm
@@ -44,7 +44,8 @@ sub connect {
     my ($package, $company, $username, $password) = @_;
     if (!$username){
         my $creds = LedgerSMB::Auth::get_credentials;
-        LedgerSMB::Auth::credential_prompt() if $creds->{login} eq 'logout';
+        LedgerSMB::Auth::credential_prompt()
+            if $creds->{login} && $creds->{login} eq 'logout';
         $username = $creds->{login};
         $password = $creds->{password};
     }

--- a/LedgerSMB/Scripts/login.pm
+++ b/LedgerSMB/Scripts/login.pm
@@ -22,7 +22,10 @@ use LedgerSMB::Locale;
 use LedgerSMB;
 use LedgerSMB::User;
 use LedgerSMB::Auth;
+use LedgerSMB::Scripts::menu;
 use LedgerSMB::Sysconfig;
+use Try::Tiny;
+
 use strict;
 use warnings;
 
@@ -46,16 +49,25 @@ Displays the login screen.
 =cut
 
 sub __default {
-   my ($request) = @_;
-    #HV _locale from request
-    #my $locale;
-    #$locale = LedgerSMB::Locale->get_handle(${LedgerSMB::Sysconfig::language})
-    #  or $request->error( __FILE__ . ':' . __LINE__ .
-    #     ": Locale not loaded: $!\n" );
+    my ($request) = @_;
 
+    if ($request->{cookie} && $request->{cookie} ne 'Login') {
+        $request->_db_init();
+        $request->initialize_with_db();
+        LedgerSMB::Scripts::menu::root_doc($request);
+        return;
+    }
+
+    my $secure = '';
+    my $path = $ENV{SCRIPT_NAME};
+    my $cookie_name = $LedgerSMB::Sysconfig::cookie_name;
+    if ($ENV{SERVER_PORT} == 443){
+        $secure = ' Secure;';
+    }
+    print qq|Set-Cookie: $cookie_name=Login; path=$path;$secure\n|;
     $request->{stylesheet} = "ledgersmb.css";
     $request->{titlebar} = "LedgerSMB $request->{VERSION}";
-     my $template = LedgerSMB::Template->new(
+    my $template = LedgerSMB::Template->new(
         user =>$request->{_user},
         locale => $request->{_locale},
         path => 'UI',
@@ -97,12 +109,10 @@ sub authenticate {
     # }
     # els
     if ($request->{dbh} and !$request->{log_out}){
-        print "Content-Type: text/html\n";
-        print "Set-Cookie: ${LedgerSMB::Sysconfig::cookie_name}=Login; path=$path\n";
+
+        print "Content-Type: text/plain\n";
+        LedgerSMB::Session::check($request->{cookie}, $request);
         print "Status: 200 Success\n\nSuccess\n";
-        if ($request->{log_out}){
-            $request->finalize_request();
-        }
     }
     else {
         if ($request->{_auth_error} =~/$LedgerSMB::Sysconfig::no_db_str/i){
@@ -111,7 +121,7 @@ sub authenticate {
         } else {
             print "WWW-Authenticate: Basic realm=\"LedgerSMB\"\n";
             print "Status: 401 Unauthorized\n\n";
-        print "Please enter your credentials.\n";
+            print "Please enter your credentials.\n";
         }
         $request->finalize_request();
     }
@@ -131,7 +141,6 @@ sub login {
     }
     require LedgerSMB::Scripts::menu;
     LedgerSMB::Scripts::menu::root_doc($request);
-
 }
 
 =item logout
@@ -146,8 +155,12 @@ sub logout {
     my ($request) = @_;
     $request->{callback}   = "";
     $request->{endsession} = 1;
-    if($request->{dbh}){LedgerSMB::Session::destroy($request);}#if logout on already logged out session
-     my $template = LedgerSMB::Template->new(
+
+    try { # failure only means we clear out the session later
+        $request->_db_init();
+        LedgerSMB::Session::destroy($request);
+    };
+    my $template = LedgerSMB::Template->new(
         user =>$request->{_user},
         locale => $request->{_locale},
         path => 'UI',

--- a/LedgerSMB/Session.pm
+++ b/LedgerSMB/Session.pm
@@ -239,7 +239,7 @@ sub destroy {
 
     my ($form) = @_;
     my $path = ($ENV{SCRIPT_NAME});
-    my $secure;
+    my $secure = '';
     $path =~ s|[^/]*$||;
 
     my $login = $form->{login};
@@ -261,7 +261,7 @@ sub destroy {
     if ($ENV{SERVER_PORT} == 443){
          $secure = ' Secure;';
     }
-    print qq|Set-Cookie: ${LedgerSMB::Sysconfig::cookie_name}=::$form->{company}; path=$path;$secure\n|;
+    print qq|Set-Cookie: ${LedgerSMB::Sysconfig::cookie_name}=Login; path=$path;$secure\n|;
     $dbh->commit; # called before anything else on the page, make sure the
                   # session is really gone.  -CT
 }


### PR DESCRIPTION
Note: before this change, the 'login.pl?action=authenticate' call would
  return a cooking with value 'Login'. This has now been corrected; initial
  login page load now sets cookie value to 'Login', unless a valid session
  is found (in which case the login phase is being skipped).

  Logout used to never clear the session being logged out of; now, the
  current session is being deleted unless there are no valid credentials.