### PR TITLE
Add custom modified badge for coveralls

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 [![Docker](https://img.shields.io/docker/pulls/ledgersmb/ledgersmb.svg)](https://hub.docker.com/r/ledgersmb/ledgersmb/)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/795/badge)](https://bestpractices.coreinfrastructure.org/projects/795)
 
+As coveralls currently has a bug with their badging for master, here is a corrected version
+[![Coverage Status](http://www.sbts.com.au/repos/github/ledgersmb/LedgerSMB/badge.svg?branch=master)](https://coveralls.io/github/ledgersmb/LedgerSMB?branch=master)
+
+
 # LedgerSMB
 
 Small and Medium business accounting and ERP


### PR DESCRIPTION
Use the coveralls api to retrieve correct coverage percentage for master branch.
This is to work around the bug causing the normal badge to show as 10% instead of 25%