### PR TITLE
Limit reconciliations to ordered dates

### DIFF
--- a/UI/reconciliation/report.html
+++ b/UI/reconciliation/report.html
@@ -205,7 +205,8 @@ END ?>
     <?lsmb END ?>
     <?lsmb END -?>
     <tr class="subtotal">
-        <th colspan=6><?lsmb text('Total') ?></th>
+        <th><?lsmb text('Total') ?></th>
+        <th colspan=5><?lsmb total_cleared_credits-total_cleared_debits ?></th>
         <td class="money"><?lsmb total_cleared_debits ?></td>
         <td class="money"><?lsmb total_cleared_credits ?></td>
     </tr>

--- a/UI/setup/stylesheet.css
+++ b/UI/setup/stylesheet.css
@@ -70,6 +70,7 @@ caption {
 
 label {
     width: 10em;
+    text-align: right;
     float: left;
     border-width: 1px;
     margin: 0;

--- a/lib/LedgerSMB/Scripts/recon.pm
+++ b/lib/LedgerSMB/Scripts/recon.pm
@@ -217,7 +217,6 @@ sub _display_report {
     $recon->add_entries($recon->import_file($contents))
         if $contents && !$recon->{submitted};
     $recon->{can_approve} = $request->is_allowed_role({allowed_roles => ['reconciliation_approve']});
-    $recon->get();
     $recon->{form_id} = $request->{form_id};
     my $template = LedgerSMB::Template->new(
         user=> $recon->{_user},

--- a/sql/Pg-database.sql
+++ b/sql/Pg-database.sql
@@ -1167,7 +1167,6 @@ CREATE TABLE cr_report (
     approved_by int references entity(id),
     approved_username text,
     recon_fx bool default false,
-    max_ac_id int,
     CHECK (deleted is not true or approved is not true)
 );
 
@@ -1479,8 +1478,6 @@ CREATE TABLE acc_trans (
   voucher_id int references voucher(id),
   entry_id SERIAL PRIMARY KEY
 );
-
-ALTER TABLE cr_report ADD FOREIGN KEY (max_ac_id) REFERENCES acc_trans(entry_id);
 
 COMMENT ON TABLE acc_trans IS
 $$This table stores line items for financial transactions.  Please note that

--- a/sql/changes/1.6/drop_cr_report_max_ac_id.sql
+++ b/sql/changes/1.6/drop_cr_report_max_ac_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE cr_report DROP COLUMN max_ac_id;

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -66,3 +66,4 @@
 1.6/fix-entity-primary-key.sql
 1.6/add-eca-business-foreign-key.sql
 1.6/add_empty_salutation.sql
+1.6/drop_cr_report_max_ac_id.sql

--- a/sql/modules/BLACKLIST
+++ b/sql/modules/BLACKLIST
@@ -219,6 +219,7 @@ pricematrix__for_vendor
 quote_ident_array
 reconciliation__add_entry
 reconciliation__check
+reconciliation__check_balanced
 reconciliation__delete_my_report
 reconciliation__delete_unapproved
 reconciliation__get_cleared_balance

--- a/sql/modules/Reconciliation.sql
+++ b/sql/modules/Reconciliation.sql
@@ -126,14 +126,14 @@ DECLARE
 BEGIN
     SELECT approved INTO failed FROM cr_report
     WHERE id = in_report_id AND approved;
-    IF failed THEN
-        RAISE EXCEPTION 'Cannot delete approved report';
+    IF FOUND THEN
+        RAISE EXCEPTION 'Cannot delete approved recon report';
         RETURN FALSE;
     END IF;
 
     -- Make sure that transactions present on this report do not have a
     -- cleared_on date or they won't ever be accessible anymore.
-    SELECT count(*) > 0 INTO failed
+    SELECT COUNT(*)>0 INTO failed
     FROM cr_report_line rl
     JOIN acc_trans ac ON rl.ledger_id = ac.entry_id
     WHERE report_id = in_report_id
@@ -153,10 +153,10 @@ BEGIN
                                     and approved IS NOT TRUE);
     DELETE FROM cr_report
      WHERE id = in_report_id AND entered_username = SESSION_USER
-           AND submitted IS NOT TRUE AND approved IS NOT TRUE
-    RETURNING TRUE;
+           AND submitted IS NOT TRUE AND approved IS NOT TRUE;
+    RETURN FOUND;
 END;
-$$ language 'plpgsql' security definer;
+$$ language PLPGSQL security definer;
 
 -- Granting execute permission to public because everyone has an ability to
 -- delete their own reconciliation reports provided they have not been

--- a/xt/42-reconciliation.pg
+++ b/xt/42-reconciliation.pg
@@ -5,7 +5,7 @@ BEGIN;
 
     -- Plan the tests.
 
-    SELECT plan(55);
+    SELECT plan(64);
 
     -- Add data
 
@@ -48,161 +48,272 @@ BEGIN;
 
     -- Run tests
 
---    PREPARE test AS SELECT count(*)
---                      FROM defaults
---                      WHERE setting_key = 'check_prefix';
---    SELECT results_eq('test',ARRAY[1],'check_prefix set');
+    \set report_end1 '''2001-02-03'''
+    \set report_end2 '''2001-03-04'''
+    
+    --TODO: Do we still need this?
+    PREPARE test AS SELECT count(*) = 1
+                      FROM defaults
+                      WHERE setting_key = 'check_prefix';
+    SELECT results_eq('test',ARRAY[true],'check_prefix set');
+    DEALLOCATE test;
 
---    UPDATE defaults
---    SET value = 'Recon gl test '
---    WHERE setting_key = 'check_prefix';
+    --TODO: Do we still need this?
+    PREPARE test AS WITH rows AS (
+                    UPDATE defaults
+                    SET value = 'Recon gl test '
+                    WHERE setting_key = 'check_prefix'
+                    RETURNING 1
+                    )
+                    SELECT count(*)::int
+                    FROM rows;
+    SELECT results_eq('test', Array[1], 'Updated check_prefix');
+    DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__new_report_id(test_get_account_id('-11111'), 100, now()::date, false);
-    SELECT results_eq('test',ARRAY[1],'Create Recon Report');
+    CREATE TEMPORARY TABLE test_parameters (id int);
+    INSERT INTO test_parameters(id) VALUES(nextval('cr_report_id_seq'));
+
+    PREPARE test AS SELECT COUNT(*)::INT FROM acc_trans
+                    WHERE cleared
+                    AND entry_id NOT IN (SELECT ledger_id FROM cr_report_line);
+    SELECT results_eq('test', Array[4], 'Transactions that should be in cr_report');
+    DEALLOCATE test;
+
+    PREPARE test AS SELECT COUNT(*)::int
+    FROM acc_trans
+    WHERE cleared AND approved AND cleared_on IS NULL;
+    SELECT results_eq('test', Array[2], 'Correct number of cleared and approved without cleared date');
+    DEALLOCATE test;
+
+    --TODO: Move this in the migration infrastructure
+    PREPARE test AS WITH rows AS (
+                        UPDATE acc_trans a
+                        SET cleared_on = GREATEST(CAST(:report_end1::date - '1 second'::INTERVAL AS DATE),
+                                                  (
+                                                      SELECT clear_time
+                                                      FROM cr_report_line crl
+                                                      WHERE a.transdate <= GREATEST(:report_end1,crl.post_date)
+                                                  )
+                                          )
+                        WHERE a.cleared AND a.approved
+                        AND a.cleared_on IS NULL
+                        RETURNING 1
+                    )
+                    SELECT count(*)::int
+                    FROM rows;
+    SELECT results_eq('test', Array[2], 'Correct number of fixed cleared dates');
+    DEALLOCATE test;
+
+    --TODO: Move this in the migration infrastructure
+    PREPARE test AS WITH rows AS (
+                        UPDATE acc_trans a
+                        SET cleared = false
+                        WHERE cleared
+                        AND entry_id NOT IN (SELECT ledger_id FROM cr_report_line)
+                        RETURNING 1
+                    )
+                    SELECT count(*)::int
+                    FROM rows;
+    SELECT results_eq('test', Array[4], 'Correct number of fixed cleared status');
+    DEALLOCATE test;
+
+    PREPARE test AS SELECT reconciliation__new_report_id(test_get_account_id('-11111'), -100, :report_end1, false);
+    SELECT results_eq('test', $$ SELECT id+1 FROM test_parameters $$, 'Create Recon Report');
     DEALLOCATE test;
 
     PREPARE test AS SELECT reconciliation__delete_my_report(currval('cr_report_id_seq')::int);
     SELECT results_eq('test',ARRAY[true],'Delete Recon Report');
     DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__new_report_id(test_get_account_id('-11111'), 100, now()::date, false);
-    SELECT results_eq('test',ARRAY[2],'Create Recon Report');
+    -- chart, total, end_date, recon_fx
+    PREPARE test AS SELECT reconciliation__new_report_id(test_get_account_id('-11111'), -100, :report_end1, false);
+    SELECT results_eq('test', $$ SELECT id+2 FROM test_parameters $$, 'Create Recon Report');
     DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__pending_transactions(currval('cr_report_id_seq')::int, 110) > 0;
-    SELECT results_eq('test',ARRAY[true],'Pending Transactions Ran');
+    PREPARE test AS SELECT reconciliation__pending_transactions(currval('cr_report_id_seq')::int, -110);
+    SELECT results_eq('test',$$ SELECT id+2 FROM test_parameters $$, 'Pending Transactions Ran');
     DEALLOCATE test;
 
-    PREPARE test AS SELECT count(*) = 10
+    PREPARE test AS SELECT count(*)::int
                       FROM cr_report_line
                       WHERE report_id = currval('cr_report_id_seq')::int;
-    SELECT results_eq('test',Array[true],'Correct number of transactions 1');
+    SELECT results_eq('test', Array[13], 'Correct number of transactions 1');
     DEALLOCATE test;
 
-    PREPARE test AS SELECT count(*) = 3
+    PREPARE test AS SELECT count(*)::int
                       FROM cr_report_line
                       WHERE scn LIKE '% gl %'
                       AND report_id = currval('cr_report_id_seq')::int;
-    SELECT results_eq('test',ARRAY[true],'Correct number of GL groups');
+    SELECT results_eq('test', ARRAY[3], 'Correct number of GL groups');
     DEALLOCATE test;
 
-    PREPARE test AS SELECT count(*) = 10
+    PREPARE test AS SELECT count(*)::int
                       FROM cr_report_line
                       WHERE report_id = currval('cr_report_id_seq')::int;
-    SELECT results_eq('test',ARRAY[true],'Correct number of report lines');
+    SELECT results_eq('test',ARRAY[13],'Correct number of report lines');
     DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__submit_set(currval('cr_report_id_seq')::int, (select as_array(id::int) from cr_report_line where report_id = currval('cr_report_id_seq')::int));
-    SELECT results_eq('test',ARRAY[true],'Report Submitted');
+    PREPARE test AS SELECT SUM(crl.our_balance) - cr.their_total
+                    FROM cr_report_line crl
+                    JOIN cr_report cr ON cr.id = crl.report_id
+                    WHERE cr.id = currval('cr_report_id_seq')::int
+                    GROUP BY cr.their_total;
+    SELECT results_eq('test',ARRAY[-20::numeric],'Report not balanced (should not be submittable)');
     DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__submit_set(currval('cr_report_id_seq')::int, (select as_array(id::int) from cr_report_line where report_id = currval('cr_report_id_seq')::int));
-    SELECT results_eq('test',ARRAY[true],'Report Submitted');
+    PREPARE test AS WITH rows AS (
+                        UPDATE cr_report_line SET cleared = 't', clear_time = '1501-02-03'
+                        WHERE report_id = currval('cr_report_id_seq')::int
+                        RETURNING 1
+                    )
+                    SELECT count(*)::int
+                    FROM rows;
+    SELECT results_eq('test',ARRAY[13],'Clear transactions');
     DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__report_approve(currval('cr_report_id_seq')::int) > 0;
-    SELECT results_eq('test',ARRAY[true],'1 Report Approved');
+--    PREPARE test AS SELECT reconciliation__submit_set(currval('cr_report_id_seq')::int, (select as_array(id::int) from cr_report_line where report_id = currval('cr_report_id_seq')::int),:report_end1);
+--    SELECT throws_ok(
+--        'test',
+--        'P0001',
+--        'Unbalanced report by -20.00',
+--        'We should get a unique violation for an unbalanced report'
+--    );
+--    DEALLOCATE test;
+
+    PREPARE test AS WITH rows AS (
+                        UPDATE cr_report
+                        SET their_total = -130
+                        WHERE id = currval('cr_report_id_seq')::int
+                        RETURNING 1
+                    )
+                    SELECT count(*)::int
+                    FROM rows;
+    SELECT results_eq('test', Array[1], 'Fixed report balance');
     DEALLOCATE test;
 
-    PREPARE test as SELECT count(*) = 2
+    PREPARE test AS SELECT reconciliation__submit_set(currval('cr_report_id_seq')::int, (select as_array(id::int) from cr_report_line where report_id = currval('cr_report_id_seq')::int),:report_end1);
+    SELECT lives_ok(
+        'test',
+        'We should not get a unique violation for an unbalanced report on submit'
+    );
+    DEALLOCATE test;
+    PREPARE test AS SELECT reconciliation__report_approve(currval('cr_report_id_seq')::int);
+    SELECT results_eq('test',ARRAY[1],'1 Report Approved');
+    DEALLOCATE test;
+
+    PREPARE test AS SELECT reconciliation__get_cleared_balance(test_get_account_id('-11111'));
+    SELECT results_eq('test',ARRAY[130.],'1 Cleared balance post-approval is 130');
+    DEALLOCATE test;
+
+    PREPARE test as SELECT count(*)::int
                       FROM acc_trans
                       JOIN account a ON (acc_trans.chart_id = a.id)
                       WHERE a.accno = '-11111'
                       AND NOT cleared;
-    SELECT results_eq('test',ARRAY[true],'1 Transactions closed');
+    SELECT results_eq('test',ARRAY[3],'1 Transactions closed');
     DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__new_report_id(test_get_account_id('-11112'), 100, now()::date, false) > 0;
-    SELECT results_eq('test',ARRAY[true],'1 Create Recon Report');
+    PREPARE test AS SELECT reconciliation__new_report_id(test_get_account_id('-11112'), 120, :report_end2, false);
+    SELECT results_eq('test', $$ SELECT id+3 FROM test_parameters $$, '1 Create Recon Report');
     DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__pending_transactions(currval('cr_report_id_seq')::int, 110) > 0;
-    SELECT results_eq('test',ARRAY[true],'1 Pending Transactions Ran');
+    -- Which are pending?
+    PREPARE test AS SELECT reconciliation__pending_transactions(currval('cr_report_id_seq')::int, 130);
+    SELECT results_eq('test',$$ SELECT id+3 FROM test_parameters $$, '1 Pending Transactions Ran');
     DEALLOCATE test;
 
-    PREPARE test AS SELECT count(*) = 10
+    PREPARE test AS SELECT count(*)::int
                       FROM cr_report_line
                       WHERE report_id = currval('cr_report_id_seq')::int;
-    SELECT results_eq('test',ARRAY[true],'Correct number of transactions 2');
+    SELECT results_eq('test',ARRAY[13],'Correct number of transactions 2');
     DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__pending_transactions(currval('cr_report_id_seq')::int, 110) > 0;
-    SELECT results_eq('test',ARRAY[true],'1 Pending Transactions Ran');
+    PREPARE test AS SELECT reconciliation__pending_transactions(currval('cr_report_id_seq')::int, 130);
+    SELECT results_eq('test',$$ SELECT id+3 FROM test_parameters $$, '1 Pending Transactions Ran');
     DEALLOCATE test;
 
-    PREPARE test AS SELECT count(*) = 10
+    PREPARE test AS SELECT count(*)::int
                       FROM cr_report_line
                       WHERE report_id = currval('cr_report_id_seq')::int;
-    SELECT results_eq('test',ARRAY[true],'Correct number of transactions 3');
+    SELECT results_eq('test',ARRAY[13],'Correct number of transactions 3');
     DEALLOCATE test;
 
-    PREPARE test AS SELECT count(*) = 3
+    PREPARE test AS SELECT count(*)::int
                       FROM cr_report_line
                       WHERE scn like '% gl %'
                       AND report_id = currval('cr_report_id_seq')::int;
-    SELECT results_eq('test',ARRAY[true],'1 Correct number of GL groups');
+    SELECT results_eq('test',ARRAY[3],'1 Correct number of GL groups');
     DEALLOCATE test;
 
-    PREPARE test AS SELECT count(*) = 10
+    PREPARE test AS SELECT count(*)::int
                       FROM cr_report_line
                       WHERE report_id = currval('cr_report_id_seq')::int;
-    SELECT results_eq('test',ARRAY[true],'1 Correct number of report lines');
+    SELECT results_eq('test',ARRAY[13],'1 Correct number of report lines');
     DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__submit_set(currval('cr_report_id_seq')::int, '{}');
-    SELECT results_eq('test',ARRAY[true],'1 Report Submitted');
+    PREPARE test AS SELECT reconciliation__submit_set(currval('cr_report_id_seq')::int, '{}',:report_end2);
+    SELECT lives_ok(
+        'test',
+        'We should not get a unique violation for an unbalanced report on submit'
+    );
     DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__get_cleared_balance(test_get_account_id('-11112')) = -10;
-    SELECT results_eq('test',ARRAY[true],'1 Cleared balance pre-approval is 10');
+    PREPARE test AS SELECT reconciliation__get_cleared_balance(test_get_account_id('-11112')) IS NULL;
+    SELECT results_eq('test',ARRAY[true],'1 Cleared balance pre-approval is empty');
     DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__report_approve(currval('cr_report_id_seq')::int) > 0;
+    PREPARE test AS SELECT reconciliation__report_approve(currval('cr_report_id_seq')::int) = 1;
     SELECT results_eq('test',ARRAY[true],'1 Report Approved');
     DEALLOCATE test;
 
-    PREPARE test AS SELECT count(*) = 14
+    PREPARE test AS SELECT count(*)::int
                       FROM acc_trans
                       JOIN account ON (acc_trans.chart_id = account.id)
                       WHERE accno = '-11112'
                       AND NOT cleared;
-    SELECT results_eq('test',ARRAY[true],'1 Transactions open');
+    SELECT results_eq('test',ARRAY[16],'1 Transactions open');
     DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__get_cleared_balance(test_get_account_id('-11112')) = -10;
-    SELECT results_eq('test',ARRAY[true],'1 Cleared balance post-approval is 10');
+    PREPARE test AS SELECT reconciliation__get_cleared_balance(test_get_account_id('-11112')) IS NULL;
+    SELECT results_eq('test',ARRAY[true],'1 Cleared balance post-approval is empty');
     DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__new_report_id(test_get_account_id('-11112'), 100, now()::date, false)>0;
-    SELECT results_eq('test',ARRAY[true],'1 Create Recon Report');
+    PREPARE test AS SELECT reconciliation__new_report_id(test_get_account_id('-11112'), 120, :report_end2, false);
+    SELECT results_eq('test',$$ SELECT id+4 FROM test_parameters $$, '1 Create Recon Report');
     DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__pending_transactions(currval('cr_report_id_seq')::int, 110) > 0;
-    SELECT results_eq('test',ARRAY[true],'1 Pending Transactions Ran');
+    PREPARE test AS SELECT reconciliation__pending_transactions(currval('cr_report_id_seq')::int, 130);
+    SELECT results_eq('test',$$ SELECT id+4 FROM test_parameters $$, '1 Pending Transactions Ran');
     DEALLOCATE test;
 
-    PREPARE test AS SELECT count(*) = 10
+    PREPARE test AS SELECT count(*)::int
                       FROM cr_report_line
                       WHERE report_id = currval('cr_report_id_seq')::int;
-    SELECT results_eq('test',ARRAY[true],'Correct number of transactions 4');
+    SELECT results_eq('test',ARRAY[13],'Correct number of transactions 4');
     DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__submit_set(currval('cr_report_id_seq')::int, (select as_array(id::int)
-                      FROM cr_report_line
-                      WHERE report_id = currval('cr_report_id_seq')::int));
-    SELECT results_eq('test',ARRAY[true],'Report Submitted');
+    PREPARE test AS SELECT reconciliation__submit_set(
+                                currval('cr_report_id_seq')::int,
+                                (select as_array(id::int)
+                                      FROM cr_report_line
+                                      WHERE report_id = currval('cr_report_id_seq')::int),
+                                :report_end2);
+    SELECT lives_ok(
+        'test',
+        'We should not get a unique violation for an unbalanced report on submit'
+    );
     DEALLOCATE test;
 
-    PREPARE test AS SELECT their_total = 110
+    PREPARE test AS SELECT their_total
                       FROM reconciliation__report_summary(currval('cr_report_id_seq')::int);
-    SELECT results_eq('test',ARRAY[true],'Their Balance Updated');
+    SELECT results_eq('test',ARRAY[130.],'Their Balance Updated');
     DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__get_cleared_balance(test_get_account_id('-11112'))= -10;
-    SELECT results_eq('test',ARRAY[true],'Cleared balance pre-approval is 10');
+    PREPARE test AS SELECT reconciliation__get_cleared_balance(test_get_account_id('-11112')) IS null;
+    SELECT results_eq('test',ARRAY[true],'Cleared balance pre-approval is empty');
     DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__report_approve(currval('cr_report_id_seq')::int) > 0;
+    PREPARE test AS SELECT reconciliation__report_approve(currval('cr_report_id_seq')::int) = 1;
     SELECT results_eq('test',ARRAY[true],'Report Approved');
     DEALLOCATE test;
 
@@ -211,18 +322,19 @@ BEGIN;
     SELECT results_eq('test',ARRAY[true],'Cannot Delete Approved Recon Report');
     DEALLOCATE test;
 
-    PREPARE test AS SELECT count(*) = 2
+    PREPARE test AS SELECT count(*)::int
                       FROM acc_trans
                       JOIN account a ON (acc_trans.chart_id = a.id)
                       WHERE accno = '-11112'
                       AND NOT cleared;
-    SELECT results_eq('test',ARRAY[true],'Transactions closed');
+    SELECT results_eq('test',ARRAY[3],'Transactions closed');
     DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__get_cleared_balance(test_get_account_id('-11112'))= -130;
-    SELECT results_eq('test',ARRAY[true],'Cleared balance post-approval is 130');
+    PREPARE test AS SELECT reconciliation__get_cleared_balance(test_get_account_id('-11112'));
+    SELECT results_eq('test',ARRAY[-130.],'Cleared balance post-approval is 130');
     DEALLOCATE test;
 
     -- Finish the tests and clean up.
     SELECT * FROM finish();
+
 ROLLBACK;

--- a/xt/42-reconciliation.pg
+++ b/xt/42-reconciliation.pg
@@ -319,8 +319,7 @@ BEGIN;
     SELECT throws_ok(
         'test',
         'P0001',
-        'Cannot Delete Approved Recon Report'
-        'We should get a unique violation for an already approved report'
+        'Cannot delete approved recon report'
     );
     DEALLOCATE test;
 

--- a/xt/42-reconciliation.pg
+++ b/xt/42-reconciliation.pg
@@ -50,7 +50,7 @@ BEGIN;
 
     \set report_end1 '''2001-02-03'''
     \set report_end2 '''2001-03-04'''
-    
+
     --TODO: Do we still need this?
     PREPARE test AS SELECT count(*) = 1
                       FROM defaults
@@ -153,16 +153,13 @@ BEGIN;
     SELECT results_eq('test',ARRAY[13],'Correct number of report lines');
     DEALLOCATE test;
 
-    PREPARE test AS SELECT SUM(crl.our_balance) - cr.their_total
-                    FROM cr_report_line crl
-                    JOIN cr_report cr ON cr.id = crl.report_id
-                    WHERE cr.id = currval('cr_report_id_seq')::int
-                    GROUP BY cr.their_total;
+    PREPARE test AS SELECT reconciliation__check_balanced(currval('cr_report_id_seq')::int);
     SELECT results_eq('test',ARRAY[-20::numeric],'Report not balanced (should not be submittable)');
     DEALLOCATE test;
 
     PREPARE test AS WITH rows AS (
-                        UPDATE cr_report_line SET cleared = 't', clear_time = '1501-02-03'
+                        UPDATE cr_report_line SET cleared = 't', clear_time = '1501-02-03',
+                               their_balance = our_balance
                         WHERE report_id = currval('cr_report_id_seq')::int
                         RETURNING 1
                     )
@@ -171,14 +168,14 @@ BEGIN;
     SELECT results_eq('test',ARRAY[13],'Clear transactions');
     DEALLOCATE test;
 
---    PREPARE test AS SELECT reconciliation__submit_set(currval('cr_report_id_seq')::int, (select as_array(id::int) from cr_report_line where report_id = currval('cr_report_id_seq')::int),:report_end1);
---    SELECT throws_ok(
---        'test',
---        'P0001',
---        'Unbalanced report by -20.00',
---        'We should get a unique violation for an unbalanced report'
---    );
---    DEALLOCATE test;
+    PREPARE test AS SELECT reconciliation__submit_set(currval('cr_report_id_seq')::int, (select as_array(id::int) from cr_report_line where report_id = currval('cr_report_id_seq')::int),:report_end1);
+    SELECT throws_ok(
+        'test',
+        'P0001',
+        'Unbalanced report by -20.00',
+        'We should get a unique violation for an unbalanced report'
+    );
+    DEALLOCATE test;
 
     PREPARE test AS WITH rows AS (
                         UPDATE cr_report
@@ -197,6 +194,7 @@ BEGIN;
         'We should not get a unique violation for an unbalanced report on submit'
     );
     DEALLOCATE test;
+
     PREPARE test AS SELECT reconciliation__report_approve(currval('cr_report_id_seq')::int);
     SELECT results_eq('test',ARRAY[1],'1 Report Approved');
     DEALLOCATE test;
@@ -258,8 +256,8 @@ BEGIN;
     );
     DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__get_cleared_balance(test_get_account_id('-11112')) IS NULL;
-    SELECT results_eq('test',ARRAY[true],'1 Cleared balance pre-approval is empty');
+    PREPARE test AS SELECT reconciliation__get_cleared_balance(test_get_account_id('-11112')) = 0;
+    SELECT results_eq('test',ARRAY[true],'1 Cleared balance pre-approval is zero');
     DEALLOCATE test;
 
     PREPARE test AS SELECT reconciliation__report_approve(currval('cr_report_id_seq')::int) = 1;
@@ -274,8 +272,8 @@ BEGIN;
     SELECT results_eq('test',ARRAY[16],'1 Transactions open');
     DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__get_cleared_balance(test_get_account_id('-11112')) IS NULL;
-    SELECT results_eq('test',ARRAY[true],'1 Cleared balance post-approval is empty');
+    PREPARE test AS SELECT reconciliation__get_cleared_balance(test_get_account_id('-11112')) = 0;
+    SELECT results_eq('test',ARRAY[true],'1 Cleared balance post-approval is 0');
     DEALLOCATE test;
 
     PREPARE test AS SELECT reconciliation__new_report_id(test_get_account_id('-11112'), 120, :report_end2, false);
@@ -309,8 +307,8 @@ BEGIN;
     SELECT results_eq('test',ARRAY[130.],'Their Balance Updated');
     DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__get_cleared_balance(test_get_account_id('-11112')) IS null;
-    SELECT results_eq('test',ARRAY[true],'Cleared balance pre-approval is empty');
+    PREPARE test AS SELECT reconciliation__get_cleared_balance(test_get_account_id('-11112')) = 0;
+    SELECT results_eq('test',ARRAY[true],'Cleared balance pre-approval is 0');
     DEALLOCATE test;
 
     PREPARE test AS SELECT reconciliation__report_approve(currval('cr_report_id_seq')::int) = 1;
@@ -318,8 +316,12 @@ BEGIN;
     DEALLOCATE test;
 
     PREPARE test AS SELECT reconciliation__delete_my_report(currval('cr_report_id_seq')::int) IS NULL;
-    -- Should we thrown an exception?
-    SELECT results_eq('test',ARRAY[true],'Cannot Delete Approved Recon Report');
+    SELECT throws_ok(
+        'test',
+        'P0001',
+        'Cannot Delete Approved Recon Report'
+        'We should get a unique violation for an already approved report'
+    );
     DEALLOCATE test;
 
     PREPARE test AS SELECT count(*)::int

--- a/xt/42-reconciliation.pg
+++ b/xt/42-reconciliation.pg
@@ -5,7 +5,7 @@ BEGIN;
 
     -- Plan the tests.
 
-    SELECT plan(64);
+    SELECT plan(65);
 
     -- Add data
 


### PR DESCRIPTION
Current reconciliation code rely on the fact that approval closely follows submit and fails when many submit are done without approval because it doesn't take reconciliation date into account.
This PR fix that and also enable proper SQL-Ledger migrations to be automatically submitted, but have delayed approval.