### PR TITLE
Suppress unnecessary location hint from warn

### DIFF
--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -21,7 +21,7 @@ if (-r $cfg_file) {
     $cfg = Config::IniFiles->new( -file => $cfg_file ) || die @Config::IniFiles::errors;
 }
 else {
-    warn "No configuration file; running with default settings";
+    warn "No configuration file; running with default settings\n";
     $cfg = Config::IniFiles->new();
 }
 


### PR DESCRIPTION
Add a trailing newline to warn () message.
This suppresses the normal location hint which in this case simply clutters up the "normal" output.