### PR TITLE
Master loader divs (#3005)

### DIFF
--- a/UI/login.html
+++ b/UI/login.html
@@ -3,7 +3,13 @@
         include_stylesheet = ["login.css", "css/ledgersmb.css"]
         include_script = [ 'login.js' ]
 ?>
-<?lsmb PROCESS elements.html ?>
+<?lsmb
+   PROCESS elements.html ;
+   IF dojo_built == 0;
+      DOJO_LOCATION = "js-src";
+   ELSE;
+      DOJO_LOCATION = "js";
+   END -?>
 <body class="login, <?lsmb dojo_theme ?>"
       id="app-login">
   <br /><br />
@@ -27,6 +33,17 @@
             <img src="images/ledgersmb.png"
                  class="logo"
                  alt="LedgerSMB Logo" /></a>
+          <div style="position:relative; width:100%; height:15em;">
+            <div id="loading" style="z-index:100;position:absolute;top:0;left:0;width:100%;height:100%;background:white">
+              <img
+                 style="display: block; margin: auto auto; font-family: "
+                 src="<?lsmb DOJO_LOCATION ?>/dijit/icons/images/loadingAnimation.gif"
+                 alt="If this text is showing, there's most likely a problem with the Dojo setup"
+                 title="Loading ..."
+                 width="20"
+                 height="20" />
+            </div>
+          <div style="z-index:10; position:absolute; top:0; left:0; width:100%; height:100%;">
           <h1 class="login" align="center">
             <?lsmb text("LedgerSMB [_1]", VERSION) ?>
           </h1>
@@ -80,6 +97,8 @@
                  accesskey="l"
                  id="action-login"
                  text=text('Login') } ?>
+          </div>
+          </div>
         </div>
         <div id="login-indicator">
           <span><?lsmb text('Logging in.  Please wait.') ?></span>
@@ -89,3 +108,11 @@
   </center>
 </body>
 </html>
+<script>
+  require(['dojo/dom', 'dojo/dom-style', 'dojo/ready'],
+  function(dom, style, ready) {
+    ready(80, function() {
+  style.set(dom.byId('loading'), 'display', 'none');
+  });
+  });
+</script>

--- a/UI/setup/credentials.html
+++ b/UI/setup/credentials.html
@@ -1,9 +1,24 @@
 <?lsmb INCLUDE "ui-header.html" 
 stylesheet="ledgersmb.css"
 include_stylesheet=["setup/stylesheet.css"] ?>
-<?lsmb PROCESS elements.html ?>
+<?lsmb
+   PROCESS elements.html ;
+   IF dojo_built == 0;
+      DOJO_LOCATION = "js-src";
+   ELSE;
+      DOJO_LOCATION = "js";
+   END -?>
 <body id="setup-login" class="lsmb <?lsmb dojo_theme?>">
-<div class="setupconsole">
+  <div class="setupconsole" style="position:relative;height:23em">
+    <div id="loading" style="z-index:100;position:absolute;top:0;left:0;width:100%;height:100%;background:white">
+      <img
+         style="display: block; margin: auto auto; font-family: "
+         src="<?lsmb DOJO_LOCATION ?>/dijit/icons/images/loadingAnimation.gif"
+         alt="If this text is showing, there's most likely a problem with the Dojo setup"
+         title="Loading ..."
+         width="20" height="20" />
+    </div>
+    <div style="z-index:90;position:absolute;top:0;left:0;width:calc(100% - 4em);height:calc(100% - 4em);padding:2em">
 <h2><?lsmb text('Database Management Console') ?></h2>
 <div class="listtop"><?lsmb text('Database administrator credentials') ?></div>
 <form id="loginform"
@@ -64,5 +79,14 @@ INCLUDE select element_data = {
 </div>
 </form>
 </div>
+</div>
 </body>
 </html>
+<script>
+  require(['dojo/dom', 'dojo/dom-style', 'dojo/ready'],
+  function(dom, style, ready) {
+    ready(80, function() {
+  style.set(dom.byId('loading'), 'display', 'none');
+  });
+  });
+</script>

--- a/t/data/Is_LSMB_running.html
+++ b/t/data/Is_LSMB_running.html
@@ -36,9 +36,17 @@
         
         <meta name="robots" content="noindex,nofollow" />
 </head>
-
 <body id="setup-login" class="lsmb claro">
-<div class="setupconsole">
+  <div class="setupconsole" style="position:relative;height:23em">
+    <div id="loading" style="z-index:100;position:absolute;top:0;left:0;width:100%;height:100%;background:white">
+      <img
+         style="display: block; margin: auto auto; font-family: "
+         src="js/dijit/icons/images/loadingAnimation.gif"
+         alt="If this text is showing, there's most likely a problem with the Dojo setup"
+         title="Loading ..."
+         width="20" height="20" />
+    </div>
+    <div style="z-index:90;position:absolute;top:0;left:0;width:calc(100% - 4em);height:calc(100% - 4em);padding:2em">
 <h2>Database Management Console</h2>
 <div class="listtop">Database administrator credentials</div>
 <form id="loginform"
@@ -80,5 +88,14 @@
 </div>
 </form>
 </div>
+</div>
 </body>
 </html>
+<script>
+  require(['dojo/dom', 'dojo/dom-style', 'dojo/ready'],
+  function(dom, style, ready) {
+    ready(80, function() {
+  style.set(dom.byId('loading'), 'display', 'none');
+  });
+  });
+</script>


### PR DESCRIPTION
* Add loader divs

Note: one of the main purposes of the loader divs
  is to detect that Dojo isn't installed properly. When it isn't,
  the div isn't being hidden, preventing buttons from being
  shown to the user.

Side note: If Dojo isn't installed properly, the loader image
  won't show. We need to find a better way to signal to the
  user a prerequisite is missing.