### PR TITLE
Backport Transaction Form datepicker widgets from 1.5

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -14,6 +14,7 @@ Changelog for 1.4.18
 * Fixed cannot create user with same user id as already in db (GH882 Chris T)
 * Fixed sales checkbox doesnt save or display correctly (GH877, Chris T)
 * Fixed orders search not respecting name field (SF1345, Chris T)
+* Add datepicker widget to Transaction Form date fields (NickP)
 
 ChrisT is Chris Travers
 

--- a/bin/aa.pl
+++ b/bin/aa.pl
@@ -679,15 +679,15 @@ $form->open_status_div . qq|
 	      </tr>
               <tr>
                 <th align=right nowrap>| . $locale->text('Invoice Created') . qq|</th>
-                <td><input name=crdate size=11 title="($myconfig{'dateformat'})" value=$form->{crdate}></td>
+                <td><input class="date" name=crdate size=11 title="($myconfig{'dateformat'})" value=$form->{crdate}></td>
               </tr>
 	      <tr>
 		<th align=right nowrap>| . $locale->text('Invoice Date') . qq|</th>
-		<td><input name=transdate id=transdate size=11 title="($myconfig{'dateformat'})" value=$form->{transdate}></td>
+		<td><input class="date" name=transdate id=transdate size=11 title="($myconfig{'dateformat'})" value=$form->{transdate}></td>
 	      </tr>
 	      <tr>
 		<th align=right nowrap>| . $locale->text('Due Date') . qq|</th>
-		<td><input name=duedate id=duedate size=11 title="$myconfig{'dateformat'}" value=$form->{duedate}></td>
+		<td><input class="date" name=duedate id=duedate size=11 title="$myconfig{'dateformat'}" value=$form->{duedate}></td>
 	      </tr>
 	      <tr>
 		<th align=right nowrap>| . $locale->text('PO Number') . qq|</th>


### PR DESCRIPTION
Adding datepicker widgets to the date fields on 1.4 branch. This patch was previously applied to 1.5.