### PR TITLE
Remove general Module::Runtime dependency

### DIFF
--- a/lib/LedgerSMB/Auth.pm
+++ b/lib/LedgerSMB/Auth.pm
@@ -54,16 +54,15 @@ use strict;
 use warnings;
 
 use LedgerSMB::Sysconfig;
-use Module::Runtime qw(use_module);
-
+use Module::Load;
 
 my $plugin = 'LedgerSMB::Auth::' . LedgerSMB::Sysconfig::auth;
-use_module($plugin) or die "Can't locate Auth parser plugin $plugin";
+load $plugin;
 
 sub factory {
     my ($psgi_env) = @_;
 
-    return use_module($plugin)->new(env => $psgi_env);
+    return $plugin->new(env => $psgi_env);
 }
 
 

--- a/lib/LedgerSMB/PSGI.pm
+++ b/lib/LedgerSMB/PSGI.pm
@@ -17,9 +17,8 @@ use warnings;
 use LedgerSMB;
 use LedgerSMB::App_State;
 use LedgerSMB::Auth;
-
+use Module::Load;
 use CGI::Emulate::PSGI;
-use Module::Runtime qw/ use_module /;
 use Try::Tiny;
 
 # To build the URL space
@@ -104,7 +103,7 @@ sub psgi_app {
         unless $module;
 
     return _internal_server_error("Unable to open module $module : $! : $@")
-        unless use_module($module);
+        unless load $module;
 
     my $action = $module->can($request->{action});
     return _internal_server_error("Action Not Defined: $request->{action}")

--- a/t/lib/PageObject.pm
+++ b/t/lib/PageObject.pm
@@ -4,7 +4,6 @@ use strict;
 use warnings;
 
 use Carp;
-use Module::Load;
 use Moose;
 extends 'Weasel::Element';
 

--- a/t/lib/PageObject.pm
+++ b/t/lib/PageObject.pm
@@ -4,8 +4,7 @@ use strict;
 use warnings;
 
 use Carp;
-use Module::Runtime qw(use_module);
-
+use Module::Load;
 use Moose;
 extends 'Weasel::Element';
 

--- a/t/lib/PageObject/App/Menu.pm
+++ b/t/lib/PageObject/App/Menu.pm
@@ -7,9 +7,7 @@ use Carp;
 use PageObject;
 use MIME::Base64;
 use Test::More;
-
-use Module::Runtime qw(use_module);
-
+use Module::Load;
 use Moose;
 extends 'PageObject';
 
@@ -100,8 +98,7 @@ sub click_menu {
         return undef;
     }
     # make sure the widget is registered before resolving the Weasel widget
-    ok(use_module($tgt_class),
-       "$tgt_class can be 'use'-d dynamically");
+    ok(load $tgt_class, "$tgt_class can be 'use'-d dynamically");
 
     do {
         $item = $item->find(".$ul/li[./a[text()='$_']]");

--- a/t/lib/Pherkin/Extension/pageobject_steps/nav_steps.pl
+++ b/t/lib/Pherkin/Extension/pageobject_steps/nav_steps.pl
@@ -4,8 +4,7 @@
 use strict;
 use warnings;
 
-use Module::Runtime qw/ use_module /;
-
+use Module::Load;
 use Test::More;
 use Test::BDD::Cucumber::StepFile;
 
@@ -23,7 +22,7 @@ my %pages = (
 When qr/I navigate to the application root/, sub {
     my $module = "PageObject::App::Login";
 
-    use_module($module);
+    load $module;
     S->{page} = $module->open(S->{ext_wsl})->verify;
 };
 
@@ -32,7 +31,7 @@ When qr/I navigate to the (.*) page/, sub {
     die "Unknown page '$page'"
         unless exists $pages{$page};
 
-    use_module($pages{$page});
+    load $pages{$page};
     S->{page} = $pages{$page}->open(S->{ext_wsl})->verify;
 };
 
@@ -126,7 +125,7 @@ When qr/I open the parts screen for '(.*)'/, sub {
         qq|.//td[contains(concat(" ",normalize-space(\@class)," "),
                           " partnumber ")]//*[text()="$partnumber"]|)->click;
 
-    use_module($screens{'part entry'});
+    load $screens{'part entry'};
     S->{ext_wsl}->page->body->maindiv->wait_for_content;
 };
 

--- a/xt/66-cucumber/11-ar/step_definitions/pageobject_steps.pl
+++ b/xt/66-cucumber/11-ar/step_definitions/pageobject_steps.pl
@@ -11,8 +11,6 @@ use LedgerSMB::Entity::Person::Employee;
 use LedgerSMB::Entity::User;
 use LedgerSMB::PGDate;
 
-
-use Module::Runtime qw(use_module);
 use PageObject::App::Login;
 
 use Test::More;


### PR DESCRIPTION
After discussion (https://matrix.to/#/!qyoLumPqusaXqFJNyK:matrix.org/$14947921991651761iyRKA:matrix.org) using Perl core module Module::Load rather than non-core Module::Runtime to dynamically load modules.

Cannot completely remove dependency on Module::Runtime as it is used for X12 EDI support. Already the cpanfile depends on Module::Runtime only if the edi feature is enabled, so doesn't need to change.