### PR TITLE
Fix transaction templates change breaking migrations

### DIFF
--- a/lib/LedgerSMB/Database.pm
+++ b/lib/LedgerSMB/Database.pm
@@ -337,6 +337,7 @@ sub load_base_schema {
         }
         closedir(LOADDIR);
     }
+    $self->apply_changes();
     return 1;
 
 }
@@ -411,7 +412,6 @@ sub create_and_load(){
     log_stdout     => $args->{log},
     errlog  => $args->{errlog},
           });
-    $self->apply_changes();
     $self->load_modules('LOADORDER', {
     log     => $args->{log},
     errlog  => $args->{errlog},
@@ -460,7 +460,8 @@ sub apply_changes {
         PrintError=>0,
         AutoCommit => 0,
         pg_server_prepare => 0});
-    my $loadorder = LedgerSMB::Database::Loadorder->new('sql/changes/LOADORDER');
+    my $loadorder =
+        LedgerSMB::Database::Loadorder->new('sql/changes/LOADORDER');
     $loadorder->init_if_needed($dbh);
     $loadorder->apply_all($dbh);
     $dbh->disconnect;

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -1030,13 +1030,13 @@ sub process_and_run_upgrade_script {
     $dbh->commit;
 
     $database->load_base_schema({
-    log     => $temp . "_stdout",
-    errlog  => $temp . "_stderr"
-                });
+        log     => $temp . "_stdout",
+        errlog  => $temp . "_stderr",
+                                });
     $database->load_modules('LOADORDER', {
-    log     => $temp . "_stdout",
-    errlog  => $temp . "_stderr"
-                });
+        log     => $temp . "_stdout",
+        errlog  => $temp . "_stderr",
+                            });
 
     $dbh->do(qq(
        INSERT INTO defaults (setting_key, value)
@@ -1294,9 +1294,12 @@ sub rebuild_modules {
     my ($request) = @_;
     my $database = _init_db($request);
 
+    # The order is important here:
+    #  New modules should be able to depend on the latest changes
+    #  e.g. table definitions, etc.
+    $database->apply_changes;
     $database->upgrade_modules('LOADORDER', $LedgerSMB::VERSION)
         or die "Upgrade failed.";
-    $database->apply_changes;
     complete($request);
 }
 


### PR DESCRIPTION
Replaces the part where #1652 moves the role application to the change file by fixing the underlying problem (the fact that the schema should be complete before trying to load the modules). 