### PR TITLE
Add Datepicker to Invoice Delivery Date field (master)

### DIFF
--- a/bin/io.pl
+++ b/bin/io.pl
@@ -364,14 +364,11 @@ qq|<td><input data-dojo-type="dijit/form/TextBox" name="description_$i" $desc_di
             }
         }
 
-
-
-
-
         $delivery = qq|
           <td colspan=2 nowrap>
-      <b>${$delvar}</b>
-      <input data-dojo-type="dijit/form/TextBox" name="${delvar}_$i" size=11 title="$myconfig{dateformat}" value="$form->{"${delvar}_$i"}"></td>
+             <b>${$delvar}</b>
+             <input class="date" data-dojo-type="lsmb/lib/DateTextBox" name="${delvar}_$i" size=11 title="$myconfig{dateformat}" value="$form->{"${delvar}_$i"}">
+          </td>
 |;
 
 


### PR DESCRIPTION
Adds a datepicker to the Delivery Date field on invoices for master branch.
With this patch, all date fields on the invoice form have the datepicker widget available.