### PR TITLE
Fix typo in Logo class

### DIFF
--- a/UI/css/gnome.css
+++ b/UI/css/gnome.css
@@ -11,7 +11,7 @@ This package is free software; you can redistribute it and/or modify it under th
 A:link { text-decoration: none; }
 A:visited {text-decoration: none; }
 A:active { text-decoration: underline; }
-A:hover { 
+A:hover {
   background-color: transparent;
   text-decoration: underline;
 }
@@ -23,7 +23,7 @@ body {
   background-color: #EDECEB;
 }
 
-.cornderlogo {
+.cornerlogo {
  border: 1px solid #000;
  width: 150px;
  margin-left: 1px;

--- a/UI/css/gnome2.css
+++ b/UI/css/gnome2.css
@@ -11,7 +11,7 @@ This package is free software; you can redistribute it and/or modify it under th
 A:link { text-decoration: none; }
 A:visited {text-decoration: none; }
 A:active { text-decoration: underline; }
-A:hover { 
+A:hover {
   background-color: transparent;
   text-decoration: underline;
 }
@@ -23,7 +23,7 @@ body {
   background-color: #EDECEB;
 }
 
-.cornderlogo {
+.cornerlogo {
  border: 1px solid #000;
  width: 150px;
  margin-left: 1px;

--- a/UI/menu/expanding.html
+++ b/UI/menu/expanding.html
@@ -1,6 +1,6 @@
 <?lsmb# HTML Snippet, for import only ?>
         <div style="text-align: center"><a target="_blank" href="http://ledgersmb.org/">
-            <img class="cornderlogo" src="images/ledgersmb_small.png" width="100" height="50" border="1" alt="LedgerSMB" />
+            <img class="cornerlogo" src="images/ledgersmb_small.png" width="100" height="50" border="1" alt="LedgerSMB" />
         </a></div>
         <div id="version_info"><?lsmb text("LedgerSMB [_1]", version) ?></div>
         <div id="company_info"><?lsmb text("Logged into [_1]", company) ?></div>


### PR DESCRIPTION
The class assigned to the logo should corner_logo.