### PR TITLE
* Reverse file/entry-point resolution

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -30,8 +30,8 @@ requires 'PGObject::Type::BigFloat';
 requires 'PGObject::Type::DateTime';
 requires 'PGObject::Util::DBMethod';
 requires 'PGObject::Util::DBAdmin', '0.08';
+requires 'Plack::App::File';
 requires 'Plack::Builder';
-requires 'Plack::Middleware::Static';
 requires 'Template', '2.14';
 requires 'namespace::autoclean';
 

--- a/lib/LedgerSMB/PSGI.pm
+++ b/lib/LedgerSMB/PSGI.pm
@@ -32,58 +32,49 @@ use CGI::Emulate::PSGI;
 local $@; # localizes just for initial load.
 eval { require LedgerSMB::Template::LaTeX; };
 $ENV{GATEWAY_INTERFACE}="cgi/1.1";
-sub app {
-   return CGI::Emulate::PSGI->handler(
-     sub {
-       my $uri = $ENV{REQUEST_URI};
-       $ENV{SCRIPT_NAME} = $uri;
-       my $script = $uri;
-       $ENV{SCRIPT_NAME} =~ s/\?.*//;
-       $script =~ s/.*[\\\/]([^\\\/\?=]+\.pl).*/$1/;
 
-       my $nscript = $script;
-       $nscript =~ s/l$/m/;
-       $nscript =~ s/\.pm//;
-       if ($uri =~ m|/rest/|){
-         do 'bin/rest-handler.pl';
-       }
-       else {
-           local $@;
-           eval "require LedgerSMB::Scripts::$nscript";
-           if (! $@){
-               _run_new($script);
-           } else {
-               _run_old($script);
-           }
-       }
-    }
-  );
-}
+sub rest_app {
+    return CGI::Emulate::PSGI->handler(
+        sub {
+            do 'bin/rest-handler.pl';
+        });
+};
 
-my $pre_dispatch = undef;
-sub pre_dispatch {
-    $pre_dispatch = shift;
-}
+sub old_app {
+    return CGI::Emulate::PSGI->handler(
+        sub {
+            my $uri = $ENV{REQUEST_URI};
+            $uri =~ s/\?.*//;
+            $ENV{SCRIPT_NAME} = $uri;
 
-my $post_dispatch = undef;
-sub post_dispatch {
-    $pre_dispatch = shift;
+            _run_old();
+        });
+};
+
+sub new_app {
+    return CGI::Emulate::PSGI->handler(
+        sub {
+            my $uri = $ENV{REQUEST_URI};
+            $ENV{SCRIPT_NAME} = $uri;
+            my $script = $uri;
+            $ENV{SCRIPT_NAME} =~ s/\?.*//;
+            $script =~ s/.*[\\\/]([^\\\/\?=]+\.pl).*/$1/;
+
+            _run_new($script);
+         });
 }
 
 sub _run_old {
     if (my $cpid = fork()){
        wait;
     } else {
-       &$pre_dispatch() if $pre_dispatch;
        do 'bin/old-handler.pl';
-       &$post_dispatch() if $post_dispatch;
        exit;
     }
 }
 
 sub _run_new {
     my ($script) = @_;
-    &$pre_dispatch() if $pre_dispatch;
     if (-f 'bin/lsmb-request.pl'){
         try {
             do 'bin/lsmb-request.pl';
@@ -97,7 +88,6 @@ sub _run_new {
     } else {
         die 'something is wrong, cannot find lsmb-request.pl';
     }
-    &$post_dispatch() if $post_dispatch;
 }
 
 1;

--- a/tools/starman.psgi
+++ b/tools/starman.psgi
@@ -1,23 +1,36 @@
-#!/usr/bin/plackup 
+#!/usr/bin/plackup
 
 package LedgerSMB::FCGI;
 
 use lib 'lib';
 use CGI::Emulate::PSGI;
 use LedgerSMB::PSGI;
+use LedgerSMB::Sysconfig;
 use Plack::Builder;
-use Plack::Middleware::Static;
+use Plack::App::File;
 
 die 'Cannot verify version of libraries, may be including out of date modules?' unless $LedgerSMB::PSGI::VERSION == '1.5';
 
 
-my $app = LedgerSMB::PSGI::app();
+my $old_app = LedgerSMB::PSGI::old_app();
+my $new_app = LedgerSMB::PSGI::new_app();
 
 builder {
-   enable "Plack::Middleware::Static",
-       path => sub { return -f "UI/$_"; }, root => 'UI';
-   mount '/stop.pl' => sub { exit; }
+    mount '/rest/' => LedgerSMB::PSGI::rest_app();
+
+    # not using @LedgerSMB::Sysconfig::scripts: it has not only entry-points
+    mount "/$_" => $old_app
+        for ('aa.pl', 'am.pl', 'ap.pl',
+             'ar.pl', 'gl.pl', 'ic.pl', 'ir.pl',
+             'is.pl', 'oe.pl', 'pe.pl');
+
+    mount "/$_" => $new_app
+        for  (@LedgerSMB::Sysconfig::newscripts);
+
+    mount '/stop.pl' => sub { exit; }
         if $ENV{COVERAGE};
-   mount '/' => $app;
+
+    mount '/' => Plack::App::File->new( root => 'UI' )->to_app;
 };
 
+# -*- perl-mode -*-


### PR DESCRIPTION
Before this change, all files not found were handed down the
new and old script handlers. This could lead to a 401 (Unauthorized)
instead of a 404, especially with setup.pl which doesn't use the
'company cookie'.

After this change, all entry-points (scripts) have been explicitly
enumerated. All other URLs must then be files. If not found, 404.