### PR TITLE
fixing the sql query in customer_details in LedgerSMB::IS

### DIFF
--- a/LedgerSMB/IS.pm
+++ b/LedgerSMB/IS.pm
@@ -769,7 +769,17 @@ sub customer_details {
                '' as contact, '' as customerphone, '' as customerfax,
                '' AS customertaxnumber, sic_code AS sic, iban, remark,
                 bic,eca.startdate,eca.enddate
-          FROM company cm
+          FROM (SELECT id, entity_id,
+                '' AS first_name, '' AS middle_name, legal_name,
+                '' AS personal_id, tax_id, sales_tax_id, license_number,
+                sic_code
+            FROM company
+            UNION
+            SELECT id, entity_id,
+                first_name, middle_name, last_name,
+                personal_id, '', '', '', ''
+            FROM person)
+            cm
           JOIN entity e ON (cm.entity_id = e.id)
                   JOIN entity_credit_account eca ON e.id = eca.entity_id
                   LEFT JOIN entity_bank_account eba ON eca.entity_id = eba.entity_id


### PR DESCRIPTION
The current query in customer_details in LedgerSMB::IS only fetches details (address etc.) to companies. With this patch the query fetches details also for private customers (persons).