### PR TITLE
Fix warning and refactor currency dropdown creation

### DIFF
--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -306,7 +306,7 @@ sub escape {
     # for Apache 2 we escape strings twice
     if (
         ( $ENV{SERVER_SIGNATURE} =~ /Apache\/2\.(\d+)\.(\d+)/ )
-        && !$beenthere 
+        && !$beenthere
     ) {
         $str = $self->escape( $str, 1 ) if $1 == 0 && $2 < 44;
     }
@@ -1205,32 +1205,24 @@ qq|<button data-dojo-type="$type" class="submit" type="submit" name="action" val
 sub generate_selects {
     my ($form, $myconfig) = @_;
 
-
     # currencies
     if (!$form->{currencies}) {
         $form->{currencies} = $form->get_setting('curr');
     }
 
     if ($form->{currencies}) {
-        my %curr;
-        my @curr = split( /:/, $form->{currencies} );
-        $form->{defaultcurrency} = $curr[0];
 
-        foreach (@curr) {
-            $curr{$_} = 1;
-        }
-
-        my @curr = keys %curr;
-        $form->{currency} = $form->{defaultcurrency}
-            unless $form->{currency};
+        my @currencies = split /:/, $form->{currencies};
+        $form->{defaultcurrency} = $currencies[0];
+        $form->{currency} ||= $form->{defaultcurrency};
         $form->{selectcurrency} = "";
 
-        for (@curr) {
-            my $selected = ($form->{currency} eq $_)
-                         ? " selected=\"selected\""
-                         : "";
+        foreach my $currency (sort @currencies) {
+            my $selected = ($form->{currency} eq $currency)
+                         ? ' selected="selected"'
+                         : '';
             $form->{selectcurrency} .=
-                "<option value=\"$_\"$selected>$_</option>\n"
+                "<option value=\"$currency\"$selected>$currency</option>\n";
         }
     }
 

--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -107,50 +107,56 @@ sub new {
     $ENV{CONTENT_LENGTH} = 0 unless defined $ENV{CONTENT_LENGTH};
     my $dojo_theme = $LedgerSMB::Sysconfig::dojo_template;
 
-    if ( ( $ENV{CONTENT_LENGTH} != 0 )
-         && ( $ENV{CONTENT_LENGTH} > $LedgerSMB::Sysconfig::max_post_size )
-         && $LedgerSMB::Sysconfig::max_post_size  != -1) {
+    if (
+        ($ENV{CONTENT_LENGTH} != 0)
+        && ($ENV{CONTENT_LENGTH} > $LedgerSMB::Sysconfig::max_post_size)
+        && $LedgerSMB::Sysconfig::max_post_size != -1
+    ) {
         print "Status: 413\n Request entity too large\n\n";
         die "Error: Request entity too large\n";
     }
     if ($argstr) {
         $_ = $argstr;
-    }elsif ($ENV{CONTENT_LENGTH}!= 0){
-        read( STDIN, $_, $ENV{CONTENT_LENGTH} );
     }
-    elsif ( $ENV{QUERY_STRING} ) {
+    elsif ($ENV{CONTENT_LENGTH}!= 0) {
+        read(STDIN, $_, $ENV{CONTENT_LENGTH});
+    }
+    elsif ($ENV{QUERY_STRING}) {
         $_ = $ENV{QUERY_STRING};
     }
-    elsif ( $ARGV[0] ) {
+    elsif ($ARGV[0]) {
         $_ = $ARGV[0];
     }
+
     $logger->trace(" RequestIn=$_") if $_;
     my $self = {};
     my $orig = {};
     %$orig = split /[&=]/ unless !defined $_;
     for ( keys %$orig ) {
-        $self->{unescape( "", $_) } = unescape( "", $orig->{$_} );
+        $self->{unescape( "", $_) } = unescape("", $orig->{$_});
     }
 
-    for my $p(keys %$self){
+    for my $p(keys %$self) {
         utf8::decode($self->{$p});
         utf8::upgrade($self->{$p});
     }
     $self->{action} = "" unless defined $self->{action};
     $self->{dojo_theme} = $dojo_theme;
 
-    if($self->{header})
-    {
-     delete $self->{header};
-     $logger->error("self->{header} unset!!");
+    if($self->{header}) {
+        delete $self->{header};
+        $logger->error("self->{header} unset!!");
     }
-    if ( substr( $self->{action}, 0, 1 ) !~ /( |\.)/ ) {
+
+    if (substr( $self->{action}, 0, 1 ) !~ /( |\.)/) {
         $self->{action} = lc $self->{action};
         $self->{action} =~ s/( |-|,|\#|\/|\.$)/_/g;
-        if (defined $self->{nextsub}){
+
+        if (defined $self->{nextsub}) {
             $self->{nextsub} = lc $self->{nextsub};
             $self->{nextsub} =~ s/( |-|,|\#|\/|\.$)/_/g;
-        } else {
+        }
+        else {
             $self->{nextsub} = '';
         }
     }
@@ -158,7 +164,7 @@ sub new {
     $self->{login} = "" unless defined $self->{login};
     $self->{login} =~ s/[^a-zA-Z0-9._+\@'-]//g;
 
-    if ($ENV{HTTP_COOKIE}){
+    if ($ENV{HTTP_COOKIE}) {
         $ENV{HTTP_COOKIE} =~ s/;\s*/;/g;
         my %cookie;
         my @cookies = split /;/, $ENV{HTTP_COOKIE};
@@ -177,23 +183,29 @@ sub new {
 
     bless $self, $type;
 
-    if ( ( $self->{script} )
-        and not List::Util::first { $_ eq $self->{script} }
-        @{LedgerSMB::Sysconfig::scripts} )
-    {
+    if (
+        ($self->{script})
+        and not List::Util::first {$_ eq $self->{script}}
+        @{LedgerSMB::Sysconfig::scripts}
+    ) {
         $self->error( 'Access Denied', __LINE__, __FILE__ );
     }
 
-    if ( ( $self->{action} =~ /(:|')/ ) || ( $self->{nextsub} =~ /(:|')/ ) ) {
+    if (( $self->{action} =~ /(:|')/ ) || ( $self->{nextsub} =~ /(:|')/ )) {
         $self->error( "Access Denied", __LINE__, __FILE__ );
     }
 
     #for ( keys %$self ) { $self->{$_} =~ s/\N{NULL}//g }
-    for ( keys %$self ) { if ( defined $self->{$_} ) { $self->{$_}=~ s/\N{NULL}//g; } }
+    for (keys %$self) {
+        if (defined $self->{$_}) {
+            $self->{$_}=~ s/\N{NULL}//g;
+        }
+    }
 
-    if ( ($self->{action} eq 'redirect') || ($self->{nextsub} eq 'redirect') ) {
+    if (($self->{action} eq 'redirect') || ($self->{nextsub} eq 'redirect')) {
         $self->error( "Access Denied", __LINE__, __FILE__ );
     }
+
     $self;
 }
 
@@ -201,28 +213,29 @@ sub new {
 sub open_form {
     my ($self) = @_;
     my @results ;
-    if ($self->{form_id} =~ '^\s*$'){
+
+    if ($self->{form_id} =~ '^\s*$') {
         delete $self->{form_id};
     }
-    if (!$ENV{GATEWAY_INTERFACE}){
+
+    if (!$ENV{GATEWAY_INTERFACE}) {
         return 1;
     }
+
     #HV session_id not always set in LedgerSMB/Auth/DB.pm because of mix old,new code-chain?
-    if($self->{session_id})
-    {
-    my $sth = $self->{dbh}->prepare('select form_open(?)');
-    my $rc=$sth->execute($self->{session_id});#HV ERROR:Invalid session,if count(*) FROM session!=1,multiple login
-    if(! $rc)
-    {
-     $logger->error("select form_open \$self->{form_id}=$self->{form_id} \$self->{session_id}=$self->{session_id} \$rc=$rc,invalid count FROM session?");
-     return undef;
+    if ($self->{session_id}) {
+        my $sth = $self->{dbh}->prepare('select form_open(?)');
+        my $rc=$sth->execute($self->{session_id});#HV ERROR:Invalid session,if count(*) FROM session!=1,multiple login
+
+        if(! $rc) {
+            $logger->error("select form_open \$self->{form_id}=$self->{form_id} \$self->{session_id}=$self->{session_id} \$rc=$rc,invalid count FROM session?");
+            return undef;
+        }
+        @results = $sth->fetchrow_array();
     }
-    @results = $sth->fetchrow_array();
-    }
-    else
-    {
-     $logger->debug("no \$self->{session_id}!");
-     return undef;
+    else {
+        $logger->debug("no \$self->{session_id}!");
+        return undef;
     }
 
     $self->{form_id} = $results[0];
@@ -231,9 +244,11 @@ sub open_form {
 
 sub check_form {
     my ($self) = @_;
-    if (!$ENV{GATEWAY_INTERFACE}){
+
+    if (!$ENV{GATEWAY_INTERFACE}) {
         return 1;
     }
+
     return 0 unless $self->{form_id};
     my $sth = $self->{dbh}->prepare('select form_check(?, ?)');
     $sth->execute($self->{session_id}, $self->{form_id});
@@ -243,12 +258,14 @@ sub check_form {
 
 sub close_form {
     my ($self) = @_;
-    if ($self->{form_id} =~ '^\s*$'){
+    if ($self->{form_id} =~ '^\s*$') {
         delete $self->{form_id};
     }
-    if (!$ENV{GATEWAY_INTERFACE}){
+
+    if (!$ENV{GATEWAY_INTERFACE}) {
         return 1;
     }
+
     my $sth = $self->{dbh}->prepare('select form_close(?, ?)');
     $sth->execute($self->{session_id}, $self->{form_id});
     my @results = $sth->fetchrow_array();
@@ -287,9 +304,10 @@ sub escape {
     my ( $self, $str, $beenthere ) = @_;
 
     # for Apache 2 we escape strings twice
-    if ( ( $ENV{SERVER_SIGNATURE} =~ /Apache\/2\.(\d+)\.(\d+)/ )
-        && !$beenthere )
-    {
+    if (
+        ( $ENV{SERVER_SIGNATURE} =~ /Apache\/2\.(\d+)\.(\d+)/ )
+        && !$beenthere 
+    ) {
         $str = $self->escape( $str, 1 ) if $1 == 0 && $2 < 44;
     }
 
@@ -336,7 +354,6 @@ sub quote {
     }
 
     $str;
-
 }
 
 =item $form->unquote($str);
@@ -354,7 +371,6 @@ sub unquote {
     }
 
     $str;
-
 }
 
 =item $form->hide_form([...]);
@@ -380,7 +396,6 @@ sub hide_form {
               . $self->quote( $self->{$_} )
               . qq|" />\n|;
         }
-
     }
     else {
         delete $self->{header};
@@ -442,25 +457,24 @@ argument.  Otherwise, this function simply prints $msg to STDOUT.
 =cut
 
 sub info {
-    my ( $self, $msg ) = @_;
+    my ($self, $msg) = @_;
 
-    if ( $ENV{GATEWAY_INTERFACE} ) {
+    if ($ENV{GATEWAY_INTERFACE}) {
         $msg =~ s/\n/<br>/g;
 
         delete $self->{pre};
 
-        if ( !$self->{header} ) {
+        if (!$self->{header}) {
             $self->header;
             print qq| <body>|;
             $self->{header} = 1;
         }
 
         print "<b>$msg</b>";
-
     }
     else {
 
-        if ( $ENV{info_function} ) {
+        if ($ENV{info_function}) {
             __PACKAGE__->can($ENV{info_function})->($msg);
         }
         else {
@@ -480,18 +494,17 @@ account while spaces are not.
 
 sub numtextrows {
 
-    my ( $self, $str, $cols, $maxrows ) = @_;
+    my ($self, $str, $cols, $maxrows) = @_;
 
     my $rows = 0;
 
-    for ( split /\n/, $str ) {
+    for (split /\n/, $str) {
         $rows += int( ( (length) - 2 ) / $cols ) + 1;
     }
 
     $maxrows = $rows unless defined $maxrows;
 
-    return ( $rows > $maxrows ) ? $maxrows : $rows;
-
+    return ($rows > $maxrows) ? $maxrows : $rows;
 }
 
 =item $form->dberror($msg);
@@ -629,16 +642,21 @@ to "new."
 sub open_status_div {
     my ($self, $div_id) = @_;
     my $class;
-    if ($self->{approved} and $self->{id}){
+    if ($self->{approved} and $self->{id}) {
         $class = "posted";
-    } elsif ($self->{id}){
+    }
+    elsif ($self->{id}){
         $class = "saved";
-    } else {
+    }
+    else {
         $class = "new";
     }
+
     my $status = $LedgerSMB::App_State::Locale->text(
-            'Action: [_1], ID: [_2]', $self->{action}, $self->{id}
-        );
+        'Action: [_1], ID: [_2]',
+        $self->{action},
+        $self->{id}
+    );
     my $id = $div_id ? "id=\"$div_id\"" : '';
     return "<div $id class=\"$class\">
             <div id=\"history\">$status</div>";
@@ -686,19 +704,25 @@ sub _redirect {
       dbh login favicon stylesheet titlebar password vc header
     );
 
-    if ( !$script ) {    # http redirect to login.pl if called w/no args
+    if (!$script) {    # http redirect to login.pl if called w/no args
         print "Location: login.pl\n";
         print "Content-type: text/html\n\n";
         return;
     }
-    if (first { $_ eq $script } @{LedgerSMB::Sysconfig::newscripts}){
+
+    if (first { $_ eq $script } @{LedgerSMB::Sysconfig::newscripts}) {
         print "Location: $form->{callback}\n";
         print "Content-type: text/html\n\n";
         return;
     }
+
     $form->error(
         LedgerSMB::App_State::Locale->text(
-            "[_1]:[_2]:[_3]: Invalid Redirect", __FILE__, __LINE__, $script)
+            "[_1]:[_2]:[_3]: Invalid Redirect",
+            __FILE__,
+            __LINE__,
+           $script
+        )
     ) unless first { $_ eq $script } @{LedgerSMB::Sysconfig::scripts};
 
     my %temphash;
@@ -747,7 +771,7 @@ sub sort_columns {
         $self->{sort} =~ s/^"*(.*?)"*$/$1/;
         if (@columns) {
             @columns = grep !/^$self->{sort}$/, @columns;
-            if ($self->{sort} !~ /^\w*$/){
+            if ($self->{sort} !~ /^\w*$/) {
                 $self->{sort} = $self->{dbh}->quote_identifier($self->{sort});
             }
             splice @columns, 0, 0, $self->{sort};
@@ -809,24 +833,21 @@ sub sort_order {
 
     if (ref $ordinal eq 'HASH') {
         #$a[0] =
-          #( $ordinal->{ $a[$_] } )
-          #? "$ordinal->{$a[0]} $self->{direction}";
-          #: "$a[0] $self->{direction}";
+        #( $ordinal->{ $a[$_] } )
+        #? "$ordinal->{$a[0]} $self->{direction}";
+        #: "$a[0] $self->{direction}";
 
-          if ( defined $_ && $ordinal->{ $a[$_] } )
-          {
-              $a[0] = "$ordinal->{$a[0]} $self->{direction}";
-          }
-          elsif ( !defined $_ && $ordinal->{ $a[0] } )
-          {
-              $a[0] = "$ordinal->{$a[0]} $self->{direction}";
-          }
-          else
-          {
-              $a[0] = "$a[0] $self->{direction}";
-          }
+        if (defined $_ && $ordinal->{ $a[$_] }) {
+            $a[0] = "$ordinal->{$a[0]} $self->{direction}";
+        }
+        elsif (!defined $_ && $ordinal->{ $a[0] }) {
+            $a[0] = "$ordinal->{$a[0]} $self->{direction}";
+        }
+        else {
+            $a[0] = "$a[0] $self->{direction}";
+        }
 
-        for ( 1 .. $#a ) {
+        for (1 .. $#a) {
             $a[$_] = $ordinal->{ $a[$_] } if $ordinal->{ $a[$_] };
         }
 
@@ -870,8 +891,8 @@ sub format_amount {
     $places = "0" unless defined $places;
     $dash = "" unless defined $dash;
     $amount = $self->parse_amount($myconfig, $amount);
-    if ($self->{money_precision}){
-       $places= $self->{money_precision};
+    if ($self->{money_precision}) {
+        $places= $self->{money_precision};
     }
     $myconfig->{numberformat} = '1000.00' unless $myconfig->{numberformat};
     $amount = $self->parse_amount( $myconfig, $amount )
@@ -907,8 +928,9 @@ sub parse_amount {
         $amount = '0';
     }
 
-    return LedgerSMB::PGNumber->from_input($amount,
-                                           {format => $myconfig->{numberformat}}
+    return LedgerSMB::PGNumber->from_input(
+        $amount,
+        {format => $myconfig->{numberformat}}
     );
 }
 
@@ -1028,28 +1050,32 @@ sub datetonum {
         return $date;
     }
 
-    if ( $date && $date =~ /\D/ ) {
+    if ($date && $date =~ /\D/) {
 
         my $yy;
         my $mm;
         my $dd;
 
-        if ( $date =~ /^\d{4}-\d\d-\d\d$/ ) {
-            ( $yy, $mm, $dd ) = split /\D/, $date;
-        } if ( $myconfig->{dateformat} =~ /^yy/ ) {
-            ( $yy, $mm, $dd ) = split /\D/, $date;
-        } elsif ( $myconfig->{dateformat} =~ /^mm/ ) {
-            ( $mm, $dd, $yy ) = split /\D/, $date;
-        } elsif ( $myconfig->{dateformat} =~ /^dd/ ) {
-            ( $dd, $mm, $yy ) = split /\D/, $date;
+        if ($date =~ /^\d{4}-\d\d-\d\d$/) {
+            ($yy, $mm, $dd) = split /\D/, $date;
+        }
+
+        if ($myconfig->{dateformat} =~ /^yy/) {
+            ($yy, $mm, $dd) = split /\D/, $date;
+        }
+        elsif ($myconfig->{dateformat} =~ /^mm/) {
+            ($mm, $dd, $yy) = split /\D/, $date;
+        }
+        elsif ($myconfig->{dateformat} =~ /^dd/) {
+            ($dd, $mm, $yy) = split /\D/, $date;
         }
 
         $dd *= 1;
         $mm *= 1;
         $yy += 2000 if length $yy == 2;
 
-        $dd = substr( "0$dd", -2 );
-        $mm = substr( "0$mm", -2 );
+        $dd = substr("0$dd", -2);
+        $mm = substr("0$mm", -2);
         $date = "$yy$mm$dd";
     }
 
@@ -1177,176 +1203,182 @@ qq|<button data-dojo-type="$type" class="submit" type="submit" name="action" val
 =cut
 
 sub generate_selects {
-     my ($form, $myconfig) = @_;
+    my ($form, $myconfig) = @_;
 
 
     # currencies
-     if (!$form->{currencies}) {
-          $form->{currencies} = $form->get_setting('curr');
-     }
-     if ($form->{currencies}) {
-          my %curr;
-          my @curr = split( /:/, $form->{currencies} );
-          $form->{defaultcurrency} = $curr[0];
-          foreach (@curr) {
-                $curr{$_} = 1;
-          }
-          my @curr = keys %curr;
+    if (!$form->{currencies}) {
+        $form->{currencies} = $form->get_setting('curr');
+    }
 
-          $form->{currency} = $form->{defaultcurrency}
-               unless $form->{currency};
-          $form->{selectcurrency} = "";
-          for (@curr) {
-                my $selected =
-                     ($form->{currency} eq $_)
-                     ? " selected=\"selected\"" : "";
-                $form->{selectcurrency} .=
-                     "<option value=\"$_\"$selected>$_</option>\n"
-          }
-     }
+    if ($form->{currencies}) {
+        my %curr;
+        my @curr = split( /:/, $form->{currencies} );
+        $form->{defaultcurrency} = $curr[0];
 
-     # partsgroups
-    if ( $form->{all_partsgroup} && @{ $form->{all_partsgroup} } ) {
+        foreach (@curr) {
+            $curr{$_} = 1;
+        }
+
+        my @curr = keys %curr;
+        $form->{currency} = $form->{defaultcurrency}
+            unless $form->{currency};
+        $form->{selectcurrency} = "";
+
+        for (@curr) {
+            my $selected = ($form->{currency} eq $_)
+                         ? " selected=\"selected\""
+                         : "";
+            $form->{selectcurrency} .=
+                "<option value=\"$_\"$selected>$_</option>\n"
+        }
+    }
+
+    # partsgroups
+    if ($form->{all_partsgroup} && @{ $form->{all_partsgroup} }) {
         $form->{selectpartsgroup} = "<option></option>\n";
         foreach my $ref ( @{ $form->{all_partsgroup} } ) {
-                my $value = "$ref->{partsgroup}--$ref->{id}";
-                my $selected = ($form->{partsgroup} eq $value) ?
+            my $value = "$ref->{partsgroup}--$ref->{id}";
+            my $selected = ($form->{partsgroup} eq $value) ?
                      ' selected="selected"' : "";
             if ( $ref->{translation} ) {
                 $form->{selectpartsgroup} .=
-                          qq|<option value="$value"$selected>$ref->{translation}</option>\n|;
+                    qq|<option value="$value"$selected>$ref->{translation}</option>\n|;
             }
             else {
                 $form->{selectpartsgroup} .=
-                          qq|<option value="$value"$selected>$ref->{partsgroup}</option>\n|;
+                    qq|<option value="$value"$selected>$ref->{partsgroup}</option>\n|;
             }
         }
     }
 
-     # projects
-    if ( $form->{all_project} && @{ $form->{all_project} } ) {
+    # projects
+    if ($form->{all_project} && @{ $form->{all_project} }) {
         $form->{selectprojectnumber} = "<option></option>\n";
-          $form->{selectprojectnumber} = "";
-        for ( @{ $form->{all_project} } ) {
+        $form->{selectprojectnumber} = "";
+
+        for (@{ $form->{all_project} }) {
             my $value = "$_->{projectnumber}--$_->{id}";
             $form->{selectprojectnumber} .=
-                     # change the format here, then change it below!
-                     qq|<option value="$value">$_->{projectnumber}</option>\n|;
+                # change the format here, then change it below!
+                qq|<option value="$value">$_->{projectnumber}</option>\n|;
         }
-          if ($form->{rowcount}) {
-                for my $i ( 1 .. $form->{rowcount} ) {
-                     $form->{"selectprojectnumber_$i"} =
-                          $form->{"selectprojectnumber"};
-                     $form->{"selectprojectnumber_$i"} =~
-                          s/(value="\Q$form->{"projectnumber_$i"}\E")/$1 selected="selected"/;
-                }
-          }
+
+        if ($form->{rowcount}) {
+            for my $i (1 .. $form->{rowcount}) {
+                $form->{"selectprojectnumber_$i"} =
+                    $form->{"selectprojectnumber"};
+                $form->{"selectprojectnumber_$i"} =~
+                    s/(value="\Q$form->{"projectnumber_$i"}\E")/$1 selected="selected"/;
+            }
+        }
     }
 
     # departments
-    if ( $form->{all_department} && @{ $form->{all_department} } ) {
+    if ($form->{all_department} && @{ $form->{all_department} }) {
         $form->{selectdepartment} = "<option></option>\n";
-        for ( @{ $form->{all_department} } ) {
-                my $value = "$_->{description}--$_->{id}";
-                my $selected = ($form->{department} eq $value) ?
-                     ' selected="selected"' : "";
+        for (@{ $form->{all_department} }) {
+            my $value = "$_->{description}--$_->{id}";
+            my $selected = ($form->{department} eq $value) ?
+                ' selected="selected"' : "";
             $form->{selectdepartment} .=
-                     qq|<option value="$value"$selected>$_->{description}</option>\n|;
+                qq|<option value="$value"$selected>$_->{description}</option>\n|;
         }
     }
 
-     # languages
-    if ( $form->{all_language} && @{ $form->{all_language} } ) {
+    # languages
+    if ($form->{all_language} && @{ $form->{all_language} }) {
         $form->{selectlanguage} = "<option></option>\n";
-        for ( @{ $form->{all_language} } ) {
-                my $value = $_->{code};
-                my $selected = ($form->{language} eq $value) ?
-                     ' selected="selected"' : "";
+        for (@{ $form->{all_language} }) {
+            my $value = $_->{code};
+            my $selected = ($form->{language} eq $value) ?
+                ' selected="selected"' : "";
             $form->{selectlanguage} .=
-              qq|<option value="$value"$selected>$_->{description}</option>\n|;
+                qq|<option value="$value"$selected>$_->{description}</option>\n|;
         }
     }
 
     # sales staff
-    if ( $form->{all_employees} && @{ $form->{all_employee} } ) {
+    if ($form->{all_employees} && @{ $form->{all_employee} }) {
         $form->{selectemployee} = "";
-        for ( @{ $form->{all_employee} } ) {
+        for (@{ $form->{all_employee} }) {
             $form->{selectemployee} .=
-              qq|<option value="$_->{name}--$_->{id}">$_->{name}</option>\n|;
+                qq|<option value="$_->{name}--$_->{id}">$_->{name}</option>\n|;
         }
     }
 
     # customers/vendors
-     if ($form->{vc}) {
-          if ( $form->{"all_$form->{vc}"} && @{ $form->{"all_$form->{vc}"} } ) {
-              $form->{"select$form->{vc}"} = "";
-              my $vc = $form->{vc};
-              my $search_value = $form->{$vc};
-              $search_value .= qq|--$form->{"${vc}_id"}|
-                  unless $search_value =~ /--/;
-              for ( @{ $form->{"all_$form->{vc}"} } ) {
-                  my $value = "$_->{name}--$_->{id}";
-                  my $selected = ($search_value eq $value) ?
-                      ' selected="selected"' : "";
-                  $form->{"select$form->{vc}"} .=
-                      qq|<option value="$value"$selected>$_->{name}</option>\n|;
-              }
-          }
+    if ($form->{vc}) {
+        if ($form->{"all_$form->{vc}"} && @{ $form->{"all_$form->{vc}"} }) {
+            $form->{"select$form->{vc}"} = "";
+            my $vc = $form->{vc};
+            my $search_value = $form->{$vc};
+            $search_value .= qq|--$form->{"${vc}_id"}|
+                unless $search_value =~ /--/;
+
+            for ( @{ $form->{"all_$form->{vc}"} } ) {
+                my $value = "$_->{name}--$_->{id}";
+                my $selected = ($search_value eq $value) ?
+                    ' selected="selected"' : "";
+                $form->{"select$form->{vc}"} .=
+                    qq|<option value="$value"$selected>$_->{name}</option>\n|;
+            }
+        }
      }
 
      # AR/AP links
      # AR_amount_*, AP_amount_*,
      if (defined $form->{ARAP}) {
-          $form->create_links( module => $form->{ARAP},
-                                      myconfig => $myconfig,
-                                      vc => $form->{vc},
-                                      billing => $form->{vc} eq 'customer'
-                                      && $form->{type} eq 'invoice')
-                unless defined $form->{"$form->{ARAP}_links"};
+        $form->create_links(
+            module => $form->{ARAP},
+            myconfig => $myconfig,
+            vc => $form->{vc},
+            billing => $form->{vc} eq 'customer'
+                       && $form->{type} eq 'invoice'
+        ) unless defined $form->{"$form->{ARAP}_links"};
 
-          foreach my $key ( keys %{ $form->{"$form->{ARAP}_links"} } ) {
+        foreach my $key (keys %{ $form->{"$form->{ARAP}_links"} }) {
 
-                $form->{"select$key"} = "";
-                foreach my $ref ( @{ $form->{"$form->{ARAP}_links"}{$key} } ) {
-                     my $value = "$ref->{accno}--$ref->{description}";
-                     $form->{"select$key"} .=
-                          # change the format here, then change it below too!
-                          qq|<option value="$value">$value</option>\n|;
-                }
-          }
+            $form->{"select$key"} = "";
+            foreach my $ref (@{ $form->{"$form->{ARAP}_links"}{$key} }) {
+                my $value = "$ref->{accno}--$ref->{description}";
+                $form->{"select$key"} .=
+                    # change the format here, then change it below too!
+                    qq|<option value="$value">$value</option>\n|;
+            }
+        }
 
-          if ($form->{rowcount}) {
-                for my $i ( 1 .. $form->{rowcount} ) {
-                     $form->{"select$form->{ARAP}_amount_$i"} =
-                          $form->{"select$form->{ARAP}_amount"};
-                     $form->{"select$form->{ARAP}_amount_$i"} =~
-                          s/(value="\Q$form->{"$form->{ARAP}_amount_$i"}\E")/$1 selected="selected"/;
-                }
-          }
-     }
-
-     # formats
-    $form->{selectformat} = qq|<option value="html">html<option value="csv">csv\n|;
-    if ( ${LedgerSMB::Sysconfig::latex} ) {
-        $form->{selectformat} .= qq|
-            <option value="postscript">|
-                . $LedgerSMB::App_State::Locale->text('Postscript')
-                . qq|<option value="pdf">|
-                . $LedgerSMB::App_State::Locale->text('PDF');
-    }
-
-    # warehouse
-    if ( $form->{all_warehouse} &&  @{ $form->{all_warehouse} } ) {
-        $form->{selectwarehouse} = "<option></option>\n";
-        for ( @{ $form->{all_warehouse} } ) {
-                my $value = "$_->{description}--$_->{id}";
-                my $selected = ($form->{warehouse} eq $value) ?
-                     ' selected="selected"' : "";
-            $form->{selectwarehouse} .=
-                     qq|<option value="$value"$selected>$_->{description}\n|;
+        if ($form->{rowcount}) {
+            for my $i (1 .. $form->{rowcount}) {
+                $form->{"select$form->{ARAP}_amount_$i"} =
+                    $form->{"select$form->{ARAP}_amount"};
+                $form->{"select$form->{ARAP}_amount_$i"} =~
+                    s/(value="\Q$form->{"$form->{ARAP}_amount_$i"}\E")/$1 selected="selected"/;
+            }
         }
     }
 
+    # formats
+    $form->{selectformat} = qq|<option value="html">html<option value="csv">csv\n|;
+    if (${LedgerSMB::Sysconfig::latex}) {
+        $form->{selectformat} .= qq|
+            <option value="postscript">|
+            . $LedgerSMB::App_State::Locale->text('Postscript')
+            . qq|<option value="pdf">|
+            . $LedgerSMB::App_State::Locale->text('PDF');
+    }
+
+    # warehouse
+    if ($form->{all_warehouse} &&  @{ $form->{all_warehouse} }) {
+        $form->{selectwarehouse} = "<option></option>\n";
+        for (@{ $form->{all_warehouse} }) {
+            my $value = "$_->{description}--$_->{id}";
+            my $selected = ($form->{warehouse} eq $value) ?
+                ' selected="selected"' : "";
+            $form->{selectwarehouse} .=
+                qq|<option value="$value"$selected>$_->{description}\n|;
+        }
+    }
 }
 
 =item test_should_get_images
@@ -1381,7 +1413,7 @@ is populated.  The connection initiated has autocommit disabled.
 sub db_init {
     my ( $self, $myconfig ) = @_;
     $logger->trace("begin");
-    if (!$self->{company}){
+    if (!$self->{company}) {
         $self->{company} = $LedgerSMB::Sysconfig::default_db;
     }
     my $dbname = $self->{company};
@@ -1399,14 +1431,14 @@ sub db_init {
     LedgerSMB::App_State::set_DBH($dbh);
     LedgerSMB::DBH->set_datestyle;
 
-
     $self->{db_dateformat} = $myconfig->{dateformat};    #shim
 
     LedgerSMB::DBH->require_version($self->{version}) if $self->{version};
 
     my $sth = $self->{dbh}->prepare("
             SELECT value FROM defaults
-             WHERE setting_key = 'role_prefix'");
+             WHERE setting_key = 'role_prefix'"
+    );
     $sth->execute;
 
     ($self->{_role_prefix}) = $sth->fetchrow_array;
@@ -1414,7 +1446,8 @@ sub db_init {
 
     $sth = $self->{dbh}->prepare("
             SELECT value FROM defaults
-             WHERE setting_key = 'dojo_theme'");
+             WHERE setting_key = 'dojo_theme'"
+    );
     $sth->execute;
 
     ($self->{dojo_theme}) = $sth->fetchrow_array;
@@ -1422,7 +1455,7 @@ sub db_init {
     $sth = $dbh->prepare('SELECT check_expiration()');
     $sth->execute;
     ($self->{warn_expire}) = $sth->fetchrow_array;
-    if ($self->{warn_expire}){
+    if ($self->{warn_expire}) {
         $sth = $dbh->prepare('SELECT user__check_my_expiration()');
         $sth->execute;
         ($self->{pw_expires})  = $sth->fetchrow_array;
@@ -1456,9 +1489,9 @@ $form->{dbh}->quote($var).
 
 sub dbquote {
 
-    my ( $self, $var ) = @_;
+    my ($self, $var) = @_;
 
-    if ( $var eq '' ) {
+    if ($var eq '') {
         $_ = "NULL";
     }
     else {
@@ -1549,6 +1582,7 @@ sub update_exchangerate {
     if ( !$set ) {
         $self->error("Exchange rate missing!");
     }
+
     if ( $sth->fetchrow_array ) {
         $query = qq|UPDATE exchangerate
                        SET $set
@@ -1589,9 +1623,13 @@ sub save_exchangerate {
     $buy  = $rate if $fld eq 'buy';
     $sell = $rate if $fld eq 'sell';
 
-    $self->update_exchangerate( $self->{dbh}, $currency, $transdate, $buy,
-        $sell );
-
+    $self->update_exchangerate(
+        $self->{dbh},
+        $currency,
+        $transdate,
+        $buy,
+        $sell
+    );
 }
 
 =item $form->get_exchangerate($dbh, $curr, $transdate, $fld);
@@ -1618,7 +1656,7 @@ sub get_exchangerate {
         $sth->execute( $curr, $transdate );
 
         ($exchangerate) = $sth->fetchrow_array;
-    $exchangerate = LedgerSMB::PGNumber->new($exchangerate);
+        $exchangerate = LedgerSMB::PGNumber->new($exchangerate);
         $sth->finish;
     }
 
@@ -1670,37 +1708,37 @@ $dbh is unused.
 
 sub add_shipto {
 
-      my ( $self,$dbh,$id, $oe) = @_;
-        if (! $self->{locationid}) {
+    my ( $self,$dbh,$id, $oe) = @_;
+    if (! $self->{locationid}) {
         return;
     }
+
     my $query = qq|
             INSERT INTO new_shipto
             (trans_id, oe_id,location_id)
             VALUES ( ?, ?, ?)
             |;
 
-        my $sth = $self->{dbh}->prepare($query) || $self->dberror($query);
-        my $trans_id;
-        my $oe_id;
-        if ($oe){
-           $trans_id = undef;
-           $oe_id = $id;
-        } else {
-           $trans_id = $id;
-           $oe_id = undef;
-        }
-        $sth->execute(
-                        $trans_id,
-            $oe_id,
-            $self->{locationid}
+    my $sth = $self->{dbh}->prepare($query) || $self->dberror($query);
+    my $trans_id;
+    my $oe_id;
 
-              ) || $self->dberror($query);
+    if ($oe) {
+        $trans_id = undef;
+        $oe_id = $id;
+    }
+    else {
+         $trans_id = $id;
+         $oe_id = undef;
+    }
+
+    $sth->execute(
+        $trans_id,
+        $oe_id,
+        $self->{locationid}
+    ) || $self->dberror($query);
 
     $sth->finish;
-
-
-
 }
 
 =item $form->get_shipto ($location_id)
@@ -1780,19 +1818,20 @@ sub get_name {
     my ( $self, $myconfig, $table, $transdate, $entity_class) = @_;
 
     if (!$entity_class){
-       if ($table eq 'customer'){
-           $entity_class = 2;
-       } elsif ($table eq 'vendor') {
-           $entity_class = 1;
-       }
+        if ($table eq 'customer') {
+            $entity_class = 2;
+        }
+        elsif ($table eq 'vendor') {
+            $entity_class = 1;
+        }
     }
+
     my @queryargs;
     my $where;
     if ($transdate) {
         $where = qq|
             AND (c.startdate IS NULL OR c.startdate <= ?)
                     AND (c.enddate IS NULL OR c.enddate >= ?)|;
-
         @queryargs = ( $transdate, $transdate );
     }
 
@@ -1800,8 +1839,9 @@ sub get_name {
     if ($table !~ /^(vendor|customer|employee)$/i) {
         $self->error('Invalid name source');
     }
+
     # Company name is stored in $self->{vendor} or $self->{customer}
-    if ($self->{"${table}number"} eq ''){
+    if ($self->{"${table}number"} eq '') {
         $self->{"${table}number"} = $self->{$table};
     }
 
@@ -1879,9 +1919,10 @@ sub all_vc {
     my $ref;
     my $table;
 
-    if ($module eq 'AR'){
+    if ($module eq 'AR') {
         $table = 'ar';
-    } elsif ($module eq 'AP'){
+    }
+    elsif ($module eq 'AP'){
         $table = 'ap';
     }
 
@@ -1893,12 +1934,14 @@ sub all_vc {
     $sth->execute('vclimit');
     ($myconfig->{vclimit}) = $sth->fetchrow_array();
 
-    if ($vc eq 'customer'){
+    if ($vc eq 'customer') {
         $self->{vc_class} = 2;
-    } else {
+    }
+    else {
         $self->{vc_class} = 1;
         $vc = 'vendor';
     }
+
     my $query = qq|SELECT count(*) FROM entity_credit_account ec
         where ec.entity_class = ?|;
     my $where;
@@ -1912,7 +1955,8 @@ sub all_vc {
             AND ec.entity_class = ?|;
         push (@queryargs, $transdate, $transdate, $self->{vc_class});
         push (@queryargs2, $transdate, $transdate);
-    } else {
+    }
+    else {
         $where = " true";
     }
 
@@ -1968,7 +2012,6 @@ sub all_vc {
         }
 
         $sth->finish;
-
     }
 
     # get self
@@ -2031,7 +2074,7 @@ sub all_accounts {
     $self->{all_accounts} = [];
     my $sth = $self->{dbh}->prepare('SELECT * FROM chart_list_all()');
     $sth->execute || $self->dberror('SELECT * FROM chart_list_all()');
-    while ($ref = $sth->fetchrow_hashref('NAME_lc')){
+    while ($ref = $sth->fetchrow_hashref('NAME_lc')) {
         push(@{$self->{all_accounts}}, $ref);
     }
     $sth->finish;
@@ -2052,7 +2095,7 @@ $myconfig and $dbh2 are unused.
 
 sub all_taxaccounts {
 
-    my ( $self, $myconfig, $dbh2, $transdate ) = @_;
+    my ($self, $myconfig, $dbh2, $transdate) = @_;
 
     my $dbh = $self->{dbh};
 
@@ -2067,7 +2110,7 @@ sub all_taxaccounts {
         push( @queryargs, $transdate );
     }
 
-    if ( $self->{taxaccounts} ) {
+    if ($self->{taxaccounts}) {
 
         # rebuild tax rates
         $query = qq|SELECT t.rate, t.taxnumber
@@ -2101,7 +2144,7 @@ $dbh2 is unused.
 
 sub all_employees {
 
-    my ( $self, $myconfig, $dbh2, $transdate, $sales ) = @_;
+    my ($self, $myconfig, $dbh2, $transdate, $sales) = @_;
 
     my $dbh       = $self->{dbh};
     my @whereargs = ();
@@ -2131,7 +2174,7 @@ sub all_employees {
     my $sth = $dbh->prepare($query);
     $sth->execute(@whereargs) || $self->dberror($query);
 
-    while ( my $ref = $sth->fetchrow_hashref('NAME_lc') ) {
+    while (my $ref = $sth->fetchrow_hashref('NAME_lc')) {
         push @{ $self->{all_employee} }, $ref;
     }
 
@@ -2153,29 +2196,28 @@ sub all_business_units {
     $self->{bu_class} = [];
     $self->{b_units} = {};
 
-    my $dbh       = $self->{dbh};
+    my $dbh = $self->{dbh};
     my $class_sth = $dbh->prepare(
-                q|SELECT * FROM business_unit__list_classes('1', ?)|
+        q|SELECT * FROM business_unit__list_classes('1', ?)|
     );
     $class_sth->execute($module_name)
         || $self->dberror(q|SELECT * FROM business_unit__list_classes('1', ?)|);
 
-    my $bu_sth    = $dbh->prepare(
-                q|SELECT * FROM business_unit__list_by_class(?, ?, ?, 'false')|
+    my $bu_sth = $dbh->prepare(
+        q|SELECT * FROM business_unit__list_by_class(?, ?, ?, 'false')|
     );
 
-    while (my $classref = $class_sth->fetchrow_hashref('NAME_lc')){
+    while (my $classref = $class_sth->fetchrow_hashref('NAME_lc')) {
         push @{$self->{bu_class}}, $classref;
         $bu_sth->execute($classref->{id}, $transdate, $credit_id)
             || $self->dberror(q|SELECT * FROM business_unit__list_by_class(?, ?, ?, 'false')|);
         $self->{b_units}->{$classref->{id}} = [];
-        while (my $buref = $bu_sth->fetchrow_hashref('NAME_lc')){
-           push @{$self->{b_units}->{$classref->{id}}}, $buref;
+        while (my $buref = $bu_sth->fetchrow_hashref('NAME_lc')) {
+            push @{$self->{b_units}->{$classref->{id}}}, $buref;
         }
     }
     $class_sth->finish;
     $bu_sth->finish;
-
 }
 
 =item $form->all_languages($myconfig);
@@ -2187,7 +2229,7 @@ languages using the form {'code' => code, 'description' => description}.
 
 sub all_languages {
 
-    my ( $self ) = @_;
+    my ($self) = @_;
 
     my $dbh = $self->{dbh};
 
@@ -2201,7 +2243,7 @@ sub all_languages {
 
     $self->{all_language} = [];
 
-    while ( my $ref = $sth->fetchrow_hashref('NAME_lc') ) {
+    while (my $ref = $sth->fetchrow_hashref('NAME_lc')) {
         push @{ $self->{all_language} }, $ref;
     }
 
@@ -2220,7 +2262,7 @@ $dbh2 is unused.
 
 sub all_years {
 
-    my ( $self, $myconfig ) = @_;
+    my ($self, $myconfig) = @_;
 
     my $dbh = $self->{dbh};
     $self->{all_years} = [];
@@ -2231,8 +2273,8 @@ sub all_years {
 
     my $sth = $dbh->prepare($query);
     $sth->execute();
-    while (my ($year) = $sth->fetchrow_array()){
-      push @{$self->{all_years}}, $year;
+    while (my ($year) = $sth->fetchrow_array()) {
+        push @{$self->{all_years}}, $year;
     }
 
     #this should probably be changed to use locale
@@ -2250,7 +2292,6 @@ sub all_years {
         '11' => 'November',
         '12' => 'December'
     );
-
 }
 
 =item $form->create_links( { module => $module,
@@ -2301,7 +2342,7 @@ sub create_links {
     my $job = $args{job};
 
     # get last customers or vendors
-    my ( $query, $sth );
+    my ($query, $sth);
 
     if (!$self->{dbh}) {
         $self->db_init($myconfig);
@@ -2345,9 +2386,9 @@ sub create_links {
 
         push(@$link,"${module}_tax") if $tax_accounts{$ref->{accno}};
 
-        foreach my $key ( @$link ) {
+        foreach my $key (@$link) {
 
-            if ( $key =~ /$module/ ) {
+            if ($key =~ /$module/) {
 
                 # cross reference for keys
                 $xkeyref{ $ref->{accno} } = $key;
@@ -2370,7 +2411,7 @@ sub create_links {
     $vc = 'vendor' unless $vc eq 'customer';
     my $seq = ( $vc eq 'customer' ) ? 'a.setting_sequence'
                                     : 'NULL as setting_sequence';
-    if ( $self->{id} ) {
+    if ($self->{id}) {
 
         $query = qq|
             SELECT a.invnumber, a.transdate,
@@ -2404,11 +2445,11 @@ sub create_links {
         $ref = $sth->fetchrow_hashref('NAME_lc');
         $self->db_parse_numeric(sth=>$sth, hashref=>$ref);
 
-        if (!defined $ref->{approved}){
+        if (!defined $ref->{approved}) {
            $ref->{approved} = 0;
         }
 
-        foreach my $key ( keys %$ref ) {
+        foreach my $key (keys %$ref) {
             $self->{$key} = $ref->{$key};
         }
 
@@ -2420,7 +2461,7 @@ sub create_links {
             FROM status s WHERE s.trans_id = ?|;
         $sth = $dbh->prepare($query);
         $sth->execute( $self->{id} ) || $self->dberror($query);
-        while ( $ref = $sth->fetchrow_hashref('NAME_lc') ) {
+        while ($ref = $sth->fetchrow_hashref('NAME_lc')) {
             $self->{printed} .= "$ref->{formname} "
               if $ref->{printed};
             $self->{emailed} .= "$ref->{formname} "
@@ -2429,7 +2470,10 @@ sub create_links {
               if $ref->{spoolfile};
         }
         $sth->finish;
-        for (qw(printed emailed queued)) { $self->{$_} =~ s/ +$//g }
+
+        for (qw(printed emailed queued)) {
+            $self->{$_} =~ s/ +$//g
+        }
 
     # get customer e-mail accounts
     $query = qq|SELECT * FROM eca__list_contacts(?)
@@ -2438,31 +2482,39 @@ sub create_links {
                 SELECT * FROM entity__list_contacts(?)
                       WHERE class_id BETWEEN 12 AND ?
                       ORDER BY class_id DESC|;
-    my %id_map = ( 12 => 'email',
-               13 => 'cc',
-               14 => 'bcc',
-               15 => 'email',
-               16 => 'cc',
-               17 => 'bcc' );
+    my %id_map = (
+        12 => 'email',
+        13 => 'cc',
+        14 => 'bcc',
+        15 => 'email',
+        16 => 'cc',
+        17 => 'bcc'
+    );
     $sth = $dbh->prepare($query);
     my $max_class = ($billing) ? 17 : 14;
-    $sth->execute( $self->{entity_credit_account}, $max_class,
-                   $self->{entity_id}, $max_class)
-                   || $self->dberror( $query );
+    $sth->execute(
+        $self->{entity_credit_account},
+        $max_class,
+        $self->{entity_id},
+        $max_class
+    ) || $self->dberror($query);
 
     my $ctype;
     my $billing_email = 0;
-    while ( $ref = $sth->fetchrow_hashref('NAME_lc') ) {
+
+    while ($ref = $sth->fetchrow_hashref('NAME_lc')) {
         $ctype = $ref->{class_id};
         $ctype = $id_map{$ctype};
         $billing_email = 1
-        if $ref->{class_id} == 15;
+            if $ref->{class_id} == 15;
 
         # If there's an explicit billing email, don't use
         # the standard email addresses; otherwise fall back to standard
         $self->{$ctype} .= ($self->{$ctype} ? ", " : "") . $ref->{contact}
-        if (($ref->{class_id} < 15 && ! $billing_email)
-            || $ref->{class_id} >= 15);
+            if (
+                ($ref->{class_id} < 15 && ! $billing_email)
+                || $ref->{class_id} >= 15
+            );
     }
     $sth->finish;
 
@@ -2487,22 +2539,30 @@ sub create_links {
         $sth = $dbh->prepare($query);
         $sth->execute( $self->{id} ) || $self->dberror($query);
 
-        my $fld = ( $vc eq 'customer' ) ? 'buy' : 'sell';
+        my $fld = ($vc eq 'customer') ? 'buy' : 'sell';
 
-        $self->{exchangerate} =
-          $self->get_exchangerate( $dbh, $self->{currency}, $self->{transdate},
-            $fld );
+        $self->{exchangerate} = $self->get_exchangerate(
+            $dbh,
+            $self->{currency},
+            $self->{transdate},
+            $fld
+        );
 
         # store amounts in {acc_trans}{$key} for multiple accounts
-        while ( my $ref = $sth->fetchrow_hashref('NAME_lc') ) {
+        while (my $ref = $sth->fetchrow_hashref('NAME_lc')) {
             $self->db_parse_numeric(sth=>$sth, hashref=>$ref);#tshvr
-            for my $aref (@{$ref->{bu_lines}}){
+
+            for my $aref (@{$ref->{bu_lines}}) {
                 $ref->{"b_unit_$aref->[0]"} = $aref->[1];
             }
-            $ref->{exchangerate} =
-              $self->get_exchangerate( $dbh, $self->{currency},
-                $ref->{transdate}, $fld );
-            if ($self->{reverse}){
+            $ref->{exchangerate} = $self->get_exchangerate(
+                $dbh,
+                $self->{currency},
+                $ref->{transdate},
+                $fld
+            );
+
+            if ($self->{reverse}) {
                 $ref->{amount} *= -1;
             }
 
@@ -2510,23 +2570,29 @@ sub create_links {
         }
 
         $sth->finish;
-
-
     }
     else {
 
-        if ( !$self->{"$self->{vc}_id"} ) {
-            $self->lastname_used( $myconfig, $dbh, $vc, $module );
+        if (!$self->{"$self->{vc}_id"}) {
+            $self->lastname_used(
+                $myconfig,
+                $dbh,
+                $vc,
+                $module
+            );
         }
     }
+
     for (qw(separate_duties current_date curr closedto revtrans lock_description)) {
-        if ($_ eq 'closedto'){
+        if ($_ eq 'closedto') {
             $query = qq|
                 SELECT value::date FROM defaults
                  WHERE setting_key = '$_'|;
-        } elsif ($_ eq 'current_date') {
+        }
+        elsif ($_ eq 'current_date') {
             $query = qq| select $_|;
-        } else {
+        }
+        else {
             $query = qq|
                 SELECT value FROM defaults
                  WHERE setting_key = '$_'|;
@@ -2536,19 +2602,28 @@ sub create_links {
         $sth->execute || $self->dberror($query);
 
         ($val) = $sth->fetchrow_array();
-        if ( $_ eq 'curr' ) {
+        if ($_ eq 'curr') {
             $self->{currencies} = $val;
         }
         else {
             $self->{$_} = $val;
         }
+
         $sth->finish;
     }
-    if (!$self->{id} && !$self->{transdate}){
+
+    if (!$self->{id} && !$self->{transdate}) {
         $self->{transdate} = $self->{current_date};
     }
 
-    $self->all_vc( $myconfig, $vc, $module, $dbh, $self->{transdate}, $job );
+    $self->all_vc(
+        $myconfig,
+        $vc,
+        $module,
+        $dbh,
+        $self->{transdate},
+        $job
+    );
 }
 
 =item $form->get_setting($setting_name)
@@ -2590,21 +2665,23 @@ sub lastname_used {
     my $where;
     if ($vc eq 'customer') {
         $arap = 'ar';
-    } else {
+    }
+    else {
         $arap = 'ap';
         $vc = 'vendor';
     }
-    my $sth;
 
-    if ( $self->{type} =~ /_order/ ) {
+    my $sth;
+    if ($self->{type} =~ /_order/) {
         $arap  = 'oe';
         $where = "quotation = '0'";
     }
 
-    if ( $self->{type} =~ /_quotation/ ) {
+    if ($self->{type} =~ /_quotation/) {
         $arap  = 'oe';
         $where = "quotation = '1'";
     }
+
     $where = "AND $where " if $where;
     my $query = qq|
         SELECT entity.name, ct.curr AS currency, entity_id AS ${vc}_id,
@@ -2620,7 +2697,9 @@ sub lastname_used {
     $sth->execute() || $self->dberror($query);
 
     my $ref = $sth->fetchrow_hashref('NAME_lc');
-    for ( keys %$ref ) { $self->{$_} = $ref->{$_} }
+    for (keys %$ref) {
+        $self->{$_} = $ref->{$_}
+    }
     $sth->finish;
 }
 
@@ -2649,22 +2728,27 @@ sub current_date {
         if ($thisdate =~ /\d\d\d\d-\d\d-\d\d/) {
             $dateformat = 'yyyy-mm-dd';
 
-        } else {
+        }
+        else {
             $dateformat = $myconfig->{dateformat};
-            if ( $myconfig->{dateformat} !~ /^y/ ) {
+
+            if ($myconfig->{dateformat} !~ /^y/) {
                 my @a = split /\D/, $thisdate;
                 $dateformat .= "yy" if ( length $a[2] > 2 );
             }
 
-            if ( $thisdate !~ /\D/ ) {
+            if ($thisdate !~ /\D/) {
                 $dateformat = 'yyyymmdd';
             }
         }
 
         $query = qq|SELECT (to_date(?, ?)
                 + ?::interval)::date AS thisdate|;
-        @queryargs = ( $thisdate, $dateformat, sprintf('%d days', $days) );
-
+        @queryargs = (
+            $thisdate,
+            $dateformat,
+            sprintf('%d days', $days)
+        );
     }
     else {
         $query     = qq|SELECT current_date AS thisdate|;
@@ -2709,26 +2793,29 @@ between $count + 1 and $numrows is deleted.
 
 sub redo_rows {
 
-    my ( $self, $flds, $new, $count, $numrows ) = @_;
-
+    my ($self, $flds, $new, $count, $numrows) = @_;
     my @ndx = ();
 
-    for ( 1 .. $count ) {
+    for (1 .. $count) {
         push @ndx, { num => $new->[ $_ - 1 ]->{runningnumber}, ndx => $_ };
     }
 
     my $i = 0;
 
     # fill rows
-    foreach my $item ( sort { $a->{num} <=> $b->{num} } @ndx ) {
+    foreach my $item (sort { $a->{num} <=> $b->{num} } @ndx) {
         $i++;
         my $j = $item->{ndx} - 1;
-        for ( @{$flds} ) { $self->{"${_}_$i"} = $new->[$j]->{$_} }
+        for (@{$flds}) {
+            $self->{"${_}_$i"} = $new->[$j]->{$_}
+        }
     }
 
     # delete empty rows
-    foreach my $i ( $count + 1 .. $numrows ) {
-        for ( @{$flds} ) { delete $self->{"${_}_$i"} }
+    foreach my $i ($count + 1 .. $numrows) {
+        for (@{$flds}) {
+            delete $self->{"${_}_$i"}
+        }
     }
 }
 
@@ -2753,7 +2840,6 @@ $myconfig is unused.
 sub get_partsgroup {
 
     my ( $self, $myconfig, $p ) = @_;
-
     my $dbh = $self->{dbh};
 
     my $query = qq|SELECT DISTINCT pg.id, pg.partsgroup
@@ -2763,27 +2849,32 @@ sub get_partsgroup {
     my $where;
     my $sortorder = "partsgroup";
 
-    if ( $p->{searchitems} eq 'part' ) {
+    if ($p->{searchitems} eq 'part') {
         $where = qq| WHERE (p.inventory_accno_id > 0
                        AND p.income_accno_id > 0)|;
-    } elsif ( $p->{searchitems} eq 'service' ) {
+    }
+    elsif ($p->{searchitems} eq 'service') {
         $where = qq| WHERE p.inventory_accno_id IS NULL|;
-    } elsif ( $p->{searchitems} eq 'assembly' ) {
+    }
+    elsif ($p->{searchitems} eq 'assembly') {
         $where = qq| WHERE p.assembly = '1'|;
-    } elsif ( $p->{searchitems} eq 'labor' ) {
+    }
+    elsif ($p->{searchitems} eq 'labor') {
         $where =
           qq| WHERE p.inventory_accno_id > 0 AND p.income_accno_id IS NULL|;
-    } elsif ( $p->{searchitems} eq 'nolabor' ) {
+    }
+    elsif ($p->{searchitems} eq 'nolabor') {
         $where = qq| WHERE p.income_accno_id > 0|;
     }
 
-    if ( $p->{all} ) {
+    if ($p->{all}) {
         $query = qq|SELECT id, partsgroup
                       FROM partsgroup|;
     }
+
     my @queryargs = ();
 
-    if ( $p->{language_code} ) {
+    if ($p->{language_code}) {
         $sortorder = "translation";
 
         $query = qq|
@@ -2793,7 +2884,9 @@ sub get_partsgroup {
             JOIN parts p ON (p.partsgroup_id = pg.id)
             LEFT JOIN translation t ON (t.trans_id = pg.id
                 AND t.language_code = ?)|;
-        @queryargs = ( $p->{language_code} );
+        @queryargs = (
+            $p->{language_code}
+        );
     }
 
     $query .= qq| $where ORDER BY $sortorder|;
@@ -2803,7 +2896,7 @@ sub get_partsgroup {
 
     $self->{all_partsgroup} = ();
 
-    while ( my $ref = $sth->fetchrow_hashref('NAME_lc') ) {
+    while (my $ref = $sth->fetchrow_hashref('NAME_lc')) {
         push @{ $self->{all_partsgroup} }, $ref;
     }
 
@@ -2825,7 +2918,7 @@ $myconfig is unused.
 
 sub update_status {
 
-    my ( $self, $myconfig, $commit ) = @_;
+    my ($self, $myconfig, $commit) = @_;
 
     # no id return
     return unless $self->{id};
@@ -2843,7 +2936,10 @@ sub update_status {
                       AND trans_id = ?|;
 
     my $sth = $dbh->prepare($query);
-    $sth->execute( $self->{formname}, $self->{id} ) || $self->dberror($query);
+    $sth->execute(
+        $self->{formname},
+        $self->{id}
+    ) || $self->dberror($query);
 
     $sth->finish;
 
@@ -2858,8 +2954,14 @@ sub update_status {
         VALUES (?, ?, ?, ?, ?)|;
 
     $sth = $dbh->prepare($query);
-    $sth->execute( $self->{id}, $printed, $emailed, $spoolfile,
-        $self->{formname} ) || $self->dberror($query);
+    $sth->execute(
+        $self->{id},
+        $printed,
+        $emailed,
+        $spoolfile,
+        $self->{formname}
+    ) || $self->dberror($query);
+
     $sth->finish;
 }
 
@@ -2875,9 +2977,7 @@ printed, and emailed fields are space separated lists.
 sub save_status {
 
     my ($self) = @_;
-
     my $dbh = $self->{dbh};
-
 
     my $formnames  = $self->{printed};
     my $emailforms = $self->{emailed};
@@ -2886,25 +2986,26 @@ sub save_status {
                     WHERE trans_id = ?|;
 
     my $sth = $dbh->prepare($query);
-    $sth->execute( $self->{id} ) || $self->dberror($query);
+    $sth->execute(
+        $self->{id}
+    ) || $self->dberror($query);
     $sth->finish;
 
     my %queued;
     my $formname;
-
     my $printed;
     my $emailed;
 
-    if ( $self->{queued} ) {
+    if ($self->{queued}) {
 
         %queued = split / +/, $self->{queued};
 
-        foreach my $formname ( keys %queued ) {
+        foreach my $formname (keys %queued) {
 
             $printed = ( $self->{printed} =~ /$formname/ ) ? "1" : "0";
             $emailed = ( $self->{emailed} =~ /$formname/ ) ? "1" : "0";
 
-            if ( $queued{$formname} ) {
+            if ($queued{$formname}) {
                 $query = qq|
                     INSERT INTO status
                         (trans_id, printed, emailed,
@@ -2912,15 +3013,18 @@ sub save_status {
                     VALUES (?, ?, ?, ?, ?)|;
 
                 $sth = $dbh->prepare($query);
-                $sth->execute( $self->{id}, $printed, $emailed,
-                    $queued{$formname}, $formname )
-                  || $self->dberror($query);
+                $sth->execute(
+                    $self->{id},
+                    $printed,
+                    $emailed,
+                    $queued{$formname},
+                    $formname
+                ) || $self->dberror($query);
                 $sth->finish;
             }
 
             $formnames  =~ s/$formname//;
             $emailforms =~ s/$formname//;
-
         }
     }
 
@@ -2929,10 +3033,15 @@ sub save_status {
     $emailforms =~ s/^ +//g;
 
     my %status = ();
-    for ( split / +/, $formnames )  { $status{$_}{printed} = 1 }
-    for ( split / +/, $emailforms ) { $status{$_}{emailed} = 1 }
+    for (split / +/, $formnames) {
+        $status{$_}{printed} = 1
+    }
 
-    foreach my $formname ( keys %status ) {
+    for (split / +/, $emailforms) {
+        $status{$_}{emailed} = 1
+    }
+
+    foreach my $formname (keys %status) {
         $printed = ( $formnames  =~ /$self->{formname}/ ) ? "1" : "0";
         $emailed = ( $emailforms =~ /$self->{formname}/ ) ? "1" : "0";
 
@@ -2942,7 +3051,12 @@ sub save_status {
             VALUES (?, ?, ?, ?)|;
 
         $sth = $dbh->prepare($query);
-        $sth->execute( $self->{id}, $printed, $emailed, $formname );
+        $sth->execute(
+            $self->{id},
+            $printed,
+            $emailed,
+            $formname
+        );
         $sth->finish;
     }
 }
@@ -2976,50 +3090,63 @@ sub get_recurring {
         WHERE s.id = ?/;
 
     my $sth = $dbh->prepare($query);
-    $sth->execute( $self->{id} ) || $self->dberror($query);
+    $sth->execute(
+        $self->{id}
+    ) || $self->dberror($query);
 
-    for (qw(email print)) { $self->{"recurring$_"} = "" }
+    for (qw(email print)) {
+        $self->{"recurring$_"} = ""
+    }
 
-    while ( my $ref = $sth->fetchrow_hashref('NAME_lc') ) {
-        for ( keys %$ref ) { $self->{"recurring$_"} = $ref->{$_} }
+    while (my $ref = $sth->fetchrow_hashref('NAME_lc')) {
+
+        for (keys %$ref) {
+            $self->{"recurring$_"} = $ref->{$_}
+        }
+
         $self->{recurringemail} .= "$ref->{emaila}:";
         $self->{recurringprint} .= "$ref->{printa}:";
-        for (qw(emaila printa)) { delete $self->{"recurring$_"} }
+
+        for (qw(emaila printa)) {
+            delete $self->{"recurring$_"}
+        }
     }
 
     $sth->finish;
     chop $self->{recurringemail};
     chop $self->{recurringprint};
 
-    if ( $self->{recurringyears} ) {
+    if ($self->{recurringyears}) {
         $self->{recurringunit} = 'years';
         $self->{recurringrepeat} = $self->{recurringyears};
     }
-    elsif ( $self->{recurringmonths} ) {
+    elsif ($self->{recurringmonths}) {
         $self->{recurringunit} = 'months';
         $self->{recurringrepeat} = $self->{recurringmonths};
     }
-    elsif ( $self->{recurringdays} && ( $self->{recurringdays} % 7 == 0 ) ) {
+    elsif ($self->{recurringdays} && ( $self->{recurringdays} % 7 == 0 )) {
         $self->{recurringunit} = 'weeks';
         $self->{recurringrepeat} = $self->{recurringdays} / 7;
     }
-    elsif ( $self->{recurringdays} ) {
+    elsif ($self->{recurringdays}) {
         $self->{recurringunit} = 'days';
         $self->{recurringrepeat} = $self->{recurringdays};
     }
 
-    if ( $self->{recurringstartdate} ) {
+    if ($self->{recurringstartdate}) {
 
-        $self->{recurringreference} =
-          $self->escape( $self->{recurringreference}, 1 );
-        $self->{recurringmessage} =
-          $self->escape( $self->{recurringmessage}, 1 );
+        $self->{recurringreference} = $self->escape(
+            $self->{recurringreference},
+            1
+        );
+        $self->{recurringmessage} = $self->escape(
+            $self->{recurringmessage},
+            1
+        );
         for (
             qw(reference startdate repeat unit howmany
             payment print email message)
-          )
-        {
-
+        ) {
             $self->{recurring} .= qq|$self->{"recurring$_"},|;
         }
 
@@ -3093,31 +3220,35 @@ $dbh2 is not used.
 
 sub save_recurring {
 
-    my ( $self, $dbh2, $myconfig, $is_oe) = @_;
-
+    my ($self, $dbh2, $myconfig, $is_oe) = @_;
     my $dbh = $self->{dbh};
-
     my $query;
 
     $query = qq|DELETE FROM recurringemail
                  WHERE id = ?|;
 
     my $sth = $dbh->prepare($query) || $self->dberror($query);
-    $sth->execute( $self->{id} ) || $self->dberror($query);
+    $sth->execute(
+        $self->{id}
+    ) || $self->dberror($query);
 
     $query = qq|DELETE FROM recurringprint
                  WHERE id = ?|;
 
     $sth = $dbh->prepare($query) || $self->dberror($query);
-    $sth->execute( $self->{id} ) || $self->dberror($query);
+    $sth->execute(
+        $self->{id}
+    ) || $self->dberror($query);
 
     $query = qq|DELETE FROM recurring
                  WHERE id = ?|;
 
     $sth = $dbh->prepare($query) || $self->dberror($query);
-    $sth->execute( $self->{id} ) || $self->dberror($query);
+    $sth->execute(
+        $self->{id}
+    ) || $self->dberror($query);
 
-    if ( $self->{recurring} ) {
+    if ($self->{recurring}) {
 
         my %s = ();
         (
@@ -3126,23 +3257,33 @@ sub save_recurring {
             $s{print},     $s{email},     $s{message}
         ) = split /,/, $self->{recurring};
 
-        if ($s{unit} !~ /^(day|week|month|year)s?$/i){
+        if ($s{unit} !~ /^(day|week|month|year)s?$/i) {
             $dbh->rollback;
             $self->error("Invalid recurrence unit");
         }
-        if ($s{howmany} == 0){
+
+        if ($s{howmany} == 0) {
             $self->error("Cannot set to recur 0 times");
         }
 
-        for (qw(reference message)) { $s{$_} = $self->unescape( $s{$_} ) }
-        for (qw(repeat howmany payment)) { $s{$_} *= 1 }
+        for (qw(reference message)) {
+            $s{$_} = $self->unescape($s{$_})
+        }
+
+        for (qw(repeat howmany payment)) {
+            $s{$_} *= 1
+        }
 
         # calculate enddate
-        my $advance = $s{repeat} * ( $s{howmany} - 1 );
+        my $advance = $s{repeat} * ($s{howmany} - 1);
 
         $query = qq|SELECT (?::date + interval '$advance $s{unit}')|;
 
-        my ($enddate) = $dbh->selectrow_array($query, undef, $s{startdate});
+        my ($enddate) = $dbh->selectrow_array(
+            $query,
+            undef,
+            $s{startdate}
+        );
 
         # calculate nextdate
         $query = qq|
@@ -3150,10 +3291,13 @@ sub save_recurring {
                 ?::date - current_date AS b|;
 
         $sth = $dbh->prepare($query) || $self->dberror($query);
-        $sth->execute( $s{startdate}, $enddate ) || $self->dberror($query);
-        my ( $a, $b ) = $sth->fetchrow_array;
+        $sth->execute(
+            $s{startdate},
+            $enddate
+        ) || $self->dberror($query);
+        my ($a, $b) = $sth->fetchrow_array;
 
-        if ( $a + $b ) {
+        if ($a + $b) {
             $advance =
               int( ( $a / ( $a + $b ) ) * ( $s{howmany} - 1 ) + 1 ) *
               $s{repeat};
@@ -3163,26 +3307,27 @@ sub save_recurring {
         }
 
         my $nextdate = $enddate;
-        if ( $advance > 0 ) {
-            if ( $advance < ( $s{repeat} * $s{howmany} ) ) {
-
+        if ($advance > 0) {
+            if ($advance < ($s{repeat} * $s{howmany})) {
                 $query = qq|SELECT (?::date + interval '$advance $s{unit}')|;
-
-                ($nextdate) = $dbh->selectrow_array($query, undef, $s{startdate}) || $self->dberror($query);
+                ($nextdate) = $dbh->selectrow_array(
+                    $query,
+                    undef,
+                    $s{startdate}
+                ) || $self->dberror($query);
             }
-
         }
         else {
             $nextdate = $s{startdate};
         }
 
-        if ( $self->{recurringnextdate} ) {
+        if ($self->{recurringnextdate}) {
 
             $nextdate = $self->{recurringnextdate};
 
             $query = qq|SELECT ?::date - ?::date|;
 
-            if ( $dbh->selectrow_array($query, undef, $enddate, $nextdate) < 0 ) {
+            if ($dbh->selectrow_array($query, undef, $enddate, $nextdate) < 0) {
                 undef $nextdate;
             }
         }
@@ -3197,9 +3342,13 @@ sub save_recurring {
 
         $sth = $dbh->prepare($query) || $self->dberror($query);
         $sth->execute(
-            $self->{id}, $s{startdate},
-            $enddate,    $nextdate,     "$s{repeat} $s{unit}",
-            $s{howmany},   $s{payment}
+            $self->{id},
+            $s{startdate},
+            $enddate,
+            $nextdate,
+            "$s{repeat} $s{unit}",
+            $s{howmany},
+            $s{payment}
         ) || $self->dberror($query);
 
         my @p;
@@ -3207,7 +3356,7 @@ sub save_recurring {
         my $i;
         my $sth;
 
-        if ( $s{email} ) {
+        if ($s{email}) {
 
             # formname:format
             @p = split /:/, $s{email};
@@ -3218,15 +3367,19 @@ sub save_recurring {
 
             $sth = $dbh->prepare($query) || $self->dberror($query);
 
-            for ( $i = 0 ; $i <= $#p ; $i += 2 ) {
-                $sth->execute( $self->{id}, $p[$i], $p[ $i + 1 ], $s{message} )
-                    || $self->dberror($query);
+            for ($i = 0 ; $i <= $#p ; $i += 2) {
+                $sth->execute(
+                    $self->{id},
+                    $p[$i],
+                    $p[ $i + 1 ],
+                    $s{message}
+                ) || $self->dberror($query);
             }
 
             $sth->finish;
         }
 
-        if ( $s{print} ) {
+        if ($s{print}) {
 
             # formname:format:printer
             @p = split /:/, $s{print};
@@ -3237,16 +3390,19 @@ sub save_recurring {
 
             $sth = $dbh->prepare($query) || $self->dberror($query);
 
-            for ( $i = 0 ; $i <= $#p ; $i += 3 ) {
-                $p = ( $p[ $i + 2 ] ) ? $p[ $i + 2 ] : "";
-                $sth->execute( $self->{id}, $p[$i], $p[ $i + 1 ], $p )
-                    || $self->dberror($query);
+            for ($i = 0; $i <= $#p; $i += 3) {
+                $p = ($p[ $i + 2 ]) ? $p[ $i + 2 ] : "";
+                $sth->execute(
+                    $self->{id},
+                    $p[$i],
+                    $p[ $i + 1 ],
+                    $p
+                ) || $self->dberror($query);
             }
 
             $sth->finish;
         }
     }
-
 }
 
 
@@ -3261,7 +3417,7 @@ Does nothing if $form->{id} is not set.
 
 sub save_intnotes {
 
-    my ( $self, $myconfig, $vc ) = @_;
+    my ($self, $myconfig, $vc) = @_;
 
     # no id return
     return unless $self->{id};
@@ -3271,7 +3427,10 @@ sub save_intnotes {
     my $query = qq|UPDATE $vc SET intnotes = ? WHERE id = ?|;
 
     my $sth = $dbh->prepare($query);
-    $sth->execute( $self->{intnotes}, $self->{id} ) || $self->dberror($query);
+    $sth->execute(
+        $self->{intnotes},
+        $self->{id}
+    ) || $self->dberror($query);
 }
 
 =item $form->update_defaults($myconfig, $fld[, $dbh [, $nocommit]);
@@ -3312,10 +3471,12 @@ Replace <?lsmb curr ?> with the value of $form->{currency}
 
 sub update_defaults {
 
-    my ( $self, $myconfig, $fld,$dbh_parm,$nocommit) = @_;
-    if ($self->{setting_sequence}){
+    my ($self, $myconfig, $fld, $dbh_parm, $nocommit) = @_;
+    if ($self->{setting_sequence}) {
         return LedgerSMB::Setting::Sequence->increment(
-              $self->{setting_sequence}, $self);
+              $self->{setting_sequence},
+              $self
+        );
     }
 
     my $dbh = LedgerSMB::App_State::DBH;
@@ -3342,12 +3503,12 @@ sub update_defaults {
     my $num = $_;
     ($num) = $num =~ /\D*(\d+)\D*$/;
 
-    if ( defined $num ) {
+    if (defined $num) {
         my $incnum;
 
         # if we have leading zeros check how long it is
 
-        if ( $num =~ /^0/ ) {
+        if ($num =~ /^0/) {
             my $l = length $num;
             $incnum = $num + 1;
             $l -= length $incnum;
@@ -3377,7 +3538,7 @@ sub update_defaults {
             $param = $1;
             $str   = "";
 
-            if ( $param =~ /<\?lsmb date \?>/i ) {
+            if ($param =~ /<\?lsmb date \?>/i) {
                 $str = (
                     $self->split_date(
                         $myconfig->{dateformat},
@@ -3389,14 +3550,12 @@ sub update_defaults {
 
             if ( $param =~
 /<\?lsmb (name|business|description|item|partsgroup|phone|custom)/i
-              )
-            {
-            #SC: XXX hairy, undoc, possibly broken
-
+            ) {
+                #SC: XXX hairy, undoc, possibly broken
                 my $fld = lc $1;
 
-                if ( $fld =~ /name/ ) {
-                    if ( $self->{type} ) {
+                if ($fld =~ /name/) {
+                    if ($self->{type}) {
                         $fld = $self->{vc};
                     }
                 }
@@ -3406,12 +3565,11 @@ sub update_defaults {
                 my @p = split / /, $p;
                 my @n = split / /, uc $self->{$fld};
 
-                if ( $#p > 0 ) {
+                if ($#p > 0) {
 
-                    for ( my $i = 1 ; $i <= $#p ; $i++ ) {
-                        $str .= substr( $n[ $i - 1 ], 0, $p[$i] );
+                    for (my $i = 1; $i <= $#p; $i++) {
+                        $str .= substr($n[ $i - 1 ], 0, $p[$i]);
                     }
-
                 }
                 else {
                     ($str) = split /--/, $self->{$fld};
@@ -3421,21 +3579,26 @@ sub update_defaults {
                 $var =~ s/\W//g if $fld eq 'phone';
             }
 
-            if ( $param =~ /<\?lsmb (yy|mm|dd)/i ) {
-        # SC: XXX Does this even work anymore?
+            if ($param =~ /<\?lsmb (yy|mm|dd)/i) {
+                # SC: XXX Does this even work anymore?
                 my $p = $param;
                 $p =~ s/lsmb//;
                 $p =~ s/[^YyMmDd]//g;
                 my %d = ( yy => 1, mm => 2, dd => 3 );
                 my $str = $p;
 
-                my @a = $self->split_date( $myconfig->{dateformat},
-                    $self->{transdate} );
-                for my $k( keys %d ) { $str =~ s/$k/$a[ $d{$k} ]/i}
+                my @a = $self->split_date(
+                    $myconfig->{dateformat},
+                    $self->{transdate}
+                );
+
+                for my $k (keys %d) {
+                    $str =~ s/$k/$a[ $d{$k} ]/i
+                }
                 $var =~ s/\Q$param\E/$str/i;
             }
 
-            if ( $param =~ /<\?lsmb curr/i ) {
+            if ($param =~ /<\?lsmb curr/i) {
                 my $curr = $self->{currency} || $self->{curr};
                 $var =~ s/<\?lsmb curr \?>/$curr/i;
             }
@@ -3448,7 +3611,10 @@ sub update_defaults {
          WHERE setting_key = ?|;
 
     $sth = $self->{dbh}->prepare($query);
-    $sth->execute( $dbvar, $fld ) || $self->dberror($query);
+    $sth->execute(
+        $dbvar,
+        $fld
+    ) || $self->dberror($query);
 
     return $var;
 }
@@ -3465,14 +3631,17 @@ sub should_update_defaults {
     my $gapless_ar = LedgerSMB::Setting->get('gapless_ar');
     return 0 if $gapless_ar and ($fldname eq 'invnumber');
 
-    if (!$self->{$fldname}){
+    if (!$self->{$fldname}) {
        return 1;
     }
-    if (!$self->{setting_sequence}){
+
+    if (!$self->{setting_sequence}) {
         return 0;
     }
 
-    my $sequence = LedgerSMB::Setting::Sequence->get($self->{setting_sequence});
+    my $sequence = LedgerSMB::Setting::Sequence->get(
+        $self->{setting_sequence}
+    );
     return 1 unless $sequence->accept_input;
     return 0;
 }
@@ -3493,11 +3662,15 @@ sub update_invnumber {
     return if defined $invnumber or !$sth->rows;
     $sth->finish;
     $sth = $LedgerSMB::App_State::DBH->prepare(
-      'update ar set invnumber = ? where id = ?'
+        'update ar set invnumber = ? where id = ?'
     );
-    $sth->execute($self->update_defaults(
-                          $LedgerSMB::App_State::User, 'sinumber'
-                                        ), $self->{id});
+    $sth->execute(
+        $self->update_defaults(
+            $LedgerSMB::App_State::User,
+            'sinumber'
+        ),
+        $self->{id}
+    );
 }
 
 =item $form->db_prepare_vars(var1, var2, ..., varI<n>)
@@ -3511,7 +3684,7 @@ sub db_prepare_vars {
     my $self = shift;
 
     for (@_) {
-        if ( !$self->{$_} and $self->{$_} ne "0" ) {
+        if (!$self->{$_} and $self->{$_} ne "0") {
             undef $self->{$_};
         }
     }
@@ -3538,7 +3711,7 @@ sub split_date {
     my $yy;
     my $rv;
 
-    if ( !$date ) {
+    if (!$date) {
         my @d = localtime;
         $dd = $d[3];
         $mm = ++$d[4];
@@ -3546,14 +3719,15 @@ sub split_date {
         $mm = substr( "0$mm", -2 );
         $dd = substr( "0$dd", -2 );
     }
+
     $dateformat = 'yyyy-mm-dd' if $date =~ /\d{4}\D\d{2}\D\d{2}/;
 
-    if ( $dateformat =~ /^yy/ ) {
+    if ($dateformat =~ /^yy/) {
 
         if ($date) {
 
-            if ( $date =~ /\D/ ) {
-                ( $yy, $mm, $dd ) = split /\D/, $date;
+            if ($date =~ /\D/) {
+                ($yy, $mm, $dd) = split /\D/, $date;
                 $mm *= 1;
                 $dd *= 1;
                 $mm = substr( "0$mm", -2 );
@@ -3569,12 +3743,12 @@ sub split_date {
             $rv = "$yy$mm$dd";
         }
     }
-    elsif ( $dateformat =~ /^mm/ ) {
+    elsif ($dateformat =~ /^mm/) {
 
         if ($date) {
 
-            if ( $date =~ /\D/ ) {
-                ( $mm, $dd, $yy ) = split /\D/, $date;
+            if ($date =~ /\D/) {
+                ($mm, $dd, $yy) = split /\D/, $date;
                 $mm *= 1;
                 $dd *= 1;
                 $mm = substr( "0$mm", -2 );
@@ -3590,12 +3764,12 @@ sub split_date {
             $rv = "$mm$dd$yy";
         }
     }
-    elsif ( $dateformat =~ /^dd/ ) {
+    elsif ($dateformat =~ /^dd/) {
 
         if ($date) {
 
-            if ( $date =~ /\D/ ) {
-                ( $dd, $mm, $yy ) = split /\D/, $date;
+            if ($date =~ /\D/) {
+                ($dd, $mm, $yy) = split /\D/, $date;
                 $mm *= 1;
                 $dd *= 1;
                 $mm = substr( "0$mm", -2 );
@@ -3612,7 +3786,7 @@ sub split_date {
         }
     }
 
-    ( $rv, $yy, $mm, $dd );
+    ($rv, $yy, $mm, $dd);
 }
 
 =item $form->format_date($date);
@@ -3629,11 +3803,12 @@ year.
 sub format_date {
 
     # takes an iso date in, and converts it to the date for printing
-    my ( $self, $date ) = @_;
+    my ($self, $date) = @_;
     my $datestring;
-    if ( $date =~ /^\d{4}\D/ ) {    # is an ISO date
+
+    if ($date =~ /^\d{4}\D/) {    # is an ISO date
         $datestring = $self->{db_dateformat};
-        my ( $yyyy, $mm, $dd ) = split( /\W/, $date );
+        my ($yyyy, $mm, $dd) = split( /\W/, $date );
         $datestring =~ s/y+/$yyyy/;
         $datestring =~ s/mm/$mm/;
         $datestring =~ s/dd/$dd/;
@@ -3641,6 +3816,7 @@ sub format_date {
     else {                          # return date
         $datestring = $date;
     }
+
     return $datestring;
 }
 
@@ -3657,7 +3833,7 @@ This function dies horribly when $mm + $interval > 24
 
 sub from_to {
 
-    my ( $self, $yyyy, $mm, $interval ) = @_;
+    my ($self, $yyyy, $mm, $interval) = @_;
 
     $yyyy = 0 unless defined $yyyy;
     $mm = 0 unless defined $mm;
@@ -3667,19 +3843,19 @@ sub from_to {
     my $fromdate = "$yyyy-${mm}-01";
     my $bd       = 1;
 
-    if ( defined $interval ) {
+    if (defined $interval) {
 
-        if ( $interval == 12 ) {
+        if ($interval == 12) {
             $yyyy++;
         }
         else {
 
-            if ( ( $mm += $interval ) > 12 ) {
+            if (($mm += $interval) > 12) {
                 $mm -= 12;
                 $yyyy++;
             }
 
-            if ( $interval == 0 ) {
+            if ($interval == 0) {
                 @t    = localtime(time);
                 $dd   = $t[3];
                 $mm   = $t[4] + 1;
@@ -3691,14 +3867,14 @@ sub from_to {
     }
     else {
 
-        if ( ++$mm > 12 ) {
+        if (++$mm > 12) {
             $mm -= 12;
             $yyyy++;
         }
     }
 
     $mm--;
-    @t = localtime( Time::Local::timelocal( 0, 0, 0, $dd, $mm, $yyyy ) - $bd );
+    @t = localtime(Time::Local::timelocal( 0, 0, 0, $dd, $mm, $yyyy ) - $bd);
 
     $t[4]++;
     $t[4] = substr( "0$t[4]", -2 );
@@ -3706,7 +3882,7 @@ sub from_to {
     $t[5] += 1900;
 
 
-    return ( $fromdate, "$t[5]-$t[4]-$t[3]" );
+    return ($fromdate, "$t[5]-$t[4]-$t[3]");
 }
 
 
@@ -3715,22 +3891,24 @@ sub from_to {
 
 sub get_batch_control_code {
 
-    my ( $self, $dbh, $batch_id) = @_;
+    my ($self, $dbh, $batch_id) = @_;
 
     my ($query,$sth,$control);
 
 
-    if ( !$dbh ) {
+    if (!$dbh) {
         $dbh = $self->{dbh};
     }
 
-    $query=qq|select control_code from batch where id=?|;
-    $sth=$dbh->prepare($query) || $self->dberror($query);
-    $sth->execute($batch_id) || $self->dberror($query);
-    $control=$sth->fetchrow();
+    $query = qq|select control_code from batch where id=?|;
+    $sth = $dbh->prepare($query) || $self->dberror($query);
+    $sth->execute(
+        $batch_id
+    ) || $self->dberror($query);
+    $control = $sth->fetchrow();
     $sth->finish();
-    return $control;
 
+    return $control;
 }
 
 
@@ -3741,19 +3919,21 @@ sub get_batch_control_code {
 
 sub get_batch_description {
 
-    my ( $self, $dbh, $batch_id) = @_;
+    my ($self, $dbh, $batch_id) = @_;
 
     my ($query,$sth,$desc);
 
 
-    if ( !$dbh ) {
+    if (!$dbh) {
         $dbh = $self->{dbh};
     }
 
-    $query=qq|select description from batch where id=?|;
-    $sth=$dbh->prepare($query) || $self->dberror($query);
-    $sth->execute($batch_id) || $self->dberror($query);
-    $desc=$sth->fetchrow();
+    $query = qq|select description from batch where id=?|;
+    $sth = $dbh->prepare($query) || $self->dberror($query);
+    $sth->execute(
+        $batch_id
+    ) || $self->dberror($query);
+    $desc = $sth->fetchrow();
     $sth->finish();
     return $desc;
 
@@ -3772,17 +3952,20 @@ sub sequence_dropdown{
     my @sequences = LedgerSMB::Setting::Sequence->list($setting_key);
     my $retval = qq|<select name='setting_sequence' class='sequence'>\n|;
     $retval .= qq|<option></option>|;
-    for my $seq (@sequences){
+
+    for my $seq (@sequences) {
         my $selected = '';
         my $label = $seq->label;
         $selected = "selected='selected'"
             if $self->{setting_sequence} eq $label;
         $retval .= qq|<option value='$label' $selected>$label</option>\n|;
     }
+
     $retval .= "</select>";
     if (@sequences){
         return $retval;
-    } else {
+    }
+    else {
         return undef
     }
 }


### PR DESCRIPTION
There are two commits in this PR.
1) Whitespace changes only, confirmed by running cmp against new and old versions after stripping all whitespace.
2) Improvement to currency dropdown generation - simpler code, fixed warning and consistent display order.