### PR TITLE
* Fix #2569 and fix #2568: invoice template improvements

### DIFF
--- a/templates/demo/invoice.html
+++ b/templates/demo/invoice.html
@@ -14,8 +14,7 @@
 
     <th colspan=3>
       <h4 style="text-transform:uppercase">
-          <?lsmb IF reverse; text('Credit'); END; ?>
-          <?lsmb text('Invoice') ?></h4>
+          <?lsmb IF reverse; text('Credit Invoice'); ELSE; text('Invoice'); END; ?>
     </th>
   </tr>
 
@@ -166,16 +165,13 @@
         <tr>
           <td colspan=9><hr noshade></td>
         </tr>
-    
+
+        <?lsmb IF tax -?>
         <tr>
-          <?lsmb IF taxincluded ?>
-          <th colspan=7 align=right><?lsmb text('Total') ?></th>
-          <td colspan=2 align=right><?lsmb invtotal ?></td>
-          <?lsmb ELSE ?>
           <th colspan=7 align=right><?lsmb text('Subtotal') ?></th>
           <td colspan=2 align=right><?lsmb subtotal ?></td>
-          <?lsmb END ?>
         </tr>
+        <?lsmb END -?>
 
         <?lsmb FOREACH tax ?>
         <?lsmb loop_count = loop.count - 1 ?>
@@ -184,23 +180,25 @@
           <td colspan=2 align=right><?lsmb tax.${loop_count} ?></td>
         </tr>
         <?lsmb END ?>
+        <tr>
+          <th colspan=7 align=right><?lsmb text('Total') ?></th>
+          <td colspan=2 align=right><?lsmb invtotal ?></td>
+        </tr>
 
-        <?lsmb IF paid ?>
+        <?lsmb IF paymentdate.0 ?>
         <tr>
           <th colspan=7 align=right><?lsmb text('Paid') ?></th>
           <td colspan=2 align=right>- <?lsmb paid ?></td>
         </tr>
-        <?lsmb END ?>
 
         <tr>
           <td colspan=5>&nbsp;</td>
           <td colspan=4><hr noshade></td>
         </tr>
 
-        <?lsmb IF total ?>
         <tr>
           <td colspan=5>&nbsp;</td>
-          <th colspan=2 align=right nowrap><?lsmb text('Balance Due') ?></th>
+          <th colspan=2 align=right nowrap><?lsmb text('Balance') ?></th>
           <th colspan=2 align=right><?lsmb total ?></th>
         </tr>
         <?lsmb END ?>
@@ -223,7 +221,7 @@
           <?lsmb END ?>
 
           <td><?lsmb text_amount ?> ***** <?lsmb decimal ?>/100</td>
-          
+
           <td align=right nowrap>
           <?lsmb text('All prices in [_1]', currency) ?>
           </td>
@@ -232,7 +230,7 @@
     </td>
   </tr>
 
-  <?lsmb IF paid_1 ?>
+  <?lsmb IF paymentdate.0 ?>
   <tr>
     <td>&nbsp;</td>
 

--- a/templates/demo/invoice.tex
+++ b/templates/demo/invoice.tex
@@ -109,7 +109,12 @@ Fax: <?lsmb shiptofax ?>
 
 \vspace{1cm}
 
-\textbf{\MakeUppercase{<?lsmb IF reverse; text('Credit'); END; ?><?lsmb text('Invoice') ?>}}
+\textbf{\MakeUppercase{<?lsmb
+    IF reverse;
+       text('Credit Invoice');
+    ELSE;
+       text('Invoice');
+    END; ?>}}
 \hfill
 
 \vspace{1cm}
@@ -153,7 +158,8 @@ Fax: <?lsmb shiptofax ?>
   <?lsmb discountrate.${lc} ?> &
   <?lsmb linetotal.${lc} ?> \\
 <?lsmb END ?>
-\hline \hline
+ \hline \hline
+<?lsmb IF tax ?>
 \multicolumn{8}{r|}{<?lsmb text('Subtotal') ?>} & <?lsmb subtotal ?> \\*
 <?lsmb FOREACH tax ?>
 <?lsmb lc = loop.count - 1 ?>
