### PR TITLE
Enable Perl::Critic RequireCleanNamespace Policy

### DIFF
--- a/lib/LedgerSMB/App_Module.pm
+++ b/lib/LedgerSMB/App_Module.pm
@@ -19,6 +19,7 @@ A default module (id 0, label '') is available for doing lookups.
 
 package LedgerSMB::App_Module;
 use Moose;
+use namespace::autoclean;
 with 'LedgerSMB::PGObject';
 
 =head1 PROPERTIES

--- a/lib/LedgerSMB/Budget.pm
+++ b/lib/LedgerSMB/Budget.pm
@@ -21,6 +21,7 @@ LedgerSMB::Budget_Report.
 =cut
 
 use Moose;
+use namespace::autoclean;
 with 'LedgerSMB::PGObject';
 
 =head1 PROPERTIES

--- a/lib/LedgerSMB/Business_Unit.pm
+++ b/lib/LedgerSMB/Business_Unit.pm
@@ -13,6 +13,7 @@ funds, and projects.
 
 package LedgerSMB::Business_Unit;
 use Moose;
+use namespace::autoclean;
 use LedgerSMB::MooseTypes;
 with 'LedgerSMB::PGObject';
 

--- a/lib/LedgerSMB/Business_Unit_Class.pm
+++ b/lib/LedgerSMB/Business_Unit_Class.pm
@@ -13,6 +13,7 @@ funds, and projects.
 
 package LedgerSMB::Business_Unit_Class;
 use Moose;
+use namespace::autoclean;
 use LedgerSMB::App_Module;
 with 'LedgerSMB::PGObject';
 

--- a/lib/LedgerSMB/Entity.pm
+++ b/lib/LedgerSMB/Entity.pm
@@ -6,6 +6,7 @@ LedgerSMB::Entity -- Entity Management base classes for LedgerSMB
 
 package LedgerSMB::Entity;
 use Moose;
+use namespace::autoclean;
 with 'LedgerSMB::PGObject';
 
 =head1 SYNOPSYS

--- a/lib/LedgerSMB/Entity/Bank.pm
+++ b/lib/LedgerSMB/Entity/Bank.pm
@@ -18,6 +18,7 @@ credit account being able to attach itself to a single bank account.
 
 package LedgerSMB::Entity::Bank;
 use Moose;
+use namespace::autoclean;
 with 'LedgerSMB::PGObject';
 use PGObject::Util::DBMethod;
 

--- a/lib/LedgerSMB/Entity/Company.pm
+++ b/lib/LedgerSMB/Entity/Company.pm
@@ -19,6 +19,7 @@ leads etc.
 
 package LedgerSMB::Entity::Company;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Entity';
 use LedgerSMB::MooseTypes;
 

--- a/lib/LedgerSMB/Entity/Contact.pm
+++ b/lib/LedgerSMB/Entity/Contact.pm
@@ -20,6 +20,7 @@ companies in LedgerSMB.
 
 package LedgerSMB::Entity::Contact;
 use Moose;
+use namespace::autoclean;
 use LedgerSMB::App_State;
 with 'LedgerSMB::PGObject';
 

--- a/lib/LedgerSMB/Entity/Credit_Account.pm
+++ b/lib/LedgerSMB/Entity/Credit_Account.pm
@@ -29,6 +29,7 @@ and the like.
 
 package LedgerSMB::Entity::Credit_Account;
 use Moose;
+use namespace::autoclean;
 use LedgerSMB::MooseTypes;
 with 'LedgerSMB::PGObject';
 

--- a/lib/LedgerSMB/Entity/Location.pm
+++ b/lib/LedgerSMB/Entity/Location.pm
@@ -19,6 +19,7 @@ attached either to the entity (person or company) or credit account
 
 package LedgerSMB::Entity::Location;
 use Moose;
+use namespace::autoclean;
 use LedgerSMB::MooseTypes;
 use LedgerSMB::App_State;
 use LedgerSMB::Locale;

--- a/lib/LedgerSMB/Entity/Note.pm
+++ b/lib/LedgerSMB/Entity/Note.pm
@@ -21,6 +21,7 @@ level.
 
 package LedgerSMB::Entity::Note;
 use Moose;
+use namespace::autoclean;
 with 'LedgerSMB::PGObject';
 
 

--- a/lib/LedgerSMB/Entity/Payroll/Deduction.pm
+++ b/lib/LedgerSMB/Entity/Payroll/Deduction.pm
@@ -25,6 +25,7 @@ To save a new deduction:
 
 package LedgerSMB::Entity::Payroll::Deduction;
 use Moose;
+use namespace::autoclean;
 use LedgerSMB::MooseTypes;
 with 'LedgerSMB::PGObject';
 

