### PR TITLE
Fixed #992, batch locking problems.

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -10,6 +10,7 @@ Changelog for 1.4.20
 * Fixed paying some invoices defaulting to 0 (Chris T, GH1021)
 * Added warning for unapproved transaction in recon period (Chris T, GH856)
 * Added warning on previous unapproved recons in recon period (Chris T, GH857)
+* Fixed batch locking problems (Chris T, GH992)
 
 
 Changelog for 1.4.19

--- a/LedgerSMB/Scripts/vouchers.pm
+++ b/LedgerSMB/Scripts/vouchers.pm
@@ -282,7 +282,9 @@ sub single_batch_unlock {
     if ($request->close_form){
         my $batch = LedgerSMB::Batch->new(base => $request);
         $batch->unlock;
-        list_batches($request);
+        $request->{report_name} = 'unapproved'; 
+        $request->{search_type} = 'batches';
+        LedgerSMB::Scripts::reports::start_report($request);
     } else {
         get_batch($request);
     }

--- a/sql/modules/Payment.sql
+++ b/sql/modules/Payment.sql
@@ -520,7 +520,15 @@ BEGIN
                 IF t_batch.approved_by IS NOT NULL THEN
                     RAISE EXCEPTION 'Approved Batch';
                 ELSIF t_batch.locked_by IS NOT NULL THEN
-                    RAISE EXCEPTION 'Locked Batch';
+                    PERFORM * FROM session 
+                       JOIN users ON (session.users_id = users.id)
+                      WHERE id = t_batch.locked_by 
+                            AND users.user_id = SESSION_USER;
+
+                    IF NOT FOUND THEN
+                        -- locked by someone else
+                        RAISE EXCEPTION 'Locked Batch';
+                    END IF;
                 END IF;
                 INSERT INTO voucher (batch_id, batch_class, trans_id)
                 values (in_batch_id,


### PR DESCRIPTION
There were two significant changes of behavior here.
First now locking for payments only throws an exception if the batch is
locked by someone else.
Secondly, the batch unlock functions were returning to screens which would
lock the batches again.  This has also been fixed.