### PR TITLE
* Don't do access control on contacts for database owners and superusers

### DIFF
--- a/sql/modules/Roles.sql
+++ b/sql/modules/Roles.sql
@@ -1213,20 +1213,16 @@ BEGIN
 IF TG_OP = 'DELETE' THEN
    RETURN OLD;
 ELSE
-   PERFORM 1 FROM pg_catalog.pg_roles rol
-            WHERE rolname = CURRENT_USER
-              AND rolsuper;
-   IF FOUND THEN RETURN NEW; -- is superuser
+   -- super user and database owner (group members)
+   -- don't need access enforcement
+   IF pg_has_role((select rolname
+                     from pg_database db inner join pg_roles rol
+                       on db.datdba = rol.oid
+                    where db.datname = current_database()),
+                  'USAGE') IS TRUE THEN
+      RETURN NEW;
    END IF;
-   PERFORM 1 FROM pg_catalog.pg_database db
-             INNER JOIN pg_catalog.pg_roles rol
-             ON db.datdba = rol.oid
-          WHERE db.datname = current_database()
-            AND rol.rolname = CURRENT_USER;
-   IF FOUND THEN RETURN NEW; -- is database owner
-   END IF;                   -- without this permission, non-superusers,
-                             -- with create-role *and* create-db perms
-                             -- can't create new companies
+
    SELECT * INTO r_eclass from entity_class WHERE id = NEW.entity_class;
    IF pg_has_role(SESSION_USER,
                   lsmb__role('contact_class_'


### PR DESCRIPTION
As pointed out on our chat channel, we don't want dbadmins to be superusers;
with this change, we're another step closer to not requiring superuser
level for the dbadmin.