### PR TITLE
T sl30 migration1

### DIFF
--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -204,7 +204,8 @@ sub login {
     _init_db($request);
     sanity_checks($database);
     $request->{login_name} = $version_info->{username};
-    if ($version_info->{status} eq 'does not exist'){
+    # $version_info->{status} isn't always defined
+    if (defined $version_info->{status} && $version_info->{status} eq 'does not exist'){
         $request->{message} = $request->{_locale}->text(
              'Database does not exist.');
         $request->{operation} = $request->{_locale}->text('Create Database?');
@@ -226,7 +227,7 @@ sub login {
         if (! defined $request->{next_action}) {
             $request->{message} = $request->{_locale}->text(
                 'Unknown database found.'
-                );
+                ) . $version_info->{full_version};
             $request->{operation} = $request->{_locale}->text('Cancel?');
             $request->{next_action} = 'cancel';
         } elsif ($request->{next_action} eq 'rebuild_modules') {

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -734,7 +734,7 @@ sub _failed_check {
             format => 'HTML',
     );
     my $rows = [];
-    my $count = 1;
+    my $count = 0;
     my $hiddens = {table => $check->table,
                     edit => $check->column,
                            id_column => $check->{id_column},
@@ -760,13 +760,12 @@ sub _failed_check {
                    size => 15,
            }};
         push @$rows, $row;
-        $hiddens->{"id_$count"} = $row->{$check->id_column};
         ++$count;
+        $hiddens->{"id_$count"} = $row->{$check->id_column};
    }
     $sth->finish();
 
     $hiddens->{count} = $count;
-#    $hiddens->{edit} = $check->column; # Why again. Set in module beginning
 
     my $buttons = [
            { type => 'submit',

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -1129,7 +1129,7 @@ sub process_and_run_upgrade_script {
         template => $template,
         no_auto_output => 1,
         format_options => {extension => 'sql'},
-        output_file => 'upgrade',
+        output_file => 'upgrade.sql',
         format => 'TXT' );
     $dbtemplate->render($request);
     $database->run_file(

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -681,7 +681,6 @@ sub upgrade {
     my $database = _init_db($request);
     my $dbinfo = $database->get_info();
     my $upgrade_type = "$dbinfo->{appname}/$dbinfo->{version}";
-    my @selectable_values = ();
 
     $request->{dbh}->{AutoCommit} = 0;
     my $locale = $request->{_locale};
@@ -690,15 +689,20 @@ sub upgrade {
         next if ($check->min_version gt $dbinfo->{version})
             || ($check->max_version lt $dbinfo->{version})
             || ($check->appname ne $dbinfo->{appname});
-        if ( $check->selectable_values ) {
-            my $sth = $request->{dbh}->prepare($check->selectable_values);
-            $sth->execute()
-                or die "Failed to execute pre-migration check " . $check->name;
-            while (my $row = $sth->fetchrow_hashref('NAME_lc')) {
-                push @selectable_values, { value => $row->{value},
-                                           text => $row->{id}
-                };
+        my @selectable_values = ();
+        for my $selectable_value (@{$check->selectable_values // []}) {
+            my @values = ();
+            if ( $selectable_value ) {
+                my $sth = $request->{dbh}->prepare($selectable_value);
+                $sth->execute()
+                    or die "Failed to execute pre-migration check " . $check->name;
+                while (my $row = $sth->fetchrow_hashref('NAME_lc')) {
+                    push @values, { value => $row->{value},
+                                     text => $row->{id}
+                    };
+                }
             }
+            push @selectable_values,[@values];
         }
         my $sth = $request->{dbh}->prepare($check->test_query);
         $sth->execute()
@@ -736,33 +740,44 @@ sub _failed_check {
     my $rows = [];
     my $count = 0;
     my $hiddens = {table => $check->table,
-                    edit => $check->column,
-                           id_column => $check->{id_column},
-                            id_where => $check->{id_where},
+               id_column => $check->{id_column},
+                id_where => $check->{id_where},
+                  insert => $check->{insert},
                 database => $request->{database}};
+    my $i = 1;
+    # Move around Can't use string "ARRAY as an ARRAY ref while "strict refs" in use
+    for my $edit (@{$check->column}) {
+      $hiddens->{"edit_$i"} = $edit;
+      $i++;
+    }
     my $header = {};
     for (@{$check->display_cols}){
         $header->{$_} = $_;
     }
     while (my $row = $sth->fetchrow_hashref('NAME_lc')) {
-        $row->{$check->column} =
-           ( $check->column && $check->selectable_values )
+      my $id = $row->{$check->{id_column}};
+      my @values = @selectable_values;
+      for my $column (@{$check->column}) {
+        my @selectable_value = shift @values;
+        $row->{$column} =
+           ( defined @selectable_value && $selectable_value[0] )
            ? { select => {
-                   name => $check->column . "_$row->{trans_id}",
-                   id => $row->{trans_id},
-                   options => \@selectable_values,
+                   name => $column . "_$id",
+                   id => $id,
+                   options => @selectable_value,
                    default_blank => 1,
            } }
            : { input => {
-                   name => $check->column . "_$row->{id}",
-                   value => $row->{$check->column},
+                   name => $column . "_$id",
+                   value => $row->{$column} // '',
                    type => 'text',
                    size => 15,
-           }};
-        push @$rows, $row;
-        ++$count;
-        $hiddens->{"id_$count"} = $row->{$check->id_column};
-   }
+          } };
+      };
+      push @$rows, $row;
+      ++$count;
+      $hiddens->{"id_$count"} = $row->{$check->id_column};
+    }
     $sth->finish();
 
     $hiddens->{count} = $count;
@@ -802,16 +817,28 @@ sub fix_tests{
     my $locale = $request->{_locale};
 
     my $table = $request->{dbh}->quote_identifier($request->{table});
-    my $edit = $request->{dbh}->quote_identifier($request->{edit});
     my $where = $request->{id_where};
+
+    my @edits;
+    my $i = 1;
+    # Move around Can't use string "ARRAY as an ARRAY ref while "strict refs" in use
+    while (defined $request->{"edit_$i"}) {
+      push @edits, $request->{"edit_$i"};
+      $i++;
+    }
     my $sth = $request->{dbh}->prepare(
-            "UPDATE $table SET $edit = ? where $where = ?"
-    );
+            "UPDATE $table SET " .
+                join(',',map {$request->{dbh}->quote_identifier($_) . " = ?"} @edits) .
+                " where $where = ?");
 
     for my $count (1 .. $request->{count}){
         my $id = $request->{"id_$count"};
-                $sth->execute($request->{"$request->{edit}_$id"}, $id) ||
-            $request->error($sth->errstr);
+        my @values;
+        for my $edit (@edits) {
+          push @values, $request->{"${edit}_$id"};
+        }
+        $sth->execute(@values, $id) ||
+          $request->error($sth->errstr);
     }
     $sth->finish();
     $request->{dbh}->commit;

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -826,7 +826,11 @@ sub fix_tests{
       push @edits, $request->{"edit_$i"};
       $i++;
     }
-    my $sth = $request->{dbh}->prepare(
+    my $sth = $request->{insert}
+      ? $request->{dbh}->prepare(
+            "INSERT INTO $table(" . join(',',@edits) . ") VALUES(" .
+                join(',',map { '?' } @edits) . ")" )
+      : $request->{dbh}->prepare(
             "UPDATE $table SET " .
                 join(',',map {$request->{dbh}->quote_identifier($_) . " = ?"} @edits) .
                 " where $where = ?");
@@ -837,8 +841,13 @@ sub fix_tests{
         for my $edit (@edits) {
           push @values, $request->{"${edit}_$id"};
         }
-        $sth->execute(@values, $id) ||
-          $request->error($sth->errstr);
+        if ( $request->{insert}) {
+          $sth->execute(@values) ||
+            $request->error($sth->errstr);
+        } else {
+          $sth->execute(@values, $id) ||
+            $request->error($sth->errstr);
+        }
     }
     $sth->finish();
     $request->{dbh}->commit;

--- a/lib/LedgerSMB/Upgrade_Tests.pm
+++ b/lib/LedgerSMB/Upgrade_Tests.pm
@@ -301,6 +301,7 @@ push @tests, __PACKAGE__->new(
  display_name => $locale->text('No NULL Amounts'),
          name => 'no_null_ac_amounts',
  display_cols => ["trans_id", "chart_id", "transdate"],
+    id_column => 'trans_id',
  instructions => $locale->text(
                    'There are NULL values in the amounts column of your
 source database. Please either find professional help to migrate your

--- a/lib/LedgerSMB/Upgrade_Tests.pm
+++ b/lib/LedgerSMB/Upgrade_Tests.pm
@@ -114,6 +114,16 @@ Repair query column to get the values from
 
 has selectable_values => (is => 'ro', isa => 'ArrayRef[Str]', required => 0);
 
+=item insert
+
+Allow insert instead of update. This to set defaults on a very limited subset
+of tables. Business, for example isn't required in SQL-Ledger but mandatory for
+LedgerSMB.
+
+=cut
+
+has insert => (is => 'ro', isa => 'Bool', required => 0, default => 0);
+
 =item id_where
 
 Repair query key to set the values if we can repair

--- a/lib/LedgerSMB/Upgrade_Tests.pm
+++ b/lib/LedgerSMB/Upgrade_Tests.pm
@@ -106,14 +106,13 @@ Repair query table to run once per result.
 
 has table => (is => 'ro', isa => 'Str', required => 0);
 
-
 =item selectable_values
 
 Repair query column to get the values from
 
 =cut
 
-has selectable_values => (is => 'ro', isa => 'Str', required => 0);
+has selectable_values => (is => 'ro', isa => 'ArrayRef[Str]', required => 0);
 
 =item id_where
 
@@ -137,7 +136,7 @@ Repair query column to run once per result
 
 =cut
 
-has column => (is => 'ro', isa => 'Str', required => 0);
+has column => (is => 'ro', isa => 'ArrayRef[Str]', required => 0);
 
 =item display_cols
 
@@ -187,7 +186,7 @@ push @tests, __PACKAGE__->new(
                    'Please make all customer numbers unique'),
          name => 'unique_customernumber',
  display_cols => ['customernumber', 'name', 'address1', 'city', 'state', 'zip'],
-       column => 'customernumber',
+       column => ['customernumber'],
         table => 'customer',
       appname => 'ledgersmb',
   min_version => '1.2',
@@ -206,7 +205,7 @@ push @tests, __PACKAGE__->new(
                    'Please make all vendor numbers unique'),
          name => 'unique_vendornumber',
  display_cols => ['vendornumber', 'name', 'address1', 'city', 'state', 'zip'],
-       column => 'customernumber',
+       column => ['customernumber'],
         table => 'customer',
       appname => 'ledgersmb',
   min_version => '1.2',
@@ -220,7 +219,7 @@ push @tests, __PACKAGE__->new(
                    'Enter employee numbers where they are missing'),
          name => 'null_employeenumber',
  display_cols => ['login', 'name', 'employeenumber'],
-       column => 'employeenumber',
+       column => ['employeenumber'],
         table => 'employee',
       appname => 'ledgersmb',
   min_version => '1.2',
@@ -235,7 +234,7 @@ push @tests, __PACKAGE__->new(
  instructions => $locale->text(
      'Make sure every name consists of alphanumeric characters (and underscores) only and is at least one character long'),
  display_cols => ['login', 'name', 'employeenumber'],
-       column => 'name',
+       column => ['name'],
         table => 'employee',
       appname => 'ledgersmb',
   min_version => '1.2',
@@ -253,7 +252,7 @@ push @tests, __PACKAGE__->new(
  instructions => $locale->text(
                    'Make employee numbers unique'),
  display_cols => ['login', 'name', 'employeenumber'],
-       column => 'employeenumber',
+       column => ['employeenumber'],
         table => 'employee',
       appname => 'ledgersmb',
   min_version => '1.2',
@@ -272,7 +271,7 @@ push @tests, __PACKAGE__->new(
  instructions => $locale->text(
                    'Make non-obsolete partnumbers unique'),
  display_cols => ['partnumber', 'description', 'sellprice'],
-       column => 'partnumber',
+       column => ['partnumber'],
         table => 'parts',
       appname => 'ledgersmb',
   min_version => '1.2',
@@ -288,7 +287,7 @@ push @tests, __PACKAGE__->new(
                    'Make invoice numbers unique'),
          name => 'unique_ar_invnumbers',
  display_cols =>  ['invnumber', 'transdate', 'amount', 'netamount', 'paid'],
-       column =>  'invnumber',
+       column =>  ['invnumber'],
         table =>  'ar',
       appname => 'ledgersmb',
   min_version => '1.2',
@@ -344,11 +343,11 @@ push @tests, __PACKAGE__->new(
  instructions => $LedgerSMB::App_State::Locale->text(
                    'The following transactions have unassigned amounts'),
                 table => 'acc_trans',
-selectable_values => "SELECT concat(accno,' -- ',description) AS id, id as value
+selectable_values => ["SELECT concat(accno,' -- ',description) AS id, id as value
                                           FROM chart
                                           WHERE charttype = 'A'
-                                          ORDER BY id",
-           column => 'chart_id',
+                                          ORDER BY id"],
+           column => ['chart_id'],
         id_column => 'trans_id',
          id_where => 'chart_id IS NULL AND trans_id',
       appname => 'sql-ledger',
@@ -367,7 +366,7 @@ push @tests, __PACKAGE__->new(
  display_name => $locale->text('No duplicate meta_numbers'),
          name => 'no_meta_number_dupes',
  display_cols => [ 'meta_number', 'class', 'description', 'name' ],
-       column => 'meta_number',
+       column => ['meta_number'],
         table => 'entity_credit_account',
  instructions => $locale->text("Make sure all meta numbers are unique."),
       appname => 'ledgersmb',
@@ -403,7 +402,7 @@ push @tests, __PACKAGE__->new(
          name => 'missing_gifi_table_rows',
  display_cols => [ 'accno', 'description' ],
         table => 'gifi',
-       column => 'description',
+       column => ['description'],
     id_column => 'accno',
      id_where => 'description IS NULL AND accno',
  instructions => $locale->text("Please add the missing GIFI accounts"),
@@ -471,7 +470,7 @@ push @tests,__PACKAGE__->new(
  instructions => $locale->text(
                    'Please make sure all accounts have a category of
 (A)sset, (L)iability, e(Q)uity, (I)ncome or (E)xpense.'),
-    column => 'category',
+    column => ['category'],
     table => 'chart',
     appname => 'sql-ledger',
     min_version => '2.7',
@@ -491,7 +490,7 @@ push @tests,__PACKAGE__->new(
                    'An account can either be a summary account (which have a
 link of "AR", "AP" or "IC" value) or be linked to dropdowns (having any
 number of "AR_*", "AP_*" and/or "IC_*" links concatenated by colons (:).'),
-    column => 'link',
+    column => ['link'],
     table => 'chart',
     appname => 'sql-ledger',
     min_version => '2.7',
@@ -527,7 +526,7 @@ push @tests,__PACKAGE__->new(
     display_cols => ['id', 'customernumber', 'name'],
  instructions => $locale->text(
                    'Please make sure there are no empty customer numbers.'),
-    column => 'customernumber',
+    column => ['customernumber'],
     table => 'customer',
     appname => 'sql-ledger',
     min_version => '2.7',
@@ -546,7 +545,7 @@ push @tests,__PACKAGE__->new(
  instructions => $locale->text(
                    'Please make sure all accounts have a category of
 (A)sset, (L)iability, e(Q)uity, (I)ncome or (E)xpense.'),
-    column => 'category',
+    column => ['category'],
     table => 'chart',
     appname => 'sql-ledger',
     min_version => '2.7',
@@ -565,7 +564,7 @@ push @tests,__PACKAGE__->new(
 #                    'An account can either be a summary account (which have a
 # link of "AR", "AP" or "IC" value) or be linked to dropdowns (having any
 # number of "AR_*", "AP_*" and/or "IC_*" links concatenated by colons (:).'),
-#     column => 'category',
+#     column => ['category'],
 #     table => 'chart',
 #     appname => 'sql-ledger',
 #     min_version => '2.7',
@@ -605,7 +604,7 @@ push @tests,__PACKAGE__->new(
     display_cols => ['id', 'customernumber', 'name'],
  instructions => $locale->text(
                    'Please make all customer numbers unique'),
-    column => 'customernumber',
+    column => ['customernumber'],
     table => 'customer',
     appname => 'sql-ledger',
     min_version => '2.7',
@@ -621,7 +620,7 @@ push @tests,__PACKAGE__->new(
     display_cols => ['id', 'vendornumber', 'name'],
  instructions => $locale->text(
                    'Please make sure there are no empty vendor numbers.'),
-    column => 'vendornumber',
+    column => ['vendornumber'],
     table => 'vendor',
     appname => 'sql-ledger',
     min_version => '2.7',
@@ -640,7 +639,7 @@ push @tests,__PACKAGE__->new(
     display_cols => ['id', 'vendornumber', 'name'],
  instructions => $locale->text(
                    'Please make all vendor numbers unique'),
-    column => 'vendornumber',
+    column => ['vendornumber'],
     table => 'vendor',
     appname => 'sql-ledger',
     min_version => '2.7',
@@ -656,7 +655,7 @@ push @tests, __PACKAGE__->new(
     display_cols => ['id', 'login', 'name', 'employeenumber'],
  instructions => $locale->text(
                    'Please make sure all employees have an employee number'),
-    column => 'employeenumber',
+    column => ['employeenumber'],
     table => 'employee',
     appname => 'sql-ledger',
     min_version => '2.7',
@@ -673,7 +672,7 @@ push @tests, __PACKAGE__->new(
     display_name => $locale->text('Null employee numbers'),
     name => 'no_duplicate_employeenumbers',
     display_cols => ['id', 'login', 'name', 'employeenumber'],
-    column => 'employeenumber',
+    column => ['employeenumber'],
  instructions => $locale->text(
                    'Please make all employee numbers unique'),
     table => 'employee',
@@ -694,7 +693,7 @@ push @tests, __PACKAGE__->new(
     name => 'no_duplicate_ar_invoicenumbers',
     display_cols => ['id', 'invnumber', 'transdate', 'duedate', 'datepaid',
                      'ordnumber', 'quonumber', 'approved'],
-    column => 'invnumber',
+    column => ['invnumber'],
  instructions => $locale->text(
                    'Please make all AR invoice numbers unique'),
     table => 'ar',
@@ -717,7 +716,7 @@ push @tests, __PACKAGE__->new(
     name => 'no_duplicate_ap_invoicenumbers',
     display_cols => ['id', 'invnumber', 'transdate', 'duedate', 'datepaid',
                      'ordnumber', 'quonumber', 'approved'],
-    column => 'invnumber',
+    column => ['invnumber'],
  instructions => $locale->text(
                    'Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please review suggestions to make all AP invoice numbers unique. Conflicting entries are presented by pairs, with a suffix added to the invoice number'),
     table => 'ap',
@@ -738,7 +737,7 @@ push @tests, __PACKAGE__->new(
  instructions => $locale->text(
                    'Make non-obsolete partnumbers unique'),
  display_cols => ['partnumber', 'description', 'sellprice'],
-       column => 'partnumber',
+       column => ['partnumber'],
         table => 'parts',
       appname => 'sql-ledger',
   min_version => '2.7',
@@ -755,7 +754,7 @@ push @tests, __PACKAGE__->new(
     display_cols => ['parts_id', 'make', 'model'],
  instructions => $locale->text(
                    'Please make sure all modelsnumbers are non-empty'),
-    column => 'model',
+    column => ['model'],
     table => 'makemodel',
     appname => 'sql-ledger',
     min_version => '2.7',
@@ -770,7 +769,7 @@ push @tests, __PACKAGE__->new(
     display_name => $locale->text('Null make numbers'),
     name => 'no_null_makenumbers',
     display_cols => ['parts_id', 'make', 'model'],
-    column => 'make',
+    column => ['make'],
     instructions => $locale->text(
                    'Please make sure all make numbers are non-empty'),
     table => 'makemodel',
@@ -805,7 +804,7 @@ push @tests, __PACKAGE__->new(
     display_name => $locale->text('Unknown charttype; should be H(eader)/A(ccount)'),
     name => 'unknown_charttype',
     display_cols => ['accno', 'charttype', 'description'],
-    column => 'charttype',
+    column => ['charttype'],
  instructions => $locale->text(
                    'Please fix the presented rows to either be "H" or "A"'),
     table => 'chart',
@@ -823,7 +822,7 @@ push @tests, __PACKAGE__->new(
     display_name => $locale->text('Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/(e)Q(uity))'),
     name => 'unknown_account_category',
     display_cols => ['accno', 'category', 'description'],
-    column => 'category',
+    column => ['category'],
  instructions => $locale->text(
                    'Please fix the pricegroup data in your partscustomer table (no UI available)'),
     table => 'chart',


### PR DESCRIPTION
Allow multiple field updates per record or inserting 1 record for migrations.
Add back default SQL extension for the upgrade file.
Add a missing column id to allow the code to use varying id.