### PR TITLE
update notification scripts for wikipedia https only

### DIFF
--- a/utils/release/notification-helpers/release-wikipedia.pl
+++ b/utils/release/notification-helpers/release-wikipedia.pl
@@ -6,7 +6,7 @@ use strict;
 use warnings;
 
   my $mw = MediaWiki::API->new();
-  $mw->{config}->{api_url} = 'http://en.wikipedia.org/w/api.php';
+  $mw->{config}->{api_url} = 'https://en.wikipedia.org/w/api.php';
 
 #  # get user info
 #  my $userinfo = $mw->api( {
@@ -196,7 +196,7 @@ print "\n";
 #printpage( getpage(), "==== Original Page Content ====" );
 
 #### Edit the English Page
-$mw->{config}->{api_url} = 'http://en.wikipedia.org/w/api.php';
+$mw->{config}->{api_url} = 'https://en.wikipedia.org/w/api.php';
 login();
 editpage( 'stable', $NewVersion, $NewDate );
 print " view the changes at \n";
@@ -205,7 +205,7 @@ print " https://en.wikipedia.org/wiki/$pagename\n";
 logout();
 
 #### Edit the Spanish Page
-$mw->{config}->{api_url} = 'http://es.wikipedia.org/w/api.php';
+$mw->{config}->{api_url} = 'https://es.wikipedia.org/w/api.php';
 $pagename =~ s/User:/Usuario:/;  # if we are using a users pagename then translate the 'User:' portion of the name
 login();
 editpage( 'stable', $NewVersion, $NewDate );

--- a/utils/release/release-notifications.sh
+++ b/utils/release/release-notifications.sh
@@ -114,35 +114,35 @@ ValidateEnvironment() {
 main() {
     clear;
         cat <<-EOF
-             ___________________________________________________________
-            /__________________________________________________________/|
-            |                                                         | |
-            |  Ready to send some updates out to the world            | |
-            |                                                         | |
-            |   *  Update Version on Wikipedia (en)                   | |
-            |   *  Update IRC Title                                   | |
-            |   *  Update Sourceforge Download Link                   | |
-            |   *  Send Release Emails to                             | |
-            |           *  $(printf "%-43s" "${cfgValue[mail_AnnounceList]}";)| |
-            |           *  $(printf "%-43s" "${cfgValue[mail_UsersList]}";)| |
-            |           *  $(printf "%-43s" "${cfgValue[mail_DevelList]}";)| |
-            |                                                         | |
-            |   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%    | |
-            |      The following are not yet complete                 | |
-            |                                                         | |
-            |   *  Post to $(printf "%-43s" "${cfgValue[drupal_URL]}";)| |
-            |      Don't forget to use the 'release'                  | |
-            |      content type, and set the correct branch           | |
-            |      to $( printf "%-46s" "${release_branch:-*** Need to add this info ***}";)  | |
-            |        http://ledgersmb.org/node/add/release            | |
-            |                                                         | |
-            |   * Publish a release on GitHub                         | |
-            |         by converting the tag                           | |
-            |                                                         | |
-            |_________________________________________________________|/
-
-
-        EOF
+	     ___________________________________________________________
+	    /__________________________________________________________/|
+	    |                                                         | |
+	    |  Ready to send some updates out to the world            | |
+	    |                                                         | |
+	    |   *  Update Version on Wikipedia (en)                   | |
+	    |   *  Update IRC Title                                   | |
+	    |   *  Update Sourceforge Download Link                   | |
+	    |   *  Send Release Emails to                             | |
+	    |           *  $(printf "%-43s" "${cfgValue[mail_AnnounceList]}";)| |
+	    |           *  $(printf "%-43s" "${cfgValue[mail_UsersList]}";)| |
+	    |           *  $(printf "%-43s" "${cfgValue[mail_DevelList]}";)| |
+	    |                                                         | |
+	    |   %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%    | |
+	    |      The following are not yet complete                 | |
+	    |                                                         | |
+	    |   *  Post to $(printf "%-43s" "${cfgValue[drupal_URL]}";)| |
+	    |      Don't forget to use the 'release'                  | |
+	    |      content type, and set the correct branch           | |
+	    |      to $( printf "%-46s" "${release_branch:-*** Need to add this info ***}";)  | |
+	    |        http://ledgersmb.org/node/add/release            | |
+	    |                                                         | |
+	    |   * Publish a release on GitHub                         | |
+	    |         by converting the tag                           | |
+	    |                                                         | |
+	    |_________________________________________________________|/
+	
+	
+	EOF
 
     ValidateEnvironment;
 


### PR DESCRIPTION
Wikipedia no-longer support http:// requests so we've updated the URL to https://
Also revert spaces to tabs in release-notifications.sh heredoc