### PR TITLE
Extend password expiry for test user to infinity

### DIFF
--- a/xt/lib/Pherkin/Extension/LedgerSMB.pm
+++ b/xt/lib/Pherkin/Extension/LedgerSMB.pm
@@ -157,7 +157,7 @@ sub create_user {
         _DBH => $dbh,
         );
     $user->create($args{password} // 'password');
-    $self->super_dbh->do(qq(ALTER USER "$username" VALID UNTIL 'infinity'));
+    $dbh->do(qq(ALTER USER "$username" VALID UNTIL 'infinity'));
 
     return $user;
 }

--- a/xt/lib/Pherkin/Extension/LedgerSMB.pm
+++ b/xt/lib/Pherkin/Extension/LedgerSMB.pm
@@ -157,7 +157,7 @@ sub create_user {
         _DBH => $dbh,
         );
     $user->create($args{password} // 'password');
-    $self->super_dbh->do(qq(ALTER USER "$username" VALID UNTIL "infinity"));
+    $self->super_dbh->do(qq(ALTER USER "$username" VALID UNTIL 'infinity'));
 
     return $user;
 }

--- a/xt/lib/Pherkin/Extension/LedgerSMB.pm
+++ b/xt/lib/Pherkin/Extension/LedgerSMB.pm
@@ -157,6 +157,7 @@ sub create_user {
         _DBH => $dbh,
         );
     $user->create($args{password} // 'password');
+    $self->super_dbh->do(qq(ALTER USER "$username" VALID UNTIL "infinity"));
 
     return $user;
 }


### PR DESCRIPTION
If the test user expiry is set for a shorter period than the default expiry notification window we show a modal dialog notifying of such. This causes tests to fail on some platforms (and should on all)