### PR TITLE
Dump More Logs if Is_LSMB_running.sh reports fail

### DIFF
--- a/utils/test/Is_LSMB_running.sh
+++ b/utils/test/Is_LSMB_running.sh
@@ -106,6 +106,8 @@ WaitForPlackup() {
     done
     if ! $httpdrunning; then
         echo "The starman/plack httpd didn't respond before the timeout";
+        DUMPfile /tmp/plackup-error.log;
+        DUMPfile /tmp/plackup-access.log;
         return 1;
     fi
 }
@@ -124,6 +126,7 @@ else    # fail early if starman is not running
     DUMPfile /tmp/Is_LSMB_running.log
     DUMPfile /tmp/Is_LSMB_running.html
     DUMPfile /tmp/plackup-error.log;
+    DUMPfile /tmp/plackup-access.log;
     exit $E;
 fi
 


### PR DESCRIPTION
As Per @ehuelsmann request [here](https://matrix.to/#/!qyoLumPqusaXqFJNyK:matrix.org/$149485313166702GDJYh:matrix.org)
Dump plackup-error.log and plackup-access.log if plack/starman appear to have failed