### PR TITLE
Fix #964 role_prefix not committed after Copy Database

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -14,8 +14,10 @@ Changelog for 1.4.18
 * Fixed cannot create user with same user id as already in db (GH882 Chris T)
 * Fixed sales checkbox doesnt save or display correctly (GH877, Chris T)
 * Fixed orders search not respecting name field (SF1345, Chris T)
+* Fixed role_prefix not committed after Copy Database (GH964, NickP)
 
 ChrisT is Chris Travers
+NickP is Nick Prater
 
 
 Changelog for 1.4.17

--- a/LedgerSMB/Scripts/setup.pm
+++ b/LedgerSMB/Scripts/setup.pm
@@ -269,6 +269,7 @@ sub copy_db {
     $dbh->prepare("SELECT setting__set('role_prefix', 
                                coalesce((setting_get('role_prefix')).value, ?))"
     )->execute("lsmb_$database->{company_name}__");
+    $dbh->commit;
     $dbh->disconnect;
     complete($request);
 }


### PR DESCRIPTION
No commit after setting role_prefix after copying a database.