--- a/lib/LedgerSMB/Entity/Payroll/Wage.pm
+++ b/lib/LedgerSMB/Entity/Payroll/Wage.pm
@@ -21,6 +21,7 @@ To save a new wage:
 
 package LedgerSMB::Entity::Payroll::Wage;
 use Moose;
+use namespace::autoclean;
 use LedgerSMB::MooseTypes;
 with 'LedgerSMB::PGObject';
 

--- a/lib/LedgerSMB/Entity/Person.pm
+++ b/lib/LedgerSMB/Entity/Person.pm
@@ -29,6 +29,7 @@ To get by control code:
 
 package LedgerSMB::Entity::Person;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Entity';
 use LedgerSMB::MooseTypes;
 

--- a/lib/LedgerSMB/Entity/Person/Employee.pm
+++ b/lib/LedgerSMB/Entity/Person/Employee.pm
@@ -30,6 +30,7 @@ To get by control code:
 
 package LedgerSMB::Entity::Person::Employee;
 use Moose;
+use namespace::autoclean;
 use LedgerSMB::Entity::Person;
 extends 'LedgerSMB::Entity::Person';
 

--- a/lib/LedgerSMB/Entity/User.pm
+++ b/lib/LedgerSMB/Entity/User.pm
@@ -6,6 +6,7 @@ LedgerSMB::Entity::User - User management Logic for LedgerSMB
 
 package LedgerSMB::Entity::User;
 use Moose;
+use namespace::autoclean;
 use Try::Tiny;
 use LedgerSMB::App_State;
 with 'LedgerSMB::PGObject';

--- a/lib/LedgerSMB/File.pm
+++ b/lib/LedgerSMB/File.pm
@@ -22,6 +22,7 @@ use strict;
 use warnings;
 
 use Moose;
+use namespace::autoclean;
 with 'LedgerSMB::PGObject';
 
 use File::MimeInfo;

--- a/lib/LedgerSMB/File/ECA.pm
+++ b/lib/LedgerSMB/File/ECA.pm
@@ -23,6 +23,7 @@ methods only
 
 package LedgerSMB::File::ECA;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::File';
 
 =head1 METHODS

--- a/lib/LedgerSMB/File/Entity.pm
+++ b/lib/LedgerSMB/File/Entity.pm
@@ -23,6 +23,7 @@ methods only
 
 package LedgerSMB::File::Entity;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::File';
 
 =head1 METHODS

--- a/lib/LedgerSMB/File/Incoming.pm
+++ b/lib/LedgerSMB/File/Incoming.pm
@@ -24,6 +24,7 @@ methods only
 
 package LedgerSMB::File::Incoming;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::File';
 
 =head1 METHODS

--- a/lib/LedgerSMB/File/Internal.pm
+++ b/lib/LedgerSMB/File/Internal.pm
@@ -23,6 +23,7 @@ methods only
 
 package LedgerSMB::File::Internal;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::File';
 
 =head1 METHODS

--- a/lib/LedgerSMB/File/Order.pm
+++ b/lib/LedgerSMB/File/Order.pm
@@ -25,6 +25,7 @@ methods only
 package LedgerSMB::File::Order;
 use strict;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::File';
 
 =head1 METHODS

--- a/lib/LedgerSMB/File/Part.pm
+++ b/lib/LedgerSMB/File/Part.pm
@@ -23,6 +23,7 @@ methods only
 
 package LedgerSMB::File::Part;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::File';
 
 =head1 METHODS

--- a/lib/LedgerSMB/File/Transaction.pm
+++ b/lib/LedgerSMB/File/Transaction.pm
@@ -21,6 +21,7 @@ methods only
 
 package LedgerSMB::File::Transaction;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::File';
 
 =back

--- a/lib/LedgerSMB/Group.pm
+++ b/lib/LedgerSMB/Group.pm
@@ -18,6 +18,7 @@ To retrieve a role from the db:
 
 package LedgerSMB::Group;
 use Moose;
+use namespace::autoclean;
 with 'LedgerSMB::PGObject';
 
 =head1 PROPERTIES

--- a/lib/LedgerSMB/I18N.pm
+++ b/lib/LedgerSMB/I18N.pm
@@ -16,6 +16,7 @@ we look only to the current locale.
 
 package LedgerSMB::I18N;
 use Moose::Role;
+use namespace::autoclean;
 use LedgerSMB::App_State;
 use LedgerSMB::Locale;
 

--- a/lib/LedgerSMB/Inventory/Adjust.pm
+++ b/lib/LedgerSMB/Inventory/Adjust.pm
@@ -13,6 +13,7 @@ LedgerSMB::Inventory::Adjust - Inventory Adjustments for LedgerSMB
 
 package LedgerSMB::Inventory::Adjust;
 use Moose;
+use namespace::autoclean;
 with 'LedgerSMB::PGObject';
 use LedgerSMB::MooseTypes;
 use LedgerSMB::Inventory::Adjust_Line;

