### PR TITLE
Semicolons not commas.

### DIFF
--- a/lib/LedgerSMB/Report.pm
+++ b/lib/LedgerSMB/Report.pm
@@ -361,7 +361,7 @@ sub _render {
         my $lines = shift;
         return unless $lines;
         my @newlines = map { { name => $_->{name} } } @{$self->header_lines};
-        return [map { { %$_, %{shift @newlines} } } @$lines ];
+        return [map { +{ %$_, %{shift @newlines} } } @$lines ];
     };
     $template = LedgerSMB::Template->new(
         user => $LedgerSMB::App_State::User,

--- a/lib/LedgerSMB/Report/Listings/Business_Unit.pm
+++ b/lib/LedgerSMB/Report/Listings/Business_Unit.pm
@@ -94,7 +94,7 @@ sub name { return LedgerSMB::Report::text('Business Unit List'); }
 sub run_report {
     my $self = shift;
     return $self->rows([
-      map { { %$_, row_id => $_->{id}, } }
+      map { +{ %$_, row_id => $_->{id}, } }
        $self->call_dbmethod(funcname => 'business_unit__list_by_class',
                               args => { business_unit_class_id => $self->id } )
     ]);

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -327,7 +327,7 @@ sub copy_db {
     my $rc = $database->copy($request->{new_name})
            || die 'An error occurred. Please check your database logs.' ;
     my $dbh = LedgerSMB::Database->new(
-           {%$database, (company_name => $request->{new_name})}
+           +{%$database, (company_name => $request->{new_name})}
     )->connect({ PrintError => 0, AutoCommit => 0 });
     $dbh->prepare("SELECT setting__set('role_prefix',
                                coalesce((setting_get('role_prefix')).value, ?))"
@@ -757,7 +757,7 @@ sub _failed_check {
                    size => 15,
            }};
         push @$rows, $row;
-        $hiddens->{"id_$count"} = $row->{$check->id_column},
+        $hiddens->{"id_$count"} = $row->{$check->id_column};
         ++$count;
    }
     $sth->finish();


### PR DESCRIPTION
Short and simple.   Four changes:  0ne apparently inadvertent comma of little consequence.
Three are just using a unary plus to silence the P::C policy's inability to tell blocks from hashes.