### PR TITLE
* Fix #976: fix 'Update' adding lines on orders and invoices

### DIFF
--- a/bin/io.pl
+++ b/bin/io.pl
@@ -39,7 +39,6 @@
 #######################################################################
 
 package lsmb_legacy;
-use List::Util qw(max);
 use Try::Tiny;
 use LedgerSMB::Tax;
 use LedgerSMB::Template;
@@ -47,7 +46,7 @@ use LedgerSMB::Sysconfig;
 use LedgerSMB::Setting;
 use LedgerSMB::Company_Config;
 use LedgerSMB::File;
-use List::Util 'reduce';
+use List::Util qw(max reduce);
 
 # any custom scripts for this one
 if ( -f "bin/custom/io.pl" ) {

--- a/bin/io.pl
+++ b/bin/io.pl
@@ -39,6 +39,7 @@
 #######################################################################
 
 package lsmb_legacy;
+use List::Util qw(max);
 use Try::Tiny;
 use LedgerSMB::Tax;
 use LedgerSMB::Template;
@@ -273,7 +274,7 @@ qq|<option value="$ref->{partsgroup}--$ref->{id}">$ref->{partsgroup}\n|;
     $exchangerate = ($exchangerate) ? $exchangerate : 1;
 
     $spc = substr( $myconfig{numberformat}, -3, 1 );
-    for $i ( 1 .. $numrows  + $min_lines) {
+    for $i ( 1 .. max($numrows, $min_lines)) {
         $desc_disabled = '' if $i == $numrows;
         if ( $spc eq '.' ) {
             ( $null, $dec ) = split /\./, $form->{"sellprice_$i"};

--- a/bin/ir.pl
+++ b/bin/ir.pl
@@ -1225,12 +1225,13 @@ sub update {
     my $current_empties = $form->{rowcount} - $non_empty_rows;
     my $new_empties =
         max(0,
-            $LedgerSMB::Company_Config::settings->{min_empty}
+            max($LedgerSMB::Company_Config::settings->{min_empty}, 1)
             - $current_empties);
 
 
     $form->{rowcount} += $new_empties;
     for my $i (1 .. $form->{rowcount}){
+        $form->{rowcount} = $i;
         next if $form->{"id_$i"};
 
         for (qw(partsgroup projectnumber)) {
@@ -1249,7 +1250,6 @@ sub update {
         }
         else {
             ($form->{"partnumber_$i"}) = split (/--/, $form->{"partnumber_$i"});
-            $form->{rowcount} = $i;
             IR->retrieve_item( \%myconfig, \%$form );
 
             my $rows = scalar @{ $form->{item_list} };
@@ -1350,6 +1350,7 @@ sub update {
         }
     }
      $form->generate_selects();
+     $form->{rowcount}--;
     display_form();
 }
 

--- a/bin/is.pl
+++ b/bin/is.pl
@@ -44,6 +44,9 @@
 #======================================================================
 
 package lsmb_legacy;
+
+use List::Util qw(max min);
+
 use LedgerSMB::IS;
 use LedgerSMB::PE;
 use LedgerSMB::Tax;
@@ -1186,10 +1189,25 @@ sub update {
 
     $exchangerate = ( $form->{exchangerate} ) ? $form->{exchangerate} : 1;
 
-    for my $i ( 1 .. $form->{rowcount}
-                   + $LedgerSMB::Company_Config::settings->{min_empty}
-          ){
-        $form->{rowcount} = $i;
+    my $non_empty_rows = 0;
+    for my $i (1 .. $form->{rowcount}) {
+        $non_empty_rows++
+            if $form->{"id_$i"}
+               || ! ( ( $form->{"partnumber_$i"} eq "" )
+                      && ( $form->{"description_$i"} eq "" )
+                      && ( $form->{"partsgroup_$i"}  eq "" ) );
+    }
+
+    my $current_empties = $form->{rowcount} - $non_empty_rows;
+    my $new_empties =
+        max(0,
+            $LedgerSMB::Company_Config::settings->{min_empty}
+            - $current_empties);
+
+
+    $form->{rowcount} += $new_empties;
+    for my $i ( 1 .. $form->{rowcount}){
+        next if $form->{"id_$i"};
         next if $form->{"id_$i"};
         if (   ( $form->{"partnumber_$i"} eq "" )
             && ( $form->{"description_$i"} eq "" )
@@ -1198,11 +1216,11 @@ sub update {
 
             $form->{creditremaining} +=
               ( $form->{oldinvtotal} - $form->{oldtotalpaid} );
-            &check_form;
 
         }
         else {
             ($form->{"partnumber_$i"}) = split(/--/, $form->{"partnumber_$i"});
+            $form->{rowcount} = $i;
             IS->retrieve_item( \%myconfig, \%$form );
 
             $rows = scalar @{ $form->{item_list} };
@@ -1309,6 +1327,7 @@ sub update {
             }
         }
     }
+    $form->{rowcount}--;
     display_form();
 }
 

--- a/bin/is.pl
+++ b/bin/is.pl
@@ -1201,13 +1201,13 @@ sub update {
     my $current_empties = $form->{rowcount} - $non_empty_rows;
     my $new_empties =
         max(0,
-            $LedgerSMB::Company_Config::settings->{min_empty}
+            max($LedgerSMB::Company_Config::settings->{min_empty},1)
             - $current_empties);
 
 
     $form->{rowcount} += $new_empties;
     for my $i ( 1 .. $form->{rowcount}){
-        next if $form->{"id_$i"};
+        $form->{rowcount} = $i;
         next if $form->{"id_$i"};
         if (   ( $form->{"partnumber_$i"} eq "" )
             && ( $form->{"description_$i"} eq "" )
@@ -1220,7 +1220,6 @@ sub update {
         }
         else {
             ($form->{"partnumber_$i"}) = split(/--/, $form->{"partnumber_$i"});
-            $form->{rowcount} = $i;
             IS->retrieve_item( \%myconfig, \%$form );
 
             $rows = scalar @{ $form->{item_list} };

--- a/bin/oe.pl
+++ b/bin/oe.pl
@@ -1041,12 +1041,13 @@ sub update {
     my $current_empties = $form->{rowcount} - $non_empty_rows;
     my $new_empties =
         max(0,
-            $LedgerSMB::Company_Config::settings->{min_empty}
+            max($LedgerSMB::Company_Config::settings->{min_empty}, 1)
             - $current_empties);
 
 
     $form->{rowcount} += $new_empties;
     for my $i (1 .. $form->{rowcount}){
+        $form->{rowcount} = $i;
         next if $form->{"id_$i"};
 
         if (   ( $form->{"partnumber_$i"} eq "" )
@@ -1059,8 +1060,6 @@ sub update {
 
         }
         else {
-            warn $i;
-            $form->{rowcount} = $i;
             ($form->{"partnumber_$i"}) = split(/--/, $form->{"partnumber_$i"});
 
             $retrieve_item = "";

--- a/bin/oe.pl
+++ b/bin/oe.pl
@@ -40,6 +40,8 @@
 #======================================================================
 
 package lsmb_legacy;
+
+use List::Util qw(max min);
 use LedgerSMB::OE;
 use LedgerSMB::IR;
 use LedgerSMB::IS;
@@ -1027,8 +1029,24 @@ sub update {
           if $form->{"select$_"};
     }
 
-    for my $i (1 .. $form->{rowcount}
-                   + $LedgerSMB::Company_Config::settings->{min_empty}){
+    my $non_empty_rows = 0;
+    for my $i (1 .. $form->{rowcount}) {
+        $non_empty_rows++
+            if $form->{"id_$i"}
+               || ! ( ( $form->{"partnumber_$i"} eq "" )
+                      && ( $form->{"description_$i"} eq "" )
+                      && ( $form->{"partsgroup_$i"}  eq "" ) );
+    }
+
+    my $current_empties = $form->{rowcount} - $non_empty_rows;
+    my $new_empties =
+        max(0,
+            $LedgerSMB::Company_Config::settings->{min_empty}
+            - $current_empties);
+
+
+    $form->{rowcount} += $new_empties;
+    for my $i (1 .. $form->{rowcount}){
         next if $form->{"id_$i"};
 
         if (   ( $form->{"partnumber_$i"} eq "" )
@@ -1168,6 +1186,7 @@ sub update {
             }
         }
     }
+    $form->{rowcount}--;
     display_form();
 }
 


### PR DESCRIPTION
Note: With this commit, the minimum number of empty lines doesn't seem
  to be consistently enforced, but every update isn't adding lines anymore
  which is (IMO) more important.