### PR TITLE
Enhance migration functionalities by allowing tables to be extended (INSERT) when REFERENCES keys are missing

### DIFF
--- a/UI/lib/elements.html
+++ b/UI/lib/elements.html
@@ -290,6 +290,12 @@
           ?>
           <?lsmb PROCESS auto_label  # Process element label. ?>
           <button<?lsmb all_attributes ?><?lsmb all_custom_attributes ?>><?lsmb element_data.text ?></button>
+          <?lsmb IF element_data.tooltip.msg;
+                INCLUDE tooltip element_data = {
+                id => element_data.tooltip.id,
+                position => element_data.tooltip.position,
+                msg => text(element_data.tooltip.msg) };
+          END ?>
   <?lsmb END ?>
 <?lsmb END ?>
 
@@ -420,7 +426,7 @@
 
 <?lsmb BLOCK tooltip;
   IF element_data && element_data.id.defined() && element_data.msg.defined();
-     props="connectId:" _ element_data.id;
+     props="connectId:'" _ element_data.id _ "'";
      IF element_data.position.defined();
         positions = [];
         FOREACH position IN element_data.position

--- a/UI/lib/elements.html
+++ b/UI/lib/elements.html
@@ -294,7 +294,7 @@
                 INCLUDE tooltip element_data = {
                 id => element_data.tooltip.id,
                 position => element_data.tooltip.position,
-                msg => text(element_data.tooltip.msg) };
+                msg => element_data.tooltip.msg };
           END ?>
   <?lsmb END ?>
 <?lsmb END ?>
@@ -436,7 +436,7 @@
         props = props _ ',position:[' _ positions.join(',') _ ']';
     END; ?>
     <div data-dojo-type="dijit/Tooltip" data-dojo-props=<?lsmb props ?>  >
-         <?lsmb element_data.msg; ?>
+         <?lsmb UNESCAPE(element_data.msg) ?>
     </div>
   <?lsmb END;
 END ?>

--- a/lib/LedgerSMB/Locale.pm
+++ b/lib/LedgerSMB/Locale.pm
@@ -16,6 +16,12 @@ Locale support module for LedgerSMB.  Uses Locale::Maketext::Lexicon as a base.
 Returns a locale handle for accessing the other methods.  Inherited from
 Locale::Maketext.
 
+=item marktext
+
+Identity function. Allows text to me marked for translation so that it 
+will be picked by the PO scanner. The actual translation has to be done
+in the calling module when the page is prepared.
+
 =item text ($string, @params)
 
 Returns the translation for the given string.  Use this method with a litteral
@@ -85,8 +91,11 @@ package LedgerSMB::Locale;
 
 use strict;
 use warnings;
+use Exporter;
 
-use base 'Locale::Maketext';
+use base qw( Locale::Maketext Exporter );
+our @EXPORT_OK = qw(marktext);
+
 use LedgerSMB::Sysconfig;
 use Locale::Maketext::Lexicon;
 use Encode;
@@ -98,6 +107,10 @@ Locale::Maketext::Lexicon->import(
         _decode => 1,
     }
 );
