### PR TITLE
Fix #2784 salesperson dropdown not shown

### DIFF
--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -1290,7 +1290,7 @@ sub generate_selects {
     }
 
     # sales staff
-    if ($form->{all_employees} && @{ $form->{all_employee} }) {
+    if ($form->{all_employee} && @{ $form->{all_employee} }) {
         $form->{selectemployee} = "";
         for (@{ $form->{all_employee} }) {
             $form->{selectemployee} .=


### PR DESCRIPTION
Select options were not being created due to variable name typo.