@@ -161,13 +167,15 @@ Fax: <?lsmb shiptofax ?>
                     ?>  on <?lsmb taxbase.${lc} ?> }
  & <?lsmb tax.${lc} ?> \\*
 <?lsmb END ?>
-<?lsmb IF paid ?>
-\multicolumn{8}{r|}{ <?lsmb text('Paid') ?> } & - <?lsmb paid ?> \\*
 <?lsmb END ?>
-<?lsmb IF total ?>
+\hline \hline
+\multicolumn{8}{r|}{<?lsmb text('Total') ?>} & <?lsmb invtotal ?> \\*
+
+<?lsmb IF paymentdate.0 ?>
+\multicolumn{8}{r|}{ <?lsmb text('Paid') ?> } & - <?lsmb paid ?> \\*
   \hline
   \hline
-\multicolumn{8}{r|}{<?lsmb text('Balance Due') ?>} & <?lsmb total ?>\\
+\multicolumn{8}{r|}{<?lsmb text('Balance') ?>} & <?lsmb total ?>\\
 <?lsmb END ?>
 
 \end{longtable}
@@ -194,7 +202,7 @@ Fax: <?lsmb shiptofax ?>
 
 \vfill
 
-<?lsmb IF paid_1 ?>
+<?lsmb IF paymentdate.0 ?>
 \begin{tabularx}{10cm}{@{}lXlr@{}}
   \textbf{<?lsmb text('Payments') ?>} & & & \\
   \hline

--- a/templates/demo_with_images/invoice.html
+++ b/templates/demo_with_images/invoice.html
@@ -14,8 +14,9 @@
 
     <th colspan=3>
       <h4 style="text-transform:uppercase">
-          <?lsmb IF reverse; text('Credit'); END; ?>
-          <?lsmb text('Invoice') ?></h4>
+        <?lsmb IF reverse; text('Credit Invoice');
+               ELSE; text('Invoice');
+               END; ?></h4>
     </th>
   </tr>
 
@@ -166,15 +167,11 @@
         <tr>
           <td colspan=9><hr noshade></td>
         </tr>
-    
+
+          <?lsmb IF tax ?>
         <tr>
-          <?lsmb IF taxincluded ?>
-          <th colspan=7 align=right><?lsmb text('Total') ?></th>
-          <td colspan=2 align=right><?lsmb invtotal ?></td>
-          <?lsmb ELSE ?>
           <th colspan=7 align=right><?lsmb text('Subtotal') ?></th>
           <td colspan=2 align=right><?lsmb subtotal ?></td>
-          <?lsmb END ?>
         </tr>
 
         <?lsmb FOREACH tax ?>
@@ -184,23 +181,27 @@
           <td colspan=2 align=right><?lsmb tax.${loop_count} ?></td>
         </tr>
         <?lsmb END ?>
+        <?lsmb END ?>
+
+        <tr>
+          <th colspan=7 align=right><?lsmb text('Total') ?></th>
+          <td colspan=2 align=right><?lsmb invtotal ?></td>
+        </tr>
 
         <?lsmb IF paid ?>
         <tr>
           <th colspan=7 align=right><?lsmb text('Paid') ?></th>
           <td colspan=2 align=right>- <?lsmb paid ?></td>
         </tr>
-        <?lsmb END ?>
 
         <tr>
           <td colspan=5>&nbsp;</td>
           <td colspan=4><hr noshade></td>
         </tr>
 
-        <?lsmb IF total ?>
         <tr>
           <td colspan=5>&nbsp;</td>
-          <th colspan=2 align=right nowrap><?lsmb text('Balance Due') ?></th>
+          <th colspan=2 align=right nowrap><?lsmb text('Balance') ?></th>
           <th colspan=2 align=right><?lsmb total ?></th>
         </tr>
         <?lsmb END ?>
@@ -232,7 +233,7 @@
     </td>
   </tr>
 
-  <?lsmb IF paid_1 ?>
+  <?lsmb IF paymentdate.0 ?>
   <tr>
     <td>&nbsp;</td>
 

--- a/templates/demo_with_images/invoice.tex
+++ b/templates/demo_with_images/invoice.tex
@@ -109,7 +109,12 @@ Fax: <?lsmb shiptofax ?>
 
 \vspace{1cm}
 
