### PR TITLE
Propose a buy exchange rate if none defined.

### DIFF
--- a/UI/Configuration/settings.html
+++ b/UI/Configuration/settings.html
@@ -6,13 +6,13 @@ PROCESS elements.html ?>
         method="post"
         action="<?lsmb form.script ?>">
     <table width="100%"><col width="25%" align="right"><col><col>
-      <tr><th colspan="2" class="listtop"><?lsmb text('System Defaults') ?></th></tr>
+      <tr><th colspan="3" class="listtop"><?lsmb text('System Defaults') ?></th></tr>
         <?lsmb FOREACH GROUP IN default_settings ?>
-      <tr><th colspan="2" class="listheading"><?lsmb GROUP.title ?></th></tr>
+      <tr><th colspan="3" class="listheading"><?lsmb GROUP.title ?></th></tr>
       <?lsmb FOREACH ITEM IN GROUP.items ?>
       <tr>
         <th align="right"><?lsmb ITEM.label ?></th>
-        <td>
+        <td colspan=<?lsmb ITEM.info ? "1" : "2" ?> style='white-space:nowrap'>
           <?lsmb
              IF ITEM.type == 'YES_NO';
                IF form.${ITEM.name};
@@ -53,7 +53,16 @@ PROCESS elements.html ?>
                        type = 'text'
                        value = form.${ITEM.name}
                        };
-             END; ?>
+             END;
+             IF ITEM.info;
+                "<td align='left'>";
+                FOREACH i IN ITEM.info;
+                    i = i.replace('\$1','<a href="http://currencies.apps.grandtrunk.net/" target="_blank">Historical currency converter web service</a>');
+                    "$i<br><br>";
+                END;
+                "</td>";
+             END;
+           ?>
         </td>
       </tr>
       <?lsmb END # FOREACH ITEM ?>

--- a/cpanfile
+++ b/cpanfile
@@ -20,6 +20,7 @@ requires 'JSON';
 requires 'List::MoreUtils';
 requires 'Locale::Maketext::Lexicon', '0.62';
 requires 'Log::Log4perl';
+requires 'LWP::Simple';
 requires 'MIME::Lite';
 requires 'Moose';
 requires 'Moose::Role';

--- a/lib/LedgerSMB/Scripts/configuration.pm
+++ b/lib/LedgerSMB/Scripts/configuration.pm
@@ -132,6 +132,14 @@ sub _default_settings {
                 type => 'YES_NO', },
               { name => 'min_empty',
                 label => $locale->text('Min Empty Lines') },
+              { name => 'default_buyexchange',
+                label => $locale->text('Use web service for current Buy Exchange Rates'),
+                type => 'YES_NO',
+                info => ['Exchangerate varies constantly.',
+                         'Buy rates can be provided automatically to the application by using a web service and providing current date and origin and destination currencies.',
+                         'When the transaction is reconcilied, the sell rate effectively used would take into account the rate variation and conversion fees.',
+                         'Please review the terms and conditions for the $1 before setting this on.']
+                },
               ] },
         );
     return @default_settings;

--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -1552,7 +1552,8 @@ sub update_exchangerate {
         @queryargs = ($sell);
     }
 
-    if (!$set) {
+    my $default_buyexchange = LedgerSMB::Setting->get('default_buyexchange');
+    if (!$set && $default_buyexchange) {
         $set = "buy = ?";
         $buy = get("http://currencies.apps.grandtrunk.net/getrate/$transdate/$curr/$self->{defaultcurrency}");
         @queryargs = ($buy);
@@ -1632,7 +1633,9 @@ sub get_exchangerate {
 
         ($exchangerate) = $sth->fetchrow_array;
         if (!$exchangerate) {
-            $exchangerate = get("http://currencies.apps.grandtrunk.net/getrate/$transdate/$curr/$self->{defaultcurrency}");
+            my $default_buyexchange = LedgerSMB::Setting->get('default_buyexchange');
+            $exchangerate = get("http://currencies.apps.grandtrunk.net/getrate/$transdate/$curr/$self->{defaultcurrency}")
+                            if $default_buyexchange;
         }
         $exchangerate = LedgerSMB::PGNumber->new($exchangerate);
         $sth->finish;
@@ -2397,7 +2400,7 @@ sub create_links {
                 a.duedate, a.ordnumber,
                 a.taxincluded, a.curr AS currency, a.notes,
                 a.intnotes, ce.name AS $vc,
-                a.amount AS oldinvtotal, 
+                a.amount AS oldinvtotal,
                 a.person_id, e.name AS employee,
                 c.language_code, a.ponumber, a.reverse,
                                 a.approved, ctf.default_reportable,


### PR DESCRIPTION
Exchangerate varies constantly. Buy rates can be provided automatically buy the application by using a [web service](http://currencies.apps.grandtrunk.net) and providing current date and origin and destination currencies.
When the transaction is reconcilied, the sell rate effectively used would take into account the rate variation and conversion fees