### PR TITLE
* Keep the same token for the entire session for now

### DIFF
--- a/sql/modules/Session.sql
+++ b/sql/modules/Session.sql
@@ -108,8 +108,7 @@ BEGIN
         END IF;
 
         UPDATE session
-           SET last_used = now(),
-               token = md5(random()::text)
+           SET last_used = now()
          WHERE session_id = in_session_id
                AND token = in_token
                AND users_id = (select id from users


### PR DESCRIPTION
New instantiations of the LedgerSMB class (subrequests) run full auth; hence changing token not supported
However, we have the XSRF token in the forms which changes on each refresh.