### PR TITLE
Remove prevention against non-existent warnings

### DIFF
--- a/t/02-number-handling.t
+++ b/t/02-number-handling.t
@@ -3,7 +3,6 @@
 use strict;
 use warnings;
 
-$ENV{TMPDIR} = 't/var';
 $ENV{REQUEST_METHOD} = 'GET';
      # Suppress warnings from LedgerSMB::_process_cookies
 

--- a/t/10-form.t
+++ b/t/10-form.t
@@ -56,8 +56,6 @@
 use strict;
 use warnings;
 
-$ENV{TMPDIR} = 't/var';
-
 use Test::More 'no_plan';
 use Test::Trap qw(trap $trap);
 use Math::BigFloat;

--- a/t/11-ledgersmb.t
+++ b/t/11-ledgersmb.t
@@ -3,11 +3,6 @@
 use strict;
 use warnings;
 
-$ENV{TMPDIR} = 't/var';
-$ENV{LANG} = 'LANG=en_US.UTF8';
-$ENV{REQUEST_METHOD} = 'GET';
-     # Suppress warnings from LedgerSMB::_process_cookies
-
 use Test::More 'no_plan';
 use Test::Exception;
 use Test::Trap qw(trap $trap);


### PR DESCRIPTION
leftovers cleanup. LedgerSMB::_process_cookies used to complain about undefined entries. Those were left overs then _process_cookies was fixed.