### PR TITLE
T sl30 migration1

### DIFF
--- a/UI/lib/utilities.html
+++ b/UI/lib/utilities.html
@@ -2,6 +2,10 @@
 <?lsmb BLOCK print_options ?>
 <div class="print-options"><?lsmb
 
+# This test is wrong. SCALAR have a size of 1, but so do ARRAY and HASHes
+# of 1 element, so we assign an object to a SCALAR at line 13.
+# So either we fix this or throw an exception is an object is passed on here - YL
+# And relying on size to discriminate between hidden and template is bound to fail.
 IF templates.size == 1;
 PROCESS input element_data = {
      name = 'template'

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -745,15 +745,13 @@ sub _failed_check {
                id_column => $check->{id_column},
                 id_where => $check->{id_where},
                   insert => $check->{insert},
-                   edits => $check->columns,
                 database => $request->{database}};
-# UI/lib/utilities.html assumes no objects and will put the string equivalent
-# of the object address, so we cannot use the code below to send edits through
-# hiddens.
-#    @{$hiddens->{edits}} = @{$check->columns // []};
+    # UI/lib/utilities.html assumes no objects and will put the string equivalent
+    # of the object address, so we cannot use the code below to send edits through
+    # hiddens.
+    #    @{$hiddens->{edits}} = @{$check->columns // []};
     my $i = 1;
-    # Move around Can't use string "ARRAY as an ARRAY ref while "strict refs" in use
-    for my $edit (@{$check->column}) {
+    for my $edit (@{$check->columns}) {
       $hiddens->{"edit_$i"} = $edit;
       $i++;
     }
@@ -825,10 +823,9 @@ sub fix_tests{
     my $table = $request->{dbh}->quote_identifier($request->{table});
     my $where = $request->{id_where};
 
-# Because of said bug with objects in hiddens.
+    # Because of said bug with objects in hiddens.
     my @edits;
     my $i = 1;
-    # Move around Can't use string "ARRAY as an ARRAY ref while "strict refs" in use
     while (defined $request->{"edit_$i"}) {
       push @edits, $request->{"edit_$i"};
       $i++;

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -760,13 +760,13 @@ sub _failed_check {
       my $id = $row->{$check->{id_column}};
       my @values = @selectable_values;
       for my $column (@{$check->column}) {
-        my @selectable_value = shift @values;
+        my $selectable_value = shift @values;
         $row->{$column} =
-           ( defined @selectable_value && $selectable_value[0] )
+           ( defined $selectable_value && $selectable_value->[0] )
            ? { select => {
                    name => $column . "_$id",
                    id => $id,
-                   options => @selectable_value,
+                   options => $selectable_value,
                    default_blank => 1,
            } }
            : { input => {

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -1131,7 +1131,7 @@ sub process_and_run_upgrade_script {
         template => $template,
         no_auto_output => 1,
         format_options => {extension => 'sql'},
-        output_file => 'upgrade',
+        output_file => 'upgrade.sql',
         format => 'TXT' );
     $dbtemplate->render($request);
     $database->run_file(

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -751,7 +751,7 @@ sub _failed_check {
     # hiddens.
     #    @{$hiddens->{edits}} = @{$check->columns // []};
     my $i = 1;
-    for my $edit (@{$check->columns}) {
+    for my $edit (@{$check->columns // []}) {
       $hiddens->{"edit_$i"} = $edit;
       $i++;
     }
@@ -761,7 +761,7 @@ sub _failed_check {
     }
     while (my $row = $sth->fetchrow_hashref('NAME_lc')) {
       my $id = $row->{$check->{id_column}};
-      for my $column (@{$check->columns}) {
+      for my $column (@{$check->columns // []}) {
         my $selectable_value = $selectable_values{$column};
         $row->{$column} =
            ( defined $selectable_value && @$selectable_value )

--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -360,9 +360,7 @@ sub new_UI {
     return $class->new(@_, no_auto_ouput => 0, format => 'HTML', path => 'UI');
 }
 
-use Dumper;
 sub preprocess {
-  warn Dumper \@_;
     my ($rawvars, $escape) = @_;
     return undef unless defined $rawvars;
 

--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -360,7 +360,9 @@ sub new_UI {
     return $class->new(@_, no_auto_ouput => 0, format => 'HTML', path => 'UI');
 }
 
+use Dumper;
 sub preprocess {
+  warn Dumper \@_;
     my ($rawvars, $escape) = @_;
     return undef unless defined $rawvars;
 

--- a/lib/LedgerSMB/Upgrade_Tests.pm
+++ b/lib/LedgerSMB/Upgrade_Tests.pm
@@ -108,7 +108,7 @@ has table => (is => 'ro', isa => 'Str', required => 0);
 
 =item selectable_values
 
-Repair query column to get the values from
+Repair query columns to get the values from
 
 =cut
 
@@ -116,7 +116,7 @@ has selectable_values => (is => 'ro', isa => 'HashRef', required => 0);
 
 =item insert
 
-Allow insert instead of update. This to set defaults on a very limited subset
+Insert data instead of update. This to set defaults on a very limited subset
 of tables. Business, for example isn't required in SQL-Ledger but mandatory for
 LedgerSMB.
 
@@ -140,13 +140,13 @@ Repair column to use as id
 
 has id_column => (is => 'ro', isa => 'Str', required => 0, default => 'id');
 
-=item column
+=item columns
 
-Repair query column to run once per result
+Repair query columns to run once per result
 
 =cut
 
-has column => (is => 'ro', isa => 'ArrayRef[Str]', required => 0);
+has columns => (is => 'ro', isa => 'ArrayRef[Str]', required => 0);
 
 =item display_cols
 
@@ -196,7 +196,7 @@ push @tests, __PACKAGE__->new(
                    'Please make all customer numbers unique'),
          name => 'unique_customernumber',
  display_cols => ['customernumber', 'name', 'address1', 'city', 'state', 'zip'],
-       column => ['customernumber'],
+      columns => ['customernumber'],
         table => 'customer',
       appname => 'ledgersmb',
   min_version => '1.2',
@@ -215,7 +215,7 @@ push @tests, __PACKAGE__->new(
                    'Please make all vendor numbers unique'),
          name => 'unique_vendornumber',
  display_cols => ['vendornumber', 'name', 'address1', 'city', 'state', 'zip'],
-       column => ['customernumber'],
+      columns => ['customernumber'],
         table => 'customer',
       appname => 'ledgersmb',
   min_version => '1.2',
@@ -229,7 +229,7 @@ push @tests, __PACKAGE__->new(
                    'Enter employee numbers where they are missing'),
          name => 'null_employeenumber',
  display_cols => ['login', 'name', 'employeenumber'],
-       column => ['employeenumber'],
+      columns => ['employeenumber'],
         table => 'employee',
       appname => 'ledgersmb',
   min_version => '1.2',
@@ -244,7 +244,7 @@ push @tests, __PACKAGE__->new(
  instructions => $locale->text(
      'Make sure every name consists of alphanumeric characters (and underscores) only and is at least one character long'),
  display_cols => ['login', 'name', 'employeenumber'],
-       column => ['name'],
+      columns => ['name'],
         table => 'employee',
       appname => 'ledgersmb',
   min_version => '1.2',
@@ -262,7 +262,7 @@ push @tests, __PACKAGE__->new(
  instructions => $locale->text(
                    'Make employee numbers unique'),
  display_cols => ['login', 'name', 'employeenumber'],
-       column => ['employeenumber'],
+      columns => ['employeenumber'],
         table => 'employee',
       appname => 'ledgersmb',
   min_version => '1.2',
@@ -281,7 +281,7 @@ push @tests, __PACKAGE__->new(
  instructions => $locale->text(
                    'Make non-obsolete partnumbers unique'),
  display_cols => ['partnumber', 'description', 'sellprice'],
-       column => ['partnumber'],
+      columns => ['partnumber'],
         table => 'parts',
       appname => 'ledgersmb',
   min_version => '1.2',
@@ -297,7 +297,7 @@ push @tests, __PACKAGE__->new(
                    'Make invoice numbers unique'),
          name => 'unique_ar_invnumbers',
  display_cols => ['invnumber', 'transdate', 'amount', 'netamount', 'paid'],
-       column => ['invnumber'],
+      columns => ['invnumber'],
         table =>  'ar',
       appname => 'ledgersmb',
   min_version => '1.2',
@@ -358,7 +358,7 @@ selectable_values => { chart_id => "SELECT concat(accno,' -- ',description) AS i
                                     FROM chart
                                     WHERE charttype = 'A'
                                     ORDER BY id" },
-           column => ['chart_id'],
+          columns => ['chart_id'],
         id_column => 'trans_id',
          id_where => 'chart_id IS NULL AND trans_id',
       appname => 'sql-ledger',
@@ -377,7 +377,7 @@ push @tests, __PACKAGE__->new(
  display_name => $locale->text('No duplicate meta_numbers'),
          name => 'no_meta_number_dupes',
  display_cols => [ 'meta_number', 'class', 'description', 'name' ],
-       column => ['meta_number'],
+      columns => ['meta_number'],
         table => 'entity_credit_account',
  instructions => $locale->text("Make sure all meta numbers are unique."),
       appname => 'ledgersmb',
@@ -413,7 +413,7 @@ push @tests, __PACKAGE__->new(
          name => 'missing_gifi_table_rows',
  display_cols => [ 'accno', 'description' ],
         table => 'gifi',
-       column => ['description'],
+      columns => ['description'],
     id_column => 'accno',
      id_where => 'description IS NULL AND accno',
  instructions => $locale->text("Please add the missing GIFI accounts"),
@@ -481,7 +481,7 @@ push @tests,__PACKAGE__->new(
  instructions => $locale->text(
                    'Please make sure all accounts have a category of
 (A)sset, (L)iability, e(Q)uity, (I)ncome or (E)xpense.'),
-    column => ['category'],
+   columns => ['category'],
     table => 'chart',
     appname => 'sql-ledger',
     min_version => '2.7',
@@ -501,7 +501,7 @@ push @tests,__PACKAGE__->new(
                    'An account can either be a summary account (which have a
 link of "AR", "AP" or "IC" value) or be linked to dropdowns (having any
 number of "AR_*", "AP_*" and/or "IC_*" links concatenated by colons (:).'),
-    column => ['link'],
+   columns => ['link'],
     table => 'chart',
     appname => 'sql-ledger',
     min_version => '2.7',
@@ -537,7 +537,7 @@ push @tests,__PACKAGE__->new(
     display_cols => ['id', 'customernumber', 'name'],
  instructions => $locale->text(
                    'Please make sure there are no empty customer numbers.'),
-    column => ['customernumber'],
+   columns => ['customernumber'],
     table => 'customer',
     appname => 'sql-ledger',
     min_version => '2.7',
@@ -556,7 +556,7 @@ push @tests,__PACKAGE__->new(
  instructions => $locale->text(
                    'Please make sure all accounts have a category of
 (A)sset, (L)iability, e(Q)uity, (I)ncome or (E)xpense.'),
-    column => ['category'],
+   columns => ['category'],
     table => 'chart',
     appname => 'sql-ledger',
     min_version => '2.7',
@@ -575,7 +575,7 @@ push @tests,__PACKAGE__->new(
 #                    'An account can either be a summary account (which have a
 # link of "AR", "AP" or "IC" value) or be linked to dropdowns (having any
 # number of "AR_*", "AP_*" and/or "IC_*" links concatenated by colons (:).'),
-#     column => ['category'],
+#    columns => ['category'],
 #     table => 'chart',
 #     appname => 'sql-ledger',
 #     min_version => '2.7',
@@ -615,7 +615,7 @@ push @tests,__PACKAGE__->new(
     display_cols => ['id', 'customernumber', 'name'],
  instructions => $locale->text(
                    'Please make all customer numbers unique'),
-    column => ['customernumber'],
+   columns => ['customernumber'],
     table => 'customer',
     appname => 'sql-ledger',
     min_version => '2.7',
@@ -631,7 +631,7 @@ push @tests,__PACKAGE__->new(
     display_cols => ['id', 'vendornumber', 'name'],
  instructions => $locale->text(
                    'Please make sure there are no empty vendor numbers.'),
-    column => ['vendornumber'],
+   columns => ['vendornumber'],
     table => 'vendor',
     appname => 'sql-ledger',
     min_version => '2.7',
@@ -650,7 +650,7 @@ push @tests,__PACKAGE__->new(
     display_cols => ['id', 'vendornumber', 'name'],
  instructions => $locale->text(
                    'Please make all vendor numbers unique'),
-    column => ['vendornumber'],
+   columns => ['vendornumber'],
     table => 'vendor',
     appname => 'sql-ledger',
     min_version => '2.7',
@@ -666,7 +666,7 @@ push @tests, __PACKAGE__->new(
     display_cols => ['id', 'login', 'name', 'employeenumber'],
  instructions => $locale->text(
                    'Please make sure all employees have an employee number'),
-    column => ['employeenumber'],
+   columns => ['employeenumber'],
     table => 'employee',
     appname => 'sql-ledger',
     min_version => '2.7',
@@ -683,7 +683,7 @@ push @tests, __PACKAGE__->new(
     display_name => $locale->text('Null employee numbers'),
     name => 'no_duplicate_employeenumbers',
     display_cols => ['id', 'login', 'name', 'employeenumber'],
-    column => ['employeenumber'],
+   columns => ['employeenumber'],
  instructions => $locale->text(
                    'Please make all employee numbers unique'),
     table => 'employee',
@@ -704,7 +704,7 @@ push @tests, __PACKAGE__->new(
     name => 'no_duplicate_ar_invoicenumbers',
     display_cols => ['id', 'invnumber', 'transdate', 'duedate', 'datepaid',
                      'ordnumber', 'quonumber', 'approved'],
-    column => ['invnumber'],
+   columns => ['invnumber'],
  instructions => $locale->text(
                    'Please make all AR invoice numbers unique'),
     table => 'ar',
@@ -727,7 +727,7 @@ push @tests, __PACKAGE__->new(
     name => 'no_duplicate_ap_invoicenumbers',
     display_cols => ['id', 'invnumber', 'transdate', 'duedate', 'datepaid',
                      'ordnumber', 'quonumber', 'approved'],
-    column => ['invnumber'],
+   columns => ['invnumber'],
  instructions => $locale->text(
                    'Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please review suggestions to make all AP invoice numbers unique. Conflicting entries are presented by pairs, with a suffix added to the invoice number'),
     table => 'ap',
@@ -748,7 +748,7 @@ push @tests, __PACKAGE__->new(
  instructions => $locale->text(
                    'Make non-obsolete partnumbers unique'),
  display_cols => ['partnumber', 'description', 'sellprice'],
-       column => ['partnumber'],
+      columns => ['partnumber'],
         table => 'parts',
       appname => 'sql-ledger',
   min_version => '2.7',
@@ -765,7 +765,7 @@ push @tests, __PACKAGE__->new(
     display_cols => ['parts_id', 'make', 'model'],
  instructions => $locale->text(
                    'Please make sure all modelsnumbers are non-empty'),
-    column => ['model'],
+   columns => ['model'],
     table => 'makemodel',
     appname => 'sql-ledger',
     min_version => '2.7',
@@ -780,7 +780,7 @@ push @tests, __PACKAGE__->new(
     display_name => $locale->text('Null make numbers'),
     name => 'no_null_makenumbers',
     display_cols => ['parts_id', 'make', 'model'],
-    column => ['make'],
+   columns => ['make'],
     instructions => $locale->text(
                    'Please make sure all make numbers are non-empty'),
     table => 'makemodel',
@@ -815,7 +815,7 @@ push @tests, __PACKAGE__->new(
     display_name => $locale->text('Unknown charttype; should be H(eader)/A(ccount)'),
     name => 'unknown_charttype',
     display_cols => ['accno', 'charttype', 'description'],
-    column => ['charttype'],
+   columns => ['charttype'],
  instructions => $locale->text(
                    'Please fix the presented rows to either be "H" or "A"'),
     table => 'chart',
@@ -833,7 +833,7 @@ push @tests, __PACKAGE__->new(
     display_name => $locale->text('Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/(e)Q(uity))'),
     name => 'unknown_account_category',
     display_cols => ['accno', 'category', 'description'],
-    column => ['category'],
+   columns => ['category'],
  instructions => $locale->text(
                    'Please fix the pricegroup data in your partscustomer table (no UI available)'),
     table => 'chart',

--- a/lib/LedgerSMB/Upgrade_Tests.pm
+++ b/lib/LedgerSMB/Upgrade_Tests.pm
@@ -301,6 +301,7 @@ push @tests, __PACKAGE__->new(
  display_name => $locale->text('No NULL Amounts'),
          name => 'no_null_ac_amounts',
  display_cols => ["trans_id", "chart_id", "transdate"],
+    id_column => 'trans_id',
  instructions => $locale->text(
                    'There are NULL values in the amounts column of your
 source database. Please either find professional help to migrate your

--- a/lib/LedgerSMB/Upgrade_Tests.pm
+++ b/lib/LedgerSMB/Upgrade_Tests.pm
@@ -114,6 +114,16 @@ Repair query column to get the values from
 
 has selectable_values => (is => 'ro', isa => 'ArrayRef[Str]', required => 0);
 
+=item insert
+
+Allow insert instead of update. This to set defaults on a very limited subset
+of tables. Business, for example isn't required in SQL-Ledger but mandatory for
+LedgerSMB.
+
+=cut
+
+has insert => (is => 'ro', isa => 'Bool', required => 0, default => 0);
+
 =item id_where
 
 Repair query key to set the values if we can repair

--- a/lib/LedgerSMB/Upgrade_Tests.pm
+++ b/lib/LedgerSMB/Upgrade_Tests.pm
@@ -106,14 +106,13 @@ Repair query table to run once per result.
 
 has table => (is => 'ro', isa => 'Str', required => 0);
 
-
 =item selectable_values
 
 Repair query column to get the values from
 
 =cut
 
-has selectable_values => (is => 'ro', isa => 'Str', required => 0);
+has selectable_values => (is => 'ro', isa => 'ArrayRef[Str]', required => 0);
 
 =item id_where
 
@@ -137,7 +136,7 @@ Repair query column to run once per result
 
 =cut
 
-has column => (is => 'ro', isa => 'Str', required => 0);
+has column => (is => 'ro', isa => 'ArrayRef[Str]', required => 0);
 
 =item display_cols
 
@@ -187,7 +186,7 @@ push @tests, __PACKAGE__->new(
                    'Please make all customer numbers unique'),
          name => 'unique_customernumber',
  display_cols => ['customernumber', 'name', 'address1', 'city', 'state', 'zip'],
-       column => 'customernumber',
+       column => ['customernumber'],
         table => 'customer',
       appname => 'ledgersmb',
   min_version => '1.2',
@@ -206,7 +205,7 @@ push @tests, __PACKAGE__->new(
                    'Please make all vendor numbers unique'),
          name => 'unique_vendornumber',
  display_cols => ['vendornumber', 'name', 'address1', 'city', 'state', 'zip'],
-       column => 'customernumber',
+       column => ['customernumber'],
         table => 'customer',
       appname => 'ledgersmb',
   min_version => '1.2',
@@ -220,7 +219,7 @@ push @tests, __PACKAGE__->new(
                    'Enter employee numbers where they are missing'),
          name => 'null_employeenumber',
  display_cols => ['login', 'name', 'employeenumber'],
-       column => 'employeenumber',
+       column => ['employeenumber'],
         table => 'employee',
       appname => 'ledgersmb',
   min_version => '1.2',
@@ -235,7 +234,7 @@ push @tests, __PACKAGE__->new(
  instructions => $locale->text(
      'Make sure every name consists of alphanumeric characters (and underscores) only and is at least one character long'),
  display_cols => ['login', 'name', 'employeenumber'],
-       column => 'name',
+       column => ['name'],
         table => 'employee',
       appname => 'ledgersmb',
   min_version => '1.2',
@@ -253,7 +252,7 @@ push @tests, __PACKAGE__->new(
  instructions => $locale->text(
                    'Make employee numbers unique'),
  display_cols => ['login', 'name', 'employeenumber'],
-       column => 'employeenumber',
+       column => ['employeenumber'],
         table => 'employee',
       appname => 'ledgersmb',
   min_version => '1.2',
@@ -272,7 +271,7 @@ push @tests, __PACKAGE__->new(
  instructions => $locale->text(
                    'Make non-obsolete partnumbers unique'),
  display_cols => ['partnumber', 'description', 'sellprice'],
-       column => 'partnumber',
+       column => ['partnumber'],
         table => 'parts',
       appname => 'ledgersmb',
   min_version => '1.2',
@@ -288,7 +287,7 @@ push @tests, __PACKAGE__->new(
                    'Make invoice numbers unique'),
          name => 'unique_ar_invnumbers',
  display_cols =>  ['invnumber', 'transdate', 'amount', 'netamount', 'paid'],
-       column =>  'invnumber',
+       column =>  ['invnumber'],
         table =>  'ar',
       appname => 'ledgersmb',
   min_version => '1.2',
@@ -344,11 +343,11 @@ push @tests, __PACKAGE__->new(
  instructions => $LedgerSMB::App_State::Locale->text(
                    'The following transactions have unassigned amounts'),
                 table => 'acc_trans',
-selectable_values => "SELECT concat(accno,' -- ',description) AS id, id as value
+selectable_values => ["SELECT concat(accno,' -- ',description) AS id, id as value
                                           FROM chart
                                           WHERE charttype = 'A'
-                                          ORDER BY id",
-           column => 'chart_id',
+                                          ORDER BY id"],
+           column => ['chart_id'],
         id_column => 'trans_id',
          id_where => 'chart_id IS NULL AND trans_id',
       appname => 'sql-ledger',
@@ -367,7 +366,7 @@ push @tests, __PACKAGE__->new(
  display_name => $locale->text('No duplicate meta_numbers'),
          name => 'no_meta_number_dupes',
  display_cols => [ 'meta_number', 'class', 'description', 'name' ],
-       column => 'meta_number',
+       column => ['meta_number'],
         table => 'entity_credit_account',
  instructions => $locale->text("Make sure all meta numbers are unique."),
       appname => 'ledgersmb',
@@ -403,7 +402,7 @@ push @tests, __PACKAGE__->new(
          name => 'missing_gifi_table_rows',
  display_cols => [ 'accno', 'description' ],
         table => 'gifi',
-       column => 'description',
+       column => ['description'],
     id_column => 'accno',
      id_where => 'description IS NULL AND accno',
  instructions => $locale->text("Please add the missing GIFI accounts"),
@@ -471,7 +470,7 @@ push @tests,__PACKAGE__->new(
  instructions => $locale->text(
                    'Please make sure all accounts have a category of
 (A)sset, (L)iability, e(Q)uity, (I)ncome or (E)xpense.'),
-    column => 'category',
+    column => ['category'],
     table => 'chart',
     appname => 'sql-ledger',
     min_version => '2.7',
@@ -491,7 +490,7 @@ push @tests,__PACKAGE__->new(
                    'An account can either be a summary account (which have a
 link of "AR", "AP" or "IC" value) or be linked to dropdowns (having any
 number of "AR_*", "AP_*" and/or "IC_*" links concatenated by colons (:).'),
-    column => 'link',
+    column => ['link'],
     table => 'chart',
     appname => 'sql-ledger',
     min_version => '2.7',
@@ -527,7 +526,7 @@ push @tests,__PACKAGE__->new(
     display_cols => ['id', 'customernumber', 'name'],
  instructions => $locale->text(
                    'Please make sure there are no empty customer numbers.'),
-    column => 'customernumber',
+    column => ['customernumber'],
     table => 'customer',
     appname => 'sql-ledger',
     min_version => '2.7',
@@ -546,7 +545,7 @@ push @tests,__PACKAGE__->new(
  instructions => $locale->text(
                    'Please make sure all accounts have a category of
 (A)sset, (L)iability, e(Q)uity, (I)ncome or (E)xpense.'),
-    column => 'category',
+    column => ['category'],
     table => 'chart',
     appname => 'sql-ledger',
     min_version => '2.7',
@@ -565,7 +564,7 @@ push @tests,__PACKAGE__->new(
 #                    'An account can either be a summary account (which have a
 # link of "AR", "AP" or "IC" value) or be linked to dropdowns (having any
 # number of "AR_*", "AP_*" and/or "IC_*" links concatenated by colons (:).'),
-#     column => 'category',
+#     column => ['category'],
 #     table => 'chart',
 #     appname => 'sql-ledger',
 #     min_version => '2.7',
@@ -605,7 +604,7 @@ push @tests,__PACKAGE__->new(
     display_cols => ['id', 'customernumber', 'name'],
  instructions => $locale->text(
                    'Please make all customer numbers unique'),
-    column => 'customernumber',
+    column => ['customernumber'],
     table => 'customer',
     appname => 'sql-ledger',
     min_version => '2.7',
@@ -621,7 +620,7 @@ push @tests,__PACKAGE__->new(
     display_cols => ['id', 'vendornumber', 'name'],
  instructions => $locale->text(
                    'Please make sure there are no empty vendor numbers.'),
-    column => 'vendornumber',
+    column => ['vendornumber'],
     table => 'vendor',
     appname => 'sql-ledger',
     min_version => '2.7',
@@ -640,7 +639,7 @@ push @tests,__PACKAGE__->new(
     display_cols => ['id', 'vendornumber', 'name'],
  instructions => $locale->text(
                    'Please make all vendor numbers unique'),
-    column => 'vendornumber',
+    column => ['vendornumber'],
     table => 'vendor',
     appname => 'sql-ledger',
     min_version => '2.7',
@@ -656,7 +655,7 @@ push @tests, __PACKAGE__->new(
     display_cols => ['id', 'login', 'name', 'employeenumber'],
  instructions => $locale->text(
                    'Please make sure all employees have an employee number'),
-    column => 'employeenumber',
+    column => ['employeenumber'],
     table => 'employee',
     appname => 'sql-ledger',
     min_version => '2.7',
@@ -673,7 +672,7 @@ push @tests, __PACKAGE__->new(
     display_name => $locale->text('Null employee numbers'),
     name => 'no_duplicate_employeenumbers',
     display_cols => ['id', 'login', 'name', 'employeenumber'],
-    column => 'employeenumber',
+    column => ['employeenumber'],
  instructions => $locale->text(
                    'Please make all employee numbers unique'),
     table => 'employee',
@@ -694,7 +693,7 @@ push @tests, __PACKAGE__->new(
     name => 'no_duplicate_ar_invoicenumbers',
     display_cols => ['id', 'invnumber', 'transdate', 'duedate', 'datepaid',
                      'ordnumber', 'quonumber', 'approved'],
-    column => 'invnumber',
+    column => ['invnumber'],
  instructions => $locale->text(
                    'Please make all AR invoice numbers unique'),
     table => 'ar',
@@ -717,7 +716,7 @@ push @tests, __PACKAGE__->new(
     name => 'no_duplicate_ap_invoicenumbers',
     display_cols => ['id', 'invnumber', 'transdate', 'duedate', 'datepaid',
                      'ordnumber', 'quonumber', 'approved'],
-    column => 'invnumber',
+    column => ['invnumber'],
  instructions => $locale->text(
                    'Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please review suggestions to make all AP invoice numbers unique. Conflicting entries are presented by pairs, with a suffix added to the invoice number'),
     table => 'ap',
@@ -738,7 +737,7 @@ push @tests, __PACKAGE__->new(
  instructions => $locale->text(
                    'Make non-obsolete partnumbers unique'),
  display_cols => ['partnumber', 'description', 'sellprice'],
-       column => 'partnumber',
+       column => ['partnumber'],
         table => 'parts',
       appname => 'sql-ledger',
   min_version => '2.7',
@@ -755,7 +754,7 @@ push @tests, __PACKAGE__->new(
     display_cols => ['parts_id', 'make', 'model'],
  instructions => $locale->text(
                    'Please make sure all modelsnumbers are non-empty'),
-    column => 'model',
+    column => ['model'],
     table => 'makemodel',
     appname => 'sql-ledger',
     min_version => '2.7',
@@ -770,7 +769,7 @@ push @tests, __PACKAGE__->new(
     display_name => $locale->text('Null make numbers'),
     name => 'no_null_makenumbers',
     display_cols => ['parts_id', 'make', 'model'],
-    column => 'make',
+    column => ['make'],
     instructions => $locale->text(
                    'Please make sure all make numbers are non-empty'),
     table => 'makemodel',
@@ -805,7 +804,7 @@ push @tests, __PACKAGE__->new(
     display_name => $locale->text('Unknown charttype; should be H(eader)/A(ccount)'),
     name => 'unknown_charttype',
     display_cols => ['accno', 'charttype', 'description'],
-    column => 'charttype',
+    column => ['charttype'],
  instructions => $locale->text(
                    'Please fix the presented rows to either be "H" or "A"'),
     table => 'chart',
@@ -823,7 +822,7 @@ push @tests, __PACKAGE__->new(
     display_name => $locale->text('Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/(e)Q(uity))'),
     name => 'unknown_account_category',
     display_cols => ['accno', 'category', 'description'],
-    column => 'category',
+    column => ['category'],
  instructions => $locale->text(
                    'Please fix the pricegroup data in your partscustomer table (no UI available)'),
     table => 'chart',


### PR DESCRIPTION
This PR bring 2 new possibilities for migration:
1. Edition of multiple fields per record, either as selects or inputs
2. Allow inserting 1 simple record in an empty table. Business is a good example. SQL-Ledger has tables which are optional but mandatory in LedgerSMB. This eases the migration process.

It generalize the migration code by using the proper column id instead of the previous fixed value.
It also add back a default SQL extension to the upgrade file.