### PR TITLE
Migration fixes

### DIFF
--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -204,7 +204,8 @@ sub login {
     _init_db($request);
     sanity_checks($database);
     $request->{login_name} = $version_info->{username};
-    if ($version_info->{status} eq 'does not exist'){
+    # $version_info->{status} isn't always defined
+    if (defined $version_info->{status} && $version_info->{status} eq 'does not exist'){
         $request->{message} = $request->{_locale}->text(
              'Database does not exist.');
         $request->{operation} = $request->{_locale}->text('Create Database?');
@@ -226,7 +227,7 @@ sub login {
         if (! defined $request->{next_action}) {
             $request->{message} = $request->{_locale}->text(
                 'Unknown database found.'
-                );
+                ) . $version_info->{full_version};
             $request->{operation} = $request->{_locale}->text('Cancel?');
             $request->{next_action} = 'cancel';
         } elsif ($request->{next_action} eq 'rebuild_modules') {

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -734,7 +734,7 @@ sub _failed_check {
             format => 'HTML',
     );
     my $rows = [];
-    my $count = 1;
+    my $count = 0;
     my $hiddens = {table => $check->table,
                     edit => $check->column,
                            id_column => $check->{id_column},
@@ -760,13 +760,12 @@ sub _failed_check {
                    size => 15,
            }};
         push @$rows, $row;
-        $hiddens->{"id_$count"} = $row->{$check->id_column};
         ++$count;
+        $hiddens->{"id_$count"} = $row->{$check->id_column};
    }
     $sth->finish();
 
     $hiddens->{count} = $count;
-#    $hiddens->{edit} = $check->column; # Why again. Set in module beginning
 
     my $buttons = [
            { type => 'submit',

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -204,7 +204,8 @@ sub login {
     _init_db($request);
     sanity_checks($database);
     $request->{login_name} = $version_info->{username};
-    # $version_info->{status} isn't always defined
+    # $version_info->{status} isn't always defined by get_info, so useless undefined messages
+    # are generated.
     if (defined $version_info->{status} && $version_info->{status} eq 'does not exist'){
         $request->{message} = $request->{_locale}->text(
              'Database does not exist.');

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -735,6 +735,7 @@ sub _failed_check {
             format => 'HTML',
     );
     my $rows = [];
+    # Count has to reflect the actual number of rows
     my $count = 0;
     my $hiddens = {table => $check->table,
                     edit => $check->column,


### PR DESCRIPTION
- Show the version found when refusing to migrate a foreign database.
- The actual count for the migration steps is 1 too many.