### PR TITLE
Enable Perl::Critic ProhibitConditionalUse Policy

### DIFF
--- a/old/bin/aa.pl
+++ b/old/bin/aa.pl
@@ -1021,7 +1021,6 @@ sub form_footer {
 <th>| . $locale->text('Attached by') . qq|</th>
 </tr> |;
         foreach my $file (@{$form->{files}}){
-     use Data::Dumper;
               print qq|
 <tr>
 <td><a href="file.pl?action=get&file_class=1&ref_key=$form->{id}&id=$file->{id}"

--- a/xt/01.1-critic.t
+++ b/xt/01.1-critic.t
@@ -99,7 +99,6 @@ my @exclude_policies = qw(
 my @exclude_policies_oldcode = qw(
     BuiltinFunctions::ProhibitStringyEval
     InputOutput::RequireEncodingWithUTF8Layer
-    Modules::ProhibitConditionalUseStatements
     Modules::ProhibitEvilModules
     Modules::ProhibitExcessMainComplexity
     Modules::ProhibitMultiplePackages


### PR DESCRIPTION
The conditional use of Data::Dumper is redundant as it's already use-d on L52