### PR TITLE
Silence warning on login - uninitialized value $path

### DIFF
--- a/lib/LedgerSMB/Scripts/login.pm
+++ b/lib/LedgerSMB/Scripts/login.pm
@@ -115,11 +115,8 @@ sub authenticate {
                      [ 'Please provide your credentials.' ]];
         }
     }
-    my $path = $ENV{SCRIPT_NAME};
-    $path =~ s|[^/]*$||;
 
     if ($request->{dbh} and !$request->{log_out}){
-
         if (!$request->{dbonly}
             && ! LedgerSMB::Session::check($request->{cookie}, $request)) {
             return [ 401,


### PR DESCRIPTION
Redundant code was looking for and performing substitution on $ENV{SCRIPT_NAME}.
This is no longer needed.