--- a/lib/LedgerSMB/Inventory/Adjust_Line.pm
+++ b/lib/LedgerSMB/Inventory/Adjust_Line.pm
@@ -12,6 +12,7 @@ LedgerSMB::Inventory::Adjust_Line - Inventory Adjustemnt Lines for LedgerSMB
 
 package LedgerSMB::Inventory::Adjust_Line;
 use Moose;
+use namespace::autoclean;
 use LedgerSMB::MooseTypes;
 with 'LedgerSMB::PGObject';
 

--- a/lib/LedgerSMB/MooseTypes.pm
+++ b/lib/LedgerSMB/MooseTypes.pm
@@ -10,6 +10,7 @@ use strict;
 use warnings;
 
 use Moose;
+use namespace::autoclean;
 use Moose::Util::TypeConstraints;
 
 use PGObject::Type::ByteString;

--- a/lib/LedgerSMB/PGObject.pm
+++ b/lib/LedgerSMB/PGObject.pm
@@ -27,6 +27,7 @@ LICENSE.TXT for more information.
 
 package LedgerSMB::PGObject;
 use Moose::Role;
+use namespace::autoclean;
 with 'PGObject::Simple::Role' => { -excludes => [qw(_get_dbh _get_schema _get_prefix)], };
 
 use LedgerSMB::App_State;

--- a/lib/LedgerSMB/Part.pm
+++ b/lib/LedgerSMB/Part.pm
@@ -13,6 +13,7 @@ use strict;
 use warnings;
 
 use Moose;
+use namespace::autoclean;
 with 'LedgerSMB::PGObject';
 
 =head1 PROPERTIES

--- a/lib/LedgerSMB/Payroll/Deduction_Type.pm
+++ b/lib/LedgerSMB/Payroll/Deduction_Type.pm
@@ -17,6 +17,7 @@ To save a type
 
 package LedgerSMB::Payroll::Deduction_Type;
 use Moose;
+use namespace::autoclean;
 with 'LedgerSMB::PGObject';
 
 =head1 DESCRIPTION

--- a/lib/LedgerSMB/Payroll/Income_Type.pm
+++ b/lib/LedgerSMB/Payroll/Income_Type.pm
@@ -16,6 +16,7 @@ To save a type
 
 package LedgerSMB::Payroll::Income_Type;
 use Moose;
+use namespace::autoclean;
 with 'LedgerSMB::PGObject';
 
 =head1 DESCRIPTION

--- a/lib/LedgerSMB/Report.pm
+++ b/lib/LedgerSMB/Report.pm
@@ -39,6 +39,7 @@ UI/reports/display_report template will be used.
 
 package LedgerSMB::Report;
 use Moose;
+use namespace::autoclean;
 with 'LedgerSMB::PGObject', 'LedgerSMB::I18N';
 use LedgerSMB::Setting;
 

--- a/lib/LedgerSMB/Report/Aging.pm
+++ b/lib/LedgerSMB/Report/Aging.pm
@@ -20,6 +20,7 @@ reportins aimed at the customer in question.
 
 package LedgerSMB::Report::Aging;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report';
 
 use LedgerSMB::Business_Unit_Class;

--- a/lib/LedgerSMB/Report/Approval_Option.pm
+++ b/lib/LedgerSMB/Report/Approval_Option.pm
@@ -1,5 +1,6 @@
 package LedgerSMB::Report::Approval_Option;
 use Moose::Role;
+use namespace::autoclean;
 
 =head1 NAME
 

--- a/lib/LedgerSMB/Report/Assets/Net_Book_Value.pm
+++ b/lib/LedgerSMB/Report/Assets/Net_Book_Value.pm
@@ -20,6 +20,7 @@ asset accounts.
 
 package LedgerSMB::Report::Assets::Net_Book_Value;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report';
 
 =head1 CRITERIA PROPERTIES

--- a/lib/LedgerSMB/Report/Axis.pm
+++ b/lib/LedgerSMB/Report/Axis.pm
@@ -18,6 +18,7 @@ final report.
 
 package LedgerSMB::Report::Axis;
 use Moose;
+use namespace::autoclean;
 
 =head1 PROPERTIES
 

--- a/lib/LedgerSMB/Report/Balance_Sheet.pm
+++ b/lib/LedgerSMB/Report/Balance_Sheet.pm
@@ -17,6 +17,7 @@ translates data structures for the report.
 
 package LedgerSMB::Report::Balance_Sheet;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report::Hierarchical';
 with 'LedgerSMB::Report::Dates';
 

--- a/lib/LedgerSMB/Report/Budget/Search.pm
+++ b/lib/LedgerSMB/Report/Budget/Search.pm
@@ -16,6 +16,7 @@ This is a basic search report for budgets.
 
 package LedgerSMB::Report::Budget::Search;
 use Moose;
+use namespace::autoclean;
 use LedgerSMB::MooseTypes;
 extends 'LedgerSMB::Report';
 

