### PR TITLE
* Fix #1116 ('curr' required by object, but not DB) by removing the c…

### DIFF
--- a/lib/LedgerSMB/Entity/Credit_Account.pm
+++ b/lib/LedgerSMB/Entity/Credit_Account.pm
@@ -183,9 +183,16 @@ has 'pricegroup_id' => (is => 'rw', isa => 'Maybe[Int]', required => 0);
 The currency to use for billing this customer or for bills received from this
 vendor.
 
+Note: we *want* to make this field required (in the database too), but due to
+the existence of the 'Inventory Entity', which is created before any currencies
+have been configured, it's impossible to set a currency on the inventory
+entity, which then makes it impossible to set a database constraint.
+So, we don't want one here: 'be strict in what you send, be liberal in what
+you accept'...
+
 =cut
 
-has 'curr' => (is => 'ro', isa => 'Str', required => 1);
+has 'curr' => (is => 'ro', isa => 'Str');
 
 =item startdate
 


### PR DESCRIPTION
…onstraint

Note: I tried to do it the other way around (add the constraint to the DB)
   but that doesn't work out because of the inventory entity being created
   before any currencies have been set.