### PR TITLE
Issue 3020 add return value checks to method do

### DIFF
--- a/bin/am.pl
+++ b/bin/am.pl
@@ -326,7 +326,7 @@ sub edit_sic {
 
     $form->{title} = "Edit";
 
-    $form->{code} =~ s/\\'/'/g;
+    $form->{code} =~ s/\\'/'/g; # ' # kludge the single quote for syntax highlighting
     $form->{code} =~ s/\\\\/\\/g;
 
     AM->get_sic( \%myconfig, \%$form );
@@ -415,7 +415,7 @@ sub edit_language {
 
     $form->{title} = "Edit";
 
-    $form->{code} =~ s/\\'/'/g;
+    $form->{code} =~ s/\\'/'/g; #' # kludge the single quote for syntax highlighting
     $form->{code} =~ s/\\\\/\\/g;
 
     AM->get_language( \%myconfig, \%$form );
@@ -1044,7 +1044,16 @@ sub edit_recurring {
     }
 
     $form->{script} = "$form->{module}.pl";
-    do "bin/$form->{script}";
+    {
+        local ($!, $@);
+        my $do_ = "bin/$form->{script}";
+        unless ( do $do_ ) {
+            if ($! or $@) {
+                print "Status: 500 Internal server error (am.pl)\n\n";
+                warn "Failed to execute $do_ ($!): $@\n";
+            }
+        }
+    };
 
     &{ $links{ $form->{module} } };
 
@@ -1123,7 +1132,16 @@ sub process_transactions {
                         $form->{module} = "ap";
                         $invfld         = "vinumber";
                     }
-                    do "bin/$form->{script}";
+                    {
+                        local ($!, $@);
+                        my $do_ = "bin/$form->{script}";
+                        unless ( do $do_ ) {
+                            if ($! or $@) {
+                                print "Status: 500 Internal server error (am.pl)\n\n";
+                                warn "Failed to execute $do_ ($!): $@\n";
+                            }
+                        }
+                    };
 
                     if ( $pt->{invoice} ) {
                         &invoice_links;

--- a/bin/io.pl
+++ b/bin/io.pl
@@ -985,7 +985,16 @@ sub create_form {
     $form->{rowcount}-- if $form->{rowcount};
     $form->{rowcount} = 0 if !$form->{"$form->{vc}_id"};
 
-    do "bin/$form->{script}";
+    {
+        local ($!, $@);
+        my $do_ = "bin/$form->{script}";
+        unless ( do $do_ ) {
+            if ($! or $@) {
+                print "Status: 500 Internal server error (io.pl)\n\n";
+                warn "Failed to execute $do_ ($!): $@\n";
+            }
+        }
+    };
 
     for ( "$form->{vc}", "currency" ) { $form->{"select$_"} = "" }
 

--- a/lib/LedgerSMB/OE.pm
+++ b/lib/LedgerSMB/OE.pm
@@ -1097,10 +1097,7 @@ sub order_details {
             my $decimalplaces = ( $dec > 2 ) ? $dec : 2;
 
             my $discount = $form->round_amount(
-                $sellprice *
-                  $form->parse_amount( $myconfig, $form->{"discount_$i"} ) /
-                  100,
-                $decimalplaces
+                $sellprice * $form->parse_amount( $myconfig, $form->{"discount_$i"} ) / 100, $decimalplaces
             );
 
             # keep a netprice as well, (sellprice - discount)

--- a/lib/LedgerSMB/Reconciliation/CSV.pm
+++ b/lib/LedgerSMB/Reconciliation/CSV.pm
@@ -23,13 +23,20 @@ use Try::Tiny;
 use base qw(LedgerSMB::PGOld);
 
 try {
-no warnings;
-opendir (DCSV, 'old/lib/LedgerSMB/Reconciliation/CSV/Formats');
-for my $format (readdir(DCSV)){
-    if ($format !~ /^\./){
-        do "old/lib/LedgerSMB/Reconciliation/CSV/Formats/$format";
+    no warnings;
+    opendir (DCSV, 'old/lib/LedgerSMB/Reconciliation/CSV/Formats');
+    for my $format (readdir(DCSV)){
+        if ($format !~ /^\./){
+            local ($!, $@);
+            my $do_ = "old/lib/LedgerSMB/Reconciliation/CSV/Formats/$format";
+            unless ( do $do_ ) {
+                if ($! or $@) {
+                    print "Status: 500 Internal server error (CSV.pm)\n\n";
+                    warn "Failed to execute $do_ ($!): $@\n";
+                }
+            }
+        }
     }
-}
 };
 
 =head1 METHODS

--- a/lib/LedgerSMB/Scripts/admin.pm
+++ b/lib/LedgerSMB/Scripts/admin.pm
@@ -167,9 +167,18 @@ sub delete_session {
     list_sessions($request);
 }
 
-###TODO-LOCALIZE-DOLLAR-AT
-eval { do "scripts/custom/admin.pl"};
-
+{
+    local ($!, $@);
+    my $do_ = 'scripts/custom/admin.pl';
+    if ( -e $do_ ) {
+        unless ( do $do_ ) {
+            if ($! or $@) {
+                print "Status: 500 Internal server error (login.pm)\n\n";
+                warn "Failed to execute $do_ ($!): $@\n";
+            }
+        }
+    }
+}
 =back
 
 =head1 COPYRIGHT

--- a/lib/LedgerSMB/Scripts/asset.pm
+++ b/lib/LedgerSMB/Scripts/asset.pm
@@ -993,8 +993,18 @@ sub run_import {
     begin_import($request);
 }
 
-###TODO-LOCALIZE-DOLLAR-AT
-eval { do "scripts/custom/asset.pl"};
+{
+    local ($!, $@);
+    my $do_ = "scripts/custom/asset.pl";
+    if ( -e $do_ ) {
+        unless ( do $do_ ) {
+            if ($! or $@) {
+                print "Status: 500 Internal server error (asset.pm)\n\n";
+                warn "Failed to execute $do_ ($!): $@\n";
+            }
+        }
+    }
+};
 
 1;
 

--- a/lib/LedgerSMB/Scripts/contact.pm
+++ b/lib/LedgerSMB/Scripts/contact.pm
@@ -45,7 +45,16 @@ my @pluginmods = grep { /^[^.]/ && -f "LedgerSMB/Entity/Plugins/$_" } readdir($d
 closedir $dh;
 
 for (@pluginmods){
-  do "lib/LedgerSMB/Entity/Plugins/$_";
+    local ($!, $@);
+    my $do_ = "lib/LedgerSMB/Entity/Plugins/$_";
+    if ( -e $do_ ) {
+        unless ( do $do_ ) {
+            if ($! or $@) {
+                print "Status: 500 Internal server error (contact.pm)\n\n";
+                warn "Failed to execute $do_ ($!): $@\n";
+            }
+        }
+    }
 }
 
 

--- a/lib/LedgerSMB/Scripts/import_csv.pm
+++ b/lib/LedgerSMB/Scripts/import_csv.pm
@@ -524,7 +524,17 @@ any later version.  Please see the included LICENSE.txt for more details.
 
 =cut
 
-###TODO-LOCALIZE-DOLLAR-AT
-eval { do 'scripts/custom/import_trans.pl'; };
+{
+    local ($!, $@);
+    my $do_ = 'scripts/custom/import_trans.pl';
+    if ( -e $do_ ) {
+        unless ( do $do_ ) {
+            if ($! or $@) {
+                print "Status: 500 Internal server error (import_csv.pm)\n\n";
+                warn "Failed to execute $do_ ($!): $@\n";
+            }
+        }
+    }
+};
 
 1;

--- a/lib/LedgerSMB/Scripts/journal.pm
+++ b/lib/LedgerSMB/Scripts/journal.pm
@@ -141,6 +141,17 @@ files.
 
 =cut
 
-###TODO-LOCALIZE-DOLLAR-AT
-eval { do "scripts/custom/journal.pl"};
+{
+    local ($!, $@);
+    my $do_ = 'scripts/custom/journal.pl';
+    if ( -e $do_ ) {
+        unless ( do $do_ ) {
+            if ($! or $@) {
+                print "Status: 500 Internal server error (journal.pm)\n\n";
+                warn "Failed to execute $do_ ($!): $@\n";
+            }
+        }
+    }
+};
+
 1;

--- a/lib/LedgerSMB/Scripts/login.pm
+++ b/lib/LedgerSMB/Scripts/login.pm
@@ -192,8 +192,18 @@ sub logout_js {
 }
 
 
-###TODO-LOCALIZE-DOLLAR-AT
-eval { do "scripts/custom/login.pl"};
+{
+    local ($!, $@);
+    my $do_ = 'scripts/custom/login.pl';
+    if ( -e $do_ ) {
+        unless ( do $do_ ) {
+            if ($! or $@) {
+                print "Status: 500 Internal server error (login.pm)\n\n";
+                warn "Failed to execute $do_ ($!): $@\n";
+            }
+        }
+    }
+};
 
 =back
 

--- a/lib/LedgerSMB/Scripts/lreports_co.pm
+++ b/lib/LedgerSMB/Scripts/lreports_co.pm
@@ -97,6 +97,16 @@ files.
 
 =cut
 
-###TODO-LOCALIZE-DOLLAR-AT
-eval { do "scripts/custom/lreports_co.pl"};
+{
+    local ($!, $@);
+    my $do_ = 'scripts/custom/lreports_co.pl';
+    if ( -e $do_ ) {
+        unless ( do $do_ ) {
+            if ($! or $@) {
+                print "Status: 500 Internal server error (lreports_co.pm)\n\n";
+                warn "Failed to execute $do_ ($!): $@\n";
+            }
+        }
+    }
+};
 1;

--- a/lib/LedgerSMB/Scripts/menu.pm
+++ b/lib/LedgerSMB/Scripts/menu.pm
@@ -173,6 +173,16 @@ files.
 
 =cut
 
-###TODO-LOCALIZE-DOLLAR-AT
-eval { do "scripts/custom/menu.pl"};
+{
+    local ($!, $@);
+    my $do_ = 'scripts/custom/menu.pl';
+    if ( -e $do_ ) {
+        unless ( do $do_ ) {
+            if ($! or $@) {
+                print "Status: 500 Internal server error (menu.pm)\n\n";
+                warn "Failed to execute $do_ ($!): $@\n";
+            }
+        }
+    }
+};
 1;

--- a/lib/LedgerSMB/Scripts/order.pm
+++ b/lib/LedgerSMB/Scripts/order.pm
@@ -161,7 +161,21 @@ sub generate {
         for my $k (keys %$request){
             $form->{$k} = $request->{$k};
         }
-        { no strict; no warnings 'redefine'; do 'bin/oe.pl'; }
+        {
+            local ($!, $@);
+            my $do_ = 'bin/oe.pl';
+            if ( -e $do_ ) {
+                no strict;
+                no warnings 'redefine';
+                unless ( do $do_ ) {
+                    if ($! or $@) {
+                        print "Status: 500 Internal server error (login.pm)\n\n";
+                        warn "Failed to execute $do_ ($!): $@\n";
+                    }
+                }
+            }
+        }
+
         my $locale = $LedgerSMB::App_State::Locale;
         lsmb_legacy::generate_purchase_orders($form, $locale);
         exit;

--- a/lib/LedgerSMB/Scripts/payment.pm
+++ b/lib/LedgerSMB/Scripts/payment.pm
@@ -1714,12 +1714,12 @@ while ($request->{"entity_id_$count"})
   #the $invoice_id_amount_to_pay hash will keep track of the amount to be paid of an specific invoice_id, this amount could not be more than the due of that invoice
   $invoice_id_amount_to_pay{qq|$request->{"invoice_id_$count"}|} += $request->{"amount_$count"};
   if($invoice_id_amount_to_pay{qq|$request->{"invoice_id_$count"}|} > $applied_due){
-    $request->{"warning"} .= "Warning\n"
+    $request->{"warning"} .= "Warning\n";
   }
 
   #The amount to be paid shouldn't be negative
   if ($request->{"amount_$count"} < 0){
-    $request->{"warning"} .= "Warning\n"
+    $request->{"warning"} .= "Warning\n";
   }
 
   #Is the amount to be paid null?, tell the user and he/she will be able to manage it
@@ -1893,7 +1893,17 @@ for my $key (keys %entity_list)
 
 =cut
 
-###TODO-LOCALIZE-DOLLAR-AT
-eval { do "scripts/custom/payment.pl"};
+{
+    local ($!, $@);
+    my $do_ = 'scripts/custom/payment.pl';
+    if ( -e $do_ ) {
+        unless ( do $do_ ) {
+            if ($! or $@) {
+                print "Status: 500 Internal server error(payment.pm)\n\n";
+                warn "Failed to execute $do_ ($!): $@\n";
+            }
+        }
+    }
+};
 1;
 

--- a/lib/LedgerSMB/Scripts/recon.pm
+++ b/lib/LedgerSMB/Scripts/recon.pm
@@ -475,8 +475,18 @@ sub pending {
     }
 }
 
-###TODO-LOCALIZE-DOLLAR-AT
-eval { do "scripts/custom/recon.pl" };
+{
+    local ($!, $@);
+    my $do_ = 'scripts/custom/recon.pl';
+    if ( -e $do_ ) {
+        unless ( do $do_ ) {
+            if ($! or $@) {
+                print "Status: 500 Internal server error (recon.pm)\n\n";
+                warn "Failed to execute $do_ ($!): $@\n";
+            }
+        }
+    }
+};
 1;
 
 =back

--- a/lib/LedgerSMB/Scripts/taxform.pm
+++ b/lib/LedgerSMB/Scripts/taxform.pm
@@ -225,6 +225,16 @@ files.
 
 =cut
 
-###TODO-LOCALIZE-DOLLAR-AT
-eval { do "scripts/custom/taxform.pl"};
+{
+    local ($!, $@);
+    my $do_ = 'scripts/custom/taxform.pl';
+    if ( -e $do_ ) {
+        unless ( do $do_ ) {
+            if ($! or $@) {
+                print "Status: 500 Internal server error (taxform.pm)\n\n";
+                warn "Failed to execute $do_ ($!): $@\n";
+            }
+        }
+    }
+};
 1;

--- a/lib/LedgerSMB/Scripts/vouchers.pm
+++ b/lib/LedgerSMB/Scripts/vouchers.pm
@@ -28,8 +28,23 @@ use warnings;
 our $VERSION = '0.1';
 our $custom_batch_types = {};
 
-###TODO-LOCALIZE-DOLLAR-AT
-eval { do "scripts/custom/vouchers.pl"};
+sub _run_script {
+    my ($script, $msg) = @_;
+    local ($!, $@);
+    if ( -e $script ) {
+        unless ( do $script ) {
+            if ($! or $@) {
+                print "Status: 500 Internal server error ($msg)\n\n";
+                warn "Failed to execute $script ($!): $@\n";
+            }
+        }
+    } else {
+        warn "$script not found.";
+    }
+}
+
+_run_script('scripts/custom/vouchers.pl', 'vouchers.pl - custom start');
+
 
 =item create_batch
 
@@ -414,7 +429,7 @@ my %print_dispatch = (
                if (my $cpid = fork()){
                   wait;
                } else {
-                  do 'bin/ar.pl';
+                    _run_script('bin/ar.pl', 'vouchers.pm disp2');
                   require LedgerSMB::Form;
                   %$lsmb_legacy::form = (%$request);
                   bless $lsmb_legacy::form, 'Form';
@@ -442,7 +457,7 @@ my %print_dispatch = (
                if (fork){
                   wait;
                } else {
-                  do 'bin/is.pl';
+                    _run_script('bin/is.pl', 'vouchers.pm disp8');
                   require LedgerSMB::Form;
                   %$lsmb_legacy::form = (%$request);
                   bless $lsmb_legacy::form, 'Form';
@@ -464,7 +479,7 @@ my %print_dispatch = (
                if (fork){
                   wait;
                } else {
-                  do 'bin/is.pl';
+                    _run_script('bin/is.pl', 'vouchers.pm disp9');
                   require LedgerSMB::Form;
                   %$lsmb_legacy::form = (%$request);
                   bless $lsmb_legacy::form, 'Form';
@@ -544,8 +559,7 @@ sub print_batch {
 
 }
 
-###TODO-LOCALIZE-DOLLAR-AT
-eval { do "scripts/custom/vouchers.pl"};
+_run_script('scripts/custom/vouchers.pl', 'vouchers.pl - custom end');
 1;
 
 =back


### PR DESCRIPTION
- (fixes #3030)
- Checks the return value of do()
- generates a simple error message on stdout which would normally be seen in the web browser
- generates a detailed error message as a warn() on the console
- paramaterises the filename to do for convenience
- adds a couple of missing semicolons from other code as noticed during this PR
- reformats a line that was obscure due to a pointless linebreak

Squashed Commits
- test return value of do()
- only attempt to do() custom scripts if they exist
- add some line terminating ;'s
- reformat a line for clarity
- remove trailing space
- revert do() changes in xt/
- handle do() return value so we actually get error messages
- test return value of do()
- only attempt to do() custom scripts if they exist
