### PR TITLE
allow print and say. Apply critique.

### DIFF
--- a/xt/perlcriticrc
+++ b/xt/perlcriticrc
@@ -136,7 +136,9 @@ pager = less
 [InputOutput::RequireCheckedClose]
     set_themes = lsmb lsmb_wip lsmb_old_wip
 [InputOutput::RequireCheckedSyscalls]
-    set_themes = lsmb lsmb_wip lsmb_old_wip
+    set_themes = lsmb lsmb_new lsmb_old_wip
+    functions = open close 
+
 [RegularExpressions::ProhibitCaptureWithoutTest]
     set_themes = lsmb lsmb_wip lsmb_old_wip
 [Subroutines::ProtectPrivateSubs]


### PR DESCRIPTION
This does nothing but require close and open to be checked.  The critique can be expanded to call regarding directories, etc.