### PR TITLE
Drop duplicate constraint entity_entity_class_fkey1

### DIFF
--- a/sql/changes/1.6/drop-entity-duplicate_constraint.sql
+++ b/sql/changes/1.6/drop-entity-duplicate_constraint.sql
@@ -1,0 +1,1 @@
+ALTER TABLE entity DROP CONSTRAINT entity_entity_class_fkey1;

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -52,3 +52,4 @@
 1.6/no-inv-entity-end-entity.sql
 !1.6/no-inv-entity-remove-entity.sql
 1.6/gl-trans-type.sql
+1.6/drop-entity-duplicate_constraint.sql


### PR DESCRIPTION
entity_entity_class_fkey1 is identical to entity_entity_class_fkey and
therefore redundant.