### PR TITLE
Make die_pretty() module scope

### DIFF
--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -19,6 +19,8 @@ binmode STDERR, ':utf8';
 
 each $line_* is a string that will be output on a separate line:
 
+=over
+
 =item line_1
 
 =item line_2

--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -15,6 +15,28 @@ use English qw(-no_match_vars);
 binmode STDOUT, ':utf8';
 binmode STDERR, ':utf8';
 
+=head2 die_pretty $line_1, $line_2, $line_N;
+
+each $line_* is a string that will be output on a separate line:
+
+=item line_1
+
+=item line_2
+
+=item line_3
+
+=item line_N
+
+=back
+
+=cut
+
+sub die_pretty {
+    my $dieHeader = '==============================================================================';
+    my $msg = "== " . join("\n== ",@_);
+    die("\n" . $dieHeader . "\n$msg\n" . $dieHeader . "\n" .' Stopped at '); # trailing "<space>" prevents the location hint from being lost when pushing it to a newline
+}
+
 my $cfg_file = $ENV{LSMB_CONFIG_FILE} // 'ledgersmb.conf';
 my $cfg;
 if (-r $cfg_file) {
@@ -402,12 +424,6 @@ sub check_permissions {
     use English qw(-no_match_vars);
 
     my $tempdir = LedgerSMB::Sysconfig::tempdir();
-
-    sub die_pretty {
-        my $dieHeader = '==============================================================================';
-        my $msg = "== " . join("\n== ",@_);
-        die("$dieHeader\n$msg\n$dieHeader\n "); # trailing "<space>" prevents the location hint from being lost when pushing it to a newline
-    }
 
     if(!(-d "$tempdir")){
         die_pretty( "$tempdir wasn't created.",


### PR DESCRIPTION
Move die_pretty() out of check_permissions() into module scope.
Improve formatting of die_pretty() text
Convert die() to die_pretty() for config file errors