### PR TITLE
Ensure that tax minvalue is defaulted to 0 if not defined

### DIFF
--- a/lib/LedgerSMB/Tax.pm
+++ b/lib/LedgerSMB/Tax.pm
@@ -83,6 +83,7 @@ sub init_taxes {
      #   $ref->{value} = LedgerSMB::PGNumber->from_db($ref->{value});
      #   $ref->{maxvalue} = LedgerSMB::PGNumber->from_db($ref->{maxvalue});
      #   $ref->{minvalue} = LedgerSMB::PGNumber->from_db($ref->{minvalue});
+        $ref->{minvalue} //= 0;
 
         my $module = "LedgerSMB/Taxes/$ref->{taxmodulename}.pm";
         require $module;


### PR DESCRIPTION
Fix for issue #1733, Leaving minimum tax empty error the application