### PR TITLE
* Fix #2835: adding/editing assemblies problems

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -10,6 +10,8 @@ Changelog for 1.5.8
 * Fix 'On Hand' goods search filter not being applied (Erik H, #2845)
 * Clean up issues found by Debian's 'lintian' (Erik H, Robert C)
 * Fix layout regression of 1.5 in single payment screen (Erik H, #1917)
+* Fix 'Update' on Assembly page resetting BOM count to 1 (Erik H, 2835)
+* Fix 'Update' on Assembly page requiring all BOM lines filled (Erik H, 2835)
 
 Erik H is Erik Huelsmann
 Robert C is Robert James Clay

--- a/bin/ic.pl
+++ b/bin/ic.pl
@@ -1332,7 +1332,7 @@ sub assembly_row {
             $column_data{qty} =
 qq|<td><input data-dojo-type="dijit/form/TextBox" name="qty_$i" size=6 value="$form->{"qty_$i"}" accesskey="$i" title="[Alt-$i]"></td>|;
             $column_data{partnumber} =
-qq|<td><input data-dojo-type="lsmb/parts/PartSelector" name="partnumber_$i" size=15 value="$form->{"partnumber_$i"}" data-dojo-props="channel: '/part/part-select/$i'"></td>|;
+qq|<td><input data-dojo-type="lsmb/parts/PartSelector" name="partnumber_$i" size=15 value="$form->{"partnumber_$i"}" data-dojo-props="required:false,channel: '/part/part-select/$i'"></td>|;
             $column_data{description} =
 qq|<td><div data-dojo-type="lsmb/parts/PartDescription" name="description_$i" size=30 data-dojo-props="channel: '/part/part-select/$i'">$form->{"description_$i"}</div></td>|;
             $column_data{partsgroup} =
@@ -1468,9 +1468,6 @@ sub update {
             $rows = scalar @{ $form->{item_list} };
 
             if ($rows) {
-                $form->{"adj_$i"} = 1;
-
-                $form->{"qty_$i"} = 1;
                 $form->{"adj_$i"} = 1;
                 for (qw(partnumber description unit)) {
                     $form->{item_list}[$i]{$_} =


### PR DESCRIPTION
Kaare reports two problems:
1. The assembly add/edit page can't be updated without adding new parts
2. The Qty field in the BOM section of the page gets reset to 1

This commit fixes both of these problems (both reported in #2835).