-\textbf{\MakeUppercase{<?lsmb IF reverse; text('Credit'); END; ?><?lsmb text('Invoice') ?>}}
+\textbf{\MakeUppercase{<?lsmb
+    IF reverse;
+       text('Credit Invoice');
+    ELSE;
+       text('Invoice');
+    END; ?>}}
 \hfill
 
 \vspace{1cm}
@@ -152,6 +157,7 @@ Fax: <?lsmb shiptofax ?>
   <?lsmb discountrate.${lc} ?> &
   <?lsmb linetotal.${lc} ?> \\
 <?lsmb END ?>
+<?lsmb IF tax ?>
 \hline \hline
 \multicolumn{8}{r|}{<?lsmb text('Subtotal') ?>} & <?lsmb subtotal ?> \\*
 <?lsmb FOREACH tax ?>
@@ -160,13 +166,15 @@ Fax: <?lsmb shiptofax ?>
                     ?>  on <?lsmb taxbase.${lc} ?> }
  & <?lsmb tax.${lc} ?> \\*
 <?lsmb END ?>
-<?lsmb IF paid ?>
-\multicolumn{8}{r|}{ <?lsmb text('Paid') ?> } & - <?lsmb paid ?> \\*
 <?lsmb END ?>
-<?lsmb IF total ?>
+\hline \hline
+\multicolumn{8}{r|}{<?lsmb text('Total') ?>} & <?lsmb invtotal ?> \\*
+
+<?lsmb IF paymentdate.0 ?>
+\multicolumn{8}{r|}{ <?lsmb text('Paid') ?> } & - <?lsmb paid ?> \\*
   \hline
   \hline
-\multicolumn{8}{r|}{<?lsmb text('Balance Due') ?>} & <?lsmb total ?>\\
+\multicolumn{8}{r|}{<?lsmb text('Balance') ?>} & <?lsmb total ?>\\
 <?lsmb END ?>
 
 \end{longtable}
@@ -193,19 +201,17 @@ Fax: <?lsmb shiptofax ?>
 
 \vfill
 
-<?lsmb IF paid_1 ?>
+<?lsmb IF paymentdate.0 ?>
 \begin{tabularx}{10cm}{@{}lXlr@{}}
   \textbf{<?lsmb text('Payments') ?>} & & & \\
   \hline
   \textbf{<?lsmb text('Date') ?>} & & \textbf{<?lsmb text('Source') ?>} 
   & \textbf{<?lsmb text('Amount') ?>} \\
-<?lsmb END ?>
 <?lsmb FOREACH payment ?>
 <?lsmb lc = loop.count - 1 ?>
   <?lsmb paymentdate.${lc} ?> & <?lsmb paymentaccount.${lc} ?> & <?lsmb paymentsource.${lc} ?> & <?lsmb payment.${lc} ?> \\
-<?lsmb END ?>
-<?lsmb IF paid_1 ?>
 \end{tabularx}
+<?lsmb END ?>
 <?lsmb END ?>
 
 <?lsmb FOR FILE IN file_list ?>

--- a/templates/xedemo/invoice.html
+++ b/templates/xedemo/invoice.html
@@ -167,14 +167,10 @@
           <td colspan=9><hr noshade></td>
         </tr>
     
+          <?lsmb IF tax; ?>
         <tr>
-          <?lsmb IF taxincluded ?>
-          <th colspan=7 align=right><?lsmb text('Total') ?></th>
-          <td colspan=2 align=right><?lsmb invtotal ?></td>
-          <?lsmb ELSE ?>
           <th colspan=7 align=right><?lsmb text('Subtotal') ?></th>
           <td colspan=2 align=right><?lsmb subtotal ?></td>
-          <?lsmb END ?>
         </tr>
 
         <?lsmb FOREACH tax ?>
@@ -184,23 +180,27 @@
           <td colspan=2 align=right><?lsmb tax.${loop_count} ?></td>
         </tr>
         <?lsmb END ?>
+        <?lsmb END ?>
 
-        <?lsmb IF paid ?>
+        <tr>
+          <th colspan=7 align=right><?lsmb text('Total') ?></th>
+          <td colspan=2 align=right><?lsmb invtotal ?></td>
+        </tr>
+
+        <?lsmb IF paymentdate.0 ?>
         <tr>
           <th colspan=7 align=right><?lsmb text('Paid') ?></th>
           <td colspan=2 align=right>- <?lsmb paid ?></td>
         </tr>
