### PR TITLE
Fixes #1715

### DIFF
--- a/bin/aa.pl
+++ b/bin/aa.pl
@@ -965,12 +965,12 @@ sub form_footer {
                    ndx   => 3,
                    key   => 'O',
                    value => $locale->text('Post') };
-           if ($form->is_allowed_role(['draft_modify']){
+           if ($form->is_allowed_role(['draft_modify'])){
                $button{edit_and_save} = {
                    ndx   => 4,
                    key   => 'E',
                    value => $locale->text('Save Draft') };
-          }
+           }
            delete $button{post_as_new};
            delete $button{post};
         }

--- a/bin/aa.pl
+++ b/bin/aa.pl
@@ -965,7 +965,7 @@ sub form_footer {
                    ndx   => 3,
                    key   => 'O',
                    value => $locale->text('Post') };
-           if (grep /^lsmb_$form->{company}__draft_edit$/, @{$form->{_roles}}){
+           if ($form->is_allowed_role(['draft_modify']){
                $button{edit_and_save} = {
                    ndx   => 4,
                    key   => 'E',

--- a/bin/gl.pl
+++ b/bin/gl.pl
@@ -295,7 +295,7 @@ sub display_form
         $a{approve} = 1;
         $a{edit_and_save} = 1;
         $a{update} = 1;
-        if (grep /__draft_edit$/, @{$form->{_roles}}){
+        if ($form->is_allowed_role(['draft_modify']);
             $button{edit_and_save} = {
             ndx   => 4,
             key   => 'O',

--- a/bin/gl.pl
+++ b/bin/gl.pl
@@ -295,7 +295,7 @@ sub display_form
         $a{approve} = 1;
         $a{edit_and_save} = 1;
         $a{update} = 1;
-        if ($form->is_allowed_role(['draft_modify']);
+        if ($form->is_allowed_role(['draft_modify']));
             $button{edit_and_save} = {
             ndx   => 4,
             key   => 'O',

--- a/bin/ir.pl
+++ b/bin/ir.pl
@@ -572,7 +572,7 @@ sub form_header {
                        ndx   => 3,
                        key   => 'O',
                        value => $locale->text('Post') };
-               if ($form->is_allowed_role(['draft_modify']){
+               if ($form->is_allowed_role(['draft_modify'])){
                    $button{edit_and_save} = {
                        ndx   => 4,
                        key   => 'E',

--- a/bin/ir.pl
+++ b/bin/ir.pl
@@ -572,7 +572,7 @@ sub form_header {
                        ndx   => 3,
                        key   => 'O',
                        value => $locale->text('Post') };
-               if (grep /^lsmb_$form->{company}__draft_modify$/, @{$form->{_roles}}){
+               if ($form->is_allowed_role(['draft_modify']){
                    $button{edit_and_save} = {
                        ndx   => 4,
                        key   => 'E',

--- a/bin/is.pl
+++ b/bin/is.pl
@@ -617,7 +617,7 @@ sub form_header {
                        ndx   => 3,
                        key   => 'O',
                        value => $locale->text('Post') };
-                   if (grep /^lsmb_$form->{company}__draft_modify$/, @{$form->{_roles}}){
+                   if ($form->is_allowed_role(['draft_modify']){
                        $button{edit_and_save} = {
                            ndx   => 4,
                            key   => 'E',

--- a/bin/is.pl
+++ b/bin/is.pl
@@ -617,7 +617,7 @@ sub form_header {
                        ndx   => 3,
                        key   => 'O',
                        value => $locale->text('Post') };
-                   if ($form->is_allowed_role(['draft_modify']){
+                   if ($form->is_allowed_role(['draft_modify'])){
                        $button{edit_and_save} = {
                            ndx   => 4,
                            key   => 'E',

--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -470,15 +470,10 @@ sub call_procedure {
 # Keeping this here due to common requirements
 sub is_allowed_role {
     my ($self, $args) = @_;
-    my @roles = @{$args->{allowed_roles}};
-    for my $role (@roles){
-        $self->{_role_prefix} = "lsmb_$self->{company}__" unless defined $self->{_role_prefix};
-        my @roleset = grep m/^$self->{_role_prefix}$role$/, @{$self->{_roles}};
-        if (scalar @roleset){
-            return 1;
-        }
-    }
-    return 0;
+    my ($access) =  $self->call_procedure(
+         funcname => 'lsmb__is_allowed_role', args => [$args->{allowed_roles}]
+    ); 
+    return $access->{lsmb__is_allowed_role};
 }
 
 sub finalize_request {
@@ -571,20 +566,6 @@ sub _db_init {
         push @{ $self->{custom_db_fields}->{ $ref->{extends} } },
           $ref->{field_def};
     }
-
-    # Adding role list to self
-    $self->{_roles} = [];
-    $query = "select rolname from pg_roles
-               where pg_has_role(SESSION_USER, 'USAGE')";
-    $sth = $self->{dbh}->prepare($query);
-    $sth->execute();
-    while (my @roles = $sth->fetchrow_array){
-        push @{$self->{_roles}}, $roles[0];
-    }
-
-    $LedgerSMB::App_State::Roles = @{$self->{_roles}};
-    $LedgerSMB::App_State::Role_Prefix = $self->{_role_prefix};
-    # @{$self->{_roles}} will eventually go away. --CT
 
     $sth->finish();
     $logger->debug("end");

--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -472,7 +472,7 @@ sub is_allowed_role {
     my ($self, $args) = @_;
     my ($access) =  $self->call_procedure(
          funcname => 'lsmb__is_allowed_role', args => [$args->{allowed_roles}]
-    ); 
+    );
     return $access->{lsmb__is_allowed_role};
 }
 

--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -471,7 +471,7 @@ sub call_procedure {
 sub is_allowed_role {
     my ($self, $args) = @_;
     my ($access) =  $self->call_procedure(
-         funcname => 'lsmb__is_allowed_role', args => [$args->{allowed_roles}]
+         procname => 'lsmb__is_allowed_role', args => [$args->{allowed_roles}]
     );
     return $access->{lsmb__is_allowed_role};
 }

--- a/lib/LedgerSMB/App_State.pm
+++ b/lib/LedgerSMB/App_State.pm
@@ -55,22 +55,6 @@ Database handle for current connection
 
 our $DBH;
 
-=item Roles
-
-This is a list (array) of role names for the current user.
-
-=cut
-
-our @Roles;
-
-=item Role_Prefix
-
-String of the beginning of the role.
-
-=cut
-
-our $Role_Prefix;
-
 =item DBName
 
 name of the database connecting to
@@ -151,24 +135,6 @@ sub set_Locale {
     return _set_n('Locale', @_);
 }
 
-=item Roles
-
-=cut
-
-sub Roles {
-    return @Roles;
-}
-
-=item set_Roles
-
-=cut
-
-sub set_Roles {
-    shift @_ if $_[0] eq __PACKAGE__;
-    @Roles = @_;
-    return @Roles;
-}
-
 =item Company_Settings
 
 =cut
@@ -201,22 +167,6 @@ sub set_DBH {
     return _set_n('DBH', @_);
 }
 
-=item Role_Prefix
-
-=cut
-
-sub Role_Prefix {
-    return $Role_Prefix;
-}
-
-=item set_Role_Prefix
-
-=cut
-
-sub set_Role_Prefix {
-    return _set_n('Role_Prefix', @_);
-}
-
 =back
 
 =head1 METHODS
@@ -239,8 +189,6 @@ sub cleanup {
     $Company_Settings = {};
     $DBH = undef;
     $DBName = undef;
-    @Roles = ();
-    $Role_Prefix = undef;
     delete $ENV{LSMB_ALWAYS_MONEY} if $ENV{LSMB_ALWAYS_MONEY};
 }
 

--- a/lib/LedgerSMB/DBObject/Account.pm
+++ b/lib/LedgerSMB/DBObject/Account.pm
@@ -144,7 +144,7 @@ sub get {
     $self->{account_list} = [];
     for my $ref (@accounts){
         bless $ref, 'LedgerSMB::DBObject::Account';
-        $ref->merge($self, keys => ['_user', '_locale', 'stylesheet', '_roles', '_request']);
+        $ref->merge($self, keys => ['_user', '_locale', 'stylesheet', '_request']);
         $ref->set_dbh;
         if ($ref->{is_temp} and ($ref->{category} eq 'Q')){
             $ref->{category} = 'Qt';

--- a/lib/LedgerSMB/Form.pm
+++ b/lib/LedgerSMB/Form.pm
@@ -1452,8 +1452,8 @@ Returns true if any roles are allowed, false otherwise.
 
 sub is_allowed_role {
     my ($self, $rolelist) = @_;
-    my $sth = $self->{dbh}->prepare('SELECT lsmb_is_allowed_role(?)');
-    $sth->execute($rolelist);
+    my $sth = $self->{dbh}->prepare('SELECT lsmb__is_allowed_role(?)');
+    $sth->execute($rolelist) || die $DBI::errstr;
     my ($access) = $sth->fetchrow_array;
     return $access;
 }

--- a/lib/LedgerSMB/PGOld.pm
+++ b/lib/LedgerSMB/PGOld.pm
@@ -111,7 +111,7 @@ none are.
 sub is_allowed_role {
     my ($self, $rolelist) = @_;
     my ($access) =  $self->call_procedure(
-         funcname => 'lsmb__is_allowed_role', args => [$rolelist]
+         procname => 'lsmb__is_allowed_role', args => [$rolelist]
     );
     return $access->{lsmb__is_allowed_role};
 }

--- a/lib/LedgerSMB/PGOld.pm
+++ b/lib/LedgerSMB/PGOld.pm
@@ -100,6 +100,22 @@ sub merge {
      return $self;
 }
 
+=item $self->is_allowed_role([@rolelist])
+
+Accepts an arrayref of roles to check.  For each role on the list, checks to
+see if the current session is granted that.  Returns true if any are, false if
+none are.
+
+=cut
+
+sub is_allowed_role {
+    my ($self, $rolelist) = @_;
+    my ($access) =  $self->call_procedure(
+         funcname => 'lsmb__is_allowed_role', args => [$rolelist]
+    ); 
+    return $access->{lsmb__is_allowed_role};
+}
+
 =back
 
 =cut

--- a/lib/LedgerSMB/PGOld.pm
+++ b/lib/LedgerSMB/PGOld.pm
@@ -112,7 +112,7 @@ sub is_allowed_role {
     my ($self, $rolelist) = @_;
     my ($access) =  $self->call_procedure(
          funcname => 'lsmb__is_allowed_role', args => [$rolelist]
-    ); 
+    );
     return $access->{lsmb__is_allowed_role};
 }
 

--- a/sql/modules/BLACKLIST
+++ b/sql/modules/BLACKLIST
@@ -165,6 +165,7 @@ location_list_country
 lsmb__create_role
 lsmb__grant_exec
 lsmb__grant_role
+lsmb__is_allowed_role
 lsmb__max_date
 lsmb__min_date
 lsmb__role

--- a/sql/modules/Roles.sql
+++ b/sql/modules/Roles.sql
@@ -40,6 +40,13 @@ BEGIN
 END;
 $$;
 
+CREATE OR REPLACE FUNCTION lsmb__is_allowed_role(in_rolelist text[])
+RETURNS BOOL LANGUAGE SQL AS
+$$
+select bool_and(pg_has_role(lsmb__role(r), 'USAGE'))
+  from unnest(in_rolelist) r;
+$$;
+
 CREATE OR REPLACE FUNCTION lsmb__grant_perms
 (in_role text, in_table text, in_perms text) RETURNS BOOL
 SECURITY INVOKER

--- a/t/11-ledgersmb.t
+++ b/t/11-ledgersmb.t
@@ -21,7 +21,7 @@ Log::Log4perl::init(\$LedgerSMB::Sysconfig::log4perl_config);
 
 
 my $lsmb;
-plan tests => 61;
+plan tests => 56;
 
 
 
@@ -164,26 +164,3 @@ is($lsmb->{pear_1}, 2, 'merge: Index 1, added pear as pear_1');
 is($lsmb->{peach_1}, 3, 'merge: Index 1, added peach as peach_1');
 like($lsmb->{path}, qr#bin/(lynx|mozilla)#, 'merge: Index 1, left existing key');
 
-# $lsmb->is_allowed_role checks, no prefix
-$lsmb = LedgerSMB->new();
-$lsmb->{_role_prefix} = '1_';
-$lsmb->{_roles} = ['1_apple', '1_pear'];
-is($lsmb->is_allowed_role({allowed_roles => ['pear']}), 1,
-	'is_allowed_role: allowed role');
-
-$lsmb->{_roles} = ['apple', 'pear'];
-is($lsmb->is_allowed_role({allowed_roles => ['peach']}), 0,
-	'is_allowed_role: disallowed role');
-is($lsmb->is_allowed_role({'allowed_roles' => []}), 0,
-	'is_allowed_role: no allowable roles');
-delete $lsmb->{_roles};
-is($lsmb->is_allowed_role({'allowed_roles' => ['apple']}), 0,
-		'is_allowed_role: no roles for user');
-
-# $lsmb->is_allowed_role checks, prefix
-$lsmb = LedgerSMB->new();
-$lsmb->{_role_prefix} = 'test__';
-
-$lsmb->{_roles} = ['test__apple', 'test__pear'];
-is($lsmb->is_allowed_role({allowed_roles => ['pear']}), 1,
-	'is_allowed_role: allowed role with prefix');


### PR DESCRIPTION
This is a somewhat disruptive fix, but it centralizes the problem domain,
enforces better code consistency, and makes debugging easier.
It also corrects another problem in master and a fix for part of this will
need to be backported.

However, for now, is_allowed_role is supported on PGOld, LedgerSMB and Form
objects out of the box and can be trivially added elsewhere.