--- a/lib/LedgerSMB/Report/Budget/Variance.pm
+++ b/lib/LedgerSMB/Report/Budget/Variance.pm
@@ -19,6 +19,7 @@ against what was budgetted.
 
 package LedgerSMB::Report::Budget::Variance;
 use Moose;
+use namespace::autoclean;
 use LedgerSMB::MooseTypes;
 extends 'LedgerSMB::Report';
 use LedgerSMB::Budget;

--- a/lib/LedgerSMB/Report/COA.pm
+++ b/lib/LedgerSMB/Report/COA.pm
@@ -26,6 +26,7 @@ Typically columns are displayed based on the permissions of the user.
 
 package LedgerSMB::Report::COA;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report';
 
 use LedgerSMB::App_State;

--- a/lib/LedgerSMB/Report/Contact/History.pm
+++ b/lib/LedgerSMB/Report/Contact/History.pm
@@ -26,6 +26,7 @@ both customers and vendors.
 
 package LedgerSMB::Report::Contact::History;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report';
 with 'LedgerSMB::Report::Dates';
 

--- a/lib/LedgerSMB/Report/Contact/Purchase.pm
+++ b/lib/LedgerSMB/Report/Contact/Purchase.pm
@@ -28,6 +28,7 @@ certain point, and locating specific transactions.
 
 package LedgerSMB::Report::Contact::Purchase;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report';
 with 'LedgerSMB::Report::Dates';
 

--- a/lib/LedgerSMB/Report/Contact/Search.pm
+++ b/lib/LedgerSMB/Report/Contact/Search.pm
@@ -27,6 +27,7 @@ referral.
 
 package LedgerSMB::Report::Contact::Search;
 use Moose;
+use namespace::autoclean;
 use LedgerSMB::MooseTypes;
 extends 'LedgerSMB::Report';
 

--- a/lib/LedgerSMB/Report/Dates.pm
+++ b/lib/LedgerSMB/Report/Dates.pm
@@ -10,6 +10,7 @@ LedgerSMB::Report::Dates - Date properties for reports in LedgerSMB
 
 package LedgerSMB::Report::Dates;
 use Moose::Role;
+use namespace::autoclean;
 use LedgerSMB::MooseTypes;
 
 =head1 DESCRIPTION

--- a/lib/LedgerSMB/Report/File.pm
+++ b/lib/LedgerSMB/Report/File.pm
@@ -11,6 +11,7 @@ LedgerSMB::Report::File - File role for querying files for a report
 
 package LedgerSMB::Report::File;
 use Moose::Role;
+use namespace::autoclean;
 use LedgerSMB::File;
 with 'LedgerSMB::I18N';
 

--- a/lib/LedgerSMB/Report/File/Incoming.pm
+++ b/lib/LedgerSMB/Report/File/Incoming.pm
@@ -10,6 +10,7 @@ LedgerSMB::Report::File::Incoming - Files for LSMB processes.
 
 package LedgerSMB::Report::File::Incoming;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report';
 with 'LedgerSMB::Report::File', 'LedgerSMB::I18N';
 

--- a/lib/LedgerSMB/Report/File/Internal.pm
+++ b/lib/LedgerSMB/Report/File/Internal.pm
@@ -10,6 +10,7 @@ LedgerSMB::Report::File::Internal - Files for LSMB processes.
 
 package LedgerSMB::Report::File::Internal;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report';
 with 'LedgerSMB::Report::File', 'LedgerSMB::I18N';
 

--- a/lib/LedgerSMB/Report/GL.pm
+++ b/lib/LedgerSMB/Report/GL.pm
@@ -25,6 +25,7 @@ searching for and reporting financial transactions.
 
 package LedgerSMB::Report::GL;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report';
 with 'LedgerSMB::Report::Dates', 'LedgerSMB::Report::Approval_Option';
 

--- a/lib/LedgerSMB/Report/Hierarchical.pm
+++ b/lib/LedgerSMB/Report/Hierarchical.pm
@@ -14,6 +14,7 @@ This report class is an abstract class.
 
 package LedgerSMB::Report::Hierarchical;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report';
 
 use LedgerSMB::Report::Axis;

--- a/lib/LedgerSMB/Report/Inventory/Activity.pm
+++ b/lib/LedgerSMB/Report/Inventory/Activity.pm
@@ -12,6 +12,7 @@ LedgerSMB
 
 package LedgerSMB::Report::Inventory::Activity;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report';
 with 'LedgerSMB::Report::Dates';
 

--- a/lib/LedgerSMB/Report/Inventory/Adj_Details.pm
+++ b/lib/LedgerSMB/Report/Inventory/Adj_Details.pm
@@ -13,6 +13,7 @@ Details report for LedgerSMB
 
 package LedgerSMB::Report::Inventory::Adj_Details;
 use Moose;
