### PR TITLE
Removing probably unneccessary use lib '.' from modules in master,

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -53,6 +53,9 @@ JohnL is John Locke
 Changelog for 1.4 Series
 Released 2014-09-15
 
+Changelog for 1.4.32
+* Moved to findbin from use lib '.' (Chris T, #1911)
+
 Changelog for 1.4.31
 * Fixed user with contact all privileges can't create contacts (Chris T #1219)
 * Fixed new user with manage users can't see employee (Chris T #1841)

--- a/bin/lsmb-request.pl
+++ b/bin/lsmb-request.pl
@@ -1,4 +1,3 @@
-use lib '.';
 sub get_script {
     my ($locale, $request) = @_;
 

--- a/bin/old-handler.pl
+++ b/bin/old-handler.pl
@@ -48,7 +48,6 @@
 
 our $logger=Log::Log4perl->get_logger('old-handler-chain');#make logger available to other old programs
 Log::Log4perl::init(\$LedgerSMB::Sysconfig::log4perl_config);
-use lib '.';
 
 # Clearing all namespaces for persistant code use
 for my $nsp (qw(lsmb_legacy Form GL AA IS IR OE PE IC AM)) {

--- a/bin/rest-handler.pl
+++ b/bin/rest-handler.pl
@@ -143,7 +143,7 @@ see the included License.txt for details.
 package LedgerSMB::REST_Handler;
 
 use FindBin;
-use lib '.';
+
 BEGIN {
   lib->import($FindBin::Bin) unless $ENV{mod_perl}
 }

--- a/lib/LedgerSMB/PSGI.pm
+++ b/lib/LedgerSMB/PSGI.pm
@@ -14,7 +14,6 @@ LedgerSMB::PSGI - PSGI application routines for LedgerSMB
 use strict;
 use warnings;
 our $VERSION = '1.5';
-use lib '.';
 
 # Preloads
 use LedgerSMB;

--- a/tools/starman.psgi
+++ b/tools/starman.psgi
@@ -6,7 +6,8 @@ BEGIN {
 
 package LedgerSMB::FCGI;
 
-use lib 'lib';
+use FindBin;
+use lib $FindBin::Bin . "/../lib";
 use CGI::Emulate::PSGI;
 use LedgerSMB::PSGI;
 use LedgerSMB::Sysconfig;


### PR DESCRIPTION
fixes #1911
Note that we already have to use lib 'lib';
