### PR TITLE
Fixes manage user permission from for users_manage group.

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -5,6 +5,7 @@ Changelog for 1.4.18
 * Fixed Net Book Value reporting '0' before depreciation (GH 879, ChrisT)
 * Fixed permissions entering assets (GH 878, ChrisT)
 * Removed broken handling of old datestyle settings (Chris T)
+* Fixed #765, manage_users broken on db creation (Chris T)
 
 ChrisT is Chris Travers
 

--- a/sql/modules/Roles.sql
+++ b/sql/modules/Roles.sql
@@ -1016,6 +1016,7 @@ SELECT lsmb__grant_menu('template_edit', id, 'allow')
 
 SELECT lsmb__create_role('users_manage');
 SELECT lsmb__grant_role('users_manage', 'contact_read');
+SELECT lsmb__grant_role('users_manage', 'contact_create');
 SELECT lsmb__grant_role('users_manage', 'contact_class_employee');
 SELECT lsmb__grant_exec('users_manage', 'admin__add_user_to_role(TEXT, TEXT)');
 SELECT lsmb__grant_exec('users_manage', 'admin__remove_user_from_role(TEXT, TEXT)');


### PR DESCRIPTION
This allows creation of employees fro those who can manage users.  Before one could manage user permissions for existing employees but not create them, which was useless on new dbs.