### PR TITLE
Fix #1696 Missing Display of Username and Password expiry in preferen…

### DIFF
--- a/UI/users/preferences.html
+++ b/UI/users/preferences.html
@@ -20,7 +20,9 @@
           <?lsmb text('Preferences Saved') ?>
   </tr><?lsmb END # if action ?>
   <tr><th class="info">
-          <?lsmb text('Your password will expire in [_1]', user.password_expires) ?>
+  	  <!-- don't translate password_expires as it's essentially a generated string with numbers and untranslatable -->
+  	  <!-- tracked in issue #1699 -->
+          <?lsmb text('Your password will expire in ')?><?lsmb user.password_expires ?>
     </th>
   </tr>
   <tr>

--- a/UI/users/preferences.html
+++ b/UI/users/preferences.html
@@ -15,12 +15,12 @@
                value = user.company
 } ?>
 <table width="100%">
-  <tr><th class="listtop"><?lsmb text('Preferences for [_1]', login) ?></th></tr>
+  <tr><th class="listtop"><?lsmb text('Preferences for ')?><?lsmb user.login ?></th></tr>
   <?lsmb IF action == 'save_preferences' ?> <tr><th class="info">
           <?lsmb text('Preferences Saved') ?>
   </tr><?lsmb END # if action ?>
   <tr><th class="info">
-          <?lsmb text('Your password will expire in [_1]', password_expires) ?>
+          <?lsmb text('Your password will expire in [_1]', user.password_expires) ?>
     </th>
   </tr>
   <tr>


### PR DESCRIPTION
…ces.html

Is translating user.password_expires sane on line 23?
it is a string that will vary from day to day, and will normally contain at least one number.
I can't imagine that we can translate it as a static phrase, rather it would need to be translated as individual words (I *think*)