+
+sub marktext {
+    return shift;
+}
 
 sub text {
     my ( $self, $text, @params ) = @_;

--- a/lib/LedgerSMB/Locale.pm
+++ b/lib/LedgerSMB/Locale.pm
@@ -16,11 +16,12 @@ Locale support module for LedgerSMB.  Uses Locale::Maketext::Lexicon as a base.
 Returns a locale handle for accessing the other methods.  Inherited from
 Locale::Maketext.
 
-=item marktext
+=item marktext ($string)
 
 Identity function. Allows text to me marked for translation so that it 
 will be picked by the PO scanner. The actual translation has to be done
 in the calling module when the page is prepared.
+Note: This isn't a method but a utility function.
 
 =item text ($string, @params)
 
@@ -91,7 +92,6 @@ package LedgerSMB::Locale;
 
 use strict;
 use warnings;
-use Exporter;
 
 use base qw( Locale::Maketext Exporter );
 our @EXPORT_OK = qw(marktext);

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -767,20 +767,15 @@ verify_check => md5_hex($check->test_query),
 
     my $heading = { map { $_ => $_ } @{$check->display_cols} };
     my %buttons = map { $_ => 1 } @{$check->buttons};
-    my %tooltips;
-    while ( my ($key, $value) = each $check->tooltips ) {
-      $tooltips{$key} = $request->{_locale}->text($value);
-    }
     my $buttons;
     push @$buttons,
            { type => 'submit',
              name => 'action',
             value => 'fix_tests',
           tooltip => { id => 'action-fix-tests',
-                       msg => $tooltips{'Save and Retry'},
-                       position => (qw/above below after before/)
+                       msg => $request->{_locale}->text($check->{tooltips}{'Save and Retry'}),
+                       position => 'above'
                      },
-             text => $request->{_locale}->text('Save and Retry'),
              text => $request->{_locale}->text('Save and Retry'),
             class => 'submit' },
         if $check->columns;
@@ -789,8 +784,8 @@ verify_check => md5_hex($check->test_query),
              name => 'action',
             value => 'cancel',
           tooltip => { id => 'action-cancel',
-                       msg => $tooltips{'Cancel'},
-                       position => (qw/above below after before/)
+                       msg => $request->{_locale}->text($check->{tooltips}{'Cancel'}),
+                       position => 'above'
                      },
              text => $request->{_locale}->text('Cancel'),
             class => 'submit' }
@@ -800,8 +795,8 @@ verify_check => md5_hex($check->test_query),
              name => 'action',
             value => 'force',
           tooltip => { id => 'action-force',
-                       msg => $tooltips{'Force'},
-                       position => (qw/above below after before/)
+                       msg => $request->{_locale}->text($check->{tooltips}{'Force'}),
+                       position => 'above'
                      },
              text => $request->{_locale}->text('Force'),
             class => 'submit' }
@@ -867,7 +862,7 @@ sub fix_tests{
 
     my $query;
     if ($check->{insert}) {
-        my @id = $id_displayed ? $request->{id_column} : ();
+        my @id = $id_displayed ? $check->{id_column} : ();
         push @id,@edits;
         my $columns = join(', ', map { $dbh->quote_identifier($_) } @id);
         my $values = join(', ', map { '?' } @id);

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -767,14 +767,19 @@ verify_check => md5_hex($check->test_query),
 
     my $heading = { map { $_ => $_ } @{$check->display_cols} };
     my %buttons = map { $_ => 1 } @{$check->buttons};
+    my %tooltips;
+    while ( my ($key, $value) = each $check->tooltips ) {
+      $tooltips{$key} = $request->{_locale}->text($value);
+    }
     my $buttons;
     push @$buttons,
            { type => 'submit',
              name => 'action',
             value => 'fix_tests',
           tooltip => { id => 'action-fix-tests',
-                       position => qw/above below after before/,
-                       msg => $check->{tooltips}{'Save and Retry'}},
+                       msg => $tooltips{'Save and Retry'},
+                       position => (qw/above below after before/)
+                     },
              text => $request->{_locale}->text('Save and Retry'),
              text => $request->{_locale}->text('Save and Retry'),
             class => 'submit' },
@@ -784,18 +789,20 @@ verify_check => md5_hex($check->test_query),
              name => 'action',
             value => 'cancel',
           tooltip => { id => 'action-cancel',
-                       position => qw/above below after before/,
-                       msg => $check->{tooltips}{'Cancel'}},
+                       msg => $tooltips{'Cancel'},
+                       position => (qw/above below after before/)
+                     },
              text => $request->{_locale}->text('Cancel'),
             class => 'submit' }
-    if $buttons{Cancel} or !$check->columns;
+    if $buttons{Cancel} or scalar($check->columns) == 0;
     push @$buttons,
            { type => 'submit',
              name => 'action',
             value => 'force',
           tooltip => { id => 'action-force',
-                       position => qw/above below after before/,
-                       msg => $check->{tooltips}{'Force'}},
+                       msg => $tooltips{'Force'},
+                       position => (qw/above below after before/)
+                     },
              text => $request->{_locale}->text('Force'),
             class => 'submit' }
     if $buttons{Force} && $check->{force_queries};
@@ -809,7 +816,8 @@ verify_check => md5_hex($check->test_query),
            form               => $request,
            base_form          => 'dijit/form/Form',
            heading            => $heading,