+use namespace::autoclean;
 use LedgerSMB::Report::Inventory::Search_Adj;
 extends 'LedgerSMB::Report';
 use LedgerSMB::Form;

--- a/lib/LedgerSMB/Report/Inventory/History.pm
+++ b/lib/LedgerSMB/Report/Inventory/History.pm
@@ -10,6 +10,7 @@ LedgerSMB::Report::Inventory::History - Sales/Purchase History for Goods
 
 package LedgerSMB::Report::Inventory::History;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report';
 with 'LedgerSMB::Report::Dates';
 

--- a/lib/LedgerSMB/Report/Inventory/Partsgroups.pm
+++ b/lib/LedgerSMB/Report/Inventory/Partsgroups.pm
@@ -11,6 +11,7 @@ LedgerSMB::Report::Inventory::Partsgroups - Partsgroup search for LedgerSMB
 
 package LedgerSMB::Report::Inventory::Partsgroups;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report';
 
 

--- a/lib/LedgerSMB/Report/Inventory/Pricegroups.pm
+++ b/lib/LedgerSMB/Report/Inventory/Pricegroups.pm
@@ -11,6 +11,7 @@ LedgerSMB::Report::Inventory::Pricegroups - Pricegroup search for LedgerSMB
 
 package LedgerSMB::Report::Inventory::Pricegroups;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report';
 
 

--- a/lib/LedgerSMB/Report/Inventory/Search.pm
+++ b/lib/LedgerSMB/Report/Inventory/Search.pm
@@ -12,6 +12,7 @@ LedgerSMB
 
 package LedgerSMB::Report::Inventory::Search;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report';
 with 'LedgerSMB::Report::Dates';
 

--- a/lib/LedgerSMB/Report/Inventory/Search_Adj.pm
+++ b/lib/LedgerSMB/Report/Inventory/Search_Adj.pm
@@ -13,6 +13,7 @@ inventory adjustments
 
 package LedgerSMB::Report::Inventory::Search_Adj;
 use Moose;
+use namespace::autoclean;
 use LedgerSMB::MooseTypes;
 extends 'LedgerSMB::Report';
 

--- a/lib/LedgerSMB/Report/Invoices/Outstanding.pm
+++ b/lib/LedgerSMB/Report/Invoices/Outstanding.pm
@@ -12,6 +12,7 @@ LedgerSMB
 
 package LedgerSMB::Report::Invoices::Outstanding;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report';
 with 'LedgerSMB::Report::Dates';
 

--- a/lib/LedgerSMB/Report/Invoices/Payments.pm
+++ b/lib/LedgerSMB/Report/Invoices/Payments.pm
@@ -11,6 +11,7 @@ LedgerSMB::Report::Invoices::Payments - Payment Search Report for LedgerSMB
 
 package LedgerSMB::Report::Invoices::Payments;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report';
 with 'LedgerSMB::Report::Dates';
 

--- a/lib/LedgerSMB/Report/Invoices/Transactions.pm
+++ b/lib/LedgerSMB/Report/Invoices/Transactions.pm
@@ -12,6 +12,7 @@ LedgerSMB
 
 package LedgerSMB::Report::Invoices::Transactions;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report';
 with 'LedgerSMB::Report::Dates', 'LedgerSMB::Report::Approval_Option';
 

--- a/lib/LedgerSMB/Report/Listings/Asset.pm
+++ b/lib/LedgerSMB/Report/Listings/Asset.pm
@@ -10,6 +10,7 @@ LedgerSMB::Report::Listings::Asset - Search Fixed Assets in LedgerSMB
 
 package LedgerSMB::Report::Listings::Asset;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report';
 use LedgerSMB::MooseTypes;
 

--- a/lib/LedgerSMB/Report/Listings/Asset_Class.pm
+++ b/lib/LedgerSMB/Report/Listings/Asset_Class.pm
@@ -10,6 +10,7 @@ LedgerSMB::Report::Listings::Asset_Class - Asset Class listings for LedgerSMB
 
 package LedgerSMB::Report::Listings::Asset_Class;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report';
 
 =head1 CRITERIA PROPERTIES

--- a/lib/LedgerSMB/Report/Listings/Business_Type.pm
+++ b/lib/LedgerSMB/Report/Listings/Business_Type.pm
@@ -20,6 +20,7 @@ None
 
 package LedgerSMB::Report::Listings::Business_Type;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report';
 
 =head1 STATIC METHODS

--- a/lib/LedgerSMB/Report/Listings/Business_Unit.pm
+++ b/lib/LedgerSMB/Report/Listings/Business_Unit.pm
@@ -10,6 +10,7 @@ LedgerSMB::Report::Listings::Business_Unit - List Business Reporting Units
 
 package LedgerSMB::Report::Listings::Business_Unit;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report';
 
 =head1 DESCRIPTION

