### PR TITLE
* Fix an error when trying to access the 'preferences' menu

### DIFF
--- a/lib/LedgerSMB/Scripts/user.pm
+++ b/lib/LedgerSMB/Scripts/user.pm
@@ -55,7 +55,7 @@ sub preference_screen {
         format   => 'HTML'
     );
 
-    my $creds = LedgerSMB::Auth::get_credentials();
+    my $creds = $request->{_auth}->get_credentials();
     $user->{login} = $creds->{login};
     $user->{password_expires} =~ s/:(\d|\.)*$//;
     return $template->render_to_psgi({ request => $request,


### PR DESCRIPTION
Found earlier by Yves, the PSGI authentication cleanup left one call
to the (now removed) LedgerSMB::Auth::get_credentials() routine in place.