### PR TITLE
* Make LedgerSMB::Database->get_info() adhere to its contract

### DIFF
--- a/lib/LedgerSMB/Database.pm
+++ b/lib/LedgerSMB/Database.pm
@@ -204,6 +204,8 @@ sub get_info {
             # different means
        $logger->debug("DBI->connect dbh=$dbh");
 
+       $retval->{status} = 'exists';
+
        my $sth;
        $sth = $dbh->prepare("SELECT SESSION_USER");
        $sth->execute;
@@ -280,7 +282,6 @@ sub get_info {
             $retval->{version} =~ s/(\d+\.\d+).*/$1/g;
        } else {
             $retval->{appname} = 'unknown';
-            $retval->{exists} = 'exists';
        }
        $dbh->rollback;
    }

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -204,9 +204,7 @@ sub login {
     _init_db($request);
     sanity_checks($database);
     $request->{login_name} = $version_info->{username};
-    # $version_info->{status} isn't always defined by get_info, so useless undefined messages
-    # are generated.
-    if (defined $version_info->{status} && $version_info->{status} eq 'does not exist'){
+    if ($version_info->{status} eq 'does not exist'){
         $request->{message} = $request->{_locale}->text(
              'Database does not exist.');
         $request->{operation} = $request->{_locale}->text('Create Database?');


### PR DESCRIPTION
And by consequence, don't check for definedness in the caller to suppress
warnings...