### PR TITLE
Update README minimum perl version

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ customers or RFQs (request for quotation) to your vendors with PDF attachments.
 
 ## Server
 
- * Perl 5.10+
+ * Perl 5.14+
  * PostgreSQL 9.4+
  * Web server (e.g. nginx, Apache, lighttpd)
 


### PR DESCRIPTION
Mimimum for lsmb 1.6 is Perl 5.14
https://matrix.to/#/!qyoLumPqusaXqFJNyK:matrix.org/$14924201571846697RiiRJ:matrix.org