-        <?lsmb END ?>
 
         <tr>
           <td colspan=5>&nbsp;</td>
           <td colspan=4><hr noshade></td>
         </tr>
 
-        <?lsmb IF total ?>
         <tr>
           <td colspan=5>&nbsp;</td>
-          <th colspan=2 align=right nowrap><?lsmb text('Balance Due') ?></th>
+          <th colspan=2 align=right nowrap><?lsmb text('Balance') ?></th>
           <th colspan=2 align=right><?lsmb total ?></th>
         </tr>
         <?lsmb END ?>
@@ -232,7 +232,7 @@
     </td>
   </tr>
 
-  <?lsmb IF paid_1 ?>
+  <?lsmb IF paymentdate.0 ?>
   <tr>
     <td>&nbsp;</td>
 

--- a/templates/xedemo/invoice.tex
+++ b/templates/xedemo/invoice.tex
@@ -108,7 +108,8 @@ Fax: <?lsmb shiptofax ?>
 
 \vspace{1cm}
 
-\textbf{\MakeUppercase{<?lsmb IF reverse; text('Credit'); END; ?><?lsmb text('Invoice') ?>}}
+\textbf{\MakeUppercase{<?lsmb IF reverse; text('Credit Invoice');
+    ELSE; text('Invoice'); END; ?>}}
 \hfill
 
 \vspace{1cm}
@@ -151,6 +152,7 @@ Fax: <?lsmb shiptofax ?>
   <?lsmb discountrate.${lc} ?> &
   <?lsmb linetotal.${lc} ?> \\
 <?lsmb END ?>
+<?lsmb IF tax ?>
 \hline \hline
 \multicolumn{8}{r|}{<?lsmb text('Subtotal') ?>} & <?lsmb subtotal ?> \\*
 <?lsmb FOREACH tax ?>
@@ -159,13 +161,15 @@ Fax: <?lsmb shiptofax ?>
                     ?>  on <?lsmb taxbase.${lc} ?> }
  & <?lsmb tax.${lc} ?> \\*
 <?lsmb END ?>
-<?lsmb IF paid ?>
-\multicolumn{8}{r|}{ <?lsmb text('Paid') ?> } & - <?lsmb paid ?> \\*
 <?lsmb END ?>
-<?lsmb IF total ?>
+\hline \hline
+\multicolumn{8}{r|}{<?lsmb text('Total') ?>} & <?lsmb invtotal ?> \\*
+
+<?lsmb IF paymentdate.0 ?>
+\multicolumn{8}{r|}{ <?lsmb text('Paid') ?> } & - <?lsmb paid ?> \\*
   \hline
   \hline
-\multicolumn{8}{r|}{<?lsmb text('Balance Due') ?>} & <?lsmb total ?>\\
+\multicolumn{8}{r|}{<?lsmb text('Balance') ?>} & <?lsmb total ?>\\
 <?lsmb END ?>
 
 \end{longtable}
@@ -193,19 +197,17 @@ Fax: <?lsmb shiptofax ?>
 
 \vfill
 
-<?lsmb IF paid_1 ?>
+<?lsmb IF paymentdate.0 ?>
 \begin{tabularx}{10cm}{@{}lXlr@{}}
   \textbf{<?lsmb text('Payments') ?>} & & & \\
   \hline
   \textbf{<?lsmb text('Date') ?>} & & \textbf{<?lsmb text('Source') ?>} 
   & \textbf{<?lsmb text('Amount') ?>} \\
-<?lsmb END ?>
 <?lsmb FOREACH payment ?>
 <?lsmb lc = loop.count - 1 ?>
   <?lsmb paymentdate.${lc} ?> & <?lsmb paymentaccount.${lc} ?> & <?lsmb paymentsource.${lc} ?> & <?lsmb payment.${lc} ?> \\
-<?lsmb END ?>
-<?lsmb IF paid_1 ?>
 \end{tabularx}
+<?lsmb END ?>
 <?lsmb END ?>
 
 \vspace{1cm}


### PR DESCRIPTION
Note: includes other invoice improvements;
 * localize 'Credit Invoice' instead of two words
 * add Total row in invoice after taxes
 * rename 'Balance Due' to Balance after 'Paid'