### PR TITLE
Remove Form module unused method arguments

### DIFF
--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -151,6 +151,7 @@ use LedgerSMB::User;
 use LedgerSMB::Setting;
 use LedgerSMB::Company_Config;
 use LedgerSMB::DBH;
+use LedgerSMB::Template::TXT;
 use utf8;
 
 

--- a/old/bin/aa.pl
+++ b/old/bin/aa.pl
@@ -1202,15 +1202,14 @@ sub update {
 
     if ( $newname = &check_name( $form->{vc} ) ) {
         $form->{notes} = $form->{intnotes} unless $form->{id};
-        &rebuild_vc($form->{vc}, $form->{transdate});
+        rebuild_vc($form->{vc}, $form->{transdate});
     }
     if ( $form->{transdate} ne $form->{oldtransdate} ) {
         $form->{duedate} =
             $form->current_date( \%myconfig, $form->{transdate},
                                  $form->{terms} * 1 );
         $form->{oldtransdate} = $form->{transdate};
-        $newproj =
-            &rebuild_vc($form->{vc}, $form->{transdate})
+        $newproj = rebuild_vc($form->{vc}, $form->{transdate})
             if !$newname;
     }
 

--- a/old/bin/aa.pl
+++ b/old/bin/aa.pl
@@ -1357,7 +1357,7 @@ sub post {
 
     if ( AA->post_transaction( \%myconfig, \%$form ) ) {
 
-        $form->update_status( \%myconfig );
+        $form->update_status;
         if ( $form->{printandpost} ) {
             &{"print_$form->{formname}"}( $old_form, 1 );
         }

--- a/old/bin/aa.pl
+++ b/old/bin/aa.pl
@@ -1202,7 +1202,7 @@ sub update {
 
     if ( $newname = &check_name( $form->{vc} ) ) {
         $form->{notes} = $form->{intnotes} unless $form->{id};
-        &rebuild_vc( $form->{vc}, $form->{ARAP}, $form->{transdate} );
+        &rebuild_vc($form->{vc}, $form->{transdate});
     }
     if ( $form->{transdate} ne $form->{oldtransdate} ) {
         $form->{duedate} =
@@ -1210,7 +1210,7 @@ sub update {
                                  $form->{terms} * 1 );
         $form->{oldtransdate} = $form->{transdate};
         $newproj =
-            &rebuild_vc( $form->{vc}, $form->{ARAP}, $form->{transdate} )
+            &rebuild_vc($form->{vc}, $form->{transdate})
             if !$newname;
     }
 

--- a/old/bin/arap.pl
+++ b/old/bin/arap.pl
@@ -309,7 +309,7 @@ sub rebuild_vc {
     my ( $vc, $ARAP, $transdate, $job ) = @_;
 
     ( $null, $form->{employee_id} ) = split /--/, $form->{employee};
-    $form->all_vc( \%myconfig, $vc, $ARAP, undef, $transdate, $job );
+    $form->all_vc( \%myconfig, $vc, $ARAP, $transdate, $job );
     $form->{"select$vc"} = "";
     for ( @{ $form->{"all_$vc"} } ) {
         $form->{"select$vc"} .=

--- a/old/bin/arap.pl
+++ b/old/bin/arap.pl
@@ -309,7 +309,7 @@ sub rebuild_vc {
     my ( $vc, $ARAP, $transdate, $job ) = @_;
 
     ( $null, $form->{employee_id} ) = split /--/, $form->{employee};
-    $form->all_vc( \%myconfig, $vc, $ARAP, $transdate, $job );
+    $form->all_vc(\%myconfig, $vc, $transdate, $job);
     $form->{"select$vc"} = "";
     for ( @{ $form->{"all_$vc"} } ) {
         $form->{"select$vc"} .=

--- a/old/bin/arap.pl
+++ b/old/bin/arap.pl
@@ -306,7 +306,7 @@ sub name_selected {
 }
 
 sub rebuild_vc {
-    my ( $vc, $ARAP, $transdate, $job ) = @_;
+    my ($vc, $transdate, $job) = @_;
 
     ( $null, $form->{employee_id} ) = split /--/, $form->{employee};
     $form->all_vc(\%myconfig, $vc, $transdate, $job);

--- a/old/bin/arapprn.pl
+++ b/old/bin/arapprn.pl
@@ -285,7 +285,7 @@ sub print_transaction {
         $form->{queued} =~ s/^ //;
 
         # save status
-        $form->update_status( \%myconfig, 1);
+        $form->update_status;
 
         $old_form->{queued} = $form->{queued};
     }
@@ -302,7 +302,7 @@ sub print_transaction {
             $form->{printed} .= " $form->{formname}";
             $form->{printed} =~ s/^ //;
 
-            $form->update_status( \%myconfig, 1);
+            $form->update_status;
         }
 
         $old_form->{printed} = $form->{printed} if %$old_form;

--- a/old/bin/ic.pl
+++ b/old/bin/ic.pl
@@ -218,7 +218,7 @@ sub link_part {
     delete $form->{IC_links};
     delete $form->{amount};
 
-    $form->get_partsgroup( \%myconfig, { all => 1 } );
+    $form->get_partsgroup({ all => 1 });
     if ( $form->{partsgroup} ) {
         $form->{partsgroup} =
           $form->quote( $form->{partsgroup} ) . "--$form->{partsgroup_id}";
@@ -245,7 +245,7 @@ sub link_part {
             }
         }
 
-        $form->get_partsgroup( \%myconfig );
+        $form->get_partsgroup();
 
         if ( @{ $form->{all_partsgroup} } ) {
             $form->{selectassemblypartsgroup} = qq|<option></option>\n|;

--- a/old/bin/io.pl
+++ b/old/bin/io.pl
@@ -187,7 +187,7 @@ sub display_row {
         $l{language_code} = $form->{language_code};
         $l{searchitems} = 'nolabor' if $form->{vc} eq 'customer';
 
-        $form->get_partsgroup( \%myconfig, \%l );
+        $form->get_partsgroup(\%l);
         if ( @{ $form->{all_partsgroup} } ) {
             $form->{selectpartsgroup} = "<option>\n";
             foreach my $ref ( @{ $form->{all_partsgroup} } ) {

--- a/old/bin/io.pl
+++ b/old/bin/io.pl
@@ -1436,7 +1436,7 @@ sub print_form {
             $form->{printed} .= " $form->{formname}";
             $form->{printed} =~ s/^ //;
 
-            $form->update_status( \%myconfig, 1);
+            $form->update_status;
         }
 
         $old_form->{printed} = $form->{printed} if %$old_form;
@@ -1452,7 +1452,7 @@ sub print_form {
             $form->{emailed} =~ s/^ //;
 
             # save status
-            $form->update_status( \%myconfig, 1);
+            $form->update_status;
         }
 
         $now = scalar localtime;
@@ -1514,7 +1514,7 @@ sub print_form {
         $form->{queued} =~ s/^ //;
 
         # save status
-        $form->update_status( \%myconfig, 1);
+        $form->update_status;
 
         $old_form->{queued} = $form->{queued};
     }

--- a/old/bin/ir.pl
+++ b/old/bin/ir.pl
@@ -1025,7 +1025,7 @@ sub update {
        for qw(transdate duedate crdate);
 
     if ( $newname = &check_name(vendor) ) {
-        &rebuild_vc(vendor, $form->{transdate}, 1);
+        rebuild_vc('vendor', $form->{transdate}, 1);
     }
     if ( $form->{transdate} ne $form->{oldtransdate} ) {
         $form->{duedate} =
@@ -1034,7 +1034,7 @@ sub update {
             $form->{terms} * 1 )
           : $form->{duedate};
         $form->{oldtransdate} = $form->{transdate};
-        &rebuild_vc(vendor, $form->{transdate}, 1) if !$newname;
+        rebuild_vc('vendor', $form->{transdate}, 1) if !$newname;
 
         if ( $form->{currency} ne $form->{defaultcurrency} ) {
             delete $form->{exchangerate};

--- a/old/bin/ir.pl
+++ b/old/bin/ir.pl
@@ -179,8 +179,9 @@ sub invoice_links {
 
     $form->{oldlanguage_code} = $form->{language_code};
 
-    $form->get_partsgroup( \%myconfig,
-        { language_code => $form->{language_code} } );
+    $form->get_partsgroup({
+        language_code => $form->{language_code}
+    });
 
     if ( $form->{all_department} && @{ $form->{all_department} } ) {
         $form->{department} = "$form->{department}--$form->{department_id}"

--- a/old/bin/ir.pl
+++ b/old/bin/ir.pl
@@ -1025,7 +1025,7 @@ sub update {
        for qw(transdate duedate crdate);
 
     if ( $newname = &check_name(vendor) ) {
-        &rebuild_vc( vendor, AP, $form->{transdate}, 1 );
+        &rebuild_vc(vendor, $form->{transdate}, 1);
     }
     if ( $form->{transdate} ne $form->{oldtransdate} ) {
         $form->{duedate} =
@@ -1034,7 +1034,7 @@ sub update {
             $form->{terms} * 1 )
           : $form->{duedate};
         $form->{oldtransdate} = $form->{transdate};
-        &rebuild_vc( vendor, AP, $form->{transdate}, 1 ) if !$newname;
+        &rebuild_vc(vendor, $form->{transdate}, 1) if !$newname;
 
         if ( $form->{currency} ne $form->{defaultcurrency} ) {
             delete $form->{exchangerate};

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -1115,7 +1115,7 @@ sub update {
       $form->parse_amount( \%myconfig, $form->{exchangerate} );
 
     if ( $newname = &check_name(customer) ) {
-        &rebuild_vc(customer, $form->{transdate}, 1);
+        rebuild_vc('customer', $form->{transdate}, 1);
     }
     $form->{$_} = LedgerSMB::PGDate->from_input($form->{$_})->to_output()
        for qw(transdate duedate crdate);
@@ -1127,7 +1127,7 @@ sub update {
           : $form->{duedate};
         $form->{oldtransdate} = $form->{transdate};
 
-          &rebuild_vc(customer, $form->{transdate}, 1) if !$newname;
+        rebuild_vc('customer', $form->{transdate}, 1) if !$newname;
 
         if ( $form->{currency} ne $form->{defaultcurrency} ) {
             delete $form->{exchangerate};

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -1115,7 +1115,7 @@ sub update {
       $form->parse_amount( \%myconfig, $form->{exchangerate} );
 
     if ( $newname = &check_name(customer) ) {
-        &rebuild_vc( customer, AR, $form->{transdate}, 1 );
+        &rebuild_vc(customer, $form->{transdate}, 1);
     }
     $form->{$_} = LedgerSMB::PGDate->from_input($form->{$_})->to_output()
        for qw(transdate duedate crdate);
@@ -1127,7 +1127,7 @@ sub update {
           : $form->{duedate};
         $form->{oldtransdate} = $form->{transdate};
 
-          &rebuild_vc( customer, AR, $form->{transdate}, 1 ) if !$newname;
+          &rebuild_vc(customer, $form->{transdate}, 1) if !$newname;
 
         if ( $form->{currency} ne $form->{defaultcurrency} ) {
             delete $form->{exchangerate};

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -165,7 +165,7 @@ sub invoice_links {
 
     $form->{oldlanguage_code} = $form->{language_code};
 
-    $form->get_partsgroup( \%myconfig, { all => 1} );
+    $form->get_partsgroup({ all => 1});
 
     $form->{oldcustomer}  = "$form->{customer}--$form->{customer_id}";
     $form->{oldtransdate} = $form->{transdate};

--- a/old/bin/oe.pl
+++ b/old/bin/oe.pl
@@ -121,9 +121,12 @@ sub order_links {
     OE->retrieve( \%myconfig, \%$form );
 
     # get projects, departments, languages
-    $form->get_regular_metadata( \%myconfig, $form->{vc},
-                 ( $form->{vc} eq 'customer' ) ? "AR" : "AP",
-                 undef, $form->{transdate}, 1 );
+    $form->get_regular_metadata(
+        \%myconfig,
+        $form->{vc},
+        $form->{transdate},
+        1,
+    );
 
     $form->{oldlanguage_code} = $form->{language_code};
 

--- a/old/bin/oe.pl
+++ b/old/bin/oe.pl
@@ -133,7 +133,7 @@ sub order_links {
     $l{language_code} = $form->{language_code};
     $l{searchitems} = 'nolabor' if $form->{vc} eq 'customer';
 
-    $form->get_partsgroup( \%myconfig, \%l );
+    $form->get_partsgroup(\%l);
 
     for (qw(terms taxincluded)) { $temp{$_} = $form->{$_} }
     $form->{shipto} = 1 if $form->{id};
@@ -2018,7 +2018,7 @@ sub search_transfer {
         $form->error( $locale->text('Nothing to transfer!') );
     }
 
-    $form->get_partsgroup( \%myconfig, { searchitems => 'part' } );
+    $form->get_partsgroup({ searchitems => 'part' });
 
      $form->generate_selects();
 

--- a/old/bin/pe.pl
+++ b/old/bin/pe.pl
@@ -48,7 +48,7 @@ sub edit {
 }
 
 sub prepare_partsgroup {
-    PE->get_partsgroup( \%myconfig, \%$form )
+    PE->get_partsgroup(\%$form)
       if $form->{id};
 }
 sub prepare_pricegroup {

--- a/old/lib/LedgerSMB/AA.pm
+++ b/old/lib/LedgerSMB/AA.pm
@@ -941,7 +941,7 @@ sub get_name {
         && ( $form->{currency} ne $form->{defaultcurrency} ) )
     {
         $form->{exchangerate} =
-          $form->get_exchangerate( $dbh, $form->{currency}, $form->{transdate},
+          $form->get_exchangerate($form->{currency}, $form->{transdate},
             $buysell );
     }
 

--- a/old/lib/LedgerSMB/AA.pm
+++ b/old/lib/LedgerSMB/AA.pm
@@ -940,9 +940,11 @@ sub get_name {
     if ( $form->{transdate}
         && ( $form->{currency} ne $form->{defaultcurrency} ) )
     {
-        $form->{exchangerate} =
-          $form->get_exchangerate($form->{currency}, $form->{transdate},
-            $buysell );
+        $form->{exchangerate} = $form->get_exchangerate(
+            $form->{currency},
+            $form->{transdate},
+            $buysell
+        );
     }
 
     $form->{forex} = $form->{exchangerate};

--- a/old/lib/LedgerSMB/AA.pm
+++ b/old/lib/LedgerSMB/AA.pm
@@ -304,7 +304,7 @@ sub post_transaction {
     #( $null, $form->{employee_id} ) = split /--/, $form->{employee};
     ( $form->{employee_name}, $form->{employee_id} ) = split /--/, $form->{employee};
     unless ( $form->{employee_id} ) {
-        ( $form->{employee}, $form->{employee_id} ) = $form->get_employee($dbh);
+        ( $form->{employee}, $form->{employee_id} ) = $form->get_employee;
     }
 
     # check if id really exists
@@ -948,7 +948,7 @@ sub get_name {
     $form->{forex} = $form->{exchangerate};
 
     # if no employee, default to login
-    ( $form->{employee}, $form->{employee_id} ) = $form->get_employee($dbh)
+    ( $form->{employee}, $form->{employee_id} ) = $form->get_employee
       unless $form->{employee_id};
 
     my $arap = ( $form->{vc} eq 'customer' ) ? 'ar' : 'ap';

--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -1623,7 +1623,7 @@ sub save_exchangerate {
     );
 }
 
-=item $form->get_exchangerate($dbh, $curr, $transdate, $fld);
+=item $form->get_exchangerate($curr, $transdate, $fld);
 
 Returns the exchange rate in relation to the default currency for $currency on
 $transdate for the purpose indicated by $fld.  $fld can be either 'buy' or
@@ -1635,7 +1635,7 @@ $dbh is not used, favouring $self->{dbh}.
 
 sub get_exchangerate {
 
-    my ( $self, $dbh, $curr, $transdate, $fld ) = @_;
+    my ($self, $curr, $transdate, $fld) = @_;
 
     my $exchangerate = 1;
 
@@ -1647,11 +1647,10 @@ sub get_exchangerate {
         $sth->execute( $curr, $transdate );
 
         ($exchangerate) = $sth->fetchrow_array;
-        $exchangerate = LedgerSMB::PGNumber->new($exchangerate);
         $sth->finish;
     }
 
-    $exchangerate;
+    return LedgerSMB::PGNumber->new($exchangerate);
 }
 
 =item $form->check_exchangerate($myconfig, $currency, $transdate, $fld);
@@ -2533,7 +2532,6 @@ sub create_links {
         my $fld = ($vc eq 'customer') ? 'buy' : 'sell';
 
         $self->{exchangerate} = $self->get_exchangerate(
-            $dbh,
             $self->{currency},
             $self->{transdate},
             $fld
@@ -2547,7 +2545,6 @@ sub create_links {
                 $ref->{"b_unit_$aref->[0]"} = $aref->[1];
             }
             $ref->{exchangerate} = $self->get_exchangerate(
-                $dbh,
                 $self->{currency},
                 $ref->{transdate},
                 $fld

--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -2854,8 +2854,6 @@ their respective $form attributes match /$form->{formname}/, and spoolfile is
 the file extracted from the string $form->{queued} or NULL if there is no entry
 for $form->{formname}.
 
-$myconfig is unused.
-
 =cut
 
 sub update_status {

--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -2008,7 +2008,7 @@ $form->all_business_units, and $form->all_taxaccounts are all run.
 
 sub get_regular_metadata {
     my ($self, $myconfig, $vc, $transdate, $job) = @_;
-    $dbh = $self->{dbh};
+    my $dbh = $self->{dbh};
     { # pre-5.14 compatibility block
         local ($@); # pre-5.14, do not die() in this block
         $transdate = $transdate->to_db if eval { $transdate->can('to_db') };

--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -2011,11 +2011,10 @@ sub all_vc {
           unless $self->{employee_id};
     }
 
-    $self->get_regular_metadata($myconfig,$vc, $module, $dbh, $transdate, $job);
+    $self->get_regular_metadata($myconfig, $vc, $transdate, $job);
 }
 
-=item $form->get_regular_metadata($myconfig, $vc, $module, $dbh, $transdate,
-                                 $job)
+=item $form->get_regular_metadata($myconfig, $vc, $transdate, $job)
 
 This is API-compatible with all_vc.  It is a handy wrapper function that calls
 the following functions:
@@ -2032,12 +2031,10 @@ $form->{all_language} is populated using the language table and is sorted by the
 description, and $form->all_employees, $form->all_departments,
 $form->all_business_units, and $form->all_taxaccounts are all run.
 
-$module and $dbh are unused.
-
 =cut
 
 sub get_regular_metadata {
-    my ( $self, $myconfig, $vc, $module, $dbh, $transdate, $job ) = @_;
+    my ($self, $myconfig, $vc, $transdate, $job) = @_;
     $dbh = $self->{dbh};
     { # pre-5.14 compatibility block
         local ($@); # pre-5.14, do not die() in this block

--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -1759,17 +1759,15 @@ sub get_shipto {
 }
 
 
-=item $form->get_employee($dbh);
+=item $form->get_employee();
 
 Returns a list containing the name and id of the employee $form->{login}.  Any
 portion of $form->{login} including and past '@' are ignored.
 
-$dbh is unused.
-
 =cut
 
 sub get_employee {
-    my ( $self, $dbh ) = @_;
+    my ($self) = @_;
 
     my $login = $self->{login};
     $login =~ s/@.*//;
@@ -1786,7 +1784,7 @@ sub get_employee {
 
     $sth->finish;
 
-    @a;
+    return @a;
 }
 
 =item $form->get_name($myconfig, $table[, $transdate])
@@ -2009,7 +2007,7 @@ sub all_vc {
     if ( !$self->{employee_id} ) {
         ( $self->{employee}, $self->{employee_id} ) = split /--/,
           $self->{employee};
-        ( $self->{employee}, $self->{employee_id} ) = $self->get_employee($dbh)
+        ( $self->{employee}, $self->{employee_id} ) = $self->get_employee
           unless $self->{employee_id};
     }
 

--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -2209,19 +2209,17 @@ sub all_languages {
     $sth->finish;
 }
 
-=item $form->all_years($myconfig[, $dbh2]);
+=item $form->all_years();
 
 Populates the hash $form->{all_month} with a mapping between a two-digit month
 number and the English month name.  Populates the list $form->{all_years} with
 all years which contain transactions.
 
-$dbh2 is unused.
-
 =cut
 
 sub all_years {
 
-    my ($self, $myconfig) = @_;
+    my ($self) = @_;
 
     my $dbh = $self->{dbh};
     $self->{all_years} = [];

--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -2763,7 +2763,7 @@ sub redo_rows {
     }
 }
 
-=item $form->get_partsgroup($myconfig[, $p]);
+=item $form->get_partsgroup([$p]);
 
 Populates the list referred to as $form->{all_partsgroup}.  $p refers to a hash
 that describes which partsgroups to retrieve.  $p->{searchitems} can be 'part',
@@ -2777,13 +2777,11 @@ The results in $form->{all_partsgroup} are normally sorted by partsgroup name.
 If a language_code is specified, the results are then sorted by the translated
 description.
 
-$myconfig is unused.
-
 =cut
 
 sub get_partsgroup {
 
-    my ( $self, $myconfig, $p ) = @_;
+    my ($self, $p) = @_;
     my $dbh = $self->{dbh};
 
     my $query = qq|SELECT DISTINCT pg.id, pg.partsgroup

--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -1882,7 +1882,7 @@ sub get_name {
     return $i;
 }
 
-=item $form->all_vc($myconfig, $vc, $module, $transdate, $job);
+=item $form->all_vc($myconfig, $vc, $transdate, $job);
 
 Populates the list referred to by $form->{all_${vc}} with hashes of either
 vendor or customer id and name, ordered by the name.  This will be vendor
@@ -1898,23 +1898,12 @@ $form->{all_language} is populated using the language table and is sorted by the
 description, and $form->all_employees, $form->all_departments,
 $form->all_business_units, and $form->all_taxaccounts are all run.
 
-$module is unused.
-
 =cut
 
 sub all_vc {
 
-    my ( $self, $myconfig, $vc, $module, $transdate, $job ) = @_;
+    my ($self, $myconfig, $vc, $transdate, $job) = @_;
     my $ref;
-    my $table;
-
-    if ($module eq 'AR') {
-        $table = 'ar';
-    }
-    elsif ($module eq 'AP'){
-        $table = 'ap';
-    }
-
     my $dbh = $self->{dbh};
 
     my $sth;
@@ -1956,22 +1945,6 @@ sub all_vc {
     my ($count) = $sth->fetchrow_array;
 
     $sth->finish;
-
-    # if ($self->{id}) {
-    # ### fixme: the segment below assumes that the form ID is a
-    # # credit account id, which it isn't necessarily (maybe never?)
-    # # when called from old/bin/oe.pl, it's an order id.
-    #     $query = qq|
-    #     SELECT ec.id, e.name
-    #       FROM entity e
-    #       JOIN entity_credit_account ec ON (ec.entity_id = e.id)
-    #      WHERE ec.id = (select entity_credit_account FROM $table
-    #             WHERE id = ?)
-    #     ORDER BY name|;
-    #     $sth = $self->{dbh}->prepare($query);
-    #     $sth->execute($self->{id});
-    #     ($self->{"${vc}_id"}, $self->{$vc}) = $sth->fetchrow_array();
-    # }
 
     if ( $count < $myconfig->{vclimit} ) {
 

--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -2576,7 +2576,6 @@ sub create_links {
     $self->all_vc(
         $myconfig,
         $vc,
-        $module,
         $self->{transdate},
         $job
     );

--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -2845,7 +2845,7 @@ sub get_partsgroup {
     $sth->finish;
 }
 
-=item $form->update_status($myconfig);
+=item $form->update_status();
 
 DELETEs all status rows which have a formname of $form->{formname} and a
 trans_id of $form->{id}.  INSERTs a new row into status where trans_id is
@@ -2860,7 +2860,7 @@ $myconfig is unused.
 
 sub update_status {
 
-    my ($self, $myconfig, $commit) = @_;
+    my ($self) = @_;
 
     # no id return
     return unless $self->{id};

--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -1882,7 +1882,7 @@ sub get_name {
     return $i;
 }
 
-=item $form->all_vc($myconfig, $vc, $module, $dbh, $transdate, $job);
+=item $form->all_vc($myconfig, $vc, $module, $transdate, $job);
 
 Populates the list referred to by $form->{all_${vc}} with hashes of either
 vendor or customer id and name, ordered by the name.  This will be vendor
@@ -1898,13 +1898,13 @@ $form->{all_language} is populated using the language table and is sorted by the
 description, and $form->all_employees, $form->all_departments,
 $form->all_business_units, and $form->all_taxaccounts are all run.
 
-$module and $dbh are unused.
+$module is unused.
 
 =cut
 
 sub all_vc {
 
-    my ( $self, $myconfig, $vc, $module, $dbh, $transdate, $job ) = @_;
+    my ( $self, $myconfig, $vc, $module, $transdate, $job ) = @_;
     my $ref;
     my $table;
 
@@ -1915,7 +1915,7 @@ sub all_vc {
         $table = 'ap';
     }
 
-    $dbh = $self->{dbh};
+    my $dbh = $self->{dbh};
 
     my $sth;
     $sth = $dbh->prepare('SELECT value FROM defaults WHERE setting_key = ?');
@@ -2604,7 +2604,6 @@ sub create_links {
         $myconfig,
         $vc,
         $module,
-        $dbh,
         $self->{transdate},
         $job
     );

--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -1685,20 +1685,21 @@ sub check_exchangerate {
     $exchangerate;
 }
 
-=item $form->add_shipto($dbh, $id);
+=item $form->add_shipto($id, $is_oe);
 
-Inserts a new address into the table shipto if the value of any of the shipto
-address components in $form differs to the regular attribute in $form.  The
-inserted value of trans_id is $id, the other fields correspond with the shipto
-address components of $form.
+Inserts a new location_id reference into the table new_shipto, using the
+Form->{locationid} property.
 
-$dbh is unused.
+$is_oe determines whether the locaation is linked with a transaction or an oe.
+
+If $is_oe is false, the value of trans_id is $id and of oe_id is NULL.
+If $is_oe is true, the value of trans_id is NULL and of oe_id is $id.
 
 =cut
 
 sub add_shipto {
 
-    my ( $self,$dbh,$id, $oe) = @_;
+    my ($self, $id, $is_oe) = @_;
     if (! $self->{locationid}) {
         return;
     }
@@ -1707,13 +1708,13 @@ sub add_shipto {
             INSERT INTO new_shipto
             (trans_id, oe_id,location_id)
             VALUES ( ?, ?, ?)
-            |;
+    |;
 
     my $sth = $self->{dbh}->prepare($query) || $self->dberror($query);
     my $trans_id;
     my $oe_id;
 
-    if ($oe) {
+    if ($is_oe) {
         $trans_id = undef;
         $oe_id = $id;
     }

--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -2531,12 +2531,7 @@ sub create_links {
     else {
 
         if (!$self->{"$self->{vc}_id"}) {
-            $self->lastname_used(
-                $myconfig,
-                $dbh,
-                $vc,
-                $module
-            );
+            $self->lastname_used($vc);
         }
     }
 
@@ -2596,7 +2591,7 @@ sub get_setting {
     return $ref->{value};
 }
 
-=item $form->lastname_used($myconfig, $dbh2, $vc, $module);
+=item $form->lastname_used($vc);
 
 Fills the name, currency, ${vc}_id, duedate, and possibly invoice_notes
 attributes of $form with the last used values for the transaction type specified
@@ -2606,15 +2601,11 @@ If $form->{type} matches /_order/, the transaction type used is order, if it
 matches /_quotation/, quotations are looked through.  If $form->{type} does not
 match either of the above, then ar or ap transactions are used.
 
-$myconfig, $dbh2, and $module are unused.
-
 =cut
 
 sub lastname_used {
 
-    my ( $self, $myconfig, $dbh2, $vc, $module ) = @_;
-
-    my $dbh = $self->{dbh};
+    my ($self, $vc) = @_;
     $vc ||= $self->{vc};    # add default to correct for improper passing
     my $arap;
     my $where;

--- a/old/lib/LedgerSMB/IC.pm
+++ b/old/lib/LedgerSMB/IC.pm
@@ -510,7 +510,7 @@ sub save {
     $a[3] = substr( "0$a[3]", -2 );
     my $shippingdate = "$a[5]$a[4]$a[3]";
 
-    ( $form->{employee}, $form->{employee_id} ) = $form->get_employee($dbh);
+    ( $form->{employee}, $form->{employee_id} ) = $form->get_employee;
 
     # add assembly records
     if ( $form->{item} eq 'assembly' && !$project_id ) {

--- a/old/lib/LedgerSMB/IR.pm
+++ b/old/lib/LedgerSMB/IR.pm
@@ -813,7 +813,7 @@ sub post_invoice {
     # add shipto
     $form->{name} = $form->{vendor};
     $form->{name} =~ s/--$form->{vendor_id}//;
-    $form->add_shipto( $dbh, $form->{id} );
+    $form->add_shipto($form->{id});
 
     if (!$form->{separate_duties}){
         $self->add_cogs($form);

--- a/old/lib/LedgerSMB/IR.pm
+++ b/old/lib/LedgerSMB/IR.pm
@@ -113,7 +113,7 @@ sub post_invoice {
     ( $null, $form->{employee_id} ) = split /--/, $form->{employee};
 
     unless ( $form->{employee_id} ) {
-        ( $form->{employee}, $form->{employee_id} ) = $form->get_employee($dbh);
+        ( $form->{employee}, $form->{employee_id} ) = $form->get_employee;
     }
 
     ( $null, $form->{department_id} ) = split( /--/, $form->{department} );

--- a/old/lib/LedgerSMB/IS.pm
+++ b/old/lib/LedgerSMB/IS.pm
@@ -1441,7 +1441,7 @@ sub post_invoice {
     # add shipto
     $form->{name} = $form->{customer};
     $form->{name} =~ s/--$form->{customer_id}//;
-    $form->add_shipto( $dbh, $form->{id} );
+    $form->add_shipto($form->{id});
 
     # save printed, emailed and queued
     $form->save_status($dbh);

--- a/old/lib/LedgerSMB/IS.pm
+++ b/old/lib/LedgerSMB/IS.pm
@@ -773,7 +773,7 @@ sub post_invoice {
 
     ( $null, $form->{employee_id} ) = split /--/, $form->{employee};
     unless ( $form->{employee_id} ) {
-        ( $form->{employee}, $form->{employee_id} ) = $form->get_employee($dbh);
+        ( $form->{employee}, $form->{employee_id} ) = $form->get_employee;
     }
 
     ( $null, $form->{department_id} ) = split( /--/, $form->{department} );

--- a/old/lib/LedgerSMB/OE.pm
+++ b/old/lib/LedgerSMB/OE.pm
@@ -455,7 +455,7 @@ sub save {
     $form->{name} = $form->{ $form->{vc} };
     $form->{name} =~ s/--$form->{"$form->{vc}_id"}//;
 
-    $form->add_shipto( $dbh, $form->{id}, 1);
+    $form->add_shipto($form->{id}, 1);
 
     # save printed, emailed, queued
 

--- a/old/lib/LedgerSMB/OE.pm
+++ b/old/lib/LedgerSMB/OE.pm
@@ -757,7 +757,7 @@ sub retrieve {
     else {
 
         # get last name used
-        $form->lastname_used( $myconfig, $dbh, $form->{vc} )
+        $form->lastname_used($form->{vc})
           unless $form->{"$form->{vc}_id"};
 
         delete $form->{notes};

--- a/old/lib/LedgerSMB/OE.pm
+++ b/old/lib/LedgerSMB/OE.pm
@@ -143,7 +143,7 @@ sub save {
 
     ( $null, $form->{employee_id} ) = split /--/, $form->{employee};
     if ( !$form->{employee_id} ) {
-        ( $form->{employee}, $form->{employee_id} ) = $form->get_employee($dbh);
+        ( $form->{employee}, $form->{employee_id} ) = $form->get_employee;
         $form->{employee} = "$form->{employee}--$form->{employee_id}";
     }
 
@@ -1604,7 +1604,7 @@ sub save_inventory {
     my $employee_id;
 
     ( $null, $employee_id ) = split /--/, $form->{employee};
-    ( $null, $employee_id ) = $form->get_employee($dbh) if !$employee_id;
+    ( $null, $employee_id ) = $form->get_employee if !$employee_id;
 
     $query = qq|
         SELECT serialnumber, ship
@@ -1942,7 +1942,7 @@ sub transfer {
 
     my $dbh = $form->{dbh};
 
-    ( $form->{employee}, $form->{employee_id} ) = $form->get_employee($dbh);
+    ( $form->{employee}, $form->{employee_id} ) = $form->get_employee;
 
     my @a = localtime;
     $a[5] += 1900;
@@ -2254,7 +2254,7 @@ sub generate_orders {
         my $employee_id;
         my $department_id;
 
-        ( $null, $employee_id ) = $form->get_employee($dbh);
+        ( $null, $employee_id ) = $form->get_employee;
         ( $null, $department_id ) = split /--/, $form->{department};
         $department_id *= 1;
 

--- a/old/lib/LedgerSMB/PE.pm
+++ b/old/lib/LedgerSMB/PE.pm
@@ -162,18 +162,16 @@ sub save_partsgroup {
 
 }
 
-=item PE->get_partsgroup($myconfig, $form);
+=item PE->get_partsgroup($form);
 
 Sets $form->{partsgroup} to the description of the partsgroup identified by
 $form->{id}.  If there are no parts entries associated with that partsgroup,
 $form->{orphaned} is made true, otherwise it is set to false.
 
-$myconfig is unused.
-
 =cut
 
 sub get_partsgroup {
-    my ( $self, $myconfig, $form ) = @_;
+    my ($self, $form) = @_;
 
     my $dbh = $form->{dbh};
 

--- a/old/lib/LedgerSMB/PE.pm
+++ b/old/lib/LedgerSMB/PE.pm
@@ -626,7 +626,7 @@ sub project_sales_order {
     my $query = qq|SELECT current_date|;
     my ($transdate) = $dbh->selectrow_array($query);
 
-    $form->all_years( $myconfig, $dbh );
+    $form->all_years;
 
     $form->all_business_units( $transdate, undef, 'Timecards');
     $form->{all_project} = $form->{b_units}->{2};


### PR DESCRIPTION
A number of methods in Form.pm have unused arguments. This patch removes them and updates their callers to them to simplify code.