### PR TITLE
Fixes #2938

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -219,6 +219,7 @@ Changelog for 1.4.41
 * Refactor filter pages for income statement and balance sheet (Erik H)
 * Follow-up to earlier compensation for '.' missing from @INC (Erik H, #2275)
 * Fix reversal of payments against non-eca-default AR/AP account (Erik H, #2558)
+* Fix goods/services search with AR/AP invoices (Chris T, #2938)
 
 Erik H is Erik Huelsmann
 

--- a/Changelog
+++ b/Changelog
@@ -32,6 +32,9 @@ Nick P is Nick Prater
 Changelog for 1.5 Series
 Released 2016-12-24
 
+Changelog for 1.5.9
+* Fix goods/services search with AR/AP invoices (Chris T, #2938)
+
 Changelog for 1.5.8
 * Fix printing of AR/AP transactions results in JavaScript error (Erik H)
 * Fix ODS output appearing on 'Title page' instead of 'Search results' (Erik H)
@@ -219,7 +222,6 @@ Changelog for 1.4.41
 * Refactor filter pages for income statement and balance sheet (Erik H)
 * Follow-up to earlier compensation for '.' missing from @INC (Erik H, #2275)
 * Fix reversal of payments against non-eca-default AR/AP account (Erik H, #2558)
-* Fix goods/services search with AR/AP invoices (Chris T, #2938)
 
 Erik H is Erik Huelsmann
 

--- a/sql/modules/Goods.sql
+++ b/sql/modules/Goods.sql
@@ -500,9 +500,6 @@ $$
           SELECT id, 'ap' as o_table, invnumber as ordnumber, 'ir' as oe_class,
                  null, transdate, entity_credit_account
             FROM ap) o ON o.id = i.trans_id
-                          AND (o_table = 'oe') = (i_type = 'o')
-                 null, transdate, entity_credit_account, 'i' as expected_line
-            FROM ap) o ON o.id = i.trans_id
                           AND o.expected_line = i.i_type
     JOIN entity_credit_account eca ON o.entity_credit_account = eca.id
     JOIN entity e ON e.id = eca.entity_id

--- a/sql/modules/Goods.sql
+++ b/sql/modules/Goods.sql
@@ -489,18 +489,21 @@ $$
                  'i' as i_type
             FROM invoice) i ON p.id = i.parts_id
     JOIN (select o.id, 'oe' as o_table, ordnumber as ordnumber, c.oe_class,
-                 o.oe_class_id, o.transdate, o.entity_credit_account
+                 o.oe_class_id, o.transdate, o.entity_credit_account, 'o' as expected_line
             FROM oe o
             JOIN oe_class c ON o.oe_class_id = c.id
            UNION
           SELECT id, 'ar' as o_table, invnumber as ordnumber, 'is' as oe_class,
-                 null, transdate, entity_credit_account
+                 null, transdate, entity_credit_account, 'i' as expected_line
             FROM ar
            UNION
           SELECT id, 'ap' as o_table, invnumber as ordnumber, 'ir' as oe_class,
                  null, transdate, entity_credit_account
             FROM ap) o ON o.id = i.trans_id
                           AND (o_table = 'oe') = (i_type = 'o')
+                 null, transdate, entity_credit_account, 'i' as expected_line
+            FROM ap) o ON o.id = i.trans_id
+                          AND o.expected_line = i.i_type
     JOIN entity_credit_account eca ON o.entity_credit_account = eca.id
     JOIN entity e ON e.id = eca.entity_id
    WHERE (in_partnumber is null or p.partnumber like in_partnumber || '%')
@@ -508,12 +511,17 @@ $$
               OR p.description @@ plainto_tsquery(in_description))
          AND (in_date_from is null or in_date_from <= o.transdate)
          and (in_date_to is null or in_date_to >= o.transdate)
-         AND (in_inc_po is not true or o.oe_class = 'Purchase Order')
-         AND (in_inc_so is not true or o.oe_class = 'Sales Order')
-         AND (in_inc_quo is not true or o.oe_class = 'Quotation')
-         AND (in_inc_rfq is not true or o.oe_class = 'RFQ')
-         AND (in_inc_ir is not true or o.oe_class = 'ir')
-         AND (in_inc_is is not true or o.oe_class = 'is')
+         AND ((in_inc_po IS NULL AND in_inc_so IS NULL
+                AND in_inc_quo IS NULL AND in_inc_rfq IS NULL
+                AND in_inc_ir IS NULL AND in_inc_is IS NULL)
+              OR (
+                 (in_inc_po is true and o.oe_class = 'Purchase Order')
+                 OR (in_inc_so is true and o.oe_class = 'Sales Order')
+                 OR (in_inc_quo is true and o.oe_class = 'Quotation')
+                 OR (in_inc_rfq is true and o.oe_class = 'RFQ')
+                 OR (in_inc_ir is true and o.oe_class = 'ir')
+                 OR (in_inc_is is true and o.oe_class = 'is')
+             ))
 ORDER BY o.transdate desc, o.id desc;
 $$;
 

--- a/sql/modules/Goods.sql
+++ b/sql/modules/Goods.sql
@@ -498,7 +498,7 @@ $$
             FROM ar
            UNION
           SELECT id, 'ap' as o_table, invnumber as ordnumber, 'ir' as oe_class,
-                 null, transdate, entity_credit_account
+                 null, transdate, entity_credit_account, 'i' as expected_line
             FROM ap) o ON o.id = i.trans_id
                           AND o.expected_line = i.i_type
     JOIN entity_credit_account eca ON o.entity_credit_account = eca.id

--- a/xt/42-cogs-fifo.pg
+++ b/xt/42-cogs-fifo.pg
@@ -4,7 +4,7 @@ BEGIN;
 
     -- Plan the tests.
 
-    SELECT plan(114);
+    SELECT plan(119);
 
     -- Add data
 

--- a/xt/42-cogs-fifo.pg
+++ b/xt/42-cogs-fifo.pg
@@ -833,7 +833,32 @@ BEGIN;
                     FROM invoice WHERE id = -5204;
     SELECT todo('Fix, Bad syntax and no id = -5204',1);
 --    SELECT results_eq('test',ARRAY[true],'post-ar-3, allocation invoice 4 series 5 is -75; ' || allocated);
-    DEALLOCATE test;
+     DEALLOCATE test;
+
+    PREPARE test AS select count(*) = 26
+  from goods__history(null, null, null, null, null, false, false, false, false, true, true);
+    select result_eq('test'. array[true], 'get correct count of ar and ap lines from inv. history (26)');
+     DEALLOCATE test;
+
+    PREPARE test AS select count(*) = 14
+  from goods__history(null, null, null, null, null, false, false, false, false, true, false);
+    select result_eq('test'. array[true], 'get correct count of ar lines from inv. history');
+     DEALLOCATE test;
+
+    PREPARE test AS select count(*) = 12
+  from goods__history(null, null, null, null, null, false, false, false, false, false, true);
+    select result_eq('test'. array[true], 'get correct count (12) of ap lines from inv. history');
+     DEALLOCATE test;
+
+    PREPARE test AS select count(*) = 0
+  from goods__history(null, null, null, null, null, false, false, false, false, false, false);
+    select result_eq('test'. array[true], 'get correct count (0) of ap lines from inv. history with all exclused');
+     DEALLOCATE test;
+
+    PREPARE test AS select count(*) = 26
+  from goods__history(null, null, null, null, null, null, null, null, null, null, null);
+    select result_eq('test'. array[true], 'get correct count (26) of ap lines from inv. history with all default');
+     DEALLOCATE test;
 
     -- Finish the tests and clean up.
     SELECT * FROM finish();

--- a/xt/42-cogs-fifo.pg
+++ b/xt/42-cogs-fifo.pg
@@ -837,27 +837,27 @@ BEGIN;
 
     PREPARE test AS select count(*) = 26
   from goods__history(null, null, null, null, null, false, false, false, false, true, true);
-    select result_eq('test', array[true], 'get correct count of ar and ap lines from inv. history (26)');
+    select results_eq('test', array[true], 'get correct count of ar and ap lines from inv. history (26)');
      DEALLOCATE test;
 
     PREPARE test AS select count(*) = 14
   from goods__history(null, null, null, null, null, false, false, false, false, true, false);
-    select result_eq('test', array[true], 'get correct count of ar lines from inv. history');
+    select results_eq('test', array[true], 'get correct count of ar lines from inv. history');
      DEALLOCATE test;
 
     PREPARE test AS select count(*) = 12
   from goods__history(null, null, null, null, null, false, false, false, false, false, true);
-    select result_eq('test', array[true], 'get correct count (12) of ap lines from inv. history');
+    select results_eq('test', array[true], 'get correct count (12) of ap lines from inv. history');
      DEALLOCATE test;
 
     PREPARE test AS select count(*) = 0
   from goods__history(null, null, null, null, null, false, false, false, false, false, false);
-    select result_eq('test', array[true], 'get correct count (0) of ap lines from inv. history with all exclused');
+    select results_eq('test', array[true], 'get correct count (0) of ap lines from inv. history with all exclused');
      DEALLOCATE test;
 
     PREPARE test AS select count(*) = 26
   from goods__history(null, null, null, null, null, null, null, null, null, null, null);
-    select result_eq('test', array[true], 'get correct count (26) of ap lines from inv. history with all default');
+    select results_eq('test', array[true], 'get correct count (26) of ap lines from inv. history with all default');
      DEALLOCATE test;
 
     -- Finish the tests and clean up.

--- a/xt/42-cogs-fifo.pg
+++ b/xt/42-cogs-fifo.pg
@@ -837,27 +837,27 @@ BEGIN;
 
     PREPARE test AS select count(*) = 26
   from goods__history(null, null, null, null, null, false, false, false, false, true, true);
-    select result_eq('test'. array[true], 'get correct count of ar and ap lines from inv. history (26)');
+    select result_eq('test', array[true], 'get correct count of ar and ap lines from inv. history (26)');
      DEALLOCATE test;
 
     PREPARE test AS select count(*) = 14
   from goods__history(null, null, null, null, null, false, false, false, false, true, false);
-    select result_eq('test'. array[true], 'get correct count of ar lines from inv. history');
+    select result_eq('test', array[true], 'get correct count of ar lines from inv. history');
      DEALLOCATE test;
 
     PREPARE test AS select count(*) = 12
   from goods__history(null, null, null, null, null, false, false, false, false, false, true);
-    select result_eq('test'. array[true], 'get correct count (12) of ap lines from inv. history');
+    select result_eq('test', array[true], 'get correct count (12) of ap lines from inv. history');
      DEALLOCATE test;
 
     PREPARE test AS select count(*) = 0
   from goods__history(null, null, null, null, null, false, false, false, false, false, false);
-    select result_eq('test'. array[true], 'get correct count (0) of ap lines from inv. history with all exclused');
+    select result_eq('test', array[true], 'get correct count (0) of ap lines from inv. history with all exclused');
      DEALLOCATE test;
 
     PREPARE test AS select count(*) = 26
   from goods__history(null, null, null, null, null, null, null, null, null, null, null);
-    select result_eq('test'. array[true], 'get correct count (26) of ap lines from inv. history with all default');
+    select result_eq('test', array[true], 'get correct count (26) of ap lines from inv. history with all default');
      DEALLOCATE test;
 
     -- Finish the tests and clean up.


### PR DESCRIPTION
The filters for the goods search are totally wrong and were set to *exclude*
anything checked while the UI said it included anything checked.  This restores
old behavior of including and makes the behavior consistent with the UI