### PR TITLE
Silence deprecation warnings

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -29,7 +29,7 @@ requires 'Moose::Role';
 requires 'Moose::Util::TypeConstraints';
 requires 'MooseX::NonMoose';
 requires 'Number::Format';
-requires 'PGObject', '1.403.2';
+requires 'PGObject', '< 2'; # '1.403.2';
 requires 'PGObject::Simple', '2.0.0';
 requires 'PGObject::Simple::Role', '1.13.2';
 requires 'PGObject::Type::BigFloat';


### PR DESCRIPTION
LedgerSMB isn't ready yet for PGObject 2. For the version to stay below 2 until then.