### PR TITLE
* Don't instantiate LedgerSMB objects in old code

### DIFF
--- a/old/bin/gl.pl
+++ b/old/bin/gl.pl
@@ -51,6 +51,8 @@ use LedgerSMB::PE;
 use LedgerSMB::Template;
 use LedgerSMB::Setting::Sequence;
 use LedgerSMB::Company_Config;
+use LedgerSMB::DBObject::Draft;
+use LedgerSMB::DBObject::TransTemplate;
 
 require 'old/bin/bridge.pl'; # needed for voucher dispatches
 require "old/bin/arap.pl";
@@ -90,24 +92,15 @@ $form->{login} = 'test';
 
 
 sub edit_and_save {
-    use LedgerSMB::DBObject::Draft;
-    use LedgerSMB;
     check_balanced($form);
-    my $lsmb = LedgerSMB->new();
-    $lsmb->merge($form);
-    my $draft = LedgerSMB::DBObject::Draft->new({base => $lsmb});
+    my $draft = LedgerSMB::DBObject::Draft->new({base => $form});
     $draft->delete();
     GL->post_transaction( \%myconfig, \%$form, $locale);
     edit();
 }
 
 sub approve {
-    use LedgerSMB::DBObject::Draft;
-    use LedgerSMB;
-    my $lsmb = LedgerSMB->new();
-    $lsmb->merge($form);
-
-    my $draft = LedgerSMB::DBObject::Draft->new({base => $lsmb});
+    my $draft = LedgerSMB::DBObject::Draft->new({base => $form});
     $draft->approve();
     if ($form->{callback}){
         print "Location: $form->{callback}\n";
@@ -351,9 +344,6 @@ sub display_form
 
 
 sub save_temp {
-    use LedgerSMB;
-    use LedgerSMB::DBObject::TransTemplate;
-    my $lsmb = LedgerSMB->new();
     my ($department_name, $department_id) = split/--/, $form->{department};
     $lsmb->{department_id} = $department_id;
     $lsmb->{reference} = $form->{reference};
@@ -375,14 +365,13 @@ sub save_temp {
                   };
         }
     }
-    $template = LedgerSMB::DBObject::TransTemplate->new({base => $lsmb});
+    $template = LedgerSMB::DBObject::TransTemplate->new({base => $form});
     $template->save;
     $form->redirect( $locale->text('Template Saved!') );
 }
 
 
 sub display_row {
-
     my ($init) = @_;
     $form->{totaldebit}  = 0;
     $form->{totalcredit} = 0;
@@ -666,9 +655,7 @@ sub post {
 sub delete {
     $form->error($locale->text('Cannot delete posted transaction'))
        if ($form->{approved});
-    my $lsmb = LedgerSMB->new();
-    $lsmb->merge($form);
-    my $draft = LedgerSMB::DBObject::Draft->new({base => $lsmb});
+    my $draft = LedgerSMB::DBObject::Draft->new({base => $form});
     $draft->delete();
     delete $form->{id};
     delete $form->{reference};

--- a/old/bin/io.pl
+++ b/old/bin/io.pl
@@ -45,6 +45,7 @@ use LedgerSMB::Template;
 use LedgerSMB::Sysconfig;
 use LedgerSMB::Setting;
 use LedgerSMB::Company_Config;
+use LedgerSMB::DBObject::Draft;
 use LedgerSMB::File;
 use List::Util qw(max reduce);
 
@@ -135,13 +136,8 @@ sub _calc_taxes {
 }
 
 sub approve {
-    use LedgerSMB::DBObject::Draft;
-    use LedgerSMB;
     $form->update_invnumber;
-    my $lsmb = LedgerSMB->new();
-    $lsmb->merge($form);
-
-    my $draft = LedgerSMB::DBObject::Draft->new({base => $lsmb});
+    my $draft = LedgerSMB::DBObject::Draft->new({base => $form});
 
     $draft->approve();
     edit();

--- a/old/bin/ir.pl
+++ b/old/bin/ir.pl
@@ -40,11 +40,13 @@
 
 package lsmb_legacy;
 use List::Util qw(min max);
+use LedgerSMB::Form;
 use LedgerSMB::IR;
 use LedgerSMB::IS;
 use LedgerSMB::PE;
 use LedgerSMB::Tax;
 use LedgerSMB::Setting;
+use LedgerSMB::DBObject::Draft;
 
 require 'old/bin/bridge.pl'; # needed for voucher dispatches
 require "old/bin/io.pl";
@@ -64,11 +66,7 @@ sub copy_to_new{
 }
 
 sub edit_and_save {
-    use LedgerSMB::DBObject::Draft;
-    use LedgerSMB;
-    my $lsmb = LedgerSMB->new();
-    $lsmb->merge($form);
-    my $draft = LedgerSMB::DBObject::Draft->new({base => $lsmb});
+    my $draft = LedgerSMB::DBObject::Draft->new({base => $form});
     $draft->delete();
     delete $form->{id};
     IR->post_invoice( \%myconfig, \%$form );
@@ -76,12 +74,7 @@ sub edit_and_save {
 }
 
 sub approve {
-    use LedgerSMB::DBObject::Draft;
-    use LedgerSMB;
-    my $lsmb = LedgerSMB->new();
-    $lsmb->merge($form);
-
-    my $draft = LedgerSMB::DBObject::Draft->new({base => $lsmb});
+    my $draft = LedgerSMB::DBObject::Draft->new({base => $form});
 
     $draft->approve();
 
@@ -99,11 +92,10 @@ sub approve {
 }
 
 sub new_screen {
-    use LedgerSMB::Form;
     my @reqprops = qw(ARAP vc dbh stylesheet type);
     $oldform = $form;
     $form = {};
-    bless $form, Form;
+    bless $form, 'Form';
     for (@reqprops){
         $form->{$_} = $oldform->{$_};
     }

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -46,11 +46,12 @@
 package lsmb_legacy;
 
 use List::Util qw(max min);
-
+use LedgerSMB::Form;
 use LedgerSMB::IS;
 use LedgerSMB::PE;
 use LedgerSMB::Tax;
 use LedgerSMB::Setting;
+use LedgerSMB::DBObject::Draft;
 
 require 'old/bin/bridge.pl'; # needed for voucher dispatches
 require "old/bin/arap.pl";
@@ -73,11 +74,7 @@ sub copy_to_new{
 }
 
 sub edit_and_save {
-    use LedgerSMB::DBObject::Draft;
-    use LedgerSMB;
-    my $lsmb = LedgerSMB->new();
-    $lsmb->merge($form);
-    my $draft = LedgerSMB::DBObject::Draft->new({base => $lsmb});
+    my $draft = LedgerSMB::DBObject::Draft->new({base => $form});
     $draft->delete();
     delete $form->{id};
     IS->post_invoice( \%myconfig, \%$form );
@@ -85,11 +82,10 @@ sub edit_and_save {
 }
 
 sub new_screen {
-    use LedgerSMB::Form;
     my @reqprops = qw(ARAP vc dbh stylesheet type);
     $oldform = $form;
     $form = {};
-    bless $form, Form;
+    bless $form, 'Form';
     for (@reqprops){
         $form->{$_} = $oldform->{$_};
     }


### PR DESCRIPTION
Note that the 'base' argument to the DBObject constructor isn't accessed
as an object at all, let alone that it requires the object to be of
LedgerSMB class.