--- a/lib/LedgerSMB/Report/Listings/GIFI.pm
+++ b/lib/LedgerSMB/Report/Listings/GIFI.pm
@@ -13,6 +13,7 @@ No $request is needed since there are no criteria.
 
 package LedgerSMB::Report::Listings::GIFI;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report';
 
 =head1 DESCRIPTION

--- a/lib/LedgerSMB/Report/Listings/Language.pm
+++ b/lib/LedgerSMB/Report/Listings/Language.pm
@@ -10,6 +10,7 @@ LedgerSMB::Report::Listings::Language - List languages for LedgerSMB
 
 package LedgerSMB::Report::Listings::Language;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report';
 
 =head1 DESCRIPTION

--- a/lib/LedgerSMB/Report/Listings/Overpayments.pm
+++ b/lib/LedgerSMB/Report/Listings/Overpayments.pm
@@ -11,6 +11,7 @@ LedgerSMB
 
 package LedgerSMB::Report::Listings::Overpayments;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report';
 with 'LedgerSMB::Report::Dates';
 

--- a/lib/LedgerSMB/Report/Listings/SIC.pm
+++ b/lib/LedgerSMB/Report/Listings/SIC.pm
@@ -10,6 +10,7 @@ LedgerSMB::Report::Listings::SIC - List SIC codes in LedgerSMB
 
 package LedgerSMB::Report::Listings::SIC;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report';
 
 =head1 DESCRIPTION

--- a/lib/LedgerSMB/Report/Listings/TemplateTrans.pm
+++ b/lib/LedgerSMB/Report/Listings/TemplateTrans.pm
@@ -6,6 +6,7 @@ LedgerSMB::Report::Listings::TemplateTrans - Listing of Template Transactions
 
 package LedgerSMB::Report::Listings::TemplateTrans;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report';
 
 =head1 SYNOPSIS

--- a/lib/LedgerSMB/Report/Listings/Templates.pm
+++ b/lib/LedgerSMB/Report/Listings/Templates.pm
@@ -16,6 +16,7 @@ and orders).  This is not used for the user interface templates.
 
 package LedgerSMB::Report::Listings::Templates;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report';
 
 =head1 CRITERIA PROPERTIES

--- a/lib/LedgerSMB/Report/Listings/Warehouse.pm
+++ b/lib/LedgerSMB/Report/Listings/Warehouse.pm
@@ -12,6 +12,7 @@ Since no parameters are required:
 
 package LedgerSMB::Report::Listings::Warehouse;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report';
 
 =head1 REPORT CRITERIA

--- a/lib/LedgerSMB/Report/Orders.pm
+++ b/lib/LedgerSMB/Report/Orders.pm
@@ -11,6 +11,7 @@ LedgerSMB::Report::Orders - Search for Orders and Quotations in LedgerSMB
 
 package LedgerSMB::Report::Orders;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report';
 with 'LedgerSMB::Report::Dates';
 use LedgerSMB::MooseTypes;

--- a/lib/LedgerSMB/Report/PNL.pm
+++ b/lib/LedgerSMB/Report/PNL.pm
@@ -16,6 +16,7 @@ and later.
 
 package LedgerSMB::Report::PNL;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report::Hierarchical';
 with 'LedgerSMB::Report::Dates';
 

--- a/lib/LedgerSMB/Report/PNL/ECA.pm
+++ b/lib/LedgerSMB/Report/PNL/ECA.pm
@@ -21,6 +21,7 @@ up since they are treated as an expense only on sale.
 
 package LedgerSMB::Report::PNL::ECA;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report::PNL';
 
 =head1 CRITERIA PROPERTIES

--- a/lib/LedgerSMB/Report/PNL/Income_Statement.pm
+++ b/lib/LedgerSMB/Report/PNL/Income_Statement.pm
@@ -15,6 +15,7 @@ This provides the income statement report for LedgerSMB on 1.4 and later.
 
 package LedgerSMB::Report::PNL::Income_Statement;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report::PNL';
 
 =head1 CRITERIA PROPERTIES

--- a/lib/LedgerSMB/Report/PNL/Invoice.pm
+++ b/lib/LedgerSMB/Report/PNL/Invoice.pm
@@ -18,6 +18,7 @@ profit margins of specific invoices.
 
 package LedgerSMB::Report::PNL::Invoice;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report::PNL';
 
 =head1 CRITERIA PROPERTIES

--- a/lib/LedgerSMB/Report/PNL/Product.pm
+++ b/lib/LedgerSMB/Report/PNL/Product.pm
@@ -21,6 +21,7 @@ real way to track revenue vs loss, for example with the case of resold services.
 
 package LedgerSMB::Report::PNL::Product;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report::PNL';
 
 =head1 CRITERIA PROPERTIES

