### PR TITLE
1.5 - Add general dependency on Module::Runtime to cpanfile

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -19,6 +19,7 @@ requires 'JSON';
 requires 'Locale::Maketext::Lexicon', '0.62';
 requires 'Log::Log4perl';
 requires 'MIME::Lite';
+requires 'Module::Runtime';
 requires 'Moose';
 requires 'Moose::Role';
 requires 'Moose::Util::TypeConstraints';
@@ -65,7 +66,6 @@ feature 'edi', "X12 EDI support" =>
     sub {
         requires 'X12::Parser';
         requires 'Path::Class';
-        requires 'Module::Runtime';
 };
 
 feature 'latex-pdf-ps', "PDF and PostScript output" =>


### PR DESCRIPTION
A number of our modules require the Module::Runtime module, but it
was listed as a dependency only if the edi feature is enabled. This
change adds it as a general dependency.

In 1.6, the general dependency on Module::Runtime has been factored-out,
but I considered that change as too invasive for the stable 1.5 branch.
Better just to correct the dependency and leave code untouched.