### PR TITLE
Add utils/test/github-badge-cache-buster.sh to "after_success" hook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -169,6 +169,12 @@ after_success:
   - coverage-report
   # display the available resources
   - utils/diagnostics/t/01-system-resources.t
+  # try and force the github camo.githubusercontent.com cache to refresh our badges
+  # with no arguments, this only refreshes the badge assests linked to by the default page shown when visiting
+  # https://github.com/ledgersmb/LedgerSMB
+  # if we want to refresh assets other than those (ie: not master branch) then we will need to add explicit arguments to do so
+  # the script is sourced from https://github.com/sbts/github-badge-cache-buster but isn't expected to change so there is no point making it a submodule
+  - utils/test/github-badge-cache-buster.sh
 
 after_failure:
   # display the available resources

--- a/utils/test/github-badge-cache-buster.sh
+++ b/utils/test/github-badge-cache-buster.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+defaultURL='https://github.com/ledgersmb/LedgerSMB'
+defaultFILE=''
+
+HELP() {
+    cat <<-EOF
+	usage: github-badge-cache-buster.sh [ -h | --help | [ repoURL | "auto"   [ badgeFile ] ] ]
+	
+	       repoURL   defaults to '$defaultURL'
+	       badgeFile defaults to '$defaultFILE'
+	
+	EOF
+    exit 1;
+}
+
+[[ "$@" =~ --help|-h ]] && HELP;
+
+paramURL="${1:-auto}"
+paramFile="$2"
+
+init() {
+    [[ -x `which curl` ]] || {
+        cat <<-EOF
+		===============================
+		===============================
+		==        FATAL ERROR        ==
+		===============================
+		===============================
+		== we need to be able to run ==
+		== curl                      ==
+		===============================
+		== please install it         ==
+		== then rerun this script    ==
+		===============================
+	EOF
+        exit 9
+    }
+
+    # try reading a repo url from the current repo. otherwise default to ledgersm/LedgerSMB
+    read -t30 autoURL < <( git config --get remote.origin.url ) || autoURL="$defaultURL"
+
+    # if a URL was passed on the command line use it, otherwise use $autoURL
+    [[ "${paramURL:-auto}" == "auto" ]] && unset paramURL;
+    repoURL="${paramURL:-$autoURL}";
+
+    # if a URL was passed on the command line use it, otherwise use $autoURL
+    badge_mdFILE="${paramFile:-$defaultFILE}"
+
+    COLUMNS=`tput cols`
+    UserAgentString='KLUDGE (Linux;) (please fix github tickets 224 116 111 218 414 etc)'
+}
+
+GetBadgeURLs() {
+    curl --silent --user-agent "$UserAgentString" --output /dev/stdout "${repoURL}${badge_mdFILE}" | grep -o 'https://camo.githubusercontent.com.*alt="[^"]*'
+}
+
+PurgeBadges() {
+    rm -f results.txt
+    while read -t5 URL Badge; do
+        URL="${URL%\"*}";
+        Badge="'${Badge#*\"}'                                        "
+        echo -n "Purging Badge ${Badge:0:25}: ";
+        read -t60 result < <( curl --silent --request 'PURGE' -H 'Content-Type:application/json' --user-agent "$UserAgentString" --output '/dev/stdout' $URL | jq .status )
+        result="${result//\"/}"
+        echo "${result:-???}"
+    done
+}
+
+main() {
+    init;
+    cat <<-EOF
+	
+	============================================
+	== about to purge cached badge images for ==
+	============================================
+	 ${repoURL}${badge_mdFILE}
+	============================================
+	
+	EOF
+
+    PurgeBadges < <( GetBadgeURLs )
+
+    echo
+}
+
+main;


### PR DESCRIPTION
  - try and force the github camo.githubusercontent.com cache to refresh our badges
  - with no arguments, this only refreshes the badge assests linked to by the default page shown when visiting
  - https://github.com/ledgersmb/LedgerSMB
  - if we want to refresh assets other than those (ie: not master branch) then we will need to add explicit arguments to do so
  - the script is sourced from https://github.com/sbts/github-badge-cache-buster but isn't expected to change so there is no point making it a submodule