--- a/lib/LedgerSMB/Report/Payroll/Deduction_Types.pm
+++ b/lib/LedgerSMB/Report/Payroll/Deduction_Types.pm
@@ -10,6 +10,7 @@ LedgerSMB::Payroll::Deduction_Types - Deduction Types Searches for LedgerSMB
 
 package LedgerSMB::Report::Payroll::Deduction_Types;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report';
 
 =head1 DESCRIPTION

--- a/lib/LedgerSMB/Report/Payroll/Income_Types.pm
+++ b/lib/LedgerSMB/Report/Payroll/Income_Types.pm
@@ -10,6 +10,7 @@ LedgerSMB::Payroll::Income_Types - Income Types Searches for LedgerSMB
 
 package LedgerSMB::Report::Payroll::Income_Types;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report';
 
 =head1 DESCRIPTION

--- a/lib/LedgerSMB/Report/Reconciliation/Summary.pm
+++ b/lib/LedgerSMB/Report/Reconciliation/Summary.pm
@@ -12,6 +12,7 @@ LedgerSMB
 
 package LedgerSMB::Report::Reconciliation::Summary;
 use Moose;
+use namespace::autoclean;
 use LedgerSMB::MooseTypes;
 extends "LedgerSMB::Report";
 with "LedgerSMB::Report::Dates";

--- a/lib/LedgerSMB/Report/Taxform/Details.pm
+++ b/lib/LedgerSMB/Report/Taxform/Details.pm
@@ -12,6 +12,7 @@ LedgerSMB
 
 package LedgerSMB::Report::Taxform::Details;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report';
 with 'LedgerSMB::Report::Dates';
 

--- a/lib/LedgerSMB/Report/Taxform/List.pm
+++ b/lib/LedgerSMB/Report/Taxform/List.pm
@@ -17,6 +17,7 @@ This is a simple list of tax forms.
 
 package LedgerSMB::Report::Taxform::List;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report';
 
 =head1 CRITERIA PROPERTIES

--- a/lib/LedgerSMB/Report/Taxform/Summary.pm
+++ b/lib/LedgerSMB/Report/Taxform/Summary.pm
@@ -13,6 +13,7 @@ forms for LedgerSMB
 package LedgerSMB::Report::Taxform::Summary;
 use LedgerSMB::DBObject::TaxForm;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report';
 with 'LedgerSMB::Report::Dates';
 

--- a/lib/LedgerSMB/Report/Timecards.pm
+++ b/lib/LedgerSMB/Report/Timecards.pm
@@ -18,6 +18,7 @@ and sales order generation among other things.
 package LedgerSMB::Report::Timecards;
 use LedgerSMB::MooseTypes;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report';
 with 'LedgerSMB::Report::Dates';
 

--- a/lib/LedgerSMB/Report/Trial_Balance.pm
+++ b/lib/LedgerSMB/Report/Trial_Balance.pm
@@ -24,6 +24,7 @@ We can also retrieve a previous report from the database and run it:
 
 package LedgerSMB::Report::Trial_Balance;
 use Moose;
+use namespace::autoclean;
 use LedgerSMB::App_State;
 extends 'LedgerSMB::Report';
 with 'LedgerSMB::Report::Dates', 'LedgerSMB::Report::Approval_Option';

--- a/lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm
+++ b/lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm
@@ -30,6 +30,7 @@ LedgerSMB::Report::Unapproved::Batch_Overview instead.
 
 package LedgerSMB::Report::Unapproved::Batch_Detail;
 use Moose;
+use namespace::autoclean;
 use LedgerSMB::DBObject::User;
 extends 'LedgerSMB::Report';
 

--- a/lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm
+++ b/lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm
@@ -28,6 +28,7 @@ use LedgerSMB::Report::Unapproved::Batch_Detail instead.
 
 package LedgerSMB::Report::Unapproved::Batch_Overview;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report';
 
 use LedgerSMB::Business_Unit_Class;

--- a/lib/LedgerSMB/Report/Unapproved/Drafts.pm
+++ b/lib/LedgerSMB/Report/Unapproved/Drafts.pm
@@ -26,6 +26,7 @@ transactions.
 
 package LedgerSMB::Report::Unapproved::Drafts;
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::Report';
 with 'LedgerSMB::Report::Dates';
 

--- a/lib/LedgerSMB/Report/co/Balance_y_Mayor.pm
+++ b/lib/LedgerSMB/Report/co/Balance_y_Mayor.pm
@@ -25,6 +25,7 @@ standards. This report shows total activity over a time period.
 
 package LedgerSMB::Report::co::Balance_y_Mayor;
 use Moose;
+use namespace::autoclean;
 use LedgerSMB::MooseTypes;
 extends 'LedgerSMB::Report';
 

--- a/lib/LedgerSMB/Report/co/Caja_Diaria.pm
+++ b/lib/LedgerSMB/Report/co/Caja_Diaria.pm
@@ -26,6 +26,7 @@ specific period.
 
 package LedgerSMB::Report::co::Caja_Diaria;
 use Moose;
