### PR TITLE
* Fix #2573: Don't cache from-db templates

### DIFF
--- a/conf/ledgersmb.conf.default
+++ b/conf/ledgersmb.conf.default
@@ -80,6 +80,12 @@ backupdir = /tmp/ledgersmb-backups
 
 localepath = locale/po
 
+# location where compiled templates are stored
+#
+# When relative, appended to the directory specified in the 'tempdir' variable
+#
+#templates_cache = lsmb_templates
+
 [programs]
 # program to use for file compression
 gzip       = gzip -S .gz

--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -205,7 +205,10 @@ def 'templates',
     default => 'templates',
     doc => qq||;
 
-our $cache_template_subdir = "lsmb_templates"; # this is a subdir of $tempdir and shouldn't have a leading slash
+def 'templates_cache',
+    section => 'paths',
+    default => 'lsmb_templates',
+    doc => qq|this is a subdir of tempdir, unless it's an absolute path|;
 
 
 ### SECTION  ---   mail

--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -160,6 +160,7 @@ use LedgerSMB::Setting;
 use LedgerSMB::Sysconfig;
 use Log::Log4perl;
 use File::Copy "cp";
+use File::Spec;
 
 my $logger = Log::Log4perl->get_logger('LedgerSMB::Template');
 

--- a/lib/LedgerSMB/Template/HTML.pm
+++ b/lib/LedgerSMB/Template/HTML.pm
@@ -47,6 +47,7 @@ use warnings;
 use strict;
 
 use CGI::Simple::Standard qw(:html);
+use File::Spec;
 use Template;
 use Template::Parser;
 use LedgerSMB::Template::TTI18N;
@@ -180,9 +181,12 @@ sub process {
         DEBUG_FORMAT => '',
         (%additional_options)
         };
-        if ($LedgerSMB::Sysconfig::cache_templates){
+        if ($LedgerSMB::Sysconfig::cache_templates
+            && $parent->{include_path} ne 'DB'){
             $arghash->{COMPILE_EXT} = '.lttc';
-            $arghash->{COMPILE_DIR} = $LedgerSMB::Sysconfig::tempdir . "/" . $LedgerSMB::Sysconfig::cache_template_subdir;
+            $arghash->{COMPILE_DIR} =
+               File::Spec->rel2abs( $LedgerSMB::Sysconfig::templates_cache,
+                                    $LedgerSMB::Sysconfig::tempdir );
         }
 
     $template = Template->new(


### PR DESCRIPTION
Note: This commit also adds the ability to specify a templates cache
  path explicitly.  Updated the default 'ledgersmb.conf' to reflect that.