### PR TITLE
* Fix #2278: No years drop-down in search dialog

### DIFF
--- a/sql/Pg-database.sql
+++ b/sql/Pg-database.sql
@@ -4942,8 +4942,6 @@ COMMENT ON VIEW cash_impact IS
 $$ This view is used by cash basis reports to determine the fraction of a
 transaction to be counted.$$;
 
--- helpful to keeping the selection of all years fast
-create index ac_transdate_year_idx on acc_trans(EXTRACT ('YEAR' FROM transdate));
 
 CREATE TABLE template ( -- not for UI templates
     id serial not null unique,

--- a/sql/changes/1.5/issue-2278-modify-acc_trans-index.sql
+++ b/sql/changes/1.5/issue-2278-modify-acc_trans-index.sql
@@ -1,0 +1,10 @@
+
+DROP INDEX IF EXISTS ac_transdate_year_idx;
+
+CREATE INDEX acc_trans_transdate_year_idx
+    ON acc_trans (transdate, date_part('YEAR', transdate))
+ WHERE transdate IS NOT NULL;
+
+COMMENT ON INDEX acc_trans_transdate_year_idx IS
+$$This index supports the function 'date_get_all_years' and
+reduces that function to a series of index scans instead of table scans$$;

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -42,6 +42,7 @@
 1.5/template_menu.sql
 1.5/template_menu2.sql
 1.5/issue-2380-modify-tax_extended_entry_id-constraint.sql
+1.5/issue-2278-modify-acc_trans-index.sql
 #1.6 changes
 1.6/drop_chart.sql
 1.6/drop_arap_cols.sql


### PR DESCRIPTION
Changes:
- sql/modules/Date: Stop dropping a function which will be created-or-replaced
  with the same parameters immediately after, which has the same effect
- sql/Pg-database: Don't create an index which is dropped in a change file
  immediately after during the creation of a new schema
- sql/changes/1.5/issue-2278-...: Add an index which reduces
  'date_get_all_dates()' to a series of 'index-only' scans