-           headers            => [$check->display_name, $check->instructions],
+           headers            => [$request->{_locale}->text($check->display_name),
+                                  $request->{_locale}->text($check->instructions)],
            columns            => $check->display_cols,
            rows               => $rows,
            hiddens            => $hiddens,

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -862,8 +862,8 @@ sub fix_tests{
 
     my $query;
     if ($check->{insert}) {
-        my @_edits = $id_displayed ? $check->{id_column} : ();
-        push @_edits,@edits;
+        my @_edits = @edits;
+        unshift @_edits, $check->{id_column} if $id_displayed;
         my $columns = join(', ', map { $dbh->quote_identifier($_) } @_edits);
         my $values = join(', ', map { '?' } @_edits);
         $query = "INSERT INTO $table ($columns) VALUES ($values)";

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -737,6 +737,10 @@ sub _failed_check {
 verify_check => md5_hex($check->test_query),
     database => $request->{database}
     };
+    # If we are inserting and id is displayed, we want to insert
+    # at this exact location
+    $hiddens->{id_displayed} = $check->{insert}
+                and grep( /^$check->{id_column}$/, @{$check->display_cols} );
 
     my $rows = [];
     while (my $row = $sth->fetchrow_hashref('NAME_lc')) {
@@ -831,8 +835,10 @@ sub fix_tests{
 
     my $query;
     if ($request->{insert}) {
-        my $columns = join(', ', map { $dbh->quote_identifier($_) } @edits);
-        my $values = join(', ', map { '?' } @edits);
+        my @id = $request->{id_displayed} ? $request->{id_column} : ();
+        push @id,@edits;
+        my $columns = join(', ', map { $dbh->quote_identifier($_) } @id);
+        my $values = join(', ', map { '?' } @id);
         $query = "INSERT INTO $table ($columns) VALUES ($values)";
     }
     else {
@@ -845,6 +851,8 @@ sub fix_tests{
     for my $count (1 .. $request->{count}){
         my $id = $request->{"id_$count"};
         my @values;
+        push @values, $id
+            if $request->{insert} and $request->{id_displayed};
         for my $edit (@edits) {
           push @values, $request->{"${edit}_$id"};
         }

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -773,34 +773,34 @@ verify_check => md5_hex($check->test_query),
              name => 'action',
             value => 'fix_tests',
           tooltip => { id => 'action-fix-tests',
-                       msg => $request->{_locale}->text($check->{tooltips}{'Save and Retry'}),
+                       msg => $request->{_locale}->maketext($check->{tooltips}->{'Save and Retry'}),
                        position => 'above'
                      },
              text => $request->{_locale}->text('Save and Retry'),
-            class => 'submit' },
+            class => 'submit' }
         if $check->columns;
     push @$buttons,
            { type => 'submit',
              name => 'action',
             value => 'cancel',
           tooltip => { id => 'action-cancel',
-                       msg => $request->{_locale}->text($check->{tooltips}{'Cancel'}),
+                       msg => $request->{_locale}->maketext($check->{tooltips}->{'Cancel'}),
                        position => 'above'
                      },
              text => $request->{_locale}->text('Cancel'),
             class => 'submit' }
-    if $buttons{Cancel} or scalar($check->columns) == 0;
+        if $buttons{Cancel} or scalar($check->columns) == 0;
     push @$buttons,
            { type => 'submit',
              name => 'action',
             value => 'force',
           tooltip => { id => 'action-force',
-                       msg => $request->{_locale}->text($check->{tooltips}{'Force'}),
+                       msg => $request->{_locale}->maketext($check->{tooltips}->{'Force'}),
                        position => 'above'
                      },
              text => $request->{_locale}->text('Force'),
             class => 'submit' }
-    if $buttons{Force} && $check->{force_queries};
+        if $buttons{Force} && $check->{force_queries};
 
     my $template = LedgerSMB::Template->new_UI(
         $request,
@@ -811,8 +811,8 @@ verify_check => md5_hex($check->test_query),
            form               => $request,
            base_form          => 'dijit/form/Form',
            heading            => $heading,
-           headers            => [$request->{_locale}->text($check->display_name),
-                                  $request->{_locale}->text($check->instructions)],
+           headers            => [$request->{_locale}->maketext($check->display_name),
+                                  $request->{_locale}->maketext($check->instructions)],
            columns            => $check->display_cols,
            rows               => $rows,
            hiddens            => $hiddens,
@@ -862,10 +862,10 @@ sub fix_tests{
 
     my $query;
     if ($check->{insert}) {
-        my @id = $id_displayed ? $check->{id_column} : ();
-        push @id,@edits;
-        my $columns = join(', ', map { $dbh->quote_identifier($_) } @id);
-        my $values = join(', ', map { '?' } @id);
+        my @_edits = $id_displayed ? $check->{id_column} : ();
+        push @_edits,@edits;
+        my $columns = join(', ', map { $dbh->quote_identifier($_) } @_edits);
+        my $values = join(', ', map { '?' } @_edits);
         $query = "INSERT INTO $table ($columns) VALUES ($values)";
     }
     else {
@@ -879,7 +879,7 @@ sub fix_tests{
         my $id = $request->{"id_$count"};
         my @values;
         push @values, $id
-            if $check->{insert} and $id_displayed;
+            if $id_displayed;
         for my $edit (@edits) {
           push @values, $request->{"${edit}_$id"};
         }

--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -530,14 +530,10 @@ sub _tt_url {
 
 sub _maketext {
     my $self = shift;
-    my $escape = shift;
 
-    if (defined $self->{locale}) {
-        return $escape->($self->{locale}->maketext(@_));
-    }
-    else {
-        return $escape->(@_);
-    }
+    return defined $self->{locale}
+        ? $self->{locale}->maketext(@_)
+        : shift;
 }
 
 sub _render {
@@ -563,7 +559,6 @@ sub _render {
         value => 'screen'
     } if $LedgerSMB::App_State::Locale;
 
-
     my $format = "LedgerSMB::Template::$self->{format}";
     my $escape = $format->can('escape');
     my $unescape = $format->can('unescape');
@@ -571,7 +566,7 @@ sub _render {
     $cleanvars->{escape} = sub { return $escape->(@_); };
     $cleanvars->{UNESCAPE} = sub { return $unescape->(@_); }
         if ($unescape && !$self->{no_escape});
-    $cleanvars->{text} = sub { return $self->_maketext($escape, @_); };
+    $cleanvars->{text} = sub { return $self->_maketext(@_); };
     $cleanvars->{tt_url} = \&_tt_url;
     $cleanvars->{$_} = $self->{additional_vars}->{$_}
         for (keys %{$self->{additional_vars}});

--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -530,10 +530,11 @@ sub _tt_url {
 
 sub _maketext {
     my $self = shift;
+    my $escape = shift;
 
-    return defined $self->{locale}
-        ? $self->{locale}->maketext(@_)
-        : shift;
+    return $escape->(defined $self->{locale}
+                    ? $self->{locale}->maketext(@_)
+                    : shift);
 }
 
 sub _render {
@@ -566,7 +567,7 @@ sub _render {
     $cleanvars->{escape} = sub { return $escape->(@_); };
     $cleanvars->{UNESCAPE} = sub { return $unescape->(@_); }
         if ($unescape && !$self->{no_escape});
-    $cleanvars->{text} = sub { return $self->_maketext(@_); };
+    $cleanvars->{text} = sub { return $self->_maketext($escape, @_); };
     $cleanvars->{tt_url} = \&_tt_url;
     $cleanvars->{$_} = $self->{additional_vars}->{$_}
         for (keys %{$self->{additional_vars}});

--- a/lib/LedgerSMB/Template/HTML.pm
+++ b/lib/LedgerSMB/Template/HTML.pm
@@ -34,6 +34,8 @@ sub escape {
     return undef unless defined $vars;
     #$vars = encode_entities($vars);
     $vars = escape_html($vars);
+    #Allow back only a few decorations.
+    $vars =~ s~&lt;(/?[biu]|br)&gt;~<$1>~g;
     return $vars;
 }
 

--- a/lib/LedgerSMB/Template/HTML.pm
+++ b/lib/LedgerSMB/Template/HTML.pm
@@ -32,10 +32,7 @@ Escapes a scalar string and returns the sanitized version.
 sub escape {
     my $vars = shift @_;
     return undef unless defined $vars;
-    #$vars = encode_entities($vars);
     $vars = escape_html($vars);
-    #Allow back only a few decorations.
-    $vars =~ s~&lt;(/?[biu]|br)&gt;~<$1>~g;
     return $vars;
 }
 

--- a/lib/LedgerSMB/Upgrade_Tests.pm
+++ b/lib/LedgerSMB/Upgrade_Tests.pm
@@ -551,17 +551,19 @@ push @tests,__PACKAGE__->new(
 
 
     push @tests,__PACKAGE__->new(
-        test_query => "select *
-                         from (
-                           select distinct business_id as id
-                             from ( select business_id from customer
+        test_query => "select id, 'auto-business-' || id as description, 0 as discount from (
+                          select distinct id from (
+                                    select business_id as id from customer
                               union select business_id from vendor
-                           ) bi where business_id not in (
-                                select id from business)) as a
-                        where id <> 0",
+                          ) a
+                           where id is not null
+                             and id <> 0
+                             and id not in (select id from business)
+                        order by id
+                      ) a",
         display_name => $locale->text('Empty businesses'),
         name => 'no_businesses',
-        display_cols => ['description', 'discount'],
+        display_cols => ['id', 'description', 'discount'],
      instructions => $locale->text(
                        'Undefined businesses. Please make sure business used by vendors and constomers are defined.'),
         columns => ['description', 'discount'],

--- a/lib/LedgerSMB/Upgrade_Tests.pm
+++ b/lib/LedgerSMB/Upgrade_Tests.pm
@@ -590,27 +590,28 @@ selectable_values => { business_id => "SELECT concat(description,' -- ',discount
     max_version => '3.0'
     );
 
-    push @tests, __PACKAGE__->new(
-        test_query => "SELECT id, name, business_id
-                         FROM customer
-                        WHERE business_id is null
-                           OR business_id NOT IN (SELECT id
-                                                  FROM business)
-                     ORDER BY name",
-        display_name => $locale->text('Customer not in a business'),
-        name => 'no_business_for_customer',
-        display_cols => ['id', 'name', 'business_id'],
-        columns => ['business_id'],
-     instructions => $locale->text(
-                       'Contrary to SQL-ledger, LedgerSMB customers must be assigned to a business. Please select the proper business from the list'),
-    selectable_values => { business_id => "SELECT concat(description,' -- ',discount) AS id, id as value
-                                            FROM business
-                                            ORDER BY id" },
-        table => 'customer',
-        appname => 'sql-ledger',
-        min_version => '2.7',
-        max_version => '3.0'
-        );
+push @tests, __PACKAGE__->new(
+    test_query => "SELECT id, name, business_id
+                     FROM customer
+                    WHERE business_id is null
+                       OR business_id NOT IN (SELECT id
+                                              FROM business)
+                 ORDER BY name",
+    display_name => $locale->text('Customer not in a business'),
+    name => 'no_business_for_customer',
+    display_cols => ['id', 'name', 'business_id'],
+    columns => ['business_id'],
+ instructions => $locale->text(
+                   'Contrary to SQL-ledger, LedgerSMB customers must be assigned to a business. ' .
+                   'Please review the selection or select the proper business from the list'),
+selectable_values => { business_id => "SELECT concat(description,' -- ',discount) AS text, id as value
+                                        FROM business
+                                        ORDER BY id"},
+    table => 'customer',
+    appname => 'sql-ledger',
+    min_version => '2.7',
+    max_version => '3.0'
+    );
 
 push @tests,__PACKAGE__->new(
     test_query => "select *

--- a/lib/LedgerSMB/Upgrade_Tests.pm
+++ b/lib/LedgerSMB/Upgrade_Tests.pm
@@ -200,7 +200,8 @@ Enabled buttons
 
 subtype 'button'
     => as 'Str'
-    => where { 1 or grep( /^$_$/, ['Save and Retry', 'Cancel', 'Force'] )};
+    => where { $_ =~ /Save and Retry|Cancel|Force/ }
+    => message { "Invalid button '$_'" };
 
 has buttons => (is => 'ro', isa => 'ArrayRef[button]',
                 default => sub {['Save and Retry', 'Cancel']},
@@ -594,8 +595,6 @@ push @tests,__PACKAGE__->new(
     max_version => '3.0'
     );
 
-##ok. Report, Give description about possible user action, impact and us clearing the data, then a Accept button to continue or Cancel if he thinks he can fix the original data.
-##And Cancel should probably become Cancel migration
     push @tests,__PACKAGE__->new(
         test_query => "select id, 'auto-business-' || id as description, 0 as discount from (
                           select distinct id from (
@@ -682,29 +681,6 @@ selectable_values => { business_id => "SELECT concat(description,' -- ',discount
     min_version => '2.7',
     max_version => '3.0'
     );
-
-    push @tests,__PACKAGE__->new(
-        test_query => "select *
-                         from (
-                           select distinct business_id as id
-                             from ( select business_id from customer
-                              union select business_id from vendor
-                           ) bi where business_id not in (
-                                select id from business)) as a
-                        where id <> 0",
-        display_name => marktext('Empty businesses'),
-        name => 'no_businesses',
-        display_cols => ['description', 'discount'],
-     instructions => marktext(
-                       'Undefined businesses. Please make sure business used by vendors and constomers are defined.'),
-        columns => ['description', 'discount'],
-        table => 'business',
-        appname => 'sql-ledger',
-        min_version => '2.7',
-        max_version => '3.0',
-        insert => 1
-        );
-
 
 push @tests, __PACKAGE__->new(
     test_query => "SELECT id, name, business_id

--- a/lib/LedgerSMB/Upgrade_Tests.pm
+++ b/lib/LedgerSMB/Upgrade_Tests.pm
@@ -632,7 +632,7 @@ Hover on buttons to see their effects and impacts'),
           tooltips => {
             'Save and Retry' => marktext('Save the fixes provided and attempt to continue migration'),
             'Cancel' => marktext('Cancel the migration'),
-            'Force' => marktext('This will remove the business references in vendor and customer tables')
+            'Force' => marktext('This will <b>remove</b> the business references in <u>vendor</u> and <u>customer</u> tables')
           }
         );
 

--- a/lib/LedgerSMB/Upgrade_Tests.pm
+++ b/lib/LedgerSMB/Upgrade_Tests.pm
@@ -552,13 +552,18 @@ push @tests,__PACKAGE__->new(
 
     push @tests,__PACKAGE__->new(
         test_query => "select *
-                         from (select count(*) as id from business) as a
-                        where id=0",
+                         from (
+                           select distinct business_id as id
+                             from ( select business_id from customer
+                              union select business_id from vendor
+                           ) bi where business_id not in (
+                                select id from business)) as a
+                        where id <> 0",
         display_name => $locale->text('Empty businesses'),
         name => 'no_businesses',
         display_cols => ['description', 'discount'],
      instructions => $locale->text(
-                       'Contrary to SQL-Ledger, LedgerSMB requires businesses. Please make sure there is at least 1 business defined.'),
+                       'Undefined businesses. Please make sure business used by vendors and constomers are defined.'),
         columns => ['description', 'discount'],
         table => 'business',
         appname => 'sql-ledger',
@@ -571,19 +576,20 @@ push @tests,__PACKAGE__->new(
 push @tests, __PACKAGE__->new(
     test_query => "SELECT id, name, business_id
                      FROM vendor
-                    WHERE business_id is null
-                       OR business_id NOT IN (SELECT id
-                                              FROM business)
+                    WHERE business_id NOT IN (SELECT id
+                     FROM business)
+                      AND business_id <> 0
                  ORDER BY name",
     display_name => $locale->text('Vendor not in a business'),
     name => 'no_business_for_vendor',
     display_cols => ['id', 'name', 'business_id'],
     columns => ['business_id'],
  instructions => $locale->text(
-                   'Contrary to SQL-ledger, LedgerSMB vendors must be assigned to a business. Please select the proper business from the list'),
-selectable_values => { business_id => "SELECT concat(description,' -- ',discount) AS id, id as value
+                   'LedgerSMB vendors must be assigned to a valid business. ' .
+                   'Please review the selection or select the proper business from the list'),
+selectable_values => { business_id => "SELECT concat(description,' -- ',discount) AS text, id as value
                                         FROM business
-                                        ORDER BY id" },
+                                        ORDER BY id"},
     table => 'vendor',
     appname => 'sql-ledger',
     min_version => '2.7',
@@ -593,16 +599,16 @@ selectable_values => { business_id => "SELECT concat(description,' -- ',discount
 push @tests, __PACKAGE__->new(
     test_query => "SELECT id, name, business_id
                      FROM customer
-                    WHERE business_id is null
-                       OR business_id NOT IN (SELECT id
+                    WHERE business_id NOT IN (SELECT id
                                               FROM business)
+                      AND business_id <> 0
                  ORDER BY name",
     display_name => $locale->text('Customer not in a business'),
     name => 'no_business_for_customer',
     display_cols => ['id', 'name', 'business_id'],
     columns => ['business_id'],
  instructions => $locale->text(
-                   'Contrary to SQL-ledger, LedgerSMB customers must be assigned to a business. ' .
+                   'LedgerSMB customers must be assigned to a valid business. ' .
                    'Please review the selection or select the proper business from the list'),
 selectable_values => { business_id => "SELECT concat(description,' -- ',discount) AS text, id as value
                                         FROM business
@@ -964,6 +970,24 @@ push @tests, __PACKAGE__->new(
     appname => 'sql-ledger',
     min_version => '2.7',
     max_version => '3.0'
+    );
+
+    push @tests, __PACKAGE__->new(
+        test_query => "select ac.trans_id,ac.id,ac.memo, ac.amount,c.description,c.accno,c.link,ac.cleared
+                        from acc_trans ac
+                        join chart c on ac.chart_id=c.id
+                        where c.link not like '%paid'
+                        and ac.cleared is not null
+                        order by accno,transdate,id",
+      display_name => $locale->text('Reconciliations on non-bank accounts'),
+              name => 'invalid_cleared_dates',
+      display_cols => ['trans_id', 'id', 'memo', 'amount', 'description','accno', 'cleared'],
+     instructions => $locale->text(
+                       "There shouldn't be reconciliations on non-bank accounts. Please review the dates in the original application"),
+            table => 'acc_trans',
+          appname => 'sql-ledger',
+      min_version => '2.7',
+      max_version => '3.0'
     );
 
 push @tests, __PACKAGE__->new(

--- a/lib/LedgerSMB/Upgrade_Tests.pm
+++ b/lib/LedgerSMB/Upgrade_Tests.pm
@@ -550,6 +550,68 @@ push @tests,__PACKAGE__->new(
     );
 
 
+    push @tests,__PACKAGE__->new(
+        test_query => "select *
+                         from (select count(*) as id from business) as a
+                        where id=0",
+        display_name => $locale->text('Empty businesses'),
+        name => 'no_businesses',
+        display_cols => ['description', 'discount'],
+     instructions => $locale->text(
+                       'Contrary to SQL-Ledger, LedgerSMB requires businesses. Please make sure there is at least 1 business defined.'),
+        columns => ['description', 'discount'],
+        table => 'business',
+        appname => 'sql-ledger',
+        min_version => '2.7',
+        max_version => '3.0',
+        insert => 1
+        );
+
+
+push @tests, __PACKAGE__->new(
+    test_query => "SELECT id, name, business_id
+                     FROM vendor
+                    WHERE business_id is null
+                       OR business_id NOT IN (SELECT id
+                                              FROM business)
+                 ORDER BY name",
+    display_name => $locale->text('Vendor not in a business'),
+    name => 'no_business_for_vendor',
+    display_cols => ['id', 'name', 'business_id'],
+    columns => ['business_id'],
+ instructions => $locale->text(
+                   'Contrary to SQL-ledger, LedgerSMB vendors must be assigned to a business. Please select the proper business from the list'),
+selectable_values => { business_id => "SELECT concat(description,' -- ',discount) AS id, id as value
+                                        FROM business
+                                        ORDER BY id" },
+    table => 'vendor',
+    appname => 'sql-ledger',
+    min_version => '2.7',
+    max_version => '3.0'
+    );
+
+    push @tests, __PACKAGE__->new(
+        test_query => "SELECT id, name, business_id
+                         FROM customer
+                        WHERE business_id is null
+                           OR business_id NOT IN (SELECT id
+                                                  FROM business)
+                     ORDER BY name",
+        display_name => $locale->text('Customer not in a business'),
+        name => 'no_business_for_customer',
+        display_cols => ['id', 'name', 'business_id'],
+        columns => ['business_id'],
+     instructions => $locale->text(
+                       'Contrary to SQL-ledger, LedgerSMB customers must be assigned to a business. Please select the proper business from the list'),
+    selectable_values => { business_id => "SELECT concat(description,' -- ',discount) AS id, id as value
+                                            FROM business
+                                            ORDER BY id" },
+        table => 'customer',
+        appname => 'sql-ledger',
+        min_version => '2.7',
+        max_version => '3.0'
+        );
+
 push @tests,__PACKAGE__->new(
     test_query => "select *
                     from chart

--- a/sql/upgrade/sl3.0-1.6.sql
+++ b/sql/upgrade/sl3.0-1.6.sql
@@ -40,6 +40,10 @@ SELECT account__save(id, accno, description, category,
 
 delete from account_link where description = 'CT_tax';
 
+-- Business
+
+INSERT INTO business SELECT * FROM sl30.business;
+
 --Entity
 
 INSERT INTO entity (name, control_code, entity_class, country_id)
@@ -328,21 +332,12 @@ WHERE entity_class = 10 AND control_code = 'R-1';
 --     SELECT entity_id, login FROM sl30.employee em
 --      WHERE login IS NOT NULL;
 
--- No manager-managee information in SL30
---INSERT
---  INTO entity_employee(entity_id, startdate, enddate, role, ssn, sales,
---       employeenumber, dob, manager_id)
---SELECT entity_id, startdate, enddate, r.description, ssn, sales,
---       employeenumber, dob,
---       (select entity_id from sl30.employee where id = em.managerid)
---  FROM sl30.employee em
---LEFT JOIN sl30.acsrole r on em.acsrole_id = r.id;
-
 INSERT
   INTO entity_employee(entity_id, startdate, enddate, role, ssn, sales,
        employeenumber, dob, manager_id)
 SELECT entity_id, startdate, enddate, r.description, ssn, sales,
-       employeenumber, dob, 0
+       employeenumber, dob,
+       (select entity_id from sl30.employee where id = em.acsrole_id)
   FROM sl30.employee em
 LEFT JOIN sl30.acsrole r on em.acsrole_id = r.id;
 
@@ -789,8 +784,6 @@ SELECT id, 2, project_id + 1000 FROM sl30.orderitems
 INSERT INTO exchangerate select * from sl30.exchangerate;
 
 INSERT INTO status SELECT * FROM sl30.status; -- may need to comment this one out sometimes
-
-INSERT INTO business SELECT * FROM sl30.business;
 
 INSERT INTO sic SELECT * FROM sl30.sic;
 

--- a/sql/upgrade/sl3.0-1.6.sql
+++ b/sql/upgrade/sl3.0-1.6.sql
@@ -70,6 +70,7 @@ UPDATE sl30.customer SET entity_id = coalesce((SELECT min(id) FROM entity WHERE 
 
 --Entity Credit Account
 
+UPDATE sl30.vendor SET business_id = NULL WHERE business_id = 0;
 INSERT INTO entity_credit_account
 (entity_id, meta_number, business_id, creditlimit, ar_ap_account_id,
         cash_account_id, startdate, enddate, threshold, entity_class)
@@ -90,6 +91,7 @@ UPDATE sl30.vendor SET credit_id =
         WHERE e.meta_number = vendornumber and entity_class = 1
         and e.entity_id = vendor.entity_id);
 
+UPDATE sl30.customer SET business_id = NULL WHERE business_id = 0;
 INSERT INTO entity_credit_account
 (entity_id, meta_number, business_id, creditlimit, ar_ap_account_id,
         cash_account_id, startdate, enddate, threshold, entity_class)

--- a/utils/devel/extract-perl
+++ b/utils/devel/extract-perl
@@ -69,7 +69,8 @@ while (<>) {
 
           $state==NUL &&
               # the reports use a workaround with a function called Text()
-              m/(?<![\w\d_])[tT]ext[\s\t\n]*\(/g
+              # or MarkText()
+              m/(?<![\w\d_])([Mm]ark)?[tT]ext[\s\t\n]*\(/g
               && do { $state = TXT; redo; };
 
           $state==TXT &&


### PR DESCRIPTION
Fix the business discounts for migration.
- Use null for unused entries instead of 0
- Ensure coherence between discount definition and usage in customer and vendor tables. Discounts usage have to refer to existing discounts.
- Provide means to either enter the missing discounts or remove their usage