### PR TITLE
* Fix #2573: Don't cache from-db templates

### DIFF
--- a/conf/ledgersmb.conf.default
+++ b/conf/ledgersmb.conf.default
@@ -85,6 +85,12 @@ backupdir = /tmp/ledgersmb-backups
 
 localepath = locale/po
 
+# location where compiled templates are stored
+#
+# When relative, appended to the directory specified in the 'tempdir' variable
+#
+#templates_cache = lsmb_templates
+
 [programs]
 # program to use for file compression
 gzip       = gzip -S .gz

--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -221,7 +221,10 @@ def 'templates',
     default => 'templates',
     doc => qq||;
 
-our $cache_template_subdir = "lsmb_templates"; # this is a subdir of $tempdir and shouldn't have a leading slash
+def 'templates_cache',
+    section => 'paths',
+    default => 'lsmb_templates',
+    doc => qq|this is a subdir of tempdir, unless it's an absolute path|;
 
 
 ### SECTION  ---   mail
@@ -415,7 +418,6 @@ if(!(-d LedgerSMB::Sysconfig::tempdir())){
          $rc = system("mkdir " . LedgerSMB::Sysconfig::tempdir());
      } else {
          $rc=system("mkdir -p " . LedgerSMB::Sysconfig::tempdir());
-     #$logger->info("created tempdir \$tempdir rc=\$rc"); log4perl not initialised yet!
      }
 }
 

--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -182,6 +182,7 @@ use LedgerSMB::Setting;
 use LedgerSMB::Sysconfig;
 use Log::Log4perl;
 use File::Copy "cp";
+use File::Spec;
 
 my $logger = Log::Log4perl->get_logger('LedgerSMB::Template');
 
@@ -374,9 +375,14 @@ sub get_template_args {
         (%additional_options)
     };
 
-    if ($LedgerSMB::Sysconfig::cache_templates){
+    if ($LedgerSMB::Sysconfig::cache_templates
+        && $self->{include_path} ne 'DB') {
+       # don't cache compiled database-retrieved templates
+       # they will vary between databases
         $arghash->{COMPILE_EXT} = '.lttc';
-        $arghash->{COMPILE_DIR} = $LedgerSMB::Sysconfig::tempdir . "/" . $LedgerSMB::Sysconfig::cache_template_subdir;
+        $arghash->{COMPILE_DIR} =
+           File::Spec->rel2abs( $LedgerSMB::Sysconfig::templates_cache,
+                                $LedgerSMB::Sysconfig::tempdir );
     }
     $self->{binmode} = $binmode;
     return $arghash;

--- a/lib/LedgerSMB/Template/XLS.pm
+++ b/lib/LedgerSMB/Template/XLS.pm
@@ -203,8 +203,7 @@ sub process {
     my $cleanvars = shift;
 
     my $output = '';
-    my $tempdir = $LedgerSMB::Sysconfig::tempdir . "/"
-                . $LedgerSMB::Sysconfig::cache_template_subdir . "/UI";
+    my $tempdir = $LedgerSMB::Sysconfig::tempdir;
     $parent->{outputfile} ||= "$tempdir/$parent->{template}-output-$$";
 
     my $arghash = $parent->get_template_args($extension,$binmode);

--- a/lib/LedgerSMB/Template/XLSX.pm
+++ b/lib/LedgerSMB/Template/XLSX.pm
@@ -203,8 +203,7 @@ sub process {
     my $cleanvars = shift;
 
     my $output = '';
-    my $tempdir = $LedgerSMB::Sysconfig::tempdir . "/"
-                . $LedgerSMB::Sysconfig::cache_template_subdir . "/UI";
+    my $tempdir = $LedgerSMB::Sysconfig::tempdir;
     $parent->{outputfile} ||= "$tempdir/$parent->{template}-output-$$";
 
     my $arghash = $parent->get_template_args($extension,$binmode);


### PR DESCRIPTION
Note: This commit also adds the ability to specify a templates cache
  path explicitly.  Updated the default 'ledgersmb.conf' to reflect that.