### PR TITLE
* Change comparison periods selector to a number spinner

### DIFF
--- a/UI/Reports/filters/balance_sheet.html
+++ b/UI/Reports/filters/balance_sheet.html
@@ -143,17 +143,10 @@
                    PROCESS input element_data = {
                    label = text('Comparison Dates')
                    name = 'comparison_periods'
-                   text_attr = 'description'
-                   value_attr = 'text'
-                   value = comparison_periods
+                   value = 0
                    size = '3'
-                   "data-dojo-type"="dijit/form/NumberTextBox"
-                   "data-dojo-props"="constraints:{min:0,max:9,places:0}," _
-                        "invalidMessage:'" _
-                        text('Please enter a numeric value bewteen 0 and 9') _
-                        "'," _
-                        "rangeMessage:'" _ text('Invalid comparisons') _ "'"
-                   default_values = 0
+                   "data-dojo-type"="dijit/form/NumberSpinner"
+                   "data-dojo-props"="constraints:{min:0,max:9,places:0},intermediateChanges:true,style:'width:7ex'"
                    };
                    ?></legend>
         <div id="comparison_dates">

--- a/UI/Reports/filters/income_statement.html
+++ b/UI/Reports/filters/income_statement.html
@@ -186,11 +186,10 @@
                    PROCESS input element_data = {
                    label = text('Comparison Periods')
                    name = 'comparison_periods'
-                   text_attr = 'description'
-                   value_attr = 'text'
-                   value = comparison_periods
+                   value = 0
                    size = '3'
-                   default_values = 0
+                   "data-dojo-type" = "dijit/form/NumberSpinner"
+                   "data-dojo-props" = "intermediateChanges:true, constraints:{min:0, max:9, places:0}, smallDelta:1, style:'width:7ex'"
                    };
                    ?></legend>
 

--- a/UI/js-src/lsmb/reports/ComparisonSelector.js
+++ b/UI/js-src/lsmb/reports/ComparisonSelector.js
@@ -40,7 +40,7 @@ define(["dojo/_base/declare",
                    this._comparison_periods =
                        registry.byId("comparison-periods");
                    this.own(
-                       on(this._comparison_periods, "keyup",
+                       on(this._comparison_periods, "change",
                           function(newvalue) {
                               self._update_display(self._comparison_periods
                                                    .get("value"));


### PR DESCRIPTION
Note that the UI for the period selector was apparently not intuitive
enough as the recent UI change was not understood by existing users.
By changing the NumberTextBox to a NumberSpinner, pre-filled with zero
the user should feel invited to change the number input.