### PR TITLE
Allow reconciliations on asset, liability and equity accounts only

### DIFF
--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -726,7 +726,7 @@ sub _applicable_upgrade_preparations {
     my $dbinfo = shift;
 
     return grep { _upgrade_test_is_applicable($dbinfo, $_) }
-                  LedgerSMB::Upgrade_preparations->get_preparations;
+                  LedgerSMB::Upgrade_Preparation->get_migration_preparations;
 }
 
 sub _applicable_upgrade_tests {

--- a/lib/LedgerSMB/Upgrade_Pre_Tests.pm
+++ b/lib/LedgerSMB/Upgrade_Pre_Tests.pm
@@ -1,0 +1,116 @@
+=head1 NAME
+
+LedgerSMB::Upgrade_Pre_Tests - Upgrade pre-tests for LedgerSMB
+
+=head1 SYNPOPSIS
+
+ TODO
+
+=head1 DESCRIPTION
+
+This module has a single function that returns upgrade pre-tests.
+
+=cut
+
+package LedgerSMB::Upgrade_Pre_Tests;
+use strict;
+use warnings;
+use Moose;
+use Moose::Util::TypeConstraints;
+use namespace::autoclean;
+
+=head1 FUNCTIONS
+
+=over
+
+=item get_pre_tests()
+
+Returns the pre-test array
+Pre-tests are run only once before any tests, to adjust some tables for
+data uniqueness to allow edit, for example.
+
+=cut
+
+sub get_pre_tests {
+    my ($self) = @_;
+    my @pre_tests = $self->_get_pre_tests;
+    return @pre_tests;
+}
+
+=back
+
+=head1 TEST DEFINITION
+
+Each test is a Moose object with the following properties (optional ones marked
+as such).
+
+=over
+
+=item name
+
+Name of the test
+
+=cut
+
+has name => (is => 'ro', isa => 'Str', required => 1);
+
+=item min_version
+
+The first version to run this against
+
+=cut
+
+has min_version => (is => 'ro', isa => 'Str', required => 1);
+
+=item max_version
+
+The maximum version to run this against
+
+=cut
+
+has max_version => (is => 'ro', isa => 'Str', required => 1);
+
+=item appname
+
+The appname of the application the test belongs to.
+Can currently be 'ledgersmb' or 'sql-leder'.
+
+=cut
+
+has appname => (is => 'ro', isa => 'Str', required => 1);
+
+=item test_query
+
+Text of the query to run
+
+=cut
+
+has test_query => (is => 'ro', isa => 'Str', required => 1);
+
+=back
+
+=head1 Methods
+
+=cut
+
+sub _get_pre_tests {
+    my ($request) = @_;
+
+    my @pre_tests;
+
+    push @pre_tests, __PACKAGE__->new(
+        # Add a unique key to allow editing
+        test_query => 'ALTER TABLE acc_trans DROP COLUMN IF EXISTS lsmb_entry_id;
+                       ALTER TABLE acc_trans add column lsmb_entry_id SERIAL UNIQUE;',
+        name => 'add_unique_acc_trans_key',
+           appname => 'sql-ledger',
+       min_version => '2.7',
+       max_version => '3.0'
+    );
+
+    return @pre_tests;
+}
+
+__PACKAGE__->meta->make_immutable;
+
+1;

--- a/lib/LedgerSMB/Upgrade_Preparation.pm
+++ b/lib/LedgerSMB/Upgrade_Preparation.pm
@@ -1,6 +1,6 @@
 =head1 NAME
 
-LedgerSMB::Upgrade_Pre_Tests - Upgrade pre-tests for LedgerSMB
+LedgerSMB::Upgrade_Preparation - Upgrade preparations for LedgerSMB
 
 =head1 SYNPOPSIS
 
@@ -8,11 +8,11 @@ LedgerSMB::Upgrade_Pre_Tests - Upgrade pre-tests for LedgerSMB
 
 =head1 DESCRIPTION
 
-This module has a single function that returns upgrade pre-tests.
+This module has a single function that returns upgrade preparations.
 
 =cut
 
-package LedgerSMB::Upgrade_Pre_Tests;
+package LedgerSMB::Upgrade_Preparation;
 use strict;
 use warnings;
 use Moose;
@@ -23,18 +23,20 @@ use namespace::autoclean;
 
 =over
 
-=item get_pre_tests()
+=item get_migration_preparations()
 
-Returns the pre-test array
-Pre-tests are run only once before any tests, to adjust some tables for
+Returns the preparation array.
+Preparations are run only once before any tests, to adjust some tables for
 data uniqueness to allow edit, for example.
+They must not alter data to prevent the user to revert to his original package,
+either a previous LedgerSMB or SQL-ledger.
 
 =cut
 
-sub get_pre_tests {
+sub get_migration_preparations {
     my ($self) = @_;
-    my @pre_tests = $self->_get_pre_tests;
-    return @pre_tests;
+    my @preparations = $self->_get_migration_preparations;
+    return @preparations;
 }
 
 =back
@@ -48,7 +50,7 @@ as such).
 
 =item name
 
-Name of the test
+Name of the preparation
 
 =cut
 
@@ -79,13 +81,13 @@ Can currently be 'ledgersmb' or 'sql-leder'.
 
 has appname => (is => 'ro', isa => 'Str', required => 1);
 
-=item test_query
+=item preparation
 
 Text of the query to run
 
 =cut
 
-has test_query => (is => 'ro', isa => 'Str', required => 1);
+has preparation => (is => 'ro', isa => 'Str', required => 1);
 
 =back
 
@@ -93,22 +95,22 @@ has test_query => (is => 'ro', isa => 'Str', required => 1);
 
 =cut
 
-sub _get_pre_tests {
+sub _get_migration_preparations {
     my ($request) = @_;
 
-    my @pre_tests;
+    my @preparations;
 
-    push @pre_tests, __PACKAGE__->new(
+    push @preparations, __PACKAGE__->new(
         # Add a unique key to allow editing
-        test_query => 'ALTER TABLE acc_trans DROP COLUMN IF EXISTS lsmb_entry_id;
-                       ALTER TABLE acc_trans add column lsmb_entry_id SERIAL UNIQUE;',
+        preparation => 'ALTER TABLE acc_trans DROP COLUMN IF EXISTS lsmb_entry_id;
+                        ALTER TABLE acc_trans add column lsmb_entry_id SERIAL UNIQUE;',
         name => 'add_unique_acc_trans_key',
            appname => 'sql-ledger',
        min_version => '2.7',
        max_version => '3.0'
     );
 
-    return @pre_tests;
+    return @preparations;
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/lib/LedgerSMB/Upgrade_Tests.pm
+++ b/lib/LedgerSMB/Upgrade_Tests.pm
@@ -21,6 +21,7 @@ use namespace::autoclean;
 use List::Util qw( first );
 
 use LedgerSMB::Locale qw(marktext);
+use List::Util qw(any);
 
 =head1 FUNCTIONS
 
@@ -244,6 +245,21 @@ sub _get_tests {
 
     my @tests;
 
+push @tests, __PACKAGE__->new(
+    test_query => "SELECT * FROM pg_settings
+                    WHERE name = 'client_encoding'
+                      AND setting <> 'UTF8'",
+    display_name => marktext('Client encoding must be UTF8'),
+    name => 'client_encoding',
+    display_cols => ['name','setting','unit','category','short_desc','extra_desc','context','vartype','source','min_val','max_val','enumvals','boot_val','reset_val','sourcefile','sourceline'],
+ instructions => marktext(
+                   'Please fix the client encoding'),
+    table => 'pg_settings',
+    appname => 'sql-ledger',
+    min_version => '2.7',
+    max_version => '3.0'
+    );
+
 # 1.2-1.3 tests
 
 push @tests, __PACKAGE__->new(
@@ -425,6 +441,98 @@ database, or delete the offending rows through PgAdmin III or psql'),
   min_version => '1.2',
   max_version => '1.4'
 );
+
+push @tests, __PACKAGE__->new(
+   test_query => "select *, eca.id as id  from entity_credit_account eca
+                     join entity_class ec on eca.entity_class = ec.id
+                     join entity e on eca.entity_id = e.id
+                   where meta_number in
+                       (select meta_number from entity_credit_account
+                        group by meta_number having count(*) > 1)
+                   order by meta_number",
+ display_name => marktext('No duplicate meta_numbers'),
+         name => 'no_meta_number_dupes',
+ display_cols => [ 'meta_number', 'class', 'description', 'name' ],
+      columns => ['meta_number'],
+        table => 'entity_credit_account',
+ instructions => marktext("Make sure all meta numbers are unique."),
+      appname => 'ledgersmb',
+  min_version => '1.3',
+  max_version => '1.4'
+);
+
+push @tests, __PACKAGE__->new(
+   test_query => "select distinct gifi_accno from chart
+                   where not exists (select 1
+                                       from gifi
+                                      where gifi.accno = chart.gifi_accno)
+                         and gifi_accno is not null
+                         and gifi_accno !~ '^\\s*\$'",
+ display_name => marktext('GIFI accounts not in "gifi" table'),
+         name => 'missing_gifi_table_rows',
+ display_cols => [ 'gifi_accno' ],
+        table => 'chart',
+ instructions => marktext("Please use the 1.2 UI to add the GIFI accounts"),
+      appname => 'ledgersmb',
+  min_version => '1.2',
+  max_version => '1.2'
+);
+
+push @tests, __PACKAGE__->new(
+   test_query => "select distinct gifi_accno from account
+                   where not exists (select 1
+                                       from gifi
+                                      where gifi.accno = account.gifi_accno)
+                         and gifi_accno is not null
+                         and gifi_accno !~ '^\\s*\$'",
+ display_name => marktext('GIFI accounts not in "gifi" table'),
+         name => 'missing_gifi_table_rows',
+ display_cols => [ 'gifi_accno' ],
+        table => 'account',
+ instructions => marktext("Please use the 1.3/1.4 UI to add the GIFI accounts"),
+      appname => 'ledgersmb',
+  min_version => '1.3',
+  max_version => '1.4'
+);
+
+#=pod
+
+# This must be done before the acc_trans test, for they have duplicates
+# and need a unique key
+    push @tests, __PACKAGE__->new(
+        # Add a unique key to allow editing
+        # Make the test serially reusable and protect against triggers
+        test_query => "ALTER TABLE acc_trans DISABLE TRIGGER USER;
+                       ALTER TABLE acc_trans DROP COLUMN IF EXISTS i_key;
+                      CREATE TABLE acc_trans1 (LIKE acc_trans INCLUDING ALL);
+                       ALTER TABLE acc_trans1 DISABLE TRIGGER USER;
+                       ALTER TABLE acc_trans1 add column i_key SERIAL UNIQUE;
+                      INSERT INTO acc_trans1 SELECT * FROM acc_trans;
+                        DROP TABLE acc_trans;
+                       ALTER TABLE acc_trans1 RENAME TO acc_trans;
+                       ALTER TABLE acc_trans ENABLE TRIGGER USER;
+                      SELECT trans_id
+                        FROM acc_trans
+                       WHERE i_key IS NULL",
+      display_name => marktext('Transactions unique key'),
+              name => 'add_unique_acc_trans_key',
+      display_cols => ['trans_id'],
+           columns => ['trans_id'],
+        id_columns => ['i_key'],
+          id_where => 'i_key IS NULL AND ',
+      instructions => marktext(
+                       "This should never show. We added a unique key to acc_trans"),
+           buttons => ['Save and Retry', 'Cancel'],
+          tooltips => {
+    'Save and Retry' => marktext('Save the fixes provided and attempt to continue migration'),
+            'Cancel' => marktext('Cancel the <b>migration</b>'),
+          },
+             table => 'acc_trans',
+           appname => 'sql-ledger',
+       min_version => '2.7',
+       max_version => '3.0'
+    );
+
 
 push @tests, __PACKAGE__->new(
    test_query => 'select *, eca.id as id  from entity_credit_account eca
@@ -1183,6 +1291,50 @@ push @tests, __PACKAGE__->new(
           'Skip'  => marktext('This will <b>skip</b> this test <b><u>without doing any correction</u></b>')
      },
         table => 'ap',
+      appname => 'sql-ledger',
+  min_version => '2.7',
+  max_version => '3.0'
+);
+
+    push @tests, __PACKAGE__->new(
+        # Add a unique key to allow editing
+        # Make the test serially reusable and protect against triggers
+        test_query => "SELECT ac.i_key, ac.trans_id, ac.id, ac.memo, ac.amount, xx.description, 
+                              ch.accno, ch.link, ch.charttype, ch.category, ac.cleared, approved
+                         FROM acc_trans ac 
+                         JOIN (
+                                   SELECT g.id, g.description FROM gl g
+                             UNION SELECT a.id, n.name        FROM ar a JOIN customer n ON n.id = a.customer_id
+                             UNION SELECT a.id, n.name        FROM ap a JOIN vendor n   ON n.id = a.vendor_id
+                         ) xx ON xx.id = ac.trans_id
+                         JOIN chart ch ON (ac.chart_id = ch.id)
+                        WHERE ( ch.category NOT IN ( 'A', 'L', 'Q' ) 
+                             OR ch.link NOT LIKE '%paid' ) 
+                          AND ac.cleared IS NOT NULL 
+                          AND ac.approved
+                     ORDER BY accno, transdate, ac.id",
+      display_name => marktext('Reconciliations on non-bank accounts'),
+              name => 'invalid_cleared_dates',
+      display_cols => ['i_key', 'trans_id', 'id', 'memo', 'amount', 'description',
+                       'accno', 'link', 'charttype', 'category', 'cleared', 'approved'],
+           columns => ['cleared'],
+        id_columns => ['i_key'],
+          id_where => 'approved and cleared IS NOT NULL AND ',
+      instructions => marktext(
+                       "There shouldn't be reconciliations on non-bank accounts.<br>
+Please review the dates in the original application"),
+           buttons => ['Save and Retry', 'Cancel', 'Force'],
+          tooltips => {
+    'Save and Retry' => marktext('Save the fixes provided and attempt to continue migration'),
+            'Cancel' => marktext('Cancel the <b>migration</b>'),
+             'Force' => marktext('This will <b>ignore</b> the non-necessary reconciliations')
+          },
+     force_queries => ["UPDATE acc_trans ac SET cleared = NULL
+                      WHERE chart_id in ( c.category NOT IN ( 'A', 'L' ) 
+                           OR c.link NOT LIKE '%paid' ) 
+                        AND ac.cleared IS NOT NULL 
+                        AND ac.approved;"],
+             table => 'acc_trans',
       appname => 'sql-ledger',
   min_version => '2.7',
   max_version => '3.0'

--- a/lib/LedgerSMB/Upgrade_Tests.pm
+++ b/lib/LedgerSMB/Upgrade_Tests.pm
@@ -1,6 +1,6 @@
 =head1 NAME
 
-LedgerSMB::Upgrade_Pre_Tests - Upgrade pre-tests for LedgerSMB
+LedgerSMB::Upgrade_Tests - Upgrade tests for LedgerSMB
 
 =head1 SYNPOPSIS
 
@@ -19,6 +19,7 @@ use Moose;
 use Moose::Util::TypeConstraints;
 use namespace::autoclean;
 use List::Util qw( first );
+
 use LedgerSMB::Locale qw(marktext);
 
 =head1 FUNCTIONS

--- a/lib/LedgerSMB/Upgrade_Tests.pm
+++ b/lib/LedgerSMB/Upgrade_Tests.pm
@@ -245,9 +245,9 @@ sub _get_tests {
     my @tests;
 
 push @tests, __PACKAGE__->new(
-    test_query => "SELECT * FROM pg_settings
+    test_query => q(SELECT * FROM pg_settings
                     WHERE name = 'client_encoding'
-                      AND setting <> 'UTF8'",
+                      AND setting <> 'UTF8'),
     display_name => marktext('Client encoding must be UTF8'),
     name => 'client_encoding',
     display_cols => ['name','setting','unit','category','short_desc','extra_desc','context','vartype','source','min_val','max_val','enumvals','boot_val','reset_val','sourcefile','sourceline'],
@@ -442,53 +442,53 @@ database, or delete the offending rows through PgAdmin III or psql'),
 );
 
 push @tests, __PACKAGE__->new(
-   test_query => "select *, eca.id as id  from entity_credit_account eca
+   test_query => 'select *, eca.id as id  from entity_credit_account eca
                      join entity_class ec on eca.entity_class = ec.id
                      join entity e on eca.entity_id = e.id
                    where meta_number in
                        (select meta_number from entity_credit_account
                         group by meta_number having count(*) > 1)
-                   order by meta_number",
+                   order by meta_number',
  display_name => marktext('No duplicate meta_numbers'),
          name => 'no_meta_number_dupes',
  display_cols => [ 'meta_number', 'class', 'description', 'name' ],
       columns => ['meta_number'],
         table => 'entity_credit_account',
- instructions => marktext("Make sure all meta numbers are unique."),
+ instructions => marktext('Make sure all meta numbers are unique.'),
       appname => 'ledgersmb',
   min_version => '1.3',
   max_version => '1.4'
 );
 
 push @tests, __PACKAGE__->new(
-   test_query => "select distinct gifi_accno from chart
+   test_query => q(select distinct gifi_accno from chart
                    where not exists (select 1
                                        from gifi
                                       where gifi.accno = chart.gifi_accno)
                          and gifi_accno is not null
-                         and gifi_accno !~ '^\\s*\$'",
+                         and gifi_accno !~ '^\\s*\$'),
  display_name => marktext('GIFI accounts not in "gifi" table'),
          name => 'missing_gifi_table_rows',
  display_cols => [ 'gifi_accno' ],
         table => 'chart',
- instructions => marktext("Please use the 1.2 UI to add the GIFI accounts"),
+ instructions => marktext('Please use the 1.2 UI to add the GIFI accounts'),
       appname => 'ledgersmb',
   min_version => '1.2',
   max_version => '1.2'
 );
 
 push @tests, __PACKAGE__->new(
-   test_query => "select distinct gifi_accno from account
+   test_query => q(select distinct gifi_accno from account
                    where not exists (select 1
                                        from gifi
                                       where gifi.accno = account.gifi_accno)
                          and gifi_accno is not null
-                         and gifi_accno !~ '^\\s*\$'",
+                         and gifi_accno !~ '^\\s*\$'),
  display_name => marktext('GIFI accounts not in "gifi" table'),
          name => 'missing_gifi_table_rows',
  display_cols => [ 'gifi_accno' ],
         table => 'account',
- instructions => marktext("Please use the 1.3/1.4 UI to add the GIFI accounts"),
+ instructions => marktext('Please use the 1.3/1.4 UI to add the GIFI accounts'),
       appname => 'ledgersmb',
   min_version => '1.3',
   max_version => '1.4'
@@ -501,7 +501,7 @@ push @tests, __PACKAGE__->new(
     push @tests, __PACKAGE__->new(
         # Add a unique key to allow editing
         # Make the test serially reusable and protect against triggers
-        test_query => "ALTER TABLE acc_trans DISABLE TRIGGER USER;
+        test_query => 'ALTER TABLE acc_trans DISABLE TRIGGER USER;
                        ALTER TABLE acc_trans DROP COLUMN IF EXISTS i_key;
                       CREATE TABLE acc_trans1 (LIKE acc_trans INCLUDING ALL);
                        ALTER TABLE acc_trans1 DISABLE TRIGGER USER;
@@ -512,7 +512,7 @@ push @tests, __PACKAGE__->new(
                        ALTER TABLE acc_trans ENABLE TRIGGER USER;
                       SELECT trans_id
                         FROM acc_trans
-                       WHERE i_key IS NULL",
+                       WHERE i_key IS NULL',
       display_name => marktext('Transactions unique key'),
               name => 'add_unique_acc_trans_key',
       display_cols => ['trans_id'],
@@ -520,7 +520,7 @@ push @tests, __PACKAGE__->new(
         id_columns => ['i_key'],
           id_where => 'i_key IS NULL AND ',
       instructions => marktext(
-                       "This should never show. We added a unique key to acc_trans"),
+                       'This should never show. We added a unique key to acc_trans'),
            buttons => ['Save and Retry', 'Cancel'],
              table => 'acc_trans',
            appname => 'sql-ledger',
@@ -1294,33 +1294,33 @@ push @tests, __PACKAGE__->new(
     push @tests, __PACKAGE__->new(
         # Add a unique key to allow editing
         # Make the test serially reusable and protect against triggers
-        test_query => "SELECT ac.i_key, ac.trans_id, ac.id, ac.memo, ac.amount, xx.description, 
-                              ch.accno, ch.link, ch.charttype, ch.category, ac.cleared, approved
-                         FROM acc_trans ac 
+        test_query => q(SELECT ac.i_key, ac.trans_id, ac.id, ac.memo, ac.amount, xx.description,
+                              ch.description as account, ch.accno, ch.link, ch.charttype, ch.category, ac.cleared, approved
+                         FROM acc_trans ac
                          JOIN (
                                    SELECT g.id, g.description FROM gl g
                              UNION SELECT a.id, n.name        FROM ar a JOIN customer n ON n.id = a.customer_id
                              UNION SELECT a.id, n.name        FROM ap a JOIN vendor n   ON n.id = a.vendor_id
                          ) xx ON xx.id = ac.trans_id
                          JOIN chart ch ON (ac.chart_id = ch.id)
-                        WHERE ( ch.category NOT IN ( 'A', 'L', 'Q' ) 
-                             OR ch.link NOT LIKE '%paid' ) 
-                          AND ac.cleared IS NOT NULL 
+                        WHERE ( ch.category NOT IN ( 'A', 'L', 'Q' )
+                             OR ch.link NOT LIKE '%paid' )
+                          AND ac.cleared IS NOT NULL
                           AND ac.approved
-                     ORDER BY accno, transdate, ac.id",
-      display_name => marktext('Reconciliations on non-bank accounts'),
-              name => 'reconciliation_on_non_bank_accounts',
+                     ORDER BY accno, transdate, ac.id),
+      display_name => marktext('Unneeded Reconciliations'),
+              name => 'reconciliation_on_unrelated_accounts',
       display_cols => ['i_key', 'trans_id', 'id', 'memo', 'amount', 'description',
-                       'accno', 'link', 'charttype', 'category', 'cleared', 'approved'],
+                       'accno', 'account', 'category', 'cleared', 'approved'],
            columns => ['cleared'],
         id_columns => ['i_key'],
           id_where => 'approved and cleared IS NOT NULL AND ',
       instructions => marktext(
-                       "There shouldn't be reconciliations on non-bank accounts.<br>
-Please review the dates in the original application"),
-           buttons => ['Save and Retry', 'Cancel', 'Force'],
+                       'Reconciliations should be on asset, liability or equity accounts only.<br>
+Please review the dates and categories in the original application if needed'),
+           buttons => ['Save and Retry', 'Cancel', 'Force', 'Skip'],
           tooltips => {
-               'Force' => marktext('This will <b>ignore</b> the non-necessary reconciliations'),
+               'Force' => marktext('This will <b>keep</b> the transactions but will <b>ignore</b> the non-necessary reconciliations'),
                'Skip'  => marktext('This will <b>skip</b> this test <b><u>without doing any correction</u></b>')
           },
      force_queries => [q(UPDATE acc_trans ac SET cleared = NULL

--- a/lib/LedgerSMB/Upgrade_Tests.pm
+++ b/lib/LedgerSMB/Upgrade_Tests.pm
@@ -1211,7 +1211,7 @@ push @tests, __PACKAGE__->new(
     id_columns => ['lsmb_entry_id'],
   instructions => marktext(
                    'Reconciliations should be on asset, liability or equity accounts only.<br>
-Please review the dates and categories in the original application if needed'),
+Please void the unneeded cleared dates here or the whole reconciliation in the original application'),
            buttons => ['Save and Retry', 'Cancel', 'Force', 'Skip'],
           tooltips => {
                'Force' => marktext('This will <b>keep</b> the transactions but will <b>ignore</b> the non-necessary reconciliations'),

--- a/lib/LedgerSMB/Upgrade_Tests.pm
+++ b/lib/LedgerSMB/Upgrade_Tests.pm
@@ -244,21 +244,6 @@ sub _get_tests {
 
     my @tests;
 
-push @tests, __PACKAGE__->new(
-    test_query => q(SELECT * FROM pg_settings
-                    WHERE name = 'client_encoding'
-                      AND setting <> 'UTF8'),
-    display_name => marktext('Client encoding must be UTF8'),
-    name => 'client_encoding',
-    display_cols => ['name','setting','unit','category','short_desc','extra_desc','context','vartype','source','min_val','max_val','enumvals','boot_val','reset_val','sourcefile','sourceline'],
- instructions => marktext(
-                   'Please fix the client encoding'),
-    table => 'pg_settings',
-    appname => 'sql-ledger',
-    min_version => '2.7',
-    max_version => '3.0'
-    );
-
 # 1.2-1.3 tests
 
 push @tests, __PACKAGE__->new(
@@ -460,40 +445,6 @@ push @tests, __PACKAGE__->new(
   max_version => '1.4'
 );
 
-push @tests, __PACKAGE__->new(
-   test_query => q(select distinct gifi_accno from chart
-                   where not exists (select 1
-                                       from gifi
-                                      where gifi.accno = chart.gifi_accno)
-                         and gifi_accno is not null
-                         and gifi_accno !~ '^\\s*\$'),
- display_name => marktext('GIFI accounts not in "gifi" table'),
-         name => 'missing_gifi_table_rows',
- display_cols => [ 'gifi_accno' ],
-        table => 'chart',
- instructions => marktext('Please use the 1.2 UI to add the GIFI accounts'),
-      appname => 'ledgersmb',
-  min_version => '1.2',
-  max_version => '1.2'
-);
-
-push @tests, __PACKAGE__->new(
-   test_query => q(select distinct gifi_accno from account
-                   where not exists (select 1
-                                       from gifi
-                                      where gifi.accno = account.gifi_accno)
-                         and gifi_accno is not null
-                         and gifi_accno !~ '^\\s*\$'),
- display_name => marktext('GIFI accounts not in "gifi" table'),
-         name => 'missing_gifi_table_rows',
- display_cols => [ 'gifi_accno' ],
-        table => 'account',
- instructions => marktext('Please use the 1.3/1.4 UI to add the GIFI accounts'),
-      appname => 'ledgersmb',
-  min_version => '1.3',
-  max_version => '1.4'
-);
-
 #=pod
 
 # This must be done before the acc_trans test, for they have duplicates
@@ -527,26 +478,6 @@ push @tests, __PACKAGE__->new(
        min_version => '2.7',
        max_version => '3.0'
     );
-
-
-push @tests, __PACKAGE__->new(
-   test_query => 'select *, eca.id as id  from entity_credit_account eca
-                     join entity_class ec on eca.entity_class = ec.id
-                     join entity e on eca.entity_id = e.id
-                   where meta_number in
-                       (select meta_number from entity_credit_account
-                        group by meta_number having count(*) > 1)
-                   order by meta_number',
- display_name => marktext('No duplicate meta_numbers'),
-         name => 'no_meta_number_dupes',
- display_cols => [ 'meta_number', 'class', 'description', 'name' ],
-      columns => ['meta_number'],
-        table => 'entity_credit_account',
- instructions => marktext('Make sure all meta numbers are unique.'),
-      appname => 'ledgersmb',
-  min_version => '1.3',
-  max_version => '1.4'
-);
 
 push @tests, __PACKAGE__->new(
    test_query => q{select distinct gifi_accno from chart
@@ -1291,32 +1222,32 @@ push @tests, __PACKAGE__->new(
   max_version => '3.0'
 );
 
-    push @tests, __PACKAGE__->new(
-        # Add a unique key to allow editing
-        # Make the test serially reusable and protect against triggers
-        test_query => q(SELECT ac.i_key, ac.trans_id, ac.id, ac.memo, ac.amount, xx.description,
-                              ch.description as account, ch.accno, ch.link, ch.charttype, ch.category, ac.cleared, approved
-                         FROM acc_trans ac
-                         JOIN (
-                                   SELECT g.id, g.description FROM gl g
-                             UNION SELECT a.id, n.name        FROM ar a JOIN customer n ON n.id = a.customer_id
-                             UNION SELECT a.id, n.name        FROM ap a JOIN vendor n   ON n.id = a.vendor_id
-                         ) xx ON xx.id = ac.trans_id
-                         JOIN chart ch ON (ac.chart_id = ch.id)
-                        WHERE ( ch.category NOT IN ( 'A', 'L', 'Q' )
-                             OR ch.link NOT LIKE '%paid' )
-                          AND ac.cleared IS NOT NULL
-                          AND ac.approved
-                     ORDER BY accno, transdate, ac.id),
-      display_name => marktext('Unneeded Reconciliations'),
-              name => 'reconciliation_on_unrelated_accounts',
-      display_cols => ['i_key', 'trans_id', 'id', 'memo', 'amount', 'description',
-                       'accno', 'account', 'category', 'cleared', 'approved'],
-           columns => ['cleared'],
-        id_columns => ['i_key'],
-          id_where => 'approved and cleared IS NOT NULL AND ',
-      instructions => marktext(
-                       'Reconciliations should be on asset, liability or equity accounts only.<br>
+push @tests, __PACKAGE__->new(
+    # Add a unique key to allow editing
+    # Make the test serially reusable and protect against triggers
+    test_query => q(SELECT ac.i_key, ac.trans_id, ac.id, ac.memo, ac.amount, xx.description,
+                          ch.description as account, ch.accno, ch.link, ch.charttype, ch.category, ac.cleared, approved
+                     FROM acc_trans ac
+                     JOIN (
+                               SELECT g.id, g.description FROM gl g
+                         UNION SELECT a.id, n.name        FROM ar a JOIN customer n ON n.id = a.customer_id
+                         UNION SELECT a.id, n.name        FROM ap a JOIN vendor n   ON n.id = a.vendor_id
+                     ) xx ON xx.id = ac.trans_id
+                     JOIN chart ch ON (ac.chart_id = ch.id)
+                    WHERE ( ch.category NOT IN ( 'A', 'L', 'Q' )
+                         OR ch.link NOT LIKE '%paid' )
+                      AND ac.cleared IS NOT NULL
+                      AND ac.approved
+                 ORDER BY accno, transdate, ac.id),
+  display_name => marktext('Unneeded Reconciliations'),
+          name => 'reconciliation_on_unrelated_accounts',
+  display_cols => ['i_key', 'trans_id', 'id', 'memo', 'amount', 'description',
+                   'accno', 'account', 'category', 'cleared', 'approved'],
+       columns => ['cleared'],
+    id_columns => ['i_key'],
+      id_where => 'approved and cleared IS NOT NULL AND ',
+  instructions => marktext(
+                   'Reconciliations should be on asset, liability or equity accounts only.<br>
 Please review the dates and categories in the original application if needed'),
            buttons => ['Save and Retry', 'Cancel', 'Force', 'Skip'],
           tooltips => {

--- a/lib/LedgerSMB/Upgrade_Tests.pm
+++ b/lib/LedgerSMB/Upgrade_Tests.pm
@@ -1211,7 +1211,7 @@ push @tests, __PACKAGE__->new(
     id_columns => ['lsmb_entry_id'],
   instructions => marktext(
                    'Reconciliations should be on asset, liability or equity accounts only.<br>
-Please void the unneeded cleared dates here or the whole reconciliation in the original application'),
+Void the clearing date in the dialog shown or go back to SQL-Ledger if you feel that you need to adjust more before migrating.'),
            buttons => ['Save and Retry', 'Cancel', 'Force', 'Skip'],
           tooltips => {
                'Force' => marktext('This will <b>keep</b> the transactions but will <b>ignore</b> the non-necessary reconciliations'),

--- a/sql/upgrade/sl3.0.sql
+++ b/sql/upgrade/sl3.0.sql
@@ -417,6 +417,7 @@ ALTER TABLE :slschema.customer ADD COLUMN company_id int;
 ALTER TABLE :slschema.customer ADD COLUMN credit_id int;
 
 -- Speed optimizations
+ALTER TABLE :slschema.acc_trans DROP COLUMN IF EXISTS lsmb_entry_id;
 ALTER TABLE :slschema.acc_trans ADD COLUMN lsmb_entry_id integer;
 ALTER TABLE :slschema.acc_trans ADD COLUMN type CHAR(2);
 ALTER TABLE :slschema.acc_trans ADD COLUMN accno TEXT;

--- a/t/01-load.t
+++ b/t/01-load.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Test::More tests => 210;
+use Test::More tests => 208;
 use File::Find;
 
 my @on_disk;
@@ -33,7 +33,6 @@ my @exception_modules =
 
      # Exclude because tested conditionally on CGI::Emulate::PSGI way below
      'LedgerSMB::PSGI',
-
      # Exclude because tested conditionally on X12::Parser way below
      'LedgerSMB::X12', 'LedgerSMB::X12::EDI850', 'LedgerSMB::X12::EDI894',
 
@@ -63,9 +62,9 @@ my @modules =
           'LedgerSMB::PGObject', 'LedgerSMB::Auth',
           'LedgerSMB::AA', 'LedgerSMB::AM', 'LedgerSMB::Batch',
           'LedgerSMB::IC', 'LedgerSMB::IR', 'LedgerSMB::PGDate',
-          'LedgerSMB::PGNumber', 'LedgerSMB::PGOld', 'LedgerSMB::Request',
+          'LedgerSMB::PGNumber', 'LedgerSMB::PGOld',
           'LedgerSMB::Setting', 'LedgerSMB::Tax', 'LedgerSMB::Upgrade_Tests',
-          'LedgerSMB::Upgrade_Pre_Tests', 'LedgerSMB::Form', 'LedgerSMB::IS',
+          'LedgerSMB::Upgrade_Preparation', 'LedgerSMB::Form', 'LedgerSMB::IS',
           'LedgerSMB::Num2text', 'LedgerSMB::OE', 'LedgerSMB::Auth::DB',
           'LedgerSMB::DBObject::Asset_Class', 'LedgerSMB::DBObject::Draft',
           'LedgerSMB::DBObject::EOY',

--- a/t/01-load.t
+++ b/t/01-load.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Test::More tests => 207;
+use Test::More tests => 210;
 use File::Find;
 
 my @on_disk;
@@ -63,9 +63,9 @@ my @modules =
           'LedgerSMB::PGObject', 'LedgerSMB::Auth',
           'LedgerSMB::AA', 'LedgerSMB::AM', 'LedgerSMB::Batch',
           'LedgerSMB::IC', 'LedgerSMB::IR', 'LedgerSMB::PGDate',
-          'LedgerSMB::PGNumber', 'LedgerSMB::PGOld',
+          'LedgerSMB::PGNumber', 'LedgerSMB::PGOld', 'LedgerSMB::Request',
           'LedgerSMB::Setting', 'LedgerSMB::Tax', 'LedgerSMB::Upgrade_Tests',
-          'LedgerSMB::Form', 'LedgerSMB::IS',
+          'LedgerSMB::Upgrade_Pre_Tests', 'LedgerSMB::Form', 'LedgerSMB::IS',
           'LedgerSMB::Num2text', 'LedgerSMB::OE', 'LedgerSMB::Auth::DB',
           'LedgerSMB::DBObject::Asset_Class', 'LedgerSMB::DBObject::Draft',
           'LedgerSMB::DBObject::EOY',


### PR DESCRIPTION
- Validate proper categories
- Warn on non-contiguous series
- Add Force and Skip buttons to apply a suitable fix or skip a test completely