### PR TITLE
Added datepicker to Invoice Delivery Date field (1.4)

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,6 +1,11 @@
 Changelog for 1.4 Series
 Released 2014-09-15
 
+Changelog for 1.4.25
+* Added datepicker to invoice Delivery Date field (Nick P)
+
+Nick P is Nick Prater
+
 
 Changelog for 1.4.24
 * Fixed new transactions not being added to recon reports (Erik H, #979)

--- a/bin/io.pl
+++ b/bin/io.pl
@@ -371,7 +371,7 @@ qq|<td><input name="description_$i" $desc_disabled size=48 value="$form->{"descr
         $delivery = qq|
           <td colspan=2 nowrap>
 	  <b>${$delvar}</b>
-	  <input name="${delvar}_$i" size=11 title="$myconfig{dateformat}" value="$form->{"${delvar}_$i"}"></td>
+	  <input class="date" name="${delvar}_$i" size=11 title="$myconfig{dateformat}" value="$form->{"${delvar}_$i"}"></td>
 |;
 
 


### PR DESCRIPTION
For possible inclusion in 1.4.25
Adds a datepicker to the Delivery Date field on invoices for 1.4 branch.
With this patch, all date fields on the invoice form have the datepicker widget available.