### PR TITLE
a no strict gone w/ minor cleanup

### DIFF
--- a/lib/LedgerSMB/Tax.pm
+++ b/lib/LedgerSMB/Tax.pm
@@ -87,14 +87,8 @@ sub init_taxes {
 
         my $module = "LedgerSMB/Taxes/$ref->{taxmodulename}.pm";
         require $module;
-        $module = $ref->{taxmodulename};
-        $module =~ s/\//::/g;
-        my $tax;
-        {
-          no strict 'refs';
-          $tax = "LedgerSMB::Taxes::$module"->new(%$ref);
-        }
 
+        my $tax = "LedgerSMB::Taxes::$ref->{taxmodulename}"->new(%$ref);
         $tax->account($taxaccount);
         $tax->taxnumber( $ref->{'taxnumber'} );
         $tax->value( 0 );


### PR DESCRIPTION
At the old line 91, it seems that `$ref->{taxmodulename}` can only be "Simple" or "Rounded", so the substitution is unnecessary.

"Rounded" appears to be undocumented vaporware, so I question if this is still overly ornamented code.
