### PR TITLE
fixing name of function called

### DIFF
--- a/LedgerSMB/DBObject/Account.pm
+++ b/LedgerSMB/DBObject/Account.pm
@@ -204,7 +204,7 @@ Returns a list of all accounts.
 
 sub list {
     my $self = shift @_;
-    @{$self->{account_list}} =  $self->exec_method(funcname => 'chart__list_all');
+    @{$self->{account_list}} =  $self->exec_method(funcname => 'chart_list_all');
     return @{$self->{account_list}};
 }
 


### PR DESCRIPTION
This matches what is defined in the SQL and otherwise breaks attempts to use this API (apparently not used in LSMB itself).