### PR TITLE
* Fix #2859: File uploads broken

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -30,7 +30,7 @@ requires 'MooseX::NonMoose';
 requires 'Number::Format';
 requires 'PGObject', '>=1.403002, < 2';
 # PGObject::Simple 3.0.1 breaks our file uploads
-requires 'PGObject::Simple', '>=2.0.0, !=3.0.1';
+requires 'PGObject::Simple', '>=2.0.0, !=3.0.0, !=3.0.1';
 requires 'PGObject::Simple::Role', '1.13.2';
 requires 'PGObject::Type::BigFloat';
 requires 'PGObject::Type::DateTime', '1.0.4';

--- a/cpanfile
+++ b/cpanfile
@@ -29,7 +29,8 @@ requires 'Moose::Util::TypeConstraints';
 requires 'MooseX::NonMoose';
 requires 'Number::Format';
 requires 'PGObject', '>=1.403002, < 2';
-requires 'PGObject::Simple', '2.0.0';
+# PGObject::Simple 3.0.1 breaks our file uploads
+requires 'PGObject::Simple', '>=2.0.0, !=3.0.1';
 requires 'PGObject::Simple::Role', '1.13.2';
 requires 'PGObject::Type::BigFloat';
 requires 'PGObject::Type::DateTime', '1.0.4';


### PR DESCRIPTION
Note that it's a dependency which broke the file uploads;
 a new version has been released for that dependency, but we're now
 excluding the broken version to prevent breakage from appearing
 with new/existing installs