### PR TITLE
Temporary fix for Travis issue between node.js and java

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,10 @@ cache:
     - $HOME/dojo_archive
 
 before_install:
+# Temp fix for node.js vs java issue ++
+  - source /opt/jdk_switcher/jdk_switcher.sh
+  - jdk_switcher use oraclejdk8
+# Temp fix for node.js vs java issue --
   - phantomjs --version
   - export PATH=$HOME/travis_phantomjs/phantomjs-2.1.1-linux-x86_64/bin:$PATH
   - phantomjs --version


### PR DESCRIPTION
Travis recently upgraded their images and brought an issue for java which prevents node.js to find it.
This is th recommended patch until a permanent fix is generated.