### PR TITLE
* Fix #2555: setup.pl admin can't access user's details

### DIFF
--- a/sql/modules/admin.sql
+++ b/sql/modules/admin.sql
@@ -185,7 +185,14 @@ CREATE OR REPLACE FUNCTION admin__get_roles_for_user(in_user_id INT) returns set
         select * into a_user from admin__get_user(in_user_id);
 
         IF a_user.username != CURRENT_USER THEN
-            IF pg_has_role(lsmb__role('users_manage'), 'USAGE') IS FALSE THEN
+            -- super users and application users match the first criterion
+            -- db owners and db owner group members match the second criterion
+            IF pg_has_role(lsmb__role('users_manage'), 'USAGE') IS FALSE
+               AND pg_has_role((select rolname
+                                 from pg_database db inner join pg_roles rol
+                                   on db.datdba = rol.oid
+                                where db.datname = current_database()),
+                               'USAGE') IS FALSE THEN
                RAISE EXCEPTION 'User % querying permissions for %, not authorised', CURRENT_USER, a_user.username;
             END IF;
         END IF;
@@ -219,7 +226,17 @@ $$ language 'plpgsql' SECURITY DEFINER;
 REVOKE EXECUTE ON FUNCTION admin__get_roles_for_user(in_entity_id INT) from PUBLIC;
 
 COMMENT ON FUNCTION admin__get_roles_for_user(in_user_id INT) IS
-$$ Returns a set of roles that  a user is a part of.$$;
+$$Returns a set of roles that  a user is a part of.
+
+Note: this function can only be used by
+ - super users
+ - database admins (setup.pl users):
+   - database owners
+   - database users (roles) which were granted the database owner role
+ - application users:
+   - application admins (users with 'manage_users' role)
+   - application users (roles) which query their own roles
+$$;
 
 CREATE OR REPLACE FUNCTION admin__get_roles_for_user_by_entity(in_entity_id INT) returns setof text as $$
 
@@ -230,7 +247,14 @@ CREATE OR REPLACE FUNCTION admin__get_roles_for_user_by_entity(in_entity_id INT)
         select * into a_user from admin__get_user_by_entity(in_entity_id);
 
         IF a_user.username != CURRENT_USER THEN
-            IF pg_has_role(lsmb__role('users_manage'), 'USAGE') IS FALSE THEN
+            -- super users and application users match the first criterion
+            -- db owners and db owner group members match the second criterion
+            IF pg_has_role(lsmb__role('users_manage'), 'USAGE') IS FALSE
+               AND pg_has_role((select rolname
+                                 from pg_database db inner join pg_roles rol
+                                   on db.datdba = rol.oid
+                                where db.datname = current_database()),
+                               'USAGE') IS FALSE THEN
                RAISE EXCEPTION 'User % querying permissions for %, not authorised', CURRENT_USER, a_user.username;
             END IF;
         END IF;
@@ -264,7 +288,17 @@ $$ language 'plpgsql' SECURITY DEFINER;
 REVOKE EXECUTE ON FUNCTION admin__get_roles_for_user_by_entity(in_entity_id INT) from PUBLIC;
 
 COMMENT ON FUNCTION admin__get_roles_for_user_by_entity(in_entity_id INT) IS
-$$ Returns a set of roles that  a user is a part of.$$;
+$$Returns a set of roles that  a user is a part of.
+
+Note: this function can only be used by
+ - super users
+ - database admins (setup.pl users):
+   - database owners
+   - database users (roles) which were granted the database owner role
+ - application users:
+   - application admins (users with 'manage_users' role)
+   - application users (roles) which query their own roles
+$$;
 
 
 CREATE OR REPLACE FUNCTION user__check_my_expiration()
@@ -321,7 +355,7 @@ END;
 $$ language plpgsql security definer;
 
 COMMENT ON FUNCTION user__change_password(in_new_password text) IS
-$$ Alloes a user to change his or her own password.  The password is set to
+$$ Allows a user to change his or her own password.  The password is set to
 expire setting_get('password_duration') days after the password change.$$;
 
 DROP FUNCTION IF EXISTS admin__save_user(int, int, text, text, bool);

--- a/sql/modules/admin.sql
+++ b/sql/modules/admin.sql
@@ -184,6 +184,8 @@ CREATE OR REPLACE FUNCTION admin__get_roles_for_user(in_user_id INT) returns set
     begin
         select * into a_user from admin__get_user(in_user_id);
 
+        -- this function used to be security definer, but that hides the true
+        -- CURRENT_USER, returning the DEFINER instead of the caller
         IF a_user.username != CURRENT_USER THEN
             -- super users and application users match the first criterion
             -- db owners and db owner group members match the second criterion
@@ -221,7 +223,7 @@ CREATE OR REPLACE FUNCTION admin__get_roles_for_user(in_user_id INT) returns set
         RETURN;
     end;
 
-$$ language 'plpgsql' SECURITY DEFINER;
+$$ language 'plpgsql';
 
 REVOKE EXECUTE ON FUNCTION admin__get_roles_for_user(in_entity_id INT) from PUBLIC;
 
@@ -246,6 +248,8 @@ CREATE OR REPLACE FUNCTION admin__get_roles_for_user_by_entity(in_entity_id INT)
     begin
         select * into a_user from admin__get_user_by_entity(in_entity_id);
 
+        -- this function used to be security definer, but that hides the true
+        -- CURRENT_USER, returning the DEFINER instead of the caller
         IF a_user.username != CURRENT_USER THEN
             -- super users and application users match the first criterion
             -- db owners and db owner group members match the second criterion
@@ -283,7 +287,7 @@ CREATE OR REPLACE FUNCTION admin__get_roles_for_user_by_entity(in_entity_id INT)
         RETURN;
     end;
 
-$$ language 'plpgsql' SECURITY DEFINER;
+$$ language 'plpgsql';
 
 REVOKE EXECUTE ON FUNCTION admin__get_roles_for_user_by_entity(in_entity_id INT) from PUBLIC;
 


### PR DESCRIPTION
Note: This fixes a regression in 1.5.1 which was introduced to allow
  users access to their preferences page. The original change granted
  liberal execution rights on a SECURITY DEFINER function which was
  restricted through an internal access check. As per this bug, it is
  shown that the prior restrictions were too tight; we're widening
  a bit again.