### PR TITLE
SL30 migration3

### DIFF
--- a/UI/reconciliation/report.html
+++ b/UI/reconciliation/report.html
@@ -193,7 +193,7 @@ END ?>
                     END;
                 END;
             ?>
-            <td id='<?lsmb id ?>' class='<?lsmb class ?>'>
+            <td id='<?lsmb id ?>' class='date <?lsmb class ?>'>
                 <?lsmb INCLUDE tooltip element_data; ?>
             <?lsmb row.clear_time ?></td>
             <td><?lsmb row.scn ?> </td>

--- a/UI/setup/stylesheet.css
+++ b/UI/setup/stylesheet.css
@@ -60,3 +60,13 @@ img.logo {
 button {
     margin-top: 10px;
 }
+
+.listtop {
+    font-size: larger;
+}
+
+tr.listheading {
+    background-color: lightgrey;
+}
+tr.listrow:nth-child(even) {background: #FFF}
+tr.listrow:nth-child(odd) {background: #EEE}

--- a/UI/setup/stylesheet.css
+++ b/UI/setup/stylesheet.css
@@ -70,3 +70,7 @@ tr.listheading {
 }
 tr.listrow:nth-child(even) {background: #FFF}
 tr.listrow:nth-child(odd) {background: #EEE}
+
+td.dijitStretch {
+    min-width: 125px;
+}

--- a/lib/LedgerSMB/Scripts/recon.pm
+++ b/lib/LedgerSMB/Scripts/recon.pm
@@ -204,7 +204,7 @@ sub _display_report {
     $recon->unapproved_checks;
 
     my $contents = '';
-    {
+    if ($request->{csv_file}) {
         local $/ = undef;
         my $handle = $request->upload('csv_file');
         $contents = <$handle>
@@ -212,7 +212,7 @@ sub _display_report {
     }
 
     $recon->add_entries($recon->import_file($contents))
-        if !$recon->{submitted};
+        if !$recon->{submitted} && $contents;
     $recon->{can_approve} = $request->is_allowed_role({allowed_roles => ['reconciliation_approve']});
     $recon->get();
     $recon->{form_id} = $request->{form_id};

--- a/lib/LedgerSMB/Scripts/recon.pm
+++ b/lib/LedgerSMB/Scripts/recon.pm
@@ -204,7 +204,7 @@ sub _display_report {
     $recon->unapproved_checks;
 
     my $contents = '';
-    if ($request->{csv_file}) {
+    {
         local $/ = undef;
         my $handle = $request->upload('csv_file');
         $contents = <$handle>
@@ -212,7 +212,7 @@ sub _display_report {
     }
 
     $recon->add_entries($recon->import_file($contents))
-        if !$recon->{submitted} && $contents;
+        if !$recon->{submitted};
     $recon->{can_approve} = $request->is_allowed_role({allowed_roles => ['reconciliation_approve']});
     $recon->get();
     $recon->{form_id} = $request->{form_id};

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -780,7 +780,7 @@ sub _failed_check {
     my $buttons = [
            { type => 'submit',
              name => 'action',
-            value => 'fix_tests',
+            value => $check->columns ? 'fix_tests' : 'cancel',
              text => $request->{_locale}->text($check->columns
                                                 ? 'Save and Retry'
                                                 : 'Cancel'),

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -420,9 +420,6 @@ sub run_backup {
 
     if ($request->{backup_type} eq 'email') {
 
-
-
-
         my $mail = LedgerSMB::Mailer->new(
             from     => $LedgerSMB::Sysconfig::backup_email_from,
             to       => $request->{email},
@@ -784,7 +781,9 @@ sub _failed_check {
            { type => 'submit',
              name => 'action',
             value => 'fix_tests',
-             text => $request->{_locale}->text('Save and Retry'),
+             text => $request->{_locale}->text($check->columns
+                                                ? 'Save and Retry'
+                                                : 'Cancel'),
             class => 'submit' },
     ];
 

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -763,7 +763,7 @@ sub _failed_check {
                    name => $column . "_$id",
                    id => $id,
                    options => $selectable_value,
-                   default_blank => 1,
+                   default_blank => ( 1 != @$selectable_value ) ? 1 : 0
            } }
            : { input => {
                    name => $column . "_$id",

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -760,7 +760,7 @@ sub _failed_check {
                    name => $column . "_$id",
                    id => $id,
                    options => $selectable_value,
-                   default_blank => ( 1 != @$selectable_value ) ? 1 : 0
+                   default_blank => ( 1 != @$selectable_value )
            } }
            : { input => {
                    name => $column . "_$id",


### PR DESCRIPTION
Cosmetic and workflow fixes.

1. Automatically select when only one entry is available in a list
2. Allow `Cancel` when migration fixing is impossible
3. Alternate row background colors, prevent dates to be wrapped and set a minimum width for selects

Protect the code when CSV option import isn't available, to reduce console warnings.