### PR TITLE
Use $tempdir to test BLACKLIST

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -288,7 +288,7 @@ endif
 
 # make blacklist
 blacklist:
-	perl tools/makeblacklist.pl
+	perl tools/makeblacklist.pl -- --regenerate
 
 # make pod
 #make submodules

--- a/t/06-blacklist.t
+++ b/t/06-blacklist.t
@@ -1,10 +1,13 @@
 #!/usr/bin/perl
 
+use LedgerSMB::Sysconfig;
+
 use Test::More tests => 3;
 use Digest::SHA 'sha512_base64'; #already a dependency
 use FindBin;
 
 my $sqldir = "$FindBin::Bin/../sql/modules";
+my $tempdir = $LedgerSMB::Sysconfig::tempdir;
 
 open my $blist, '<', "$sqldir/BLACKLIST";
 my $contents = join "", map { $a = $_; chomp $a; $a } <$blist>;
@@ -14,7 +17,7 @@ ok($contents, "Got contents from original blacklist");
 
 diag `perl $FindBin::Bin/../tools/makeblacklist.pl`;
 
-open $blist, '<', "$sqldir/BLACKLIST";
+open $blist, '<', "$tempdir/BLACKLIST";
 my $contents2 = join "", map {  $a = $_; chomp $a; $a } <$blist>;
 close $blist;
 ok($contents, "Got contents from new blacklist");

--- a/tools/makeblacklist.pl
+++ b/tools/makeblacklist.pl
@@ -7,6 +7,13 @@ use lib "$FindBin::Bin/../lib";
 use 5.010; # say makes things easier
 no lib '.'; # can run from anywhere
 
+use LedgerSMB::Sysconfig;
+
+my $tempdir = $LedgerSMB::Sysconfig::tempdir;
+my $outputfile = ( defined $ARGV[1] && $ARGV[1] eq '--regenerate')
+               ? "$FindBin::Bin/../sql/modules/BLACKLIST"
+               : "$tempdir/BLACKLIST";
+
 my %func = (); # set of functions as keys
 
 my $order;
@@ -32,7 +39,7 @@ sub process_mod {
 
 sub write_blacklist {
     my @funcs = @_;
-    open my $bl, '>', "$FindBin::Bin/../sql/modules/BLACKLIST"
+    open my $bl, '>', $outputfile
         or die "Cannot write BLACKLIST";
     say $bl $_ for @funcs;
     close $bl;


### PR DESCRIPTION
In order to have the source tree read-only, move the temporary file required to test the BLACKLIST into the temporary directory. Provide a switch to allow make to regenerate it in place.