### PR TITLE
* Move printing of auth requirements to old code

### DIFF
--- a/lib/LedgerSMB/Auth.pm
+++ b/lib/LedgerSMB/Auth.pm
@@ -27,20 +27,6 @@ Must return a hashref with the following entries:
 login
 password
 
-=item credential_prompt
-
-Prompt user for credentials
-
-=back
-
-=head1 METHODS PROVIDED IN COMMON
-
-=over
-
-=item http_error
-
-Send an http error to the browser.
-
 =back
 
 =cut
@@ -48,7 +34,6 @@ Send an http error to the browser.
 package LedgerSMB::Auth;
 
 use LedgerSMB::Sysconfig;
-use CGI::Simple;
 use strict;
 use warnings;
 
@@ -58,53 +43,6 @@ if ( !$LedgerSMB::Sysconfig::auth ) {
 
 my $auth_lib = "LedgerSMB/Auth/" . $LedgerSMB::Sysconfig::auth . ".pm";
 require $auth_lib || die $!;
-
-sub http_error {
-    #my ($errcode, $msg_plus) = @_;
-    my ($unknown,$errcode, $msg_plus) = @_;#tshvr4 called as LedgerSMB::Auth->http_error('401');
-    $msg_plus = '' if not defined $msg_plus;
-    my $cgi = CGI::Simple->new();
-
-    my $err = {
-    '500' => {status  => '500 Internal Server Error',
-          message => 'An error occurred. Information on this error has been logged.',
-                  others  => {}},
-        '403' => {status  => '403 Forbidden',
-                  message => 'You are not allowed to access the specified resource.',
-                  others  => {}},
-        '401' => {status  => '401 Unauthorized',
-                  message => 'Please enter your credentials',
-                  others  => {'WWW-Authenticate' => "Basic realm=\"LedgerSMB\""}
-                 },
-        '404' => {status  => '404 Resource not Found',
-                  message => "The following resource was not found, $msg_plus",
-                 },
-        '454' => {status  => '454 Database Does Not Exist',
-                  message => 'Database Does Not Exist' },
-    };
-    # Ordinarily I would use $cgi->header to generate the headers
-    # but this doesn't seem to be working.  Although it is generally desirable
-    # to create the headers using the package, I think we should print them
-    # manually.  -CT
-    if ($errcode eq '401'){
-        if ($msg_plus eq 'setup'){
-           $err->{'401'}->{others}->{'WWW-Authenticate'}
-                = "Basic realm=\"LedgerSMB-$msg_plus\"";
-        }
-        print $cgi->header(
-           -type               => 'text/text',
-           -status             => $err->{'401'}->{status},
-           "-WWW-Authenticate" => $err->{'401'}->{others}->{'WWW-Authenticate'}
-        );
-    } else {
-        print $cgi->header(
-           -type   => 'text/text',
-           -status => $err->{$errcode}->{status},
-        );
-    }
-    print $err->{$errcode}->{message};
-    die;
-}
 
 =head1 COPYRIGHT
 

--- a/lib/LedgerSMB/Auth/DB.pm
+++ b/lib/LedgerSMB/Auth/DB.pm
@@ -57,17 +57,6 @@ sub get_credentials {
 
 }
 
-=item credential_prompt
-
-Sends a 401 error to the browser popping up browser credential prompt.
-
-=cut
-
-sub credential_prompt{
-    my ($suffix) = @_;
-    LedgerSMB::Auth->http_error(401, $suffix);#tshvr4
-}
-
 =back
 
 =head1 COPYRIGHT

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -67,7 +67,10 @@ sub _get_database {
     my ($request) = @_;
     my $creds = LedgerSMB::Auth::get_credentials('setup');
 
-    LedgerSMB::Auth->http_error('401')
+    return [ 401,
+             [ 'WWW-Authenticate' => 'Basic realm="LedgerSMB"',
+               'Content-Type' => 'text/text; charset=UTF-8' ],
+             [ 'Please enter your credentials' ] ]
         if ! defined $creds->{password};
 
     return LedgerSMB::Database->new(

--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -60,7 +60,7 @@ package Form;
 use strict;
 
 use LedgerSMB::Sysconfig;
-use LedgerSMB::Auth;
+use LedgerSMB::Session;
 use List::Util qw(first);
 use Time::Local;
 use Cwd;
@@ -1393,12 +1393,12 @@ sub db_init {
     my $dbname = $self->{company};
     $self->{dbh} = LedgerSMB::App_State::DBH;
     $self->{dbh} ||= LedgerSMB::DBH->connect($self->{company});
-    LedgerSMB::Auth::credential_prompt unless $self->{dbh};
+    LedgerSMB::Session::credential_prompt unless $self->{dbh};
     my $dbh = $self->{dbh};
 
     if ($ENV{GATEWAY_INTERFACE} and !$ENV{LSMB_NOHEAD}) {
         if (! LedgerSMB::Session::check( $self->{cookie}, $self)) {
-            LedgerSMB::Auth::credential_prompt;
+            LedgerSMB::Session::credential_prompt;
         }
     }
 


### PR DESCRIPTION
Return triplets elsewhere

Note: This fixes a leak to the standard console on setup.pl