### PR TITLE
Ensure that migrated reconciliations are not viewed as mismatched

### DIFF
--- a/sql/upgrade/sl3.0-1.5.sql
+++ b/sql/upgrade/sl3.0-1.5.sql
@@ -651,7 +651,8 @@ FROM (
   FROM _cr_report_line
 ) cr1
 WHERE cr.id = cr1.id;
-UPDATE cr_report_line SET insert_time = post_date;
+UPDATE cr_report_line SET insert_time = post_date,
+                          our_balance = their_balance;
 
 -- Log out the Migrator
 DELETE FROM users


### PR DESCRIPTION
Migration from SL30 must have our_balance set from their_balance otherwise they will appear as problem imports.