### PR TITLE
Fix LedgerSMB->to_json missing LedgerSMB::Template::TXT module

### DIFF
--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -151,6 +151,7 @@ use LedgerSMB::User;
 use LedgerSMB::Setting;
 use LedgerSMB::Company_Config;
 use LedgerSMB::DBH;
+use LedgerSMB::Template::TXT;
 use utf8;
 
 


### PR DESCRIPTION
Calling LedgerSMB->to_json failed with a missing subroutine because
it was trying to call LedgerSMB::Template::TXT::preprocess without
use-ing that module.