### PR TITLE
* Add Ctrl+LeftMouse, Meta+LeftMouse and MiddleMouse handling

### DIFF
--- a/UI/js-src/lsmb/menus/Tree.js
+++ b/UI/js-src/lsmb/menus/Tree.js
@@ -1,11 +1,14 @@
 define(["dojo/_base/declare",
+        "dojo/on",
+        "dojo/_base/lang",
+        "dojo/_base/event",
+        "dojo/mouse",
         "dojo/_base/array",
-    "dojo/store/JsonRest", "dojo/store/Observable",
-    "dojo/store/Memory", "dojo/store/Cache",
-    "dijit/Tree", "dijit/tree/ObjectStoreModel"
-       ], function(declare, array, JsonRest, Observable,
-    Memory, Cache,
-    Tree, ObjectStoreModel
+        "dojo/store/JsonRest", "dojo/store/Observable",
+        "dojo/store/Memory", "dojo/store/Cache",
+        "dijit/Tree", "dijit/tree/ObjectStoreModel"
+       ], function(declare, on, lang, event, mouse, array,
+                   JsonRest, Observable, Memory, Cache, Tree, ObjectStoreModel
 ){
         // set up the store to get the tree data, plus define the method
         // to query the children of a node
@@ -36,26 +39,55 @@ define(["dojo/_base/declare",
         });
 
     return declare("lsmb/menus/Tree", [Tree], {
-            model: model,
-            showRoot: false,
-            openOnClick: true,
-            onClick: function(item){
-                var url = '';
-                if ( item.module ) {
-                    url += item.module + "?";
-                    url += item.args.join("&");
-                }
-                if ( array.some( item.args,
-                                 function (q) {
-                                     return ("new=1" == q);
-                                 }) ) {
-                    // Simulate a target="_blank" attribute on an A tag
-                    window.open(location.origin + location.pathname + location.search + '#' + url);
-                }
-                else {
-                    location.hash = url;
-                }
+        model: model,
+        showRoot: false,
+        openOnClick: true,
+        postCreate: function() {
+            this.inherited(arguments);
+
+            this.own(
+                on(this.containerNode, "mousedown",
+                   lang.hitch(this, this.__onClick)));
+        },
+        onClick: function(item, node, event){
+            // regular handling of non-leafs
+            if (item.menu) return;
+
+            // for leafs, either open in the current application,
+            // or open a new window, depending on the trigger.
+            var url = '',
+                newWindow = ((mouse.isLeft(event)
+                              && (event.ctrlKey || event.metaKey))
+                             || (mouse.isMiddle(event))
+                             || array.some( item.args,
+                                            function (q) {
+                                                return ("new=1" == q)
+                                            }));
+            if ( item.module ) {
+                url += item.module + "?";
+                url += item.args.join("&");
             }
-        });
+            if ( newWindow ) {
+                // Simulate a target="_blank" attribute on an A tag
+                window.open(location.origin + location.pathname
+                            + location.search + '#' + url, "_blank");
+            }
+            else {
+                location.hash = url;
+            }
+        },
+        __onClick: function(e) {
+            // simulate "click opening in background tab"
+            // (Ctrl+LeftMouse or MiddleMouse)
+            if (mouse.isLeft(e) && !(e.ctrlKey || e.metaKey)) return;
+
+            event.stop(e);
+            e.preventDefault();
+
+            var node = dijit.getEnclosingWidget(e.target);
+            var item = node.item;
+            this.onClick(item, node, e);
+        }
+    });
 });
 


### PR DESCRIPTION
All of which normally open the clicked link in a new window.
We used to do that too, because our menu consisted of links,
which would automatically trigger that behaviour. Now that the
menu no longer consists of links (yet some of our users really
*do* expect this behaviour), we need to simulate it instead.