### PR TITLE
Enable Perl::Critic tests on files in lib/LedgerSMB/Auth/

### DIFF
--- a/lib/LedgerSMB/Auth/DB.pm
+++ b/lib/LedgerSMB/Auth/DB.pm
@@ -24,10 +24,9 @@ use Carp;
 
 use MIME::Base64;
 use Log::Log4perl;
-
 use LedgerSMB::Sysconfig;
-
 use Moose;
+use namespace::autoclean;
 
 my $logger = Log::Log4perl->get_logger('LedgerSMB::Auth');
 

--- a/xt/01.1-critic.t
+++ b/xt/01.1-critic.t
@@ -148,7 +148,6 @@ my @on_disk_oldcode =
 
 @on_disk =
     grep { ! m#^old/# }
-    grep { ! m#^lib/LedgerSMB/Auth/# }
     @on_disk;
 
 plan tests => scalar(@on_disk) + scalar(@on_disk_oldcode);


### PR DESCRIPTION
For some historic reason, files in lib/LedgerSMB/Auth/ were excluded
from tests. Only one change needed for them to pass the tests -
adding `use namespace::autoclean`.