### PR TITLE
Removing warnings with PGObject2

### DIFF
--- a/lib/LedgerSMB/PGDate.pm
+++ b/lib/LedgerSMB/PGDate.pm
@@ -13,9 +13,17 @@ use base qw(PGObject::Type::DateTime);
 use strict;
 use warnings;
 
-PGObject->register_type(pg_type => $_,
+if ($PGObject::VERSION =~ /^1\./){
+    PGObject->register_type(pg_type => $_,
                                   perl_class => __PACKAGE__)
-   for ('date');
+    for ('date');
+} else {
+    PGObject::Type::Registry->register_type(
+                                  registry => 'default',
+                                    dbtype => $_,
+                                   apptype => __PACKAGE__)
+        for ('date');
+}
 
 
 =head1 SYNPOSIS

--- a/lib/LedgerSMB/PGNumber.pm
+++ b/lib/LedgerSMB/PGNumber.pm
@@ -21,8 +21,8 @@ for ('float4', 'float8', 'double precision', 'float', 'numeric'){
         PGObject->register_type(pg_type => $_,
                                   perl_class => __PACKAGE__);
     } else {
-	PGObject::Type::Registry->register_type(registry => 'default',
-		dbtype => $_, apptype => __PACKAGE__);
+        PGObject::Type::Registry->register_type(registry => 'default',
+                dbtype => $_, apptype => __PACKAGE__);
     }
 }
 

--- a/lib/LedgerSMB/PGNumber.pm
+++ b/lib/LedgerSMB/PGNumber.pm
@@ -14,9 +14,17 @@ use warnings;
 use Number::Format;
 use LedgerSMB::Setting;
 
-PGObject->register_type(pg_type => $_,
-                                  perl_class => __PACKAGE__)
-   for ('float4', 'float8', 'double precision', 'float', 'numeric');
+# For 1.6, better to move to the type's registration API rather than 
+# do it ourselves, but this keeps the logic the same.
+for ('float4', 'float8', 'double precision', 'float', 'numeric'){
+    if ($PGObject::VERSION =~ /^1\./){
+        PGObject->register_type(pg_type => $_,
+                                  perl_class => __PACKAGE__);
+    } else {
+	PGObject::Type::Registry->register_type(registry => 'default',
+		dbtype => $_, apptype => __PACKAGE__);
+    }
+}
 
 
 =head1 SYNPOSIS


### PR DESCRIPTION
This is a minimal shim to avoid warnings (and call the correct APIs) for PGObject 2 and type registration.

The major incompatibilities in PGObject 2 do *not* affect LedgerSMB and appropriate interfaces have been provided to allow it to run.  However since these will be removed in the future at some point they throw warnings when called (at startup).  This results in several pages warnings.  No additional warnings are shows even without this patch while operating the software however, at least as far as I can see.

One extremely important thing to note here is that the first version of PGObject released was 1.0, so the only versions we have to worry about are those which start with a 1.  This logic has been ported so far into all of the type modules and all have been released except BigFloat (where PGObject has broken something in 1.x but this has been fixed in 2.x pending release and Bytestream (where I am waiting for author review).