### PR TITLE
* Make MainContentPane lenient about missing closing BODY tags

### DIFF
--- a/UI/js-src/lsmb/MainContentPane.js
+++ b/UI/js-src/lsmb/MainContentPane.js
@@ -27,7 +27,7 @@ define([
                   },
                   set_main_div: function(doc){
                       var self = this;
-                      var body = doc.match(/<body[^>]*>([\s\S]*)<\/body>/i);
+                      var body = doc.match(/<body[^>]*>([\s\S]*)(<\/body>)?/i);
 
                       if (! body) {
                           this.report_error('Invalid server response: document lacks BODY tag');


### PR DESCRIPTION
Note: such documents are generated by old code; saying 'Draft Posted'
   the source lies in Form::info