### PR TITLE
Fixing #2027, last issue, amounts printing as 0

### DIFF
--- a/UI/payments/payments_detail.html
+++ b/UI/payments/payments_detail.html
@@ -381,7 +381,7 @@
                                                                                 <?lsmb PROCESS input element_data = {
                                                                                         type = "hidden"
                                                                                         name = "net_$i.0"
-                                                                                        value = payment.${"$r.contact_id_$i.0"} } ?>
+                                                                                        value = i.7 } ?>
                                                                         </td>
                                                                 </tr>
                                                         <?lsmb ELSE #not $i.7 ?>

--- a/lib/LedgerSMB/Scripts/payment.pm
+++ b/lib/LedgerSMB/Scripts/payment.pm
@@ -473,6 +473,7 @@ sub display_payments {
             }
             $invoice->[6] = $invoice->[3] - $invoice->[4] - $invoice->[5];
             $contact_to_pay += $invoice->[6];
+            $invoice->[7] = $invoice->[6]->to_db;
 
             my $fld = "payment_" . $invoice->[0];
             $contact_total += LedgerSMB::PGNumber->from_input($payment->{$fld});


### PR DESCRIPTION
Fixed by adding a second to-pay formatted for the db rather than the user, as a hidden input.