### PR TITLE
* Fix #2558: reversal of payments against non-eca-default AR/AP-account

### DIFF
--- a/sql/modules/Payment.sql
+++ b/sql/modules/Payment.sql
@@ -1178,7 +1178,18 @@ BEGIN
                 t_voucher_inserted := FALSE;
         END IF;
         FOR pay_row IN
-                SELECT a.*, c.ar_ap_account_id, arap.curr, arap.fxrate
+                SELECT a.*,
+                       (select distinct chart_id
+                          from acc_trans ac
+                               join account at on ac.chart_id = at.id
+                               join account_link al on at.id = al.account_id
+                         where ((al.description = 'AP'
+                                   and in_account_class = 1)
+                                 or (al.description = 'AR'
+                                    and in_account_class = 2))
+                               and ac.trans_id = a.trans_id)
+                             as ar_ap_account_id,
+                       arap.curr, arap.fxrate
                 FROM acc_trans a
                 JOIN (select id, curr, entity_credit_account,
                              CASE WHEN curr = t_currs[1] THEN 1


### PR DESCRIPTION
#2558 is about transactions being reversed using the ECA default AR/AP
account while the transaction originally was not created against that
account, leading to multiple AR/AP accounts being used for the transaction.

The resulting database state is broken in the sense that various parts
of the software start drawing incorrect conclusions after the reversal
has been posted.

This commit looks up the transaction original AR/AP account instead of
using the ECA default one.