### PR TITLE
* Fix #2607: Invoice line items not visible until clicked

### DIFF
--- a/UI/css/system/global.css
+++ b/UI/css/system/global.css
@@ -432,6 +432,8 @@ html, body {
     padding: 0;
 }
 
-.claro textarea.dijitInputInner {
+.claro .dijitTextBox textarea.dijitInputInner {
     outline: none;
+    padding-top: 0;
+    padding-bottom: 0;
 }

--- a/UI/js-src/lsmb/parts/PartDescription.js
+++ b/UI/js-src/lsmb/parts/PartDescription.js
@@ -53,6 +53,7 @@ define([
                                 }
                             });
                 }
+                this._autoSize();
             }, // startup
             _autoSize: function() {
                 if (! this.autoSizing) return;


### PR DESCRIPTION
Note: this commit makes sure the descriptions are visible
   *and* that the height of the textarea control has the same height
   as the other controls on the same line.