### PR TITLE
Enable critic ProhibitIndirectSyntax Policy

### DIFF
--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -344,7 +344,7 @@ sub _get_password {
     my ($self) = shift @_;
     $self->{sessionexpired} = shift @_;
 
-    my $q = new CGI::Simple;
+    my $q = CGI::Simple->new;
     print $q->redirect('login.pl?action=logout&reason=timeout');
 }
 
@@ -391,7 +391,10 @@ sub _process_argstr {
     my ($self, $argstr) = @_;
 
     my %params=();
-    my $query = ($argstr) ? new CGI::Simple($argstr) : new CGI::Simple;
+
+    # Don't pass an empty string to CGI::Simple
+    my $query = ($argstr) ? CGI::Simple->new($argstr) : CGI::Simple->new;
+
     # my $params = $query->Vars; returns a tied hash with keys that
     # are not parameters of the CGI query.
     %params = $query->Vars;

--- a/lib/LedgerSMB/PGDate.pm
+++ b/lib/LedgerSMB/PGDate.pm
@@ -296,7 +296,7 @@ sub to_output {
     $fmt .= ' %T' if $self->is_time();
     $fmt =~ s/^\s+//;
 
-    my $formatter = new DateTime::Format::Strptime(
+    my $formatter = DateTime::Format::Strptime->new(
              pattern => $fmt,
               locale => 'en_US',
             on_error => 'croak',

--- a/lib/LedgerSMB/PGNumber.pm
+++ b/lib/LedgerSMB/PGNumber.pm
@@ -226,12 +226,12 @@ sub to_output {
     $places = 0 unless defined $places and ($places > 0);
     my $zfill = ($places > 0) ? 1 : 0;
     $dplaces = 5 unless defined $dplaces;
-    my $formatter = new Number::Format(
+    my $formatter = Number::Format->new(
         -thousands_sep => $lsmb_formats->{$format}->{thousands_sep},
         -decimal_point => $lsmb_formats->{$format}->{decimal_sep},
         -decimal_fill => $zfill,
         -neg_format => 'x'
-        );
+    );
     $str = $formatter->format_number($str, $dplaces);
 
     my $neg_format = ($args{neg_format}) ? $args{neg_format} : 'def';

--- a/lib/LedgerSMB/PGNumber.pm
+++ b/lib/LedgerSMB/PGNumber.pm
@@ -144,26 +144,27 @@ sub from_input {
         return $string if eval { $string->isa(__PACKAGE__) };
     }
     #tshvr4 avoid 'Use of uninitialized value $string in string eq'
-    if(!defined $string || $string eq ''){
-     return undef;
+    if (!defined $string || $string eq '') {
+        return undef;
     }
-    #$string = undef if $string eq '';
-    my %args   = (ref($_[0]) eq 'HASH')? %{$_[0]}: @_;
+    my %args   = (ref($_[0]) eq 'HASH') ? %{$_[0]} : @_;
     my $format = ($args{format}) ? $args{format}
-                              : $LedgerSMB::App_State::User->{numberformat};
+                                 : $LedgerSMB::App_State::User->{numberformat};
     die 'LedgerSMB::PGNumber No Format Set' if !$format;
     #return undef if !defined $string;
     my $negate;
     my $pgnum;
     my $newval;
     $negate = 1 if $string =~ /(^\(|DR$)/;
-    if ( UNIVERSAL::isa( $string, 'LedgerSMB::PGNumber' ) )
-    {
+
+    if (UNIVERSAL::isa($string, 'LedgerSMB::PGNumber')) {
         return $string;
     }
-    if (UNIVERSAL::isa( $string, 'LedgerSMB::PGNumber' ) ) {
+
+    if (UNIVERSAL::isa($string, 'LedgerSMB::PGNumber')) {
         $pgnum = $string;
-    } else {
+    }
+    else {
         my $formatter = Number::Format->new(
             -thousands_sep => $lsmb_formats->{$format}->{thousands_sep},
             -decimal_point => $lsmb_formats->{$format}->{decimal_sep},
@@ -172,6 +173,7 @@ sub from_input {
         $pgnum = LedgerSMB::PGNumber->new($newval);
         $self->round_mode('+inf');
     }
+
     bless $pgnum, $self;
     $pgnum->bmul(-1) if $negate;
     die 'LedgerSMB::PGNumber Invalid Number' if $pgnum->is_nan();

--- a/lib/LedgerSMB/PGNumber.pm
+++ b/lib/LedgerSMB/PGNumber.pm
@@ -164,9 +164,9 @@ sub from_input {
     if (UNIVERSAL::isa( $string, 'LedgerSMB::PGNumber' ) ) {
         $pgnum = $string;
     } else {
-        my $formatter = new Number::Format(
-                    -thousands_sep => $lsmb_formats->{$format}->{thousands_sep},
-                    -decimal_point => $lsmb_formats->{$format}->{decimal_sep},
+        my $formatter = Number::Format->new(
+            -thousands_sep => $lsmb_formats->{$format}->{thousands_sep},
+            -decimal_point => $lsmb_formats->{$format}->{decimal_sep},
         );
         $newval = $formatter->unformat_number($string);
         $pgnum = LedgerSMB::PGNumber->new($newval);

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -417,12 +417,12 @@ sub run_backup {
         no warnings 'once';
 
         my $csettings = $LedgerSMB::Company_Config::settings;
-        my $mail = new LedgerSMB::Mailer(
+        my $mail = LedgerSMB::Mailer->new(
             from          => $LedgerSMB::Sysconfig::backup_email_from,
             to            => $request->{email},
             subject       => "Email of Backup",
             message       => 'The Backup is Attached',
-            );
+        );
         $mail->attach(
             mimetype => $mimetype,
             filename => 'ledgersmb-backup.sqlc',

--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -653,18 +653,18 @@ sub _email_output {
         @mailmime = ('contenttype', $self->{mimetype});
     }
 
-        # User default for email from
-        $args->{from} ||= $self->{user}->{email};
+    # User default for email from
+    $args->{from} ||= $self->{user}->{email};
 
-        # Default addresses
-        my $csettings = $LedgerSMB::Company_Config::settings;
-        $args->{from} ||= $csettings->{default_email_from};
-        $args->{to} ||= $csettings->{default_email_to};
-        $args->{cc} ||= $csettings->{default_email_cc};
-        $args->{bcc} ||= $csettings->{default_email_bcc};
+    # Default addresses
+    my $csettings = $LedgerSMB::Company_Config::settings;
+    $args->{from} ||= $csettings->{default_email_from};
+    $args->{to} ||= $csettings->{default_email_to};
+    $args->{cc} ||= $csettings->{default_email_cc};
+    $args->{bcc} ||= $csettings->{default_email_bcc};
 
 
-        # Mailer stuff
+    # Mailer stuff
     my $mail = LedgerSMB::Mailer->new(
         from => $args->{from},
         to => $args->{to},
@@ -678,18 +678,21 @@ sub _email_output {
     if ($args->{attach} or $self->{mimetype} !~ m#^text/# or $self->{rendered}) {
         my @attachment;
         my $name = $args->{filename};
+
         if ($self->{rendered}) {
             @attachment = ('file', $self->{rendered});
             $name ||= $self->{rendered};
-        } else {
+        }
+        else {
             @attachment = ('data', $self->{output});
         }
+
         $mail->attach(
             mimetype => $self->{mimetype},
             filename => $name,
             strip => $$,
             @attachment,
-            );
+        );
     }
     $mail->send;
 }
@@ -711,7 +714,7 @@ sub _lpr_output {
     open my $file, '<', "$self->{rendered}"
         or die "Failed to open rendered file $self->{rendered} : $!";
 
-    while (my $line = <$file>){
+    while (my $line = <$file>) {
         print $pipe $line;
     }
 

--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -665,7 +665,7 @@ sub _email_output {
 
 
         # Mailer stuff
-    my $mail = new LedgerSMB::Mailer(
+    my $mail = LedgerSMB::Mailer->new(
         from => $args->{from},
         to => $args->{to},
         cc => $args->{cc},

--- a/lib/LedgerSMB/X12.pm
+++ b/lib/LedgerSMB/X12.pm
@@ -152,7 +152,7 @@ $self->parser.
 
 sub _parser {
     my ($self) = @_;
-    my $parser = new X12::Parser;
+    my $parser = X12::Parser->new;
     my $file = $self->message;
     return $parser;
 }

--- a/lib/LedgerSMB/X12/EDI850.pm
+++ b/lib/LedgerSMB/X12/EDI850.pm
@@ -53,7 +53,7 @@ sub _order {
     my ($self) = @_;
     $self->parse;
     my $sep = $self->parser->get_element_separator;
-    my $form = new Form;
+    my $form = Form->new;
     my $sender_idx;
     my $sender_id;
 

--- a/lib/LedgerSMB/X12/EDI894.pm
+++ b/lib/LedgerSMB/X12/EDI894.pm
@@ -51,7 +51,7 @@ has order => (is => 'ro', isa => 'HashRef[Any]', lazy => 1,
 sub _order {
     my ($self) = @_;
     my $sep = $self->parser->get_element_separator;
-    my $form = new Form;
+    my $form = Form->new;
     my $sender_idx;
     my $sender_id;
 

--- a/old/bin/aa.pl
+++ b/old/bin/aa.pl
@@ -236,9 +236,9 @@ sub create_links {
     $netamount = 0;
     $tax       = 0;
     $taxrate   = 0;
-    #$ml        = ( $form->{ARAP} eq 'AR' ) ? 1 : -1;
-    $ml        = new LedgerSMB::PGNumber( ( $form->{ARAP} eq 'AR' ) ? 1 : -1);
-
+    $ml = LedgerSMB::PGNumber->new(
+        ($form->{ARAP} eq 'AR') ? 1 : -1
+    );
 
     foreach my $key ( keys %{ $form->{"$form->{ARAP}_links"} } ) {
 

--- a/old/bin/aa.pl
+++ b/old/bin/aa.pl
@@ -237,9 +237,7 @@ sub create_links {
     $tax       = 0;
     $taxrate   = 0;
     #$ml        = ( $form->{ARAP} eq 'AR' ) ? 1 : -1;
-    $ml = LedgerSMB::PGNumber->new(
-        ($form->{ARAP} eq 'AR') ? 1 : -1)
-    );
+    $ml        = new LedgerSMB::PGNumber( ( $form->{ARAP} eq 'AR' ) ? 1 : -1);
 
 
     foreach my $key ( keys %{ $form->{"$form->{ARAP}_links"} } ) {

--- a/old/bin/aa.pl
+++ b/old/bin/aa.pl
@@ -237,7 +237,9 @@ sub create_links {
     $tax       = 0;
     $taxrate   = 0;
     #$ml        = ( $form->{ARAP} eq 'AR' ) ? 1 : -1;
-    $ml        = new LedgerSMB::PGNumber( ( $form->{ARAP} eq 'AR' ) ? 1 : -1);
+    $ml = LedgerSMB::PGNumber->new(
+        ($form->{ARAP} eq 'AR') ? 1 : -1)
+    );
 
 
     foreach my $key ( keys %{ $form->{"$form->{ARAP}_links"} } ) {

--- a/old/bin/am.pl
+++ b/old/bin/am.pl
@@ -1060,7 +1060,7 @@ sub edit_recurring {
 
 sub process_transactions {
     # save variables
-    my $pt = new Form;
+    my $pt = Form->new;
     for ( keys %$form ) { $pt->{$_} = $form->{$_} }
 
     my $defaultprinter;

--- a/old/bin/arapprn.pl
+++ b/old/bin/arapprn.pl
@@ -87,7 +87,7 @@ sub print {
     if ( $form->{media} !~ /screen/ ) {
         $form->error( $locale->text('Select postscript or PDF!')  )
           if $form->{format} !~ /(postscript|pdf)/;
-        $old_form = new Form;
+        $old_form = Form->new;
         for ( keys %$form ) { $old_form->{$_} = $form->{$_} }
     }
 
@@ -122,7 +122,7 @@ sub print {
 
     $form->{queued} .= " $form->{formname} $filename";
     $form->{queued} =~ s/^ //;
-    $printform = new Form;
+    $printform = Form->new;
     for ( keys %$form ) {
         $printform->{$_} = $form->{$_};
     }

--- a/old/bin/gl.pl
+++ b/old/bin/gl.pl
@@ -475,8 +475,8 @@ sub edit {
     }
 
     my $i = 0;
-    my $minusOne    = new LedgerSMB::PGNumber(-1);#HV make sure BigFloat stays BigFloat
-    my $plusOne     = new LedgerSMB::PGNumber(1);#HV make sure BigFloat stays BigFloat
+    my $minusOne = LedgerSMB::PGNumber->new(-1); #HV make sure BigFloat stays BigFloat
+    my $plusOne  = LedgerSMB::PGNumber->new(1);  #HV make sure BigFloat stays BigFloat
 
     foreach my $ref (@{ $form->{GL} }) {
         $form->{"accno_$i"} = "$ref->{accno}--$ref->{description}";

--- a/old/bin/io.pl
+++ b/old/bin/io.pl
@@ -1097,7 +1097,7 @@ sub e_mail {
 
 sub send_email {
 
-    $old_form = new Form;
+    $old_form = Form->new;
 
     for ( keys %$form ) { $old_form->{$_} = $form->{$_} }
     $old_form->{media} = $old_form->{oldmedia};
@@ -1135,7 +1135,7 @@ sub print {
           if ( $form->{format} !~ /(txt|postscript|pdf)/ );
     }
 
-    $old_form = new Form;
+    $old_form = Form->new;
     for ( keys %$form ) { $old_form->{$_} = $form->{$_} }
 
     $form->{rowcount}++;

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -1428,7 +1428,7 @@ sub print_and_post {
         }
     }
 
-    $old_form = new Form;
+    $old_form = Form->new;
     $form->{display_form} = "post";
     for ( keys %$form ) { $old_form->{$_} = $form->{$_} }
     $old_form->{rowcount}++;

--- a/old/bin/oe.pl
+++ b/old/bin/oe.pl
@@ -1287,7 +1287,7 @@ sub print_and_save {
     $form->error( $locale->text('Select a Printer!') )
       if $form->{media} eq 'screen';
 
-    $old_form = new Form;
+    $old_form = Form->new;
     $form->{display_form} = "save";
     for ( keys %$form ) { $old_form->{$_} = $form->{$_} }
     $old_form->{rowcount}++;

--- a/old/bin/old-handler.pl
+++ b/old/bin/old-handler.pl
@@ -79,7 +79,7 @@ use LedgerSMB::Locale;
 use LedgerSMB::Auth;
 use LedgerSMB::App_State;
 
-$form = new Form;
+$form = Form->new;
 use LedgerSMB;
 use LedgerSMB::Sysconfig;
 

--- a/old/bin/pe.pl
+++ b/old/bin/pe.pl
@@ -1262,7 +1262,7 @@ sub generate_sales_orders {
         }
     }
 
-    $order = new Form;
+    $order = Form->new;
     for ( keys %{ $form->{order} } ) {
         $order->{dbh} = $form->{dbh};
 

--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -732,7 +732,7 @@ sub _redirect {
     $temphash{action} = $form->{action};
 
     undef $form;
-    $form = new Form($argv);
+    $form = Form->new($argv);
 
     for (@common_attrs) {
         $form->{$_} = $temphash{$_};

--- a/xt/01.1-critic.t
+++ b/xt/01.1-critic.t
@@ -29,6 +29,7 @@ my @cert_policies = qw(
     Miscellanea::ProhibitFormats
     Modules::ProhibitEvilModules
     Modules::RequireEndWithOne
+    Objects::ProhibitIndirectSyntax
     Subroutines::ProhibitReturnSort
     Subroutines::ProhibitSubroutinePrototypes
     TestingAndDebugging::ProhibitProlongedStrictureOverride
@@ -50,7 +51,6 @@ my @cert_policies = qw(
 #    BuiltinFunctions::ProhibitUniversalIsa
 #    InputOutput::RequireCheckedClose
 #    InputOutput::RequireCheckedSyscalls
-#    Objects::ProhibitIndirectSyntax
 #    RegularExpressions::ProhibitCaptureWithoutTest
 #    Subroutines::ProhibitBuiltinHomonyms
 #    Subroutines::ProhibitExplicitReturnUndef   --explicitly excluded


### PR DESCRIPTION
Instead of

    my $o = new Form();

use

    my $o = Form->new();

See: https://metacpan.org/source/SZABGAB/CGI-Simple-1.115/lib/CGI/Simple.pm

> Perl needs to make a number of assumptions at compile time to disambiguate the first form, so it tends to be fragile and to produce hard-to-track-down bugs.