### PR TITLE
Forbid Data::Printer in production

### DIFF
--- a/xt/01.1-critic.t
+++ b/xt/01.1-critic.t
@@ -47,7 +47,7 @@ my @on_disk_oldcode =
 plan tests => scalar(@on_disk) + scalar(@on_disk_oldcode);
 
 &test_files(Perl::Critic->new(
-                -profile => 't/perlcriticrc',
+                -profile => 'xt/perlcriticrc',
                 -severity => 5,
                 -theme => '',
                 -exclude => [ 'BuiltinFunctions',
@@ -76,7 +76,7 @@ plan tests => scalar(@on_disk) + scalar(@on_disk_oldcode);
             \@on_disk);
 
 &test_files(Perl::Critic->new(
-                -profile => 't/perlcriticrc',
+                -profile => 'xt/perlcriticrc',
                 -severity => 5,
                 -theme => '',
                 -exclude => [ 'BuiltinFunctions',

--- a/xt/perlcriticrc
+++ b/xt/perlcriticrc
@@ -1,4 +1,4 @@
 [Modules::ProhibitEvilModules]
-modules = Carp::Always Data::Dumper
+modules = Carp::Always Data::Dumper Data::Printer
     [CodeLayout::ProhibitHardTabs]
     allow_leading_tabs = 0


### PR DESCRIPTION
- Data::Printer is similar to Data::Dumper. Both should be prevented to go to production.
- perlcriticrc is moved to xt. It is only required for xt/01.1-critic.t, so both should be kept together.
