### PR TITLE
Fix ship/receive column alignments

### DIFF
--- a/old/bin/oe.pl
+++ b/old/bin/oe.pl
@@ -1730,10 +1730,12 @@ sub display_ship_receive {
 
     if ( $form->{vc} eq 'customer' ) {
         $form->{title} = $locale->text('Ship Merchandise');
+        $form->{type} = "ship_order";
         $shipped = $locale->text('Shipping Date');
     }
     else {
         $form->{title} = $locale->text('Receive Merchandise');
+        $form->{type} = "receive_order";
         $shipped = $locale->text('Date Received');
     }
 


### PR DESCRIPTION
When we rewrite the order listing to use the new reporting engine in 1.4
we neglected to pass in all expected parameters.  This corrects this
oversight by using the existing order information to determine whether
we are shipping or receiving.