### PR TITLE
* Remove 'lang' attribute because its combination with an empty dojoC…

### DIFF
--- a/UI/lib/ui-header.html
+++ b/UI/lib/ui-header.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 	<title><?lsmb form.titlebar ? form.titlebar : titlebar ?></title>
 	<meta http-equiv="Pragma" content="no-cache" />


### PR DESCRIPTION
…onfig isn't supported.

For more information see https://bugs.dojotoolkit.org/ticket/15630

Since our pages can be translated, statically declaring lang='en' seems plain wrong.