### PR TITLE
* Fix #2709: can't save vendor address

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -2,6 +2,14 @@
 Changelog for 1.5 Series
 Released 2016-12-24
 
+Changelog for 1.5.8
+* Fix printing of AR/AP transactions results in JavaScript error (Erik H)
+* Fix ODS output appearing on 'Title page' instead of 'Search results' (Erik H)
+* Fix Edit Vendor address misses 'Save' button (Erik H, #2709)
+
+Erik H is Erik Huelsmann
+
+
 Changelog for 1.5.7
 * Fix missing trailing zeros in cheque printing (Erik H, #2565)
 * Change comparison periods selector to a number spinner (Erik H)

--- a/UI/Contact/divs/address.html
+++ b/UI/Contact/divs/address.html
@@ -52,7 +52,7 @@
         LOC.delete= '[' _ text('Delete') _ ']';
         base_suffix = "$request.script?entity_id=$entity_id&location_id=$LOC.id" _
                "&credit_id=$credit_act.id&is_for_credit=$LOC.is_for_credit&target_div=address_div" _
-               "location_class=$LOC.location_class";
+               "&location_class=$LOC.location_class";
         LOC.edit_href_suffix= base_suffix _ '&action=edit';
         LOC.delete_href_suffix= base_suffix _ '&action=delete_location';
         IF LOC.id == request.location_id && request.action == 'edit';


### PR DESCRIPTION
Due to the missing ampersand, both the tab selection on update as well
as the appearence of the 'Save Location' button are malfunctioning:
the parameter causing the selection was missing.