### PR TITLE
fixes #2048

### DIFF
--- a/lib/LedgerSMB/Scripts/timecard.pm
+++ b/lib/LedgerSMB/Scripts/timecard.pm
@@ -149,9 +149,9 @@ sub save {
     $request->{total} = ($request->{qty}//0) + ($request->{non_chargeable}//0);
     $request->{checkedin} = $request->{transdate};
     die $request->{_locale}->text('Please submit a start/end time or a qty')
-        unless defined $request->{qty} 
+        unless defined $request->{qty}
                or ($request->{checkedin} and $request->{checkedout});
-    
+    $request->{qty} //= _get_qty($request->{checkedin}, $request->{checkedout});
     my $timecard = LedgerSMB::Timecard->new(%$request);
     $timecard->save;
     $request->{id} = $timecard->id;
@@ -159,6 +159,13 @@ sub save {
     $request->{templates} = ['timecard'];
     @{$request->{printers}} = %LedgerSMB::Sysconfig::printer; # List context
     display($request);
+}
+
+sub _get_qty {
+    my ($checkedin, $checkedout) = @_;
+    my $when_in = LedgerSMB::PGDate->from_input($checkedin);
+    my $when_out = LedgerSMB::PGDate->from_input($checkedout);
+    return ($when_in->epoch - $when_out->epoch) / 3600;
 }
 
 =item save_week

--- a/lib/LedgerSMB/Scripts/timecard.pm
+++ b/lib/LedgerSMB/Scripts/timecard.pm
@@ -148,6 +148,10 @@ sub save {
     $request->{jctype} ||= 1;
     $request->{total} = ($request->{qty}//0) + ($request->{non_chargeable}//0);
     $request->{checkedin} = $request->{transdate};
+    die $request->{_locale}->text('Please submit a start/end time or a qty')
+        unless defined $request->{qty} 
+               or ($request->{checkedin} and $request->{checkedout});
+    
     my $timecard = LedgerSMB::Timecard->new(%$request);
     $timecard->save;
     $request->{id} = $timecard->id;


### PR DESCRIPTION
Fixes #2048, and adds back missing duration calculation capabilities.

The fix to 1.4 is simpler given that it is effectively becoming oldstable and the fix would apply differently.