### PR TITLE
Critic

### DIFF
--- a/xt/01.1-critic.t
+++ b/xt/01.1-critic.t
@@ -5,69 +5,22 @@ use warnings;
 use Test::More; # plan automatically generated below
 use File::Find;
 use Perl::Critic;
+use Perl::Critic::Violation;
 
 my @on_disk;
 
 
-# LedgerSMB aims to comply with the Perl::Critic policies recommended
-# by by CERT. See:
-# https://gist.github.com/briandfoy/4525877
-# https://www.securecoding.cert.org/confluence/display/perl/SEI+CERT+Perl+Coding+Standard
-#
-# Currently our code violates some of the recommended policies, so tests
-# are being added to this list as violations are fixed.
-
-# lsmb_new
-
-
-# The CERT recommended policies yet to be applied are listed below. Some
-# of these are explicitly excluded below, as they would otherwise be
-# applied by the -severity option in use.
-
-# lsmb_wip ( lsmb_new_wip, lsmb_old_wip)
-
-# The following CERT recommended policies will not be enforced:
-#
-#    ErrorHandling::RequireCarping
-#      As per ledgerSMB coding guidelines, calling "die" is the preferred
-#      way to signal an error. We can't stop die()ing, because that's how
-#      our error handling is implemented.  See:
-#      https://ledgersmb.org/community-guide/community-guide/development/coding-guidelines/perl-coding-guidelines
-#      https://matrix.to/#/!qyoLumPqusaXqFJNyK:matrix.org/$1492804519389522uYnup:matrix.org
-#
-#    Subroutines::ProhibitUnusedPrivateSubroutines
-#      This policy doesn't recognise when private subroutines are legitimately
-#      used as builder functions for Moose properties, which is a common
-#      pattern employed in LedgerSMB code. Neither does it recognise when
-#      private methods are used to compose roles in other files.
-
-# lsmb_reject
-
-# LedgerSMB enforces some other Perl::Critic policies
-#
-#  lsmb_new
-
-
-# LedgerSMB explicitly excludes some policies which we currently violate
-# and which would be applied automatically by the -severity option in use.
-# As violations are fixed, we can gradually remove these exclusions.
-
-# more lsmb_new_wip, less for lsmb_new
-# my @exclude_policies = qw(
-
-# more lsmb_old_wip, less for lsmb_old
-# my @exclude_policies_oldcode = qw(
-
-
 sub test_files {
     my ($critic, $files) = @_;
+
+    Perl::Critic::Violation::set_format( '%s %p %f: %l\n');
 
     for my $file (@$files) {
         my @findings = $critic->critique($file);
 
         ok(scalar(@findings) == 0, "Critique for $file");
         for my $finding (@findings) {
-            diag($finding->description);
+            diag ("$finding");
         }
     }
 

--- a/xt/01.1-critic.t
+++ b/xt/01.1-critic.t
@@ -82,7 +82,7 @@ my @cert_policies = qw(
 
 # LedgerSMB enforces some other Perl::Critic policies
 my @lsmb_policies = qw(
-    ProhibitTrailingWhitespace
+    CodeLayout::ProhibitTrailingWhitespace
     ProhibitHardTabs
     Modules
     Moose::RequireMakeImmutable
@@ -167,6 +167,7 @@ plan tests => scalar(@on_disk) + scalar(@on_disk_oldcode);
 
 &test_files(
     Perl::Critic->new(
+        -only => 1,
         -profile => 'xt/perlcriticrc',
         -severity => 5,
         -theme => '',

--- a/xt/01.1-critic.t
+++ b/xt/01.1-critic.t
@@ -16,53 +16,15 @@ my @on_disk;
 #
 # Currently our code violates some of the recommended policies, so tests
 # are being added to this list as violations are fixed.
-my @cert_policies = qw(
-    BuiltinFunctions::ProhibitStringySplit
-    BuiltinFunctions::ProhibitUniversalCan
-    ClassHierarchies::ProhibitExplicitISA
-    ControlStructures::ProhibitMutatingListFunctions
-    ControlStructures::ProhibitUnreachableCode
-    InputOutput::ProhibitBarewordFileHandles
-    InputOutput::ProhibitInteractiveTest
-    InputOutput::ProhibitOneArgSelect
-    InputOutput::ProhibitTwoArgOpen
-    InputOutput::RequireCheckedOpen
-    Miscellanea::ProhibitFormats
-    Modules::ProhibitEvilModules
-    Modules::RequireEndWithOne
-    Objects::ProhibitIndirectSyntax
-    Subroutines::ProhibitReturnSort
-    Subroutines::ProhibitSubroutinePrototypes
-    TestingAndDebugging::ProhibitProlongedStrictureOverride
-    TestingAndDebugging::RequireUseStrict
-    TestingAndDebugging::RequireUseWarnings
-    ValuesAndExpressions::ProhibitLeadingZeros
-    Variables::ProhibitPerl4PackageNames
-    Variables::ProhibitUnusedVariables
-    Variables::ProtectPrivateVars
-    Variables::RequireLexicalLoopIterators
-);
+
+# lsmb_new
+
 
 # The CERT recommended policies yet to be applied are listed below. Some
 # of these are explicitly excluded below, as they would otherwise be
 # applied by the -severity option in use.
-#    BuiltinFunctions::ProhibitBooleanGrep
-#    BuiltinFunctions::ProhibitUniversalIsa
-#    InputOutput::RequireCheckedClose
-#    InputOutput::RequireCheckedSyscalls
-#    RegularExpressions::ProhibitCaptureWithoutTest
-#    Subroutines::ProhibitBuiltinHomonyms
-#    Subroutines::ProhibitExplicitReturnUndef   --explicitly excluded
-#    Subroutines::ProtectPrivateSubs
-#    Subroutines::RequireFinalReturn
-#    TestingAndDebugging::ProhibitNoStrict      --explicitly excluded
-#    TestingAndDebugging:;ProhibitNoWarnings    --explicitly excluded
-#    ValuesAndExpressions::ProhibitCommaSeparatedStatements
-#    ValuesAndExpressions::ProhibitMagicNumbers
-#    ValuesAndExpressions::ProhibitMismatchedOperators
-#    ValuesAndExpressions::ProhibitMixedBooleanOperators
-#    Variables::RequireInitializationForLocalVars
-#    Variables::RequireLocalizedPunctuationVars
+
+# lsmb_wip ( lsmb_new_wip, lsmb_old_wip)
 
 # The following CERT recommended policies will not be enforced:
 #
@@ -79,41 +41,22 @@ my @cert_policies = qw(
 #      pattern employed in LedgerSMB code. Neither does it recognise when
 #      private methods are used to compose roles in other files.
 
+# lsmb_reject
 
 # LedgerSMB enforces some other Perl::Critic policies
-my @lsmb_policies = qw(
-    CodeLayout::ProhibitTrailingWhitespace
-    ProhibitHardTabs
-    Modules
-    Moose::RequireMakeImmutable
-    Moose::RequireCleanNamespace
-    TestingAndDebugging
-    ProhibitPuncutationVars
-);
+#
+#  lsmb_new
+
 
 # LedgerSMB explicitly excludes some policies which we currently violate
 # and which would be applied automatically by the -severity option in use.
 # As violations are fixed, we can gradually remove these exclusions.
-my @exclude_policies = qw(
-    Modules::RequireVersionVar
-    Subroutines::ProhibitExplicitReturnUndef
-    TestingAndDebugging::ProhibitNoWarnings
-    TestingAndDebugging::ProhibitNoStrict
-    InputOutput::RequireEncodingWithUTF8Layer
-);
-my @exclude_policies_oldcode = qw(
-    InputOutput::RequireEncodingWithUTF8Layer
-    Modules::ProhibitExcessMainComplexity
-    Modules::ProhibitMultiplePackages
-    Modules::RequireBarewordIncludes
-    Modules::RequireFilenameMatchesPackage
-    Modules::RequireVersionVar
-    Subroutines::ProhibitExplicitReturnUndef
-    TestingAndDebugging::ProhibitNoStrict
-    TestingAndDebugging::ProhibitNoWarnings
-    TestingAndDebugging::RequireUseStrict
-    TestingAndDebugging::RequireUseWarnings
-);
+
+# more lsmb_new_wip, less for lsmb_new
+# my @exclude_policies = qw(
+
+# more lsmb_old_wip, less for lsmb_old
+# my @exclude_policies_oldcode = qw(
 
 
 sub test_files {
@@ -149,35 +92,21 @@ my @on_disk_oldcode =
 
 plan tests => scalar(@on_disk) + scalar(@on_disk_oldcode);
 
-&test_files(
+test_files(
     Perl::Critic->new(
         -profile => 'xt/perlcriticrc',
-        -severity => 5,
-        -theme => '',
-        -exclude => [
-            @exclude_policies,
-        ],
-        -include => [
-            @cert_policies,
-            @lsmb_policies,
-        ],
+        -severity => 1,
+        -theme => 'lsmb_new',
     ),
     \@on_disk
 );
 
-&test_files(
+test_files(
     Perl::Critic->new(
         -only => 1,
         -profile => 'xt/perlcriticrc',
-        -severity => 5,
-        -theme => '',
-        -exclude => [
-            @exclude_policies_oldcode,
-        ],
-        -include => [
-            @cert_policies,
-            @lsmb_policies,
-        ],
+        -severity => 1,
+        -theme => 'lsmb_old',
     ),
     \@on_disk_oldcode
 );

--- a/xt/01.1-critic.t
+++ b/xt/01.1-critic.t
@@ -13,7 +13,7 @@ my @on_disk;
 sub test_files {
     my ($critic, $files) = @_;
 
-    Perl::Critic::Violation::set_format( '%s %p %f: %l\n');
+    Perl::Critic::Violation::set_format( 'S%s %p %f: %l\n');
 
     for my $file (@$files) {
         my @findings = $critic->critique($file);

--- a/xt/01.1-critic.t
+++ b/xt/01.1-critic.t
@@ -94,6 +94,7 @@ plan tests => scalar(@on_disk) + scalar(@on_disk_oldcode);
 
 test_files(
     Perl::Critic->new(
+        -only => 1,
         -profile => 'xt/perlcriticrc',
         -severity => 1,
         -theme => 'lsmb_new',

--- a/xt/perlcriticrc
+++ b/xt/perlcriticrc
@@ -122,7 +122,7 @@ pager = less
 
 ##### 
 
-[ProhibitPunctuationVars]
+[Variables::ProhibitPunctuationVars]
     set_themes = lsmb lsmb_new lsmb_old
 
 ###############################################################

--- a/xt/perlcriticrc
+++ b/xt/perlcriticrc
@@ -8,13 +8,13 @@
 #    lsmb_new -- themes that are enforced in testing on 'new' code
 #    lsmb_old --  themes that are enforced in testing on 'old' code; subset of lsmb_new
 #    lsmb_new_wip -- themes we want to use on 'new' code
-#    lsmb_wip -- rename for lsmb_new_wip  DEFAULT
+#  * lsmb_wip -- rename for lsmb_new_wip  DEFAULT
 #    lsmb_old_wip -- themes we want to use on 'old' code, subset of lsmb_new_wip, UNNECESSARY!
 #    lsmb -- includes all themes we want to use and do enforce;  all of the above
 #    lsmb_reject -- explicitly rejected themes      # just a documentation
 #    lsmb_consider  -- themes we are confused about using       # just a documentation
 
-theme = lsmb_new_wip
+#theme = lsmb_new_wip
 only = 1
 severity = 1
 verbose =%s %p %f   %l\n

--- a/xt/perlcriticrc
+++ b/xt/perlcriticrc
@@ -1,4 +1,22 @@
+# LedgerSMB perlcriticrc file
+
+#This config is set up to avoid interaction with
+# the larger local perlcritic environment.
+#To avoid pulling in unwanted policies use the -only option and
+#these themes:
+#
+#    lsmb_new -- themes that are enforced in testing on 'new' code
+#    lsmb_old --  themes that are enforced in testing on 'old' code; subset of lsmb_new
+#    lsmb_new_wip -- themes we want to use on 'new' code
+#    lsmb_wip -- rename for lsmb_new_wip  DEFAULT
+#    lsmb_old_wip -- themes we want to use on 'old' code, subset of lsmb_new_wip, UNNECESSARY!
+#    lsmb -- includes all themes we want to use and do enforce;  all of the above
+#    lsmb_reject -- explicitly rejected themes      # just a documentation
+#    lsmb_consider  -- themes we are confused about using       # just a documentation
+
+theme = lsmb_new_wip
 only = 1
+severity = 1
 verbose =%s %p %f   %l\n
 color =  0
 pager = less
@@ -87,7 +105,7 @@ pager = less
 [Modules::RequireEndWithOne]
     set_themes = lsmb lsmb_new lsmb_old
 [Modules::RequireExplicitInclusion]
-    set_themes = lsmb lsmb_new lsmb_old
+    set_themes = lsmb lsmb_consider
 [Modules::RequireExplicitPackage]
     set_themes = lsmb lsmb_new lsmb_old
 [Modules::RequireFilenameMatchesPackage]
@@ -122,8 +140,10 @@ pager = less
 
 ##### 
 
+# this was not in play for being misspelled.  
+# I don't like this one, it is not helpful.
 [Variables::ProhibitPunctuationVars]
-    set_themes = lsmb lsmb_new lsmb_old
+    set_themes = lsmb lsmb_consider
 
 ###############################################################
 # What was in exclude_policies is now themed lsmb_new_wip
@@ -170,5 +190,4 @@ pager = less
     set_themes = lsmb lsmb_new_wip lsmb_old_wip
 [Variables::RequireLocalizedPunctuationVars]
     set_themes = lsmb lsmb_new_wip lsmb_old_wip
-
 

--- a/xt/perlcriticrc
+++ b/xt/perlcriticrc
@@ -1,9 +1,174 @@
-[Modules::ProhibitEvilModules]
-modules_file = xt/prohibited_modules
-
-[CodeLayout::ProhibitHardTabs]
-allow_leading_tabs = 0
+only = 1
+verbose =%s %p %f   %l\n
+color =  0
+pager = less
 
 [ValuesAndExpressions::ProhibitMagicNumbers]
-allowed_values = -1 0 1 2
+    allowed_values = -1 0 1 2
+    set_themes = lsmb lsmb_new_wip lsmb_old_wip
+
+
+###########################################################
+## What were in cert_policies
+
+[BuiltinFunctions::ProhibitStringySplit]
+    set_themes = lsmb lsmb_new
+[BuiltinFunctions::ProhibitUniversalCan]
+    set_themes = lsmb lsmb_new
+[ClassHierarchies::ProhibitExplicitISA]
+    set_themes = lsmb lsmb_new lsmb_old_wip
+[ControlStructures::ProhibitMutatingListFunctions]
+    set_themes = lsmb lsmb_new
+[ControlStructures::ProhibitUnreachableCode]
+    set_themes = lsmb lsmb_new
+[InputOutput::ProhibitBarewordFileHandles]
+    set_themes = lsmb lsmb_new
+[InputOutput::ProhibitInteractiveTest]
+    set_themes = lsmb lsmb_new
+[InputOutput::ProhibitOneArgSelect]
+    set_themes = lsmb lsmb_new
+[InputOutput::ProhibitTwoArgOpen]
+    set_themes = lsmb lsmb_new
+[InputOutput::RequireCheckedOpen]
+    set_themes = lsmb lsmb_new
+[Miscellanea::ProhibitFormats]
+    set_themes = lsmb lsmb_new
+[Modules::ProhibitEvilModules]
+    set_themes = lsmb lsmb_new
+    modules_file = xt/prohibited_modules
+[Modules::RequireEndWithOne]
+    set_themes = lsmb lsmb_new  lsmb_old
+[Objects::ProhibitIndirectSyntax]
+    set_themes = lsmb lsmb_new
+[Subroutines::ProhibitReturnSort]
+    set_themes = lsmb lsmb_new
+[Subroutines::ProhibitSubroutinePrototypes]
+    set_themes = lsmb lsmb_new
+[TestingAndDebugging::ProhibitProlongedStrictureOverride]
+    set_themes = lsmb lsmb_new
+[TestingAndDebugging::RequireUseStrict]
+    set_themes = lsmb lsmb_new
+[TestingAndDebugging::RequireUseWarnings]
+    set_themes = lsmb lsmb_new
+[ValuesAndExpressions::ProhibitLeadingZeros]
+    set_themes = lsmb lsmb_new
+[Variables::ProhibitPerl4PackageNames]
+    set_themes = lsmb lsmb_new
+[Variables::ProhibitUnusedVariables]
+    set_themes = lsmb lsmb_new
+[Variables::ProtectPrivateVars]
+    set_themes = lsmb lsmb_new
+[Variables::RequireLexicalLoopIterators]
+
+###############################################################
+# What were in lsmb_policies
+
+[CodeLayout::ProhibitTrailingWhitespace]
+    set_themes = lsmb lsmb_new lsmb_old
+    
+[CodeLayout::ProhibitHardTabs]
+    set_themes = lsmb lsmb_new lsmb_old
+    allow_leading_tabs = 0
+
+#####   [Modules]  a theme expands to:   
+
+[Modules::ProhibitAutomaticExportation]
+    set_themes = lsmb lsmb_new lsmb_old
+[Modules::ProhibitConditionalUseStatements]
+    set_themes = lsmb lsmb_new lsmb_old
+[Modules::ProhibitEvilModules]
+    set_themes = lsmb lsmb_new lsmb_old
+[Modules::ProhibitExcessMainComplexity]
+    set_themes = lsmb lsmb_new lsmb_old_wip
+[Modules::ProhibitMultiplePackages]
+    set_themes = lsmb lsmb_new lsmb_old_wip
+[Modules::RequireBarewordIncludes]
+    set_themes = lsmb lsmb_new lsmb_old_wip
+[Modules::RequireEndWithOne]
+    set_themes = lsmb lsmb_new lsmb_old
+[Modules::RequireExplicitInclusion]
+    set_themes = lsmb lsmb_new lsmb_old
+[Modules::RequireExplicitPackage]
+    set_themes = lsmb lsmb_new lsmb_old
+[Modules::RequireFilenameMatchesPackage]
+    set_themes = lsmb lsmb_new lsmb_old_wip
+[Modules::RequireNoMatchVarsWithUseEnglish]
+    set_themes = lsmb lsmb_new lsmb_old
+[Modules::RequireVersionVar]
+    set_themes = lsmb lsmb_new_wip lsmb_old_wip
+
+#####
+
+
+[Moose::RequireMakeImmutable]
+    set_themes = lsmb lsmb_new lsmb_old
+[Moose::RequireCleanNamespace]
+    set_themes = lsmb lsmb_new lsmb_old
+
+######    [TestingAndDebugging]  a theme expands to:
+
+[TestingAndDebugging::ProhibitNoStrict]
+    set_themes = lsmb lsmb_new_wip lsmb_old_wip
+[TestingAndDebugging::ProhibitNoWarnings]
+    set_themes = lsmb lsmb_new_wip lsmb_old_wip
+[TestingAndDebugging::ProhibitProlongedStrictureOverride]
+    set_themes = lsmb lsmb_new lsmb_old
+[TestingAndDebugging::RequireTestLabels]
+    set_themes = lsmb lsmb_new lsmb_old
+[TestingAndDebugging::RequireUseStrict]
+    set_themes = lsmb lsmb_new lsmb_old_wip
+[TestingAndDebugging::RequireUseWarnings]
+    set_themes = lsmb lsmb_new lsmb_old_wip
+
+##### 
+
+[ProhibitPunctuationVars]
+    set_themes = lsmb lsmb_new lsmb_old
+
+###############################################################
+# What was in exclude_policies is now themed lsmb_new_wip
+#  Some is above.
+
+[InputOutput::RequireEncodingWithUTF8Layer]
+    set_themes = lsmb lsmb_new_wip lsmb_old_wip
+[Subroutines::ProhibitExplicitReturnUndef]
+    set_themes = lsmb lsmb_new_wip lsmb_old_wip
+
+
+###############################################################
+# What was in exclude_policies_oldcode is now themed lsmb_old_wip
+#  All is above.
+
+###############################################################
+# What was commented out as to be applied CERT recommended is
+# now themed lsmb_new_wip lsmb_old_wip
+# Some is above.
+
+[BuiltinFunctions::ProhibitBooleanGrep]
+    set_themes = lsmb lsmb_new_wip lsmb_old_wip
+[BuiltinFunctions::ProhibitUniversalIsa]
+    set_themes = lsmb lsmb_new_wip lsmb_old_wip
+[InputOutput::RequireCheckedClose]
+    set_themes = lsmb lsmb_new_wip lsmb_old_wip
+[InputOutput::RequireCheckedSyscalls]
+    set_themes = lsmb lsmb_new_wip lsmb_old_wip
+[RegularExpressions::ProhibitCaptureWithoutTest]
+    set_themes = lsmb lsmb_new_wip lsmb_old_wip
+[Subroutines::ProhibitBuiltinHomonyms]
+    set_themes = lsmb lsmb_new_wip lsmb_old_wip
+[Subroutines::ProtectPrivateSubs]
+    set_themes = lsmb lsmb_new_wip lsmb_old_wip
+[Subroutines::RequireFinalReturn]
+    set_themes = lsmb lsmb_new_wip lsmb_old_wip
+[ValuesAndExpressions::ProhibitCommaSeparatedStatements]
+    set_themes = lsmb lsmb_new_wip lsmb_old_wip
+[ValuesAndExpressions::ProhibitMismatchedOperators]
+    set_themes = lsmb lsmb_new_wip lsmb_old_wip
+[ValuesAndExpressions::ProhibitMixedBooleanOperators]
+    set_themes = lsmb lsmb_new_wip lsmb_old_wip
+[Variables::RequireInitializationForLocalVars]
+    set_themes = lsmb lsmb_new_wip lsmb_old_wip
+[Variables::RequireLocalizedPunctuationVars]
+    set_themes = lsmb lsmb_new_wip lsmb_old_wip
+
 

--- a/xt/perlcriticrc
+++ b/xt/perlcriticrc
@@ -1,33 +1,27 @@
 # LedgerSMB perlcriticrc file
 
-#This config is set up to avoid interaction with
-# the larger local perlcritic environment.
-#To avoid pulling in unwanted policies use the -only option and
-#these themes:
-#
-#    lsmb_new -- themes that are enforced in testing on 'new' code
-#    lsmb_old --  themes that are enforced in testing on 'old' code; subset of lsmb_new
-#    lsmb_new_wip -- themes we want to use on 'new' code
-#  * lsmb_wip -- rename for lsmb_new_wip  DEFAULT
-#    lsmb_old_wip -- themes we want to use on 'old' code, subset of lsmb_new_wip, UNNECESSARY!
-#    lsmb -- includes all themes we want to use and do enforce;  all of the above
-#    lsmb_reject -- explicitly rejected themes      # just a documentation
-#    lsmb_consider  -- themes we are confused about using       # just a documentation
+# Use these themes:
 
-#theme = lsmb_new_wip
+#  lsmb         -- includes all themes we want to use 
+#  lsmb_new     -- themes enforced on 'new' code
+#  lsmb_old     --  themes enforced on 'old' code; subset of lsmb_new
+#  lsmb_wip     -- themes we want to use on 'new' code
+#  lsmb_old_wip -- themes we want to use on 'old' code, subset of lsmb_wip, UNNECESSARY!
+
+#  lsmb_reject   -- explicitly rejected themes
+#  lsmb_consider -- themes we are confused about using
+
+theme = lsmb_wip
 only = 1
 severity = 1
 verbose =%s %p %f   %l\n
+#verbose =%f %p   %l  (%s)\n
 color =  0
 pager = less
 
 [ValuesAndExpressions::ProhibitMagicNumbers]
     allowed_values = -1 0 1 2
-    set_themes = lsmb lsmb_new_wip lsmb_old_wip
-
-
-###########################################################
-## What were in cert_policies
+    set_themes = lsmb lsmb_wip lsmb_old_wip
 
 [BuiltinFunctions::ProhibitStringySplit]
     set_themes = lsmb lsmb_new
@@ -78,8 +72,6 @@ pager = less
     set_themes = lsmb lsmb_new
 [Variables::RequireLexicalLoopIterators]
 
-###############################################################
-# What were in lsmb_policies
 
 [CodeLayout::ProhibitTrailingWhitespace]
     set_themes = lsmb lsmb_new lsmb_old
@@ -88,7 +80,6 @@ pager = less
     set_themes = lsmb lsmb_new lsmb_old
     allow_leading_tabs = 0
 
-#####   [Modules]  a theme expands to:   
 
 [Modules::ProhibitAutomaticExportation]
     set_themes = lsmb lsmb_new lsmb_old
@@ -112,10 +103,6 @@ pager = less
     set_themes = lsmb lsmb_new lsmb_old_wip
 [Modules::RequireNoMatchVarsWithUseEnglish]
     set_themes = lsmb lsmb_new lsmb_old
-[Modules::RequireVersionVar]
-    set_themes = lsmb lsmb_new_wip lsmb_old_wip
-
-#####
 
 
 [Moose::RequireMakeImmutable]
@@ -123,12 +110,11 @@ pager = less
 [Moose::RequireCleanNamespace]
     set_themes = lsmb lsmb_new lsmb_old
 
-######    [TestingAndDebugging]  a theme expands to:
 
 [TestingAndDebugging::ProhibitNoStrict]
-    set_themes = lsmb lsmb_new_wip lsmb_old_wip
+    set_themes = lsmb lsmb_wip lsmb_old_wip
 [TestingAndDebugging::ProhibitNoWarnings]
-    set_themes = lsmb lsmb_new_wip lsmb_old_wip
+    set_themes = lsmb lsmb_wip lsmb_old_wip
 [TestingAndDebugging::ProhibitProlongedStrictureOverride]
     set_themes = lsmb lsmb_new lsmb_old
 [TestingAndDebugging::RequireTestLabels]
@@ -138,56 +124,47 @@ pager = less
 [TestingAndDebugging::RequireUseWarnings]
     set_themes = lsmb lsmb_new lsmb_old_wip
 
-##### 
+[InputOutput::RequireEncodingWithUTF8Layer]
+    set_themes = lsmb lsmb_wip lsmb_old_wip
+[Subroutines::ProhibitExplicitReturnUndef]
+    set_themes = lsmb lsmb_wip lsmb_old_wip
 
-# this was not in play for being misspelled.  
-# I don't like this one, it is not helpful.
+[BuiltinFunctions::ProhibitBooleanGrep]
+    set_themes = lsmb lsmb_wip lsmb_old_wip
+[BuiltinFunctions::ProhibitUniversalIsa]
+    set_themes = lsmb lsmb_wip lsmb_old_wip
+[InputOutput::RequireCheckedClose]
+    set_themes = lsmb lsmb_wip lsmb_old_wip
+[InputOutput::RequireCheckedSyscalls]
+    set_themes = lsmb lsmb_wip lsmb_old_wip
+[RegularExpressions::ProhibitCaptureWithoutTest]
+    set_themes = lsmb lsmb_wip lsmb_old_wip
+[Subroutines::ProtectPrivateSubs]
+    set_themes = lsmb lsmb_wip lsmb_old_wip
+[Subroutines::RequireFinalReturn]
+    set_themes = lsmb lsmb_wip lsmb_old_wip
+[ValuesAndExpressions::ProhibitCommaSeparatedStatements]
+    set_themes = lsmb lsmb_new lsmb_old_wip
+[ValuesAndExpressions::ProhibitMismatchedOperators]
+    set_themes = lsmb lsmb_new lsmb_old_wip
+[ValuesAndExpressions::ProhibitMixedBooleanOperators]
+    set_themes = lsmb lsmb_new lsmb_old_wip
+[Variables::RequireInitializationForLocalVars]
+    set_themes = lsmb lsmb_wip lsmb_old_wip
+[Variables::RequireLocalizedPunctuationVars]
+    set_themes = lsmb lsmb_wip lsmb_old_wip
+
+# I don't like this one, it is not helpful. It is easier
+# to recognize the punct namespace and look them up
+# as needed than to remember all the long names.
+
 [Variables::ProhibitPunctuationVars]
     set_themes = lsmb lsmb_consider
 
-###############################################################
-# What was in exclude_policies is now themed lsmb_new_wip
-#  Some is above.
+# VersionVar unnecessary, really an app
+[Modules::RequireVersionVar]
+    set_themes = lsmb lsmb_reject
 
-[InputOutput::RequireEncodingWithUTF8Layer]
-    set_themes = lsmb lsmb_new_wip lsmb_old_wip
-[Subroutines::ProhibitExplicitReturnUndef]
-    set_themes = lsmb lsmb_new_wip lsmb_old_wip
-
-
-###############################################################
-# What was in exclude_policies_oldcode is now themed lsmb_old_wip
-#  All is above.
-
-###############################################################
-# What was commented out as to be applied CERT recommended is
-# now themed lsmb_new_wip lsmb_old_wip
-# Some is above.
-
-[BuiltinFunctions::ProhibitBooleanGrep]
-    set_themes = lsmb lsmb_new_wip lsmb_old_wip
-[BuiltinFunctions::ProhibitUniversalIsa]
-    set_themes = lsmb lsmb_new_wip lsmb_old_wip
-[InputOutput::RequireCheckedClose]
-    set_themes = lsmb lsmb_new_wip lsmb_old_wip
-[InputOutput::RequireCheckedSyscalls]
-    set_themes = lsmb lsmb_new_wip lsmb_old_wip
-[RegularExpressions::ProhibitCaptureWithoutTest]
-    set_themes = lsmb lsmb_new_wip lsmb_old_wip
+# Too many methods
 [Subroutines::ProhibitBuiltinHomonyms]
-    set_themes = lsmb lsmb_new_wip lsmb_old_wip
-[Subroutines::ProtectPrivateSubs]
-    set_themes = lsmb lsmb_new_wip lsmb_old_wip
-[Subroutines::RequireFinalReturn]
-    set_themes = lsmb lsmb_new_wip lsmb_old_wip
-[ValuesAndExpressions::ProhibitCommaSeparatedStatements]
-    set_themes = lsmb lsmb_new_wip lsmb_old_wip
-[ValuesAndExpressions::ProhibitMismatchedOperators]
-    set_themes = lsmb lsmb_new_wip lsmb_old_wip
-[ValuesAndExpressions::ProhibitMixedBooleanOperators]
-    set_themes = lsmb lsmb_new_wip lsmb_old_wip
-[Variables::RequireInitializationForLocalVars]
-    set_themes = lsmb lsmb_new_wip lsmb_old_wip
-[Variables::RequireLocalizedPunctuationVars]
-    set_themes = lsmb lsmb_new_wip lsmb_old_wip
-
+    set_themes = lsmb_reject


### PR DESCRIPTION
Things were good until I added some policies to aid in decoupling modules; then thousands of extraneous messages.

Any questionable stuff is at the bottom of the perlcriticrc.

If someone can fix or no-critic Sysconfig.pm, RequireLocalizedPunctuationVars will be done for new code.

This PR addresses problems with perl::critic'ing.

The problems that this fixes:

1)  The set of policies is not stable.  If you install policies which have TestingAndDebugging or Modules in their longname, those policies will be enforced.

2) The set of policies is poorly defined because only the authors know what policies they had installed.

3) Missing policies are silently ignored.  So the missing  ProhibitPuncutationVars goes unnoticed and the punctuation errors go unchecked.

4) Devs need to build a perlcriticrc file or write code to run our policies outside of testing.

5) Starting with a gentle criticism with the intent of increasing harshness is not a workable approach. Increasing severity is too coarse.  Rather the criticism plan as implemented, addressing specific critiques as able, is good.