+use namespace::autoclean;
 use LedgerSMB::MooseTypes;
 extends 'LedgerSMB::Report';
 

--- a/lib/LedgerSMB/Request/Error.pm
+++ b/lib/LedgerSMB/Request/Error.pm
@@ -17,6 +17,7 @@ or
 package LedgerSMB::Request::Error;
 use LedgerSMB::App_State;
 use Moose;
+use namespace::autoclean;
 
 =head2 status (default 500)
 

--- a/lib/LedgerSMB/Setting/Sequence.pm
+++ b/lib/LedgerSMB/Setting/Sequence.pm
@@ -23,6 +23,7 @@ package LedgerSMB::Setting::Sequence;
 use LedgerSMB::Setting;
 use Carp;
 use Moose;
+use namespace::autoclean;
 with 'LedgerSMB::PGObject';
 
 =head1 DESCRIPTION

--- a/lib/LedgerSMB/Taxes/Simple.pm
+++ b/lib/LedgerSMB/Taxes/Simple.pm
@@ -42,6 +42,7 @@ use strict;
 use warnings;
 
 use Moose;
+use namespace::autoclean;
 use LedgerSMB::PGNumber;
 use LedgerSMB::MooseTypes;
 

--- a/lib/LedgerSMB/Template/DB.pm
+++ b/lib/LedgerSMB/Template/DB.pm
@@ -6,6 +6,7 @@ LedgerSMB::Template::DB - Template administration functions for LedgerSMB
 
 package LedgerSMB::Template::DB;
 use Moose;
+use namespace::autoclean;
 with 'LedgerSMB::PGObject', 'LedgerSMB::I18N';
 
 use LedgerSMB::App_State;

--- a/lib/LedgerSMB/Template/DBProvider.pm
+++ b/lib/LedgerSMB/Template/DBProvider.pm
@@ -23,6 +23,7 @@ use Template::Provider;
 use PGObject::Type::DateTime;
 
 use Moose;
+use namespace::autoclean;
 use MooseX::NonMoose;
 extends 'Template::Provider';
 with 'LedgerSMB::PGObject';

--- a/lib/LedgerSMB/Timecard.pm
+++ b/lib/LedgerSMB/Timecard.pm
@@ -30,6 +30,7 @@ like.
 
 package LedgerSMB::Timecard;
 use Moose;
+use namespace::autoclean;
 with 'LedgerSMB::PGObject';
 use LedgerSMB::MooseTypes;
 

--- a/lib/LedgerSMB/Timecard/Type.pm
+++ b/lib/LedgerSMB/Timecard/Type.pm
@@ -16,6 +16,7 @@ To list all types, ordered by label:
 
 package LedgerSMB::Timecard::Type;
 use Moose;
+use namespace::autoclean;
 with 'LedgerSMB::PGObject';
 
 =head1 DESCRIPTION

--- a/lib/LedgerSMB/Upgrade_Tests.pm
+++ b/lib/LedgerSMB/Upgrade_Tests.pm
@@ -16,6 +16,7 @@ package LedgerSMB::Upgrade_Tests;
 use strict;
 use warnings;
 use Moose;
+use namespace::autoclean;
 use LedgerSMB::App_State;
 
 =head1 FUNCTIONS

--- a/lib/LedgerSMB/X12.pm
+++ b/lib/LedgerSMB/X12.pm
@@ -29,6 +29,7 @@ supported by X12::Parser.
 
 package LedgerSMB::X12;
 use Moose;
+use namespace::autoclean;
 use X12::Parser;
 use LedgerSMB::Sysconfig;
 use DateTime;

--- a/lib/LedgerSMB/X12/EDI850.pm
+++ b/lib/LedgerSMB/X12/EDI850.pm
@@ -21,6 +21,7 @@ use LedgerSMB::Form;
 
 
 use Moose;
+use namespace::autoclean;
 use feature 'switch';
 extends 'LedgerSMB::X12';
 

--- a/lib/LedgerSMB/X12/EDI894.pm
+++ b/lib/LedgerSMB/X12/EDI894.pm
@@ -20,6 +20,7 @@ use LedgerSMB::Form;
 use feature 'switch';
 
 use Moose;
+use namespace::autoclean;
 extends 'LedgerSMB::X12';
 
 sub _config {

--- a/xt/01.1-critic.t
+++ b/xt/01.1-critic.t
@@ -80,6 +80,7 @@ my @lsmb_policies = qw(
     ProhibitHardTabs
     Modules
     Moose::RequireMakeImmutable
+    Moose::RequireCleanNamespace
     TestingAndDebugging
     ProhibitPuncutationVars
 );


### PR DESCRIPTION
Our coding policy says that classes using Moose should also use namespace::autoclean; This PR adds that to modules missing it and applies a Perl::Critic policy to enforce it.