### PR TITLE
Move to Test::Class::Moose for COA tests

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -101,15 +101,18 @@ on 'develop' => sub {
     requires 'HTML::Lint::Pluggable::WhiteList';
     recommends 'Linux::Inotify2';
     requires 'Module::CPANfile'; # for 01.2-deps.t
+    requires 'Parallel::ForkManager';
     requires 'Perl::Critic';
     requires 'Pherkin::Extension::Weasel', '0.02';
     requires 'Test::BDD::Cucumber', '0.52';
+    requires 'Test::Class::Moose';
+    requires 'Test::Class::Moose::Role';
+    requires 'Test::Class::Moose::Role::ParameterizedInstances';
     requires 'Test::Exception';
     requires 'Test::Trap';
     requires 'Test::Dependencies', '0.20';
     requires 'Test::Exception';
     requires 'Test::Harness', '3.36';
-    requires 'Test::ParallelSubtest';
     requires 'Perl::Critic';
     requires 'Plack::Middleware::Pod'; # YLA - Generate browseable documentation
     requires 'Selenium::Remote::Driver';

--- a/xt/41-coaload.t
+++ b/xt/41-coaload.t
@@ -27,3 +27,9 @@ my $test_suite = Test::Class::Moose::Runner->new(
 
 $test_suite->runtests;
 $test_suite->test_report;
+
+# Expected results until parallel works
+# Test classes:    1
+# Test instances:  45
+# Test methods:    45
+# Total tests run: 180

--- a/xt/41-coaload.t
+++ b/xt/41-coaload.t
@@ -1,51 +1,29 @@
-use Test::More;
-use Test::ParallelSubtest;
-use File::Find::Rule;
+#!/usr/bin/env perl
+
 use strict;
 use warnings;
+
+use lib 'xt/41-coaload';
+
+use Test::Requires {
+    'Parallel::ForkManager' => 0,
+};
+
+use Test::Most; # To check missing
+
+use Test::Class::Moose::Load qw(xt/41-coaload);
+use Test::Class::Moose::Runner;
 
 my @missing = grep { ! $ENV{$_} } (qw(LSMB_NEW_DB COA_TESTING LSMB_TEST_DB));
 plan skip_all => (join ', ', @missing) . ' not set' if @missing;
 
-my $rule = File::Find::Rule->new;
-$rule->or($rule->new
-               ->directory
-               ->name(qr(gifi|sic))
-               ->prune
-               ->discard,
-          $rule->new);
-my @files = sort $rule->name("*.sql")->file->in("sql/coa");
+my $test_suite = Test::Class::Moose::Runner->new(
+    jobs        => 5,
+    randomize   => 1, # Random order
+#    show_timing => 1, # Detailed timings of each test
+    statistics  => 1, # Display statistics at the end of the tests
+    test_classes => 'TestsFor::COATest',
+);
 
-for my $sqlfile (@files) {
-
-    bg_subtest "$sqlfile" => sub {
-        local $!;
-
-        my ($_1,$dir,$type,$name) = $sqlfile =~ qr(sql\/coa\/(([a-z]{2})\/)?(.+\/)?([^\/\.]+)\.sql$);
-        $type //= "";
-
-        my $test_db = "$ENV{LSMB_NEW_DB}_lsmb_test_coa";
-        $test_db .= "_${dir}" if $dir;
-        $test_db .= "_${name}";
-
-        $! = undef; # reset if drop failed
-        system("dropdb '$test_db' 2>/dev/null");
-        system("createdb '$test_db' -T '$ENV{LSMB_NEW_DB}'");
-        ok(! $!, "DB created for $sqlfile testing");
-
-        system("psql $test_db -f $sqlfile");
-        ok(! $!, "psql run file succeeded");
-
-        my $returnstring = `psql '$test_db' -c "SELECT COUNT(*), 'TESTRESULT' from account"`;
-        my ($testval) = grep { /TESTRESULT/ } split("\n", $returnstring);
-        $testval =~ s/\D//g;
-        ok($testval, "Got rows back for account, for $sqlfile");
-
-        system("dropdb '$test_db'");
-    }
-}
-
-
-ok(1,"coaload done");
-
-done_testing;
+$test_suite->runtests;
+$test_suite->test_report;

--- a/xt/41-coaload.t
+++ b/xt/41-coaload.t
@@ -17,12 +17,47 @@ use Test::Class::Moose::Runner;
 my @missing = grep { ! $ENV{$_} } (qw(LSMB_NEW_DB COA_TESTING LSMB_TEST_DB));
 plan skip_all => (join ', ', @missing) . ' not set' if @missing;
 
+use File::Find::Rule;
+
+my $rule = File::Find::Rule->new;
+$rule->or($rule->new
+               ->directory
+               ->name(qr(gifi|sic))
+               ->prune
+               ->discard,
+          $rule->new);
+my @files = sort $rule->name("*.sql")->file->in("sql/coa"); # "sql/coa/ar/chart/General.sql"
+
+my @classes = qw(TestsFor::COATest);
+my %tests;
+
+for my $sqlfile (@files) {
+    my ($_1,$dir,$type,$name) = $sqlfile =~ qr(sql\/coa\/(([a-z]{2})\/)?(.+\/)?([^\/\.]+)\.sql$);
+    $dir //= '';
+    if (!defined($tests{"x$dir"})) {
+        $tests{"x$dir"} = 1;
+        if ( $dir ) {
+            Class::MOP::Class->create(
+                "TestsFor::COATest::$dir" => (
+                    version      => '0.01',
+                    superclasses => ['TestsFor::COATest'],
+                    attributes   => [
+                    ],
+                    methods => {
+                    }
+                )
+            );
+            push @classes, "TestsFor::COATest::$dir";
+        }
+    }
+}
+
 my $test_suite = Test::Class::Moose::Runner->new(
     jobs        => 5,
-    randomize   => 1, # Random order
+    randomize   => 0, # Random order
 #    show_timing => 1, # Detailed timings of each test
     statistics  => 1, # Display statistics at the end of the tests
-    test_classes => 'TestsFor::COATest',
+    test_classes => \@classes,
 );
 
 $test_suite->runtests;

--- a/xt/41-coaload/COATest.pm
+++ b/xt/41-coaload/COATest.pm
@@ -1,0 +1,35 @@
+package COATest;
+use Moose;
+
+has 'sqlfile' => (
+    is => 'rw',
+    isa => 'Str',
+    trigger => sub {
+        my $self = shift;
+        my ($_1,$dir,$type,$name) = $self->{sqlfile} =~ qr(sql\/coa\/(([a-z]{2})\/)?(.+\/)?([^\/\.]+)\.sql$);
+        $self->dir($dir // "");
+        $self->type($type // "");
+        $self->name($name);
+    }
+);
+
+has [ 'dir', 'type', 'name' ] => (
+    is => 'rw',
+    isa => 'Str',
+);
+
+has 'test_db' => (
+    is => 'ro',
+    isa => 'Str',
+    lazy => 1,
+    builder => '_build_test_db'
+);
+
+sub _build_test_db {
+    my $self = shift;
+    return "$ENV{LSMB_NEW_DB}_lsmb_test_coa"
+          . ( $self->{dir} ? "_$self->{dir}" : "" )
+          . "_$self->{name}";
+}
+
+1;

--- a/xt/41-coaload/TestsFor/COATest.pm
+++ b/xt/41-coaload/TestsFor/COATest.pm
@@ -1,0 +1,89 @@
+package TestsFor::COATest;
+
+use Test::Class::Moose;
+with 'Test::Class::Moose::Role::ParameterizedInstances';
+
+use lib 'xt/41-coaload';
+use COATest;
+
+use File::Find::Rule;
+
+# sort, run everything in parallel but the ones for the same country, for they need the same database
+sub _constructor_parameter_sets {
+    my $class = shift;
+    my $rule = File::Find::Rule->new;
+    $rule->or($rule->new
+                   ->directory
+                   ->name(qr(gifi|sic))
+                   ->prune
+                   ->discard,
+              $rule->new);
+    my @files = sort $rule->name("*.sql")->file->in("sql/coa");
+    my %tests = ();
+
+    # This should be instance_name => { new parameters },
+    # but I failed to get the sqlfile installed in the structure
+    for my $sqlfile (@files) {
+        $tests{$sqlfile} = { sqlfile => $sqlfile };
+    }
+    return %tests;
+}
+
+# Runs at the start of each test class
+#sub test_startup {
+#    my $test = shift;
+#    $test->next::method; # optional to call parent test_startup
+#    # more startup
+#}
+
+# Runs at the start of each test method.
+#sub test_setup {
+#    my $test = shift;
+#    $test->next::method; # optional to call parent test_setup
+#    # more setup
+#}
+
+sub test_constructor {
+    my $test = shift;
+
+    local $!;
+
+    my $sqlfile = $test->test_instance_name;
+    my $coatest = COATest->new( sqlfile => $sqlfile );
+    ok($coatest, "Cannot set new COATest");
+
+    my $db = $coatest->test_db;
+    $! = undef; # reset if drop failed
+
+    system("dropdb '$db' 2>/dev/null");
+    system("createdb '$db' -T '$ENV{LSMB_NEW_DB}'");
+    ok(! $!, "DB created for $sqlfile testing");
+
+    system("psql $db -f $sqlfile");
+    ok(! $!, "psql run file succeeded");
+
+    my $returnstring = `psql '$db' -c "SELECT COUNT(*), 'TESTRESULT' from account"`;
+    my $testval;
+    if ( $returnstring ) {
+        $testval = grep { /TESTRESULT/ } split("\n", $returnstring);
+        $testval =~ s/\D//g;
+    }
+    ok($testval, "Got rows back for account, for $sqlfile");
+    system("dropdb '$db'");
+}
+
+# teardown methods are run after every test method.
+#sub test_teardown {
+#    my $test = shift;
+#    # more teardown
+#    $test->next::method; # optional to call parent test_teardown
+#}
+
+# Runs at the end of each test class.
+#sub test_shutdown {
+#     my $test = shift;
+#     # more teardown
+#     $test->next::method; # # optional to call parent test_shutdown
+#}
+
+1;

--- a/xt/41-coaload/TestsFor/COATest.pm
+++ b/xt/41-coaload/TestsFor/COATest.pm
@@ -19,18 +19,29 @@ sub _constructor_parameter_sets {
                    ->discard,
               $rule->new);
     my @files = sort $rule->name("*.sql")->file->in("sql/coa");
-    my %tests = ();
+    my %tests = (); my $i = 1;
 
     # This should be instance_name => { new parameters },
     # but I failed to get the sqlfile installed in the structure
     for my $sqlfile (@files) {
-        $tests{$sqlfile} = { sqlfile => $sqlfile };
+        $tests{$i++} = { sqlfile => $sqlfile };
     }
     return %tests;
 }
 
+has 'test_data' => (
+    is => 'rw',
+    isa => 'COATest',
+);
+
+sub BUILD {
+    my $test = shift;
+    $test->test_data(COATest->new( @_ ));
+}
+
 # Runs at the start of each test class
 #sub test_startup {
+#    warn p @_;
 #    my $test = shift;
 #    $test->next::method; # optional to call parent test_startup
 #    # more startup
@@ -48,9 +59,9 @@ sub test_constructor {
 
     local $!;
 
-    my $sqlfile = $test->test_instance_name;
-    my $coatest = COATest->new( sqlfile => $sqlfile );
+    my $coatest = $test->{test_data};
     ok($coatest, "Cannot set new COATest");
+    my $sqlfile = $coatest->sqlfile;
 
     my $db = $coatest->test_db;
     $! = undef; # reset if drop failed


### PR DESCRIPTION
Move COA tests from Test::ParallelSubtest to Test::Class::Moose.
Fixes #2639