### PR TITLE
Add translation support for decorated text

### DIFF
--- a/UI/form-dynatable.html
+++ b/UI/form-dynatable.html
@@ -9,7 +9,11 @@
       method="post"
       action="<?lsmb form.script ?>"
       id="search-report-dynatable">
-<?lsmb FOREACH header IN headers ?><div class="listtop"><?lsmb header ?></div><?lsmb END ?>
+<?lsmb FOREACH header IN headers ?><div class="listtop">
+         <?lsmb INCLUDE decorated_text element_data = {
+                msg => header };
+         ?></div>
+<?lsmb END ?>
 
 <?lsmb PROCESS 'dynatable' ?>
 <br />

--- a/UI/lib/elements.html
+++ b/UI/lib/elements.html
@@ -424,6 +424,12 @@
 
 <?lsmb BLOCK CLOSE_STATUS_DIV ?></div><?lsmb END ?>
 
+<?lsmb BLOCK decorated_text;
+  IF element_data && element_data.msg.defined();
+    UNESCAPE(element_data.msg);
+  END;
+END ?>
+
 <?lsmb BLOCK tooltip;
   IF element_data && element_data.id.defined() && element_data.msg.defined();
      props="connectId:'" _ element_data.id _ "'";
@@ -436,7 +442,9 @@
         props = props _ ',position:[' _ positions.join(',') _ ']';
     END; ?>
     <div data-dojo-type="dijit/Tooltip" data-dojo-props=<?lsmb props ?>  >
-         <?lsmb UNESCAPE(element_data.msg) ?>
+         <?lsmb INCLUDE decorated_text element_data = {
+                msg => element_data.msg };
+         ?>
     </div>
   <?lsmb END;
 END ?>

--- a/UI/lib/elements.html
+++ b/UI/lib/elements.html
@@ -426,7 +426,7 @@
 
 <?lsmb BLOCK decorated_text;
   IF element_data && element_data.msg.defined();
-    decorated_text(element_data.msg.replace('&lt;((/?[ibup]|br))&gt;','<$1>'));
+    element_data.msg.replace('&lt;((/?[ibup]|br))&gt;','<$1>');
   END;
 END ?>
 

--- a/UI/lib/elements.html
+++ b/UI/lib/elements.html
@@ -426,7 +426,7 @@
 
 <?lsmb BLOCK decorated_text;
   IF element_data && element_data.msg.defined();
-    UNESCAPE(element_data.msg);
+    decorated_text(element_data.msg.replace('&lt;((/?[ibup]|br))&gt;','<$1>'));
   END;
 END ?>
 

--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -568,7 +568,6 @@ sub _render {
     $cleanvars->{UNESCAPE} = sub { return $unescape->(@_); }
         if ($unescape && !$self->{no_escape});
     $cleanvars->{text} = sub { return $self->_maketext($escape, @_); };
-    $cleanvars->{decorated_text} = sub { return $self->{locale}->maketext(@_); };
     $cleanvars->{tt_url} = \&_tt_url;
     $cleanvars->{$_} = $self->{additional_vars}->{$_}
         for (keys %{$self->{additional_vars}});

--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -568,6 +568,7 @@ sub _render {
     $cleanvars->{UNESCAPE} = sub { return $unescape->(@_); }
         if ($unescape && !$self->{no_escape});
     $cleanvars->{text} = sub { return $self->_maketext($escape, @_); };
+    $cleanvars->{decorated_text} = sub { return $self->{locale}->maketext(@_); };
     $cleanvars->{tt_url} = \&_tt_url;
     $cleanvars->{$_} = $self->{additional_vars}->{$_}
         for (keys %{$self->{additional_vars}});

--- a/lib/LedgerSMB/Upgrade_Tests.pm
+++ b/lib/LedgerSMB/Upgrade_Tests.pm
@@ -218,7 +218,7 @@ has tooltips => (is => 'ro',
     default => sub {
         return {
             'Save and Retry' => marktext('Save the fixes provided and attempt to continue migration'),
-            'Cancel' => marktext('Cancel the migration')
+            'Cancel' => marktext('Cancel the <b>migration</b>')
     }},
     required => 0);
 
@@ -630,7 +630,7 @@ Please make sure business used by vendors and constomers are defined.<br>
           # I want to add to the tooltips already defaulted properly - YL
           tooltips => {
             'Save and Retry' => marktext('Save the fixes provided and attempt to continue migration'),
-            'Cancel' => marktext('Cancel the migration'),
+            'Cancel' => marktext('Cancel the <b>migration</b>'),
             'Force' => marktext('This will <b>remove</b> the business references in <u>vendor</u> and <u>customer</u> tables')
           }
         );

--- a/lib/LedgerSMB/Upgrade_Tests.pm
+++ b/lib/LedgerSMB/Upgrade_Tests.pm
@@ -610,9 +610,9 @@ push @tests,__PACKAGE__->new(
               name => 'no_businesses',
       display_cols => ['id', 'description', 'discount'],
       instructions => marktext(
-                       'Undefined businesses.
-Please make sure business used by vendors and constomers are defined.
-Hover on buttons to see their effects and impacts'),
+                       'Undefined businesses.<br>
+Please make sure business used by vendors and constomers are defined.<br>
+<i><b>Hover on buttons</b> to see their effects and impacts</i>'),
            columns => ['description', 'discount'],
              table => 'business',
            appname => 'sql-ledger',
@@ -648,8 +648,8 @@ push @tests, __PACKAGE__->new(
     display_cols => ['id', 'name', 'business_id'],
     columns => ['business_id'],
  instructions => marktext(
-                   'LedgerSMB vendors must be assigned to a valid business. ' .
-                   'Please review the selection or select the proper business from the list'),
+                   'LedgerSMB vendors must be assigned to a valid business.<br>
+Please review the selection or select the proper business from the list'),
 selectable_values => { business_id => "SELECT concat(description,' -- ',discount) AS text, id as value
                                         FROM business
                                         ORDER BY id"},
@@ -671,8 +671,8 @@ push @tests, __PACKAGE__->new(
     display_cols => ['id', 'name', 'business_id'],
     columns => ['business_id'],
  instructions => marktext(
-                   'LedgerSMB customers must be assigned to a valid business. ' .
-                   'Please review the selection or select the proper business from the list'),
+                   'LedgerSMB customers must be assigned to a valid business.<br>
+Please review the selection or select the proper business from the list'),
 selectable_values => { business_id => "SELECT concat(description,' -- ',discount) AS text, id as value
                                         FROM business
                                         ORDER BY id"},
@@ -694,8 +694,8 @@ push @tests, __PACKAGE__->new(
     display_cols => ['id', 'name', 'business_id'],
     columns => ['business_id'],
  instructions => marktext(
-                   'LedgerSMB vendors must be assigned to a valid business. ' .
-                   'Please review the selection or select the proper business from the list'),
+                   'LedgerSMB vendors must be assigned to a valid business.<br>
+Please review the selection or select the proper business from the list'),
 selectable_values => { business_id => "SELECT concat(description,' -- ',discount) AS text, id as value
                                         FROM business
                                         ORDER BY id"},
@@ -717,8 +717,8 @@ push @tests, __PACKAGE__->new(
     display_cols => ['id', 'name', 'business_id'],
     columns => ['business_id'],
  instructions => marktext(
-                   'LedgerSMB customers must be assigned to a valid business. ' .
-                   'Please review the selection or select the proper business from the list'),
+                   'LedgerSMB customers must be assigned to a valid business.<br>
+Please review the selection or select the proper business from the list'),
 selectable_values => { business_id => "SELECT concat(description,' -- ',discount) AS text, id as value
                                         FROM business
                                         ORDER BY id"},

--- a/locale/po/fr_CA.po
+++ b/locale/po/fr_CA.po
@@ -5,7 +5,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LedgerSMB\n"
 "Report-Msgid-Bugs-To: ledger-smb-devel@lists.sourceforge.net\n"
-"POT-Creation-Date: 2016-08-06 17:28+0000\n"
+"POT-Creation-Date: 2017-08-11 13:18+0000\n"
 "PO-Revision-Date: 2016-07-31 08:15+0000\n"
 "Last-Translator: Erik Huelsmann <ehuels@gmail.com>\n"
 "Language-Team: French (Canada) (http://www.transifex.com/ledgersmb/ledgersmb/"
@@ -16,364 +16,422 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:163
+#: UI/Reports/custom/reports.pl:130
+#, fuzzy
+msgid " by month"
+msgstr "en mois"
+
+#: UI/Reports/custom/reports.pl:132
+msgid " by month and customer"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:131
+msgid " by month and group"
+msgstr ""
+
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:164
 msgid "# Invoices"
 msgstr "# Factures"
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:112
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:113
 msgid "% Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:96
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:97
 msgid "(+) Salvage Value"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:104
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:105
 msgid "(-) Accum. Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:108
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:109
 msgid "(=) NBV"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:160
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:161
 msgid "(Locked)"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:132 templates/demo/statement.html:65
-#: templates/demo_with_images/statement.html:65
-#: templates/xedemo/statement.html:65
+#: UI/Reports/custom/reports.pl:3970 UI/Reports/custom/reports.pl:4002
+msgid "101 - Supplies"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:3966
+msgid "103 - GST collectible and adjustments"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:3971
+msgid "103 - GST/HST collectible"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:3968
+msgid "104 - GST adjustments"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:3972
+msgid "104 - GST/HST adjustments"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:4003
+msgid "105 - GST/HST collectible and adjustments"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:3973
+msgid "105 - Total of GST/HST collectible and adjustments"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:3974 UI/Reports/custom/reports.pl:4004
+msgid "106 - Input tax credits (ITCs)"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:3975
+msgid "107 - ITC adjustments and other adjustments"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:4005
+msgid "108 - ITCs and adjustments"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:3976
+msgid "108 - Total of ITCs and adjustments"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:3977 UI/Reports/custom/reports.pl:4006
+msgid "109 - Net tax"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:3978
+msgid "110 - GST/HST paid in instalments"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:4007
+msgid "110 - Tax instalments"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:3979
+msgid "111 - GST/HST refund for public service bodies and other QST/HST rebates"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:4008
+msgid "111 - Other credits"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:3980
+msgid "112 - Total of other credits"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:3981
+msgid "113 - GST/HST payable or refund"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:3982 UI/Reports/custom/reports.pl:4009
+msgid "201 - Supplies"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:3983
+msgid "203 - QST collectible"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:3967
+msgid "203 - QST collectible and adjustments"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:3984
+msgid "204 - Adjustments of QST"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:3969
+msgid "204 - QST adjustments"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:4010
+msgid "205 - QST collectible and adjustments"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:3985
+msgid "205 - Total of QST collectible and adjustments"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:3986
+msgid "206 - Input tax refunds (ITRs)"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:3987
+msgid "207 - ITR adjustments and other adjustments"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:4011
+msgid "208 - ITRs and adjustments"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:3988
+msgid "208 - Total of ITRs and adjustments"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:3989
+msgid "209 - Net QST"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:3990
+msgid "210 - QST paid in instalments"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:4012
+msgid "210 - Tax Instalments"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:4013
+msgid "211 - Other refunds"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:3991
+msgid "211 - QST rebate for public service bodies and other QST rebates"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:3992
+msgid "212 - Total of other QST credits"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:3993
+msgid "213 - QST payable or refund"
+msgstr ""
+
+#: lib/LedgerSMB/Report/Aging.pm:133
 msgid "30"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:138 templates/demo/statement.html:66
-#: templates/demo_with_images/statement.html:66
-#: templates/xedemo/statement.html:66
+#: lib/LedgerSMB/Report/Aging.pm:139
 msgid "60"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Aging.pm:144 templates/demo/statement.html:67
-#: templates/demo_with_images/statement.html:67
-#: templates/xedemo/statement.html:67
+#: lib/LedgerSMB/Report/Aging.pm:145
 msgid "90"
 msgstr ""
 
-#: templates/demo/invoice.tex:32 templates/demo/packing_list.tex:22
-#: templates/demo_with_images/invoice.tex:32
-#: templates/demo_with_images/packing_list.tex:22
-#: templates/xedemo/invoice.tex:31 templates/xedemo/packing_list.tex:22
-msgid ""
-"A return authorization must be obtained from [_1] before goods are returned. "
-"Returns must be shipped prepaid and properly insured. [_1] will not be "
-"responsible for damages during transit."
+#: UI/Reports/custom/reports.pl:3961 UI/Reports/custom/reports.pl:3997
+#, fuzzy
+msgid "??? - Business taxes"
+msgstr "Type d'affaire enregistré!"
+
+#: UI/Reports/custom/reports.pl:3998
+msgid "??? - GST paid"
 msgstr ""
 
-#: sql/Pg-database.sql:798
+#: UI/Reports/custom/reports.pl:3964 UI/Reports/custom/reports.pl:4000
+msgid "??? - Income tax"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:3999
+msgid "??? - QST paid"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:3962
+msgid "??? - TPS paid"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:3963
+msgid "??? - TVQ paid"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:3965 UI/Reports/custom/reports.pl:4001
+msgid "??? - Tax instalments"
+msgstr ""
+
+#: sql/Pg-database.sql:812
 msgid "AIM"
 msgstr ""
 
-#: bin/am.pl:860 UI/Reports/filters/unapproved.html:13
-#: UI/setup/complete.html:21 UI/setup/confirm_operation.html:108
-#: sql/Pg-database.sql:2849
+#: old/bin/am.pl:798 UI/Reports/custom/reports.pl:126 sql/Pg-database.sql:2853
 msgid "AP"
 msgstr "Dépenses"
 
-#: sql/Pg-database.sql:2798
+#: sql/Pg-database.sql:2802
 msgid "AP Aging"
 msgstr "Dépenses exigibles"
 
-#: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:106
+#: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:107
 msgid "AP Invoice"
 msgstr ""
 
-#: UI/Reports/filters/search_goods.html:160
-msgid "AP Invoices"
-msgstr ""
-
-#: bin/aa.pl:1544 lib/LedgerSMB/Report/Invoices/Outstanding.pm:300
-#: UI/Reports/filters/invoice_outstanding.html:5
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:301 old/bin/aa.pl:1526
 msgid "AP Outstanding"
 msgstr "Dépenses en retard"
 
-#: t/data/04-complex_template.html:325 templates/demo/ap_transaction.html:4
-#: templates/demo/ap_transaction.html:18 templates/demo/ap_transaction.tex:18
-#: templates/demo_with_images/ap_transaction.html:4
-#: templates/demo_with_images/ap_transaction.html:18
-#: templates/demo_with_images/ap_transaction.tex:18
-#: templates/xedemo/ap_transaction.html:4
-#: templates/xedemo/ap_transaction.html:18
-#: templates/xedemo/ap_transaction.tex:18 UI/Contact/divs/credit.html:349
-#: sql/Pg-database.sql:2947 sql/Pg-database.sql:2960
+#: sql/Pg-database.sql:2951 sql/Pg-database.sql:2964
 msgid "AP Transaction"
 msgstr "Écriture dépenses"
 
-#: bin/aa.pl:1500 lib/LedgerSMB/Report/Contact/Purchase.pm:128
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:129 old/bin/aa.pl:1482
 msgid "AP Transactions"
 msgstr "Mouvements - Dépenses"
 
-#: sql/Pg-database.sql:2912
+#: sql/Pg-database.sql:2916
 msgid "AP Voucher"
 msgstr ""
 
-#: UI/import_csv/import_inventory_csv.html:22
-msgid "AP account"
-msgstr ""
-
-#: bin/am.pl:859 UI/Reports/filters/unapproved.html:14
-#: UI/setup/complete.html:22 UI/setup/confirm_operation.html:109
-#: sql/Pg-database.sql:2848
+#: old/bin/am.pl:797 UI/Reports/custom/reports.pl:125 sql/Pg-database.sql:2852
 msgid "AR"
 msgstr "Recettes"
 
-#: sql/Pg-database.sql:2795
+#: sql/Pg-database.sql:2799
 msgid "AR Aging"
 msgstr "Recettes exigibles"
 
-#: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:102
+#: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:103
 msgid "AR Invoice"
 msgstr ""
 
-#: UI/Reports/filters/search_goods.html:137
-msgid "AR Invoices"
-msgstr ""
-
-#: bin/aa.pl:1543 lib/LedgerSMB/Report/Invoices/Outstanding.pm:302
-#: UI/Reports/filters/invoice_outstanding.html:9
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:303 old/bin/aa.pl:1525
 msgid "AR Outstanding"
 msgstr "Recettes en retard"
 
-#: templates/demo/ar_transaction.html:4 templates/demo/ar_transaction.html:18
-#: templates/demo/ar_transaction.tex:33
-#: templates/demo_with_images/ar_transaction.html:4
-#: templates/demo_with_images/ar_transaction.html:18
-#: templates/demo_with_images/ar_transaction.tex:33
-#: templates/xedemo/ar_transaction.html:4
-#: templates/xedemo/ar_transaction.html:18
-#: templates/xedemo/ar_transaction.tex:33 sql/Pg-database.sql:2946
-#: sql/Pg-database.sql:2959
+#: sql/Pg-database.sql:2950 sql/Pg-database.sql:2963
 msgid "AR Transaction"
 msgstr "Écriture recettes"
 
-#: bin/aa.pl:1499 lib/LedgerSMB/Report/Contact/Purchase.pm:130
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:131 old/bin/aa.pl:1481
 msgid "AR Transactions"
 msgstr "Mouvements - Recettes"
 
-#: sql/Pg-database.sql:2911
+#: sql/Pg-database.sql:2915
 msgid "AR Voucher"
 msgstr ""
 
-#: UI/import_csv/import_inventory_csv.html:13
-msgid "AR account"
-msgstr ""
-
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:115
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:105
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:116
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:107
 msgid "AR/AP/GL Amount"
 msgstr ""
 
-#: sql/Pg-database.sql:3787
+#: sql/Pg-database.sql:3791
 msgid "Abandonment"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/Details.pm:90
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:87
+#: UI/Reports/custom/reports.pl:119 UI/Reports/custom/reports.pl:181
+msgid "AccNo."
+msgstr ""
+
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:88
 msgid "Acc_trans Sum"
 msgstr ""
 
-#: lib/LedgerSMB.pm:609 lib/LedgerSMB.pm:610
-#: lib/LedgerSMB/Scripts/configuration.pm:332
-#: lib/LedgerSMB/Scripts/setup.pm:839
+#: lib/LedgerSMB.pm:434 lib/LedgerSMB.pm:435
+#: lib/LedgerSMB/Scripts/configuration.pm:336 lib/LedgerSMB/Scripts/setup.pm:951
 msgid "Access Denied"
 msgstr "Accès refusé"
 
-#: bin/aa.pl:598 bin/aa.pl:662 bin/aa.pl:819 bin/aa.pl:1679 bin/ic.pl:1125
-#: bin/ir.pl:454 bin/ir.pl:842 bin/is.pl:467 bin/is.pl:919 bin/oe.pl:436
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:66
-#: lib/LedgerSMB/Report/co/Caja_Diaria.pm:67
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:209
-#: lib/LedgerSMB/Report/Reconciliation/Summary.pm:132
-#: t/data/04-complex_template.html:27 templates/demo/invoice.html:254
-#: templates/demo/printPayment.html:44
-#: templates/demo_with_images/invoice.html:254
-#: templates/demo_with_images/printPayment.html:44
-#: templates/xedemo/invoice.html:254 templates/xedemo/printPayment.html:44
-#: UI/accounts/edit.html:93 UI/budgetting/budget_entry.html:62
-#: UI/Contact/contact.html:20 UI/Contact/divs/credit.html:187
-#: UI/Contact/divs/credit.html:188 UI/journal/journal_entry.html:113
-#: UI/orders/order.html:253 UI/payments/payment2.html:86
-#: UI/payments/payment2.html:240 UI/payments/payment2.html:304
-#: UI/payments/payments_detail.html:213 UI/payments/payments_filter.html:95
-#: UI/payroll/deduction.html:50 UI/payroll/income.html:52
-#: UI/rc-reconciliation.html:12 UI/reconciliation/upload.html:25
-#: UI/Reports/filters/aging.html:25 UI/Reports/filters/gl.html:33
-#: UI/Reports/filters/gl.html:248
-#: UI/Reports/filters/invoice_outstanding.html:32
-#: UI/Reports/filters/invoice_search.html:28 UI/Reports/filters/orders.html:30
-#: UI/Reports/filters/orders.html:159
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:67
+#: lib/LedgerSMB/Report/co/Caja_Diaria.pm:68
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:210
+#: lib/LedgerSMB/Report/Reconciliation/Summary.pm:133 old/bin/aa.pl:597
+#: old/bin/aa.pl:661 old/bin/aa.pl:813 old/bin/aa.pl:1661 old/bin/ic.pl:1123
+#: old/bin/ir.pl:445 old/bin/ir.pl:833 old/bin/is.pl:464 old/bin/is.pl:916
+#: old/bin/oe.pl:437 UI/Reports/custom/reports.pl:1996
+#: UI/Reports/custom/reports.pl:3360 UI/Reports/custom/reports.pl:4690
 msgid "Account"
 msgstr "Compte"
 
-#: lib/LedgerSMB/Report/Trial_Balance.pm:160
-#: UI/payments/use_overpayment2.html:124
+#: lib/LedgerSMB/Report/Trial_Balance.pm:161
 msgid "Account Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:77
+#: lib/LedgerSMB/Report/Budget/Variance.pm:78
 msgid "Account Label"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:152 UI/Reports/co/filter_bm.html:85
-#: UI/Reports/co/filter_cd.html:69 UI/Reports/filters/gl.html:260
+#: lib/LedgerSMB/Report/GL.pm:153
 msgid "Account Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:147
+#: lib/LedgerSMB/Report/GL.pm:148
 msgid "Account No."
 msgstr "N° de compte"
 
-#: bin/ic.pl:1024 bin/ic.pl:1678 lib/LedgerSMB/Report/Budget/Search.pm:124
-#: lib/LedgerSMB/Report/Budget/Variance.pm:73 lib/LedgerSMB/Report/COA.pm:88
-#: lib/LedgerSMB/Report/Contact/History.pm:60
-#: lib/LedgerSMB/Report/Contact/History.pm:141
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:143
-#: lib/LedgerSMB/Report/Contact/Search.pm:101 lib/LedgerSMB/Report/GL.pm:211
-#: lib/LedgerSMB/Report/Invoices/Payments.pm:191
-#: lib/LedgerSMB/Report/PNL/ECA.pm:92
-#: lib/LedgerSMB/Report/Taxform/Details.pm:82
-#: lib/LedgerSMB/Report/Taxform/Details.pm:111
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:79
-#: lib/LedgerSMB/Report/Trial_Balance.pm:154
-#: lib/LedgerSMB/Scripts/payment.pm:152 t/data/04-complex_template.html:558
-#: UI/accounts/edit.html:32 UI/accounts/edit.html:102
-#: UI/Contact/divs/bank_act.html:22 UI/payments/use_overpayment2.html:123
-#: UI/Reports/co/filter_bm.html:78 UI/Reports/co/filter_cd.html:62
-#: UI/Reports/filters/contact_search.html:85
-#: UI/rp-search-generate_balance_sheet.html:88
-#: UI/rp-search-generate_income_statement.html:138
+#: lib/LedgerSMB/Report/Budget/Search.pm:125
+#: lib/LedgerSMB/Report/Budget/Variance.pm:74 lib/LedgerSMB/Report/COA.pm:89
+#: lib/LedgerSMB/Report/Contact/History.pm:61
+#: lib/LedgerSMB/Report/Contact/History.pm:142
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:144
+#: lib/LedgerSMB/Report/Contact/Search.pm:102 lib/LedgerSMB/Report/GL.pm:212
+#: lib/LedgerSMB/Report/Invoices/Payments.pm:192
+#: lib/LedgerSMB/Report/PNL/ECA.pm:93 lib/LedgerSMB/Report/Taxform/Details.pm:83
+#: lib/LedgerSMB/Report/Taxform/Details.pm:112
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:80
+#: lib/LedgerSMB/Report/Trial_Balance.pm:155
+#: lib/LedgerSMB/Scripts/payment.pm:153 old/bin/ic.pl:1022 old/bin/ic.pl:1672
+#: UI/Reports/custom/reports.pl:5244
 msgid "Account Number"
 msgstr "Numéro de compte"
 
-#: lib/LedgerSMB/Report/co/Caja_Diaria.pm:131
+#: lib/LedgerSMB/Report/co/Caja_Diaria.pm:132
 msgid "Account Number End"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Caja_Diaria.pm:129
+#: lib/LedgerSMB/Report/co/Caja_Diaria.pm:130
 msgid "Account Number Start"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:153
+#: lib/LedgerSMB/Scripts/payment.pm:154
 msgid "Account Title"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/Details.pm:78
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:75 UI/accounts/edit.html:179
+#: lib/LedgerSMB/Report/Taxform/Details.pm:79
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:76
 msgid "Account Type"
 msgstr "Type de compte"
 
-#: lib/LedgerSMB/GL.pm:206
+#: old/lib/LedgerSMB/GL.pm:206
 msgid "Account [_1] not found"
 msgstr ""
 
-#: bin/gl.pl:611
+#: old/bin/gl.pl:588
 msgid "Account [_1] not found."
 msgstr ""
 
-#: UI/Reports/filters/balance_sheet.html:61
-#: UI/Reports/filters/income_statement.html:116
-msgid "Account category"
-msgstr ""
-
-#: bin/am.pl:132
+#: old/bin/am.pl:129
 msgid "Account does not exist!"
 msgstr "Compte non existant!"
 
-#: UI/Reports/filters/balance_sheet.html:30
-#: UI/Reports/filters/income_statement.html:85
-msgid "Account numbers"
-msgstr ""
-
-#: UI/payments/payments_detail.html:132 UI/reconciliation/report.html:16
-#: UI/Reports/filters/reconciliation_search.html:48
-msgid "Account:"
-msgstr "Compte:"
-
-#: UI/lib/report_base.html:57 UI/rp-search.html:24
+#: UI/Reports/custom/reports.pl:183 UI/Reports/custom/reports.pl:5095
 msgid "Accounts"
 msgstr "Comptes"
 
-#: UI/Reports/co/filter_cd.html:24
-msgid "Accounts From"
-msgstr ""
-
-#: UI/Reports/co/filter_cd.html:29
-msgid "Accounts To"
-msgstr ""
-
-#: lib/LedgerSMB/Upgrade_Tests.pm:508 lib/LedgerSMB/Upgrade_Tests.pm:582
+#: lib/LedgerSMB/Upgrade_Tests.pm:571 lib/LedgerSMB/Upgrade_Tests.pm:777
 msgid "Accounts without heading"
 msgstr ""
 
-#: UI/Reports/filters/income_statement.html:33
-#: UI/rp-search-generate_balance_sheet.html:64
-#: UI/rp-search-generate_income_statement.html:114
-#: UI/rp-search-generate_tax_report.html:92
+#: UI/Reports/custom/reports.pl:4334 UI/Reports/custom/reports.pl:4515
+#: UI/Reports/custom/reports.pl:5185
 msgid "Accrual"
 msgstr "Accumulation"
 
-#: UI/taxform/add_taxform.html:77
-msgid "Accrual Basis:"
-msgstr ""
-
-#: lib/LedgerSMB/Scripts/asset.pm:770
+#: lib/LedgerSMB/Scripts/asset.pm:773
 msgid "Accum. Depreciation"
 msgstr ""
 
-#: bin/lsmb-request.pl:99
-msgid "Action Not Defined: "
-msgstr ""
-
-#: lib/LedgerSMB/Form.pm:653 UI/lib/elements.html:382
+#: old/lib/LedgerSMB/Form.pm:638
 msgid "Action: [_1], ID: [_2]"
 msgstr ""
 
-#: t/data/04-complex_template.html:390 t/data/04-complex_template.html:560
-msgid "Actions"
-msgstr ""
-
-#: t/data/04-complex_template.html:496
-msgid "Actions:"
-msgstr ""
-
-#: UI/am-audit-control.html:28
-msgid "Activate Audit trail"
-msgstr "Activer la journalisation des accès aux écritures clôturées"
-
-#: bin/aa.pl:1710 UI/business_units/list_classes.html:13
-#: UI/Reports/filters/contact_search.html:115
-#: UI/Reports/filters/invoice_outstanding.html:86
-#: UI/Reports/filters/invoice_search.html:179
-#: UI/Reports/filters/search_goods.html:92
+#: old/bin/aa.pl:1692
 msgid "Active"
 msgstr "Actif"
 
-#: UI/business_units/filter.html:35
-msgid "Active On"
-msgstr ""
-
-#: lib/LedgerSMB/Scripts/admin.pm:146
+#: lib/LedgerSMB/Scripts/admin.pm:76
 msgid "Active Sessions"
 msgstr "Sessions actives"
 
-#: bin/am.pl:1528 bin/ic.pl:2104 lib/LedgerSMB/Report/File/Incoming.pm:102
-#: lib/LedgerSMB/Report/File/Internal.pm:90
+#: lib/LedgerSMB/Report/File/Incoming.pm:103
+#: lib/LedgerSMB/Report/File/Internal.pm:91 old/bin/am.pl:1487
+#: old/bin/ic.pl:2098
 msgid "Add"
 msgstr "Ajouter"
 
-#: bin/aa.pl:375 bin/aa.pl:414
+#: old/bin/aa.pl:374 old/bin/aa.pl:413
 msgid "Add AP Transaction"
 msgstr "Ajouter une dépense"
 
-#: bin/aa.pl:374
+#: old/bin/aa.pl:373
 msgid "Add AR Transaction"
 msgstr "Ajouter une recette"
 
@@ -381,15 +439,15 @@ msgstr "Ajouter une recette"
 msgid "Add Account"
 msgstr "Ajouter compte"
 
-#: sql/Pg-database.sql:2791
+#: sql/Pg-database.sql:2795
 msgid "Add Accounts"
 msgstr "Ajouter comptes"
 
-#: bin/ic.pl:65 sql/Pg-database.sql:2866
+#: old/bin/ic.pl:63 sql/Pg-database.sql:2870
 msgid "Add Assembly"
 msgstr "Ajouter produit"
 
-#: lib/LedgerSMB/Scripts/asset.pm:213
+#: lib/LedgerSMB/Scripts/asset.pm:214
 msgid "Add Asset"
 msgstr ""
 
@@ -397,949 +455,601 @@ msgstr ""
 msgid "Add Asset Class"
 msgstr ""
 
-#: sql/Pg-database.sql:2888
+#: sql/Pg-database.sql:2892
 msgid "Add Assets"
 msgstr ""
 
-#: sql/Pg-database.sql:2913
+#: sql/Pg-database.sql:2917
 msgid "Add Budget"
 msgstr ""
 
-#: bin/am.pl:273 sql/Pg-database.sql:2840
+#: old/bin/am.pl:267 sql/Pg-database.sql:2844
 msgid "Add Business"
 msgstr "Ajouter type d'affaire"
 
-#: sql/Pg-database.sql:2886
+#: sql/Pg-database.sql:2890
 msgid "Add Class"
 msgstr ""
 
-#: sql/Pg-database.sql:2787
+#: sql/Pg-database.sql:2791
 msgid "Add Contact"
 msgstr ""
 
-#: bin/is.pl:104
+#: old/bin/is.pl:98
 msgid "Add Credit Invoice"
 msgstr ""
 
-#: bin/aa.pl:412
+#: old/bin/aa.pl:411
 msgid "Add Credit Note"
 msgstr ""
 
-#: t/data/04-complex_template.html:16 UI/Contact/contact.html:31
-msgid "Add Customer"
-msgstr "Ajouter client"
-
-#: bin/is.pl:108
+#: old/bin/is.pl:102
 msgid "Add Customer Return"
 msgstr ""
 
-#: bin/ir.pl:117 bin/ir.pl:144
+#: old/bin/ir.pl:107 old/bin/ir.pl:138
 msgid "Add Debit Invoice"
 msgstr ""
 
-#: bin/aa.pl:410
+#: old/bin/aa.pl:409
 msgid "Add Debit Note"
 msgstr ""
 
-#: t/data/04-complex_template.html:20 UI/Contact/contact.html:35
-#: sql/Pg-database.sql:2808
+#: sql/Pg-database.sql:2812
 msgid "Add Employee"
 msgstr "Ajouter employé"
 
-#: bin/oe.pl:1511
+#: old/bin/oe.pl:1513
 msgid "Add Exchange Rate"
 msgstr "Ajouter taux de change"
 
-#: bin/am.pl:156 sql/Pg-database.sql:2907
+#: old/bin/am.pl:152 sql/Pg-database.sql:2911
 msgid "Add GIFI"
 msgstr "Ajouter code d'identification comptable ou fiscale"
 
-#: bin/pe.pl:106 sql/Pg-database.sql:2933
+#: UI/Reports/custom/reports.pl:3019
+msgid "Add General Ledger Expenses Report"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:3060
+#, fuzzy
+msgid "Add General Ledger Transaction"
+msgstr "Ajouter une dépense"
+
+#: old/bin/pe.pl:104 sql/Pg-database.sql:2937
 msgid "Add Group"
 msgstr "Ajouter groupe"
 
-#: bin/ic.pl:66
+#: old/bin/ic.pl:64
 msgid "Add Labor/Overhead"
 msgstr "Ajouter coût de production"
 
-#: bin/am.pl:447 sql/Pg-database.sql:2842
+#: old/bin/am.pl:437 sql/Pg-database.sql:2846
 msgid "Add Language"
 msgstr "Ajouter langue"
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:80
+#: lib/LedgerSMB/Report/Taxform/List.pm:81
 msgid "Add New Tax Form"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:175
-msgid "Add Note"
-msgstr ""
-
-#: sql/Pg-database.sql:2932
+#: sql/Pg-database.sql:2936
 msgid "Add Overhead"
 msgstr ""
 
-#: bin/ic.pl:63 sql/Pg-database.sql:2864
+#: old/bin/ic.pl:61 sql/Pg-database.sql:2868
 msgid "Add Part"
 msgstr "Ajouter marchandise"
 
-#: bin/pe.pl:191 sql/Pg-database.sql:2934
+#: old/bin/pe.pl:189 sql/Pg-database.sql:2938
 msgid "Add Pricegroup"
 msgstr "Ajouter groupe de prix"
 
-#: bin/io.pl:936 bin/oe.pl:64
+#: old/bin/io.pl:930 old/bin/oe.pl:62
 msgid "Add Purchase Order"
 msgstr "Établir commande d'achat"
 
-#: bin/io.pl:969 bin/oe.pl:76
+#: old/bin/io.pl:963 old/bin/oe.pl:74
 msgid "Add Quotation"
 msgstr "Établir devis"
 
-#: UI/business_units/edit.html:16
-msgid "Add Reporting Unit"
-msgstr ""
-
-#: bin/io.pl:958 bin/oe.pl:72
+#: old/bin/io.pl:952 old/bin/oe.pl:70
 msgid "Add Request for Quotation"
 msgstr "Établir demande de devis"
 
-#: sql/Pg-database.sql:2976
+#: sql/Pg-database.sql:2980
 msgid "Add Return"
 msgstr ""
 
-#: bin/am.pl:359 sql/Pg-database.sql:2844
+#: old/bin/am.pl:351 sql/Pg-database.sql:2848
 msgid "Add SIC"
 msgstr "Ajouter code secteur économique"
 
-#: bin/is.pl:113 bin/oe.pl:1427
+#: old/bin/is.pl:107 old/bin/oe.pl:1429
 msgid "Add Sales Invoice"
 msgstr "Établir facture de vente"
 
-#: bin/io.pl:947 bin/oe.pl:68
+#: old/bin/io.pl:941 old/bin/oe.pl:66
 msgid "Add Sales Order"
 msgstr "Établir commande de vente"
 
-#: bin/ic.pl:64 sql/Pg-database.sql:2865
+#: old/bin/ic.pl:62 sql/Pg-database.sql:2869
 msgid "Add Service"
 msgstr "Ajouter prestation"
 
-#: sql/Pg-database.sql:2872
+#: sql/Pg-database.sql:2876
 msgid "Add Tax Form"
 msgstr ""
 
-#: UI/taxform/add_taxform.html:2
-msgid "Add TaxForm"
-msgstr ""
-
-#: sql/Pg-database.sql:2831
+#: sql/Pg-database.sql:2835
 msgid "Add Timecard"
 msgstr ""
 
-#: bin/io.pl:1809
+#: old/bin/io.pl:1829
 msgid "Add To List"
 msgstr ""
 
-#: sql/Pg-database.sql:2794 sql/Pg-database.sql:2797
+#: sql/Pg-database.sql:2798 sql/Pg-database.sql:2801
 msgid "Add Transaction"
 msgstr "Saisie d'écriture"
 
-#: UI/business_units/list_classes.html:108
-msgid "Add Unit"
-msgstr ""
-
-#: UI/Contact/divs/employee.html:221 UI/Contact/divs/user.html:98
-#: UI/setup/confirm_operation.html:56 UI/setup/edit_user.html:96
-msgid "Add User"
-msgstr "Ajouter utilisateur"
-
-#: t/data/04-complex_template.html:18 UI/Contact/contact.html:33
-msgid "Add Vendor"
-msgstr "Ajouter fournisseur"
-
-#: bin/ir.pl:126 bin/oe.pl:1419
+#: old/bin/ir.pl:116 old/bin/oe.pl:1421
 msgid "Add Vendor Invoice"
 msgstr "Établir facture d'achat"
 
-#: bin/ir.pl:121
+#: old/bin/ir.pl:111
 msgid "Add Vendor Return"
 msgstr ""
 
-#: bin/am.pl:768 sql/Pg-database.sql:2838
+#: old/bin/am.pl:712 sql/Pg-database.sql:2842
 msgid "Add Warehouse"
 msgstr "Ajouter entrepôt"
 
-#: bin/io.pl:1624
+#: old/bin/io.pl:1644
 msgid "Add line1"
 msgstr ""
 
-#: bin/io.pl:1627
+#: old/bin/io.pl:1647
 msgid "Add line2"
 msgstr ""
 
-#: bin/io.pl:1631
+#: old/bin/io.pl:1651
 msgid "Add line3 "
 msgstr ""
 
-#: UI/Contact/divs/wage.html:72
-msgid "Add/Change Deductions"
-msgstr ""
-
-#: UI/Contact/divs/wage.html:43
-msgid "Add/Change Wage"
-msgstr ""
-
-#: lib/LedgerSMB/Scripts/business_unit.pm:189
+#: lib/LedgerSMB/Scripts/business_unit.pm:181
 msgid "Added id [_1]"
 msgstr ""
 
-#: bin/aa.pl:603 bin/arap.pl:175 bin/ic.pl:1681 bin/ir.pl:464 bin/is.pl:477
-#: bin/oe.pl:441 bin/pe.pl:668 UI/Contact/divs/address.html:80
-#: UI/Contact/divs/address.html:125 UI/Reports/filters/contact_search.html:90
-#: UI/Reports/filters/purchase_history.html:70
+#: old/bin/aa.pl:602 old/bin/arap.pl:173 old/bin/ic.pl:1675 old/bin/ir.pl:455
+#: old/bin/is.pl:474 old/bin/oe.pl:442 old/bin/pe.pl:666
 msgid "Address"
 msgstr "Adresse"
 
-#: t/data/04-complex_template.html:385
-msgid "Address1"
-msgstr ""
-
-#: t/data/04-complex_template.html:420
-msgid "Address:"
-msgstr ""
-
-#: templates/demo/printPayment.html:26
-#: templates/demo_with_images/printPayment.html:26
-#: templates/xedemo/printPayment.html:26
-msgid "Address: [_1]"
-msgstr ""
-
-#: lib/LedgerSMB/Scripts/contact.pm:180 t/data/04-complex_template.html:30
-#: UI/Contact/divs/address.html:2
+#: lib/LedgerSMB/Scripts/contact.pm:193
 msgid "Addresses"
 msgstr ""
 
-#: bin/ic.pl:1275
+#: old/bin/ic.pl:1273
 msgid "Adj"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:772
+#: lib/LedgerSMB/Report/Inventory/Activity.pm:124
+msgid "Adjusted"
+msgstr ""
+
+#: lib/LedgerSMB/Scripts/asset.pm:775
 msgid "Adjusted Basis"
 msgstr ""
 
-#: UI/inventory/adjustment_entry.html:31
-msgid "Adjustment"
-msgstr ""
-
-#: UI/inventory/adjustment_entry.html:13
-msgid "Adjustment Date"
-msgstr ""
-
-#: UI/inventory/adjustment_setup.html:9
-msgid "Adjustment Details"
-msgstr ""
-
-#: UI/Reports/filters/aging.html:80
-msgid "Aged"
-msgstr ""
-
-#: lib/LedgerSMB/Report/Aging.pm:177 UI/Reports/filters/aging.html:7
+#: lib/LedgerSMB/Report/Aging.pm:178
 msgid "Aging Report"
 msgstr ""
 
-#: UI/payments/payments_detail.html:287 UI/Reports/filters/gl.html:129
-#: UI/Reports/filters/invoice_outstanding.html:78
-#: UI/Reports/filters/invoice_search.html:171
+#: UI/Reports/custom/reports.pl:162
 msgid "All"
 msgstr "Tous"
 
-#: bin/aa.pl:1709
+#: UI/Reports/custom/reports.pl:161
+#, fuzzy
+msgid "All Accounts"
+msgstr "Ajouter comptes"
+
+#: old/bin/aa.pl:1691
 msgid "All Invoices"
 msgstr ""
 
-#: UI/Reports/filters/trial_balance.html:38
-msgid "All accounts"
-msgstr ""
-
-#: UI/Reports/co/filter_cd.html:15
-msgid "All fields are required"
-msgstr ""
-
-#: templates/demo/invoice.html:228 templates/demo_with_images/invoice.html:228
-#: templates/xedemo/invoice.html:228
-msgid "All prices in [_1]"
-msgstr ""
-
-#: templates/demo/sales_order.html:211 templates/demo/sales_quotation.html:179
-#: templates/demo_with_images/sales_order.html:211
-#: templates/demo_with_images/sales_quotation.html:179
-#: templates/xedemo/sales_order.html:211
-#: templates/xedemo/sales_quotation.html:179
-msgid "All prices in [_1] Funds"
-msgstr ""
-
-#: templates/demo/product_receipt.html:203
-#: templates/demo/purchase_order.html:203
-#: templates/demo_with_images/product_receipt.html:203
-#: templates/demo_with_images/purchase_order.html:203
-#: templates/xedemo/product_receipt.html:205
-#: templates/xedemo/purchase_order.html:203
-msgid "All prices in [_1] funds"
-msgstr ""
-
-#: templates/demo/invoice.tex:186 templates/demo/product_receipt.tex:147
-#: templates/demo/purchase_order.tex:153 templates/demo/sales_order.tex:158
-#: templates/demo/sales_quotation.tex:123
-#: templates/demo_with_images/invoice.tex:185
-#: templates/demo_with_images/product_receipt.tex:147
-#: templates/demo_with_images/purchase_order.tex:153
-#: templates/demo_with_images/sales_order.tex:158
-#: templates/demo_with_images/sales_quotation.tex:123
-#: templates/xedemo/invoice.tex:184 templates/xedemo/product_receipt.tex:147
-#: templates/xedemo/purchase_order.tex:153 templates/xedemo/sales_order.tex:158
-#: templates/xedemo/sales_quotation.tex:125
-msgid "All prices in [_1]."
-msgstr ""
-
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:125 UI/timecards/timecard.html:132
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:125
 msgid "Allocated"
 msgstr ""
 
-#: UI/Configuration/sequence.html:11
-msgid "Allow Input"
-msgstr ""
-
-#: bin/aa.pl:660 bin/aa.pl:817 bin/aa.pl:1637 bin/am.pl:850 bin/ir.pl:670
-#: bin/ir.pl:840 bin/is.pl:754 bin/is.pl:917 bin/pe.pl:1043
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:82
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:218
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:83
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:219
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:271
-#: lib/LedgerSMB/Report/Orders.pm:234
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:119
-#: templates/demo/ap_transaction.html:196
-#: templates/demo/ar_transaction.html:194 templates/demo/ar_transaction.tex:129
-#: templates/demo/invoice.html:256 templates/demo/invoice.tex:141
-#: templates/demo/invoice.tex:202 templates/demo/printPayment.html:53
-#: templates/demo/product_receipt.html:133
-#: templates/demo/product_receipt.tex:120
-#: templates/demo/purchase_order.html:133 templates/demo/purchase_order.tex:120
-#: templates/demo/sales_order.html:135 templates/demo/sales_order.tex:122
-#: templates/demo/sales_quotation.html:104
-#: templates/demo/sales_quotation.tex:90
-#: templates/demo_with_images/ap_transaction.html:196
-#: templates/demo_with_images/ar_transaction.html:194
-#: templates/demo_with_images/ar_transaction.tex:129
-#: templates/demo_with_images/invoice.html:256
-#: templates/demo_with_images/invoice.tex:141
-#: templates/demo_with_images/invoice.tex:201
-#: templates/demo_with_images/printPayment.html:53
-#: templates/demo_with_images/product_receipt.html:133
-#: templates/demo_with_images/product_receipt.tex:120
-#: templates/demo_with_images/purchase_order.html:133
-#: templates/demo_with_images/purchase_order.tex:120
-#: templates/demo_with_images/sales_order.html:135
-#: templates/demo_with_images/sales_order.tex:122
-#: templates/demo_with_images/sales_quotation.html:104
-#: templates/demo_with_images/sales_quotation.tex:90
-#: templates/xedemo/ap_transaction.html:196
-#: templates/xedemo/ar_transaction.html:194
-#: templates/xedemo/ar_transaction.tex:129 templates/xedemo/invoice.html:256
-#: templates/xedemo/invoice.tex:140 templates/xedemo/invoice.tex:201
-#: templates/xedemo/printPayment.html:53
-#: templates/xedemo/product_receipt.html:135
-#: templates/xedemo/product_receipt.tex:120
-#: templates/xedemo/purchase_order.html:133
-#: templates/xedemo/purchase_order.tex:120
-#: templates/xedemo/sales_order.html:135 templates/xedemo/sales_order.tex:122
-#: templates/xedemo/sales_quotation.html:104
-#: templates/xedemo/sales_quotation.tex:91 UI/orders/order.html:249
-#: UI/payments/payment2.html:308 UI/Reports/filters/gl.html:102
-#: UI/Reports/filters/gl.html:108
-#: UI/Reports/filters/invoice_outstanding.html:197
-#: UI/Reports/filters/invoice_search.html:287
-#: UI/Reports/filters/orders.html:172 UI/rp-search-generate_tax_report.html:158
+#: lib/LedgerSMB/Report/Orders.pm:236
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:120 old/bin/aa.pl:659
+#: old/bin/aa.pl:811 old/bin/aa.pl:1619 old/bin/am.pl:788 old/bin/ir.pl:661
+#: old/bin/ir.pl:831 old/bin/is.pl:751 old/bin/is.pl:914 old/bin/pe.pl:1041
+#: UI/Reports/custom/reports.pl:118 UI/Reports/custom/reports.pl:121
+#: UI/Reports/custom/reports.pl:184 UI/Reports/custom/reports.pl:4771
 msgid "Amount"
 msgstr "Montant"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:82
+#: lib/LedgerSMB/Report/Budget/Variance.pm:83
 msgid "Amount Budgetted"
 msgstr ""
 
-#: bin/aa.pl:1655 lib/LedgerSMB/Report/Invoices/Outstanding.pm:238
-#: lib/LedgerSMB/Scripts/payment.pm:775 lib/LedgerSMB/Scripts/payment.pm:781
-#: templates/demo/check_base.tex:53
-#: templates/demo_with_images/check_base.tex:53
-#: templates/xedemo/check_base.tex:53
-#: UI/Reports/filters/invoice_outstanding.html:243
-#: UI/Reports/filters/invoice_search.html:333
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:239
+#: lib/LedgerSMB/Scripts/payment.pm:797 lib/LedgerSMB/Scripts/payment.pm:803
+#: old/bin/aa.pl:1637
 msgid "Amount Due"
 msgstr "Montant dû"
 
-#: lib/LedgerSMB/Report/Listings/Overpayments.pm:104
-#: UI/Reports/filters/reconciliation_search.html:29
+#: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
 msgid "Amount From"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:156
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:136
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:157
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:138
 msgid "Amount Greater Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:158
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:138
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:159
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:140
 msgid "Amount Less Than"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Overpayments.pm:105
+#: lib/LedgerSMB/Report/Listings/Overpayments.pm:106
 msgid "Amount To"
 msgstr ""
 
-#: UI/payments/use_overpayment2.html:155
-msgid "Amount to be used"
-msgstr ""
-
-#: UI/payments/payment2.html:220
-#, fuzzy
-msgid "Amount to pay"
-msgstr "Montant"
-
-#: UI/Contact/divs/wage.html:8
-msgid "Amount/Rate"
-msgstr ""
-
-#: sql/Pg-database.sql:3756
+#: sql/Pg-database.sql:3760
 msgid "Annual Straight Line Daily"
 msgstr ""
 
-#: sql/Pg-database.sql:3764
+#: sql/Pg-database.sql:3768
 msgid "Annual Straight Line Monthly"
 msgstr ""
 
-#: lib/LedgerSMB/Batch.pm:103
+#: old/lib/LedgerSMB/Batch.pm:104
 msgid "Any"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:1164
+#: lib/LedgerSMB/Scripts/payment.pm:1193
 msgid "Applied discount"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:1719 lib/LedgerSMB/Scripts/payment.pm:1797
+#: lib/LedgerSMB/Scripts/payment.pm:1760 lib/LedgerSMB/Scripts/payment.pm:1838
 msgid "Applied discount by an overpayment"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:773
+#: lib/LedgerSMB/Scripts/payment.pm:795
 msgid "Apply Disc"
 msgstr ""
 
-#: UI/Reports/filters/reconciliation_search.html:65
-msgid "Approval Status"
-msgstr ""
-
-#: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:116
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:205
-#: lib/LedgerSMB/Scripts/asset.pm:584 lib/LedgerSMB/Scripts/asset.pm:662
-#: lib/LedgerSMB/Scripts/asset.pm:730 lib/LedgerSMB/Scripts/asset.pm:794
-#: lib/LedgerSMB/Scripts/budgets.pm:112 UI/reconciliation/report.html:294
+#: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:114
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:207
+#: lib/LedgerSMB/Scripts/asset.pm:587 lib/LedgerSMB/Scripts/asset.pm:663
+#: lib/LedgerSMB/Scripts/asset.pm:732 lib/LedgerSMB/Scripts/asset.pm:797
+#: lib/LedgerSMB/Scripts/budgets.pm:112
 msgid "Approve"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Reconciliation/Summary.pm:143
-#: UI/asset/search_reports.html:61
-#: UI/Reports/filters/reconciliation_search.html:60
-#: UI/Reports/filters/unapproved.html:65
+#: lib/LedgerSMB/Report/Reconciliation/Summary.pm:144
 msgid "Approved"
 msgstr "Approuvé"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:93
-#: lib/LedgerSMB/Report/Reconciliation/Summary.pm:155
+#: lib/LedgerSMB/Report/Budget/Search.pm:94
+#: lib/LedgerSMB/Report/Reconciliation/Summary.pm:156
 msgid "Approved By"
 msgstr "Approuvé par"
 
-#: lib/LedgerSMB/Scripts/asset.pm:536
+#: lib/LedgerSMB/Scripts/asset.pm:539
 msgid "Approved at"
 msgstr ""
 
-#: templates/demo/printPayment.html:117
-#: templates/demo_with_images/printPayment.html:117
-#: templates/xedemo/printPayment.html:117
-msgid "Approved signature"
-msgstr ""
-
-#: bin/aa.pl:89 bin/gl.pl:82 bin/io.pl:83 lib/LedgerSMB/App_State.pm:356
+#: lib/LedgerSMB/App_State.pm:266 old/bin/aa.pl:90 old/bin/gl.pl:83
+#: old/bin/io.pl:82 UI/Reports/custom/reports.pl:101
+#: UI/Reports/custom/reports.pl:5304
 msgid "Apr"
 msgstr "Avril"
 
-#: bin/aa.pl:75 bin/gl.pl:68 bin/io.pl:69 lib/LedgerSMB/App_State.pm:356
-#: lib/LedgerSMB/DBObject/Date.pm:65
+#: lib/LedgerSMB/App_State.pm:266 old/bin/aa.pl:76 old/bin/gl.pl:69
+#: old/bin/io.pl:68 old/lib/LedgerSMB/DBObject/Date.pm:66
+#: UI/Reports/custom/reports.pl:87 UI/Reports/custom/reports.pl:5290
 msgid "April"
 msgstr "Avril"
 
-#: lib/LedgerSMB/Scripts/asset.pm:635 lib/LedgerSMB/Scripts/asset.pm:699
-#: lib/LedgerSMB/Scripts/asset.pm:768
+#: lib/LedgerSMB/Scripts/asset.pm:636 lib/LedgerSMB/Scripts/asset.pm:701
+#: lib/LedgerSMB/Scripts/asset.pm:771
 msgid "Aquired Value"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:705
+#: lib/LedgerSMB/Scripts/asset.pm:707
 msgid "Aquired Value Remaining"
 msgstr ""
 
-#: bin/oe.pl:1303
+#: old/bin/oe.pl:1305
 msgid "Are you sure you want to delete Order Number"
 msgstr "Êtes vous sûr de vouloir supprimer la commande n°"
 
-#: bin/oe.pl:1308
+#: old/bin/oe.pl:1310
 msgid "Are you sure you want to delete Quotation Number"
 msgstr "Êtes vous sûr de vouloir supprimer le devis n°"
 
-#: bin/ic.pl:2224
+#: lib/LedgerSMB/Report/Inventory/Activity.pm:119
+#, fuzzy
+msgid "Assembled"
+msgstr "Ajouter produit"
+
+#: old/bin/ic.pl:2218
 msgid "Assemblies restocked!"
 msgstr "Renvoyer produits vers stock!"
 
-#: UI/accounts/edit.html:183 UI/Reports/filters/gl.html:136
-#: sql/Pg-database.sql:3825
+#: UI/Reports/custom/reports.pl:166 sql/Pg-database.sql:3829
 msgid "Asset"
 msgstr "Actif"
 
-#: lib/LedgerSMB/Report/Listings/Asset_Class.pm:74 UI/asset/edit_asset.html:159
-#: UI/asset/edit_class.html:37 UI/asset/search_asset.html:143
-#: UI/asset/search_class.html:45
+#: lib/LedgerSMB/Report/Listings/Asset_Class.pm:75
 msgid "Asset Account"
 msgstr "Compte d'actif"
 
-#: lib/LedgerSMB/Scripts/asset.pm:534 UI/asset/begin_approval.html:16
-#: UI/asset/begin_report.html:15 UI/asset/search_reports.html:13
+#: lib/LedgerSMB/Scripts/asset.pm:537
 msgid "Asset Class"
 msgstr "Classe d'actif"
 
-#: lib/LedgerSMB/Report/Listings/Asset_Class.pm:104
+#: lib/LedgerSMB/Report/Listings/Asset_Class.pm:105
 msgid "Asset Class List"
 msgstr ""
 
-#: UI/asset/edit_asset.html:60 UI/asset/search_asset.html:51
-msgid "Asset Class:"
-msgstr "Classe d'actif:"
-
-#: sql/Pg-database.sql:2884
+#: sql/Pg-database.sql:2888
 msgid "Asset Classes"
 msgstr "Classes d'actif"
 
-#: lib/LedgerSMB/Scripts/asset.pm:454
+#: lib/LedgerSMB/Scripts/asset.pm:456
 msgid "Asset Depreciation Report"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:456
+#: lib/LedgerSMB/Scripts/asset.pm:458
 msgid "Asset Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:133
+#: lib/LedgerSMB/Report/Listings/Asset.pm:134
 msgid "Asset Listing"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:461
+#: lib/LedgerSMB/Scripts/asset.pm:463
 msgid "Asset Partial Disposal Report"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:396
+#: lib/LedgerSMB/Scripts/asset.pm:398
 msgid "Asset Tag"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Balance_Sheet.pm:213
-#: lib/LedgerSMB/Report/Balance_Sheet.pm:215 lib/LedgerSMB/Report/PNL.pm:190
-#: lib/LedgerSMB/Report/PNL.pm:192 sql/Pg-database.sql:2885
+#: lib/LedgerSMB/Report/Balance_Sheet.pm:198
+#: lib/LedgerSMB/Report/Balance_Sheet.pm:200 lib/LedgerSMB/Report/PNL.pm:199
+#: lib/LedgerSMB/Report/PNL.pm:201 sql/Pg-database.sql:2889
 msgid "Assets"
 msgstr "Actifs"
 
-#: UI/Reports/balance_sheet.html:105
-msgid "Assets to Equity"
-msgstr ""
-
-#: UI/Reports/balance_sheet.html:102
-msgid "Assets to Liabilities"
-msgstr ""
-
-#: bin/aa.pl:1073 bin/ic.pl:929 bin/ir.pl:1011 bin/is.pl:1094 bin/oe.pl:927
-#: lib/LedgerSMB/Report/File/Incoming.pm:108 UI/journal/journal_entry.html:361
+#: lib/LedgerSMB/Report/File/Incoming.pm:109 old/bin/aa.pl:1069
+#: old/bin/ic.pl:927 old/bin/ir.pl:1004 old/bin/is.pl:1093 old/bin/oe.pl:930
 msgid "Attach"
 msgstr ""
 
-#: UI/file/attachment_screen.html:22
-msgid "Attach File"
-msgstr ""
-
-#: UI/Contact/divs/address.html:105 UI/Contact/divs/contact_info.html:78
-msgid "Attach To"
-msgstr ""
-
-#: UI/Contact/divs/address.html:111 UI/Contact/divs/contact_info.html:82
-msgid "Attach to"
-msgstr ""
-
-#: UI/Contact/divs/files.html:58
-msgid "Attach to Credit Account"
-msgstr ""
-
-#: UI/Contact/divs/files.html:54
-msgid "Attach to Entity"
-msgstr ""
-
-#: UI/Contact/divs/files.html:13
-msgid "Attached At"
-msgstr ""
-
-#: UI/Contact/divs/files.html:15
-msgid "Attached By"
-msgstr ""
-
-#: bin/aa.pl:1045 bin/ic.pl:901 bin/ir.pl:985 bin/is.pl:1068 bin/oe.pl:901
-#: UI/journal/journal_entry.html:337
+#: old/bin/aa.pl:1041 old/bin/ic.pl:899 old/bin/ir.pl:978 old/bin/is.pl:1067
+#: old/bin/oe.pl:904
 msgid "Attached To"
 msgstr ""
 
-#: bin/aa.pl:1044 bin/ic.pl:900 bin/ir.pl:984 bin/is.pl:1067 bin/oe.pl:900
-#: UI/journal/journal_entry.html:336
+#: old/bin/aa.pl:1040 old/bin/ic.pl:898 old/bin/ir.pl:977 old/bin/is.pl:1066
+#: old/bin/oe.pl:903
 msgid "Attached To Type"
 msgstr ""
 
-#: bin/aa.pl:1020 bin/ic.pl:877 bin/ir.pl:961 bin/is.pl:1044 bin/oe.pl:877
-#: UI/journal/journal_entry.html:314
+#: old/bin/aa.pl:1017 old/bin/ic.pl:875 old/bin/ir.pl:954 old/bin/is.pl:1043
+#: old/bin/oe.pl:880
 msgid "Attached and Linked Files"
 msgstr ""
 
-#: bin/aa.pl:1024 bin/aa.pl:1046 bin/ic.pl:881 bin/ic.pl:902 bin/ir.pl:965
-#: bin/ir.pl:986 bin/is.pl:1048 bin/is.pl:1069 bin/oe.pl:881 bin/oe.pl:902
-#: UI/journal/journal_entry.html:318 UI/journal/journal_entry.html:338
+#: old/bin/aa.pl:1021 old/bin/aa.pl:1042 old/bin/ic.pl:879 old/bin/ic.pl:900
+#: old/bin/ir.pl:958 old/bin/ir.pl:979 old/bin/is.pl:1047 old/bin/is.pl:1068
+#: old/bin/oe.pl:884 old/bin/oe.pl:905
 msgid "Attached at"
 msgstr ""
 
-#: bin/aa.pl:1025 bin/aa.pl:1047 bin/ic.pl:882 bin/ic.pl:903 bin/ir.pl:966
-#: bin/ir.pl:987 bin/is.pl:1049 bin/is.pl:1070 bin/oe.pl:882 bin/oe.pl:903
-#: UI/journal/journal_entry.html:319 UI/journal/journal_entry.html:339
+#: old/bin/aa.pl:1022 old/bin/aa.pl:1043 old/bin/ic.pl:880 old/bin/ic.pl:901
+#: old/bin/ir.pl:959 old/bin/ir.pl:980 old/bin/is.pl:1048 old/bin/is.pl:1069
+#: old/bin/oe.pl:885 old/bin/oe.pl:906
 msgid "Attached by"
 msgstr ""
 
-#: bin/printer.pl:119
+#: old/bin/io.pl:1065
+msgid "Attached document for [_1] [_2]"
+msgstr ""
+
+#: old/bin/printer.pl:119 UI/Reports/custom/reports.pl:2328
 msgid "Attachment"
 msgstr "Pièce jointe"
 
-#: templates/demo/bin_list.html:51 templates/demo/bin_list.html:84
-#: templates/demo/packing_list.html:52 templates/demo/pick_list.html:51
-#: templates/demo/product_receipt.html:50
-#: templates/demo/product_receipt.html:78 templates/demo/product_receipt.tex:47
-#: templates/demo/product_receipt.tex:82 templates/demo/purchase_order.html:50
-#: templates/demo/purchase_order.html:78 templates/demo/purchase_order.tex:47
-#: templates/demo/purchase_order.tex:82
-#: templates/demo/request_quotation.html:51
-#: templates/demo/request_quotation.html:79 templates/demo/sales_order.html:49
-#: templates/demo/sales_quotation.html:44
-#: templates/demo_with_images/bin_list.html:51
-#: templates/demo_with_images/bin_list.html:84
-#: templates/demo_with_images/packing_list.html:52
-#: templates/demo_with_images/pick_list.html:51
-#: templates/demo_with_images/product_receipt.html:50
-#: templates/demo_with_images/product_receipt.html:78
-#: templates/demo_with_images/product_receipt.tex:47
-#: templates/demo_with_images/product_receipt.tex:82
-#: templates/demo_with_images/purchase_order.html:50
-#: templates/demo_with_images/purchase_order.html:78
-#: templates/demo_with_images/purchase_order.tex:47
-#: templates/demo_with_images/purchase_order.tex:82
-#: templates/demo_with_images/request_quotation.html:51
-#: templates/demo_with_images/request_quotation.html:79
-#: templates/demo_with_images/sales_order.html:49
-#: templates/demo_with_images/sales_quotation.html:44
-#: templates/demo_with_images/work_order.html:49
-#: templates/demo/work_order.html:49 templates/xedemo/bin_list.html:51
-#: templates/xedemo/bin_list.html:84 templates/xedemo/packing_list.html:52
-#: templates/xedemo/pick_list.html:51 templates/xedemo/product_receipt.html:50
-#: templates/xedemo/product_receipt.html:78
-#: templates/xedemo/product_receipt.tex:47
-#: templates/xedemo/product_receipt.tex:82
-#: templates/xedemo/purchase_order.html:50
-#: templates/xedemo/purchase_order.html:78
-#: templates/xedemo/purchase_order.tex:47
-#: templates/xedemo/purchase_order.tex:82
-#: templates/xedemo/request_quotation.html:51
-#: templates/xedemo/request_quotation.html:79
-#: templates/xedemo/sales_order.html:49
-#: templates/xedemo/sales_quotation.html:44 templates/xedemo/work_order.html:49
-msgid "Attn: [_1]"
-msgstr ""
-
-#: UI/am-audit-control.html:6
-msgid "Audit Control"
-msgstr ""
-
-#: bin/aa.pl:93 bin/gl.pl:86 bin/io.pl:87 lib/LedgerSMB/App_State.pm:362
+#: lib/LedgerSMB/App_State.pm:272 old/bin/aa.pl:94 old/bin/gl.pl:87
+#: old/bin/io.pl:86 UI/Reports/custom/reports.pl:105
+#: UI/Reports/custom/reports.pl:5308
 msgid "Aug"
 msgstr "Août"
 
-#: bin/aa.pl:79 bin/gl.pl:72 bin/io.pl:73 lib/LedgerSMB/App_State.pm:362
-#: lib/LedgerSMB/DBObject/Date.pm:69
+#: lib/LedgerSMB/App_State.pm:272 old/bin/aa.pl:80 old/bin/gl.pl:73
+#: old/bin/io.pl:72 old/lib/LedgerSMB/DBObject/Date.pm:70
+#: UI/Reports/custom/reports.pl:91 UI/Reports/custom/reports.pl:5294
 msgid "August"
 msgstr "Août"
 
-#: UI/Contact/divs/notes.html:79
-msgid "Author: [_1]"
-msgstr ""
-
-#: bin/ir.pl:632 bin/is.pl:414 bin/is.pl:712
+#: old/bin/ir.pl:623 old/bin/is.pl:411 old/bin/is.pl:709
 msgid "Automatic"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Overpayments.pm:144
-#: UI/payments/use_overpayment2.html:125
+#: lib/LedgerSMB/Report/Listings/Overpayments.pm:145
 msgid "Available"
 msgstr "Disponible"
 
-#: UI/setup/list_databases.html:9
-msgid "Available Databases"
-msgstr ""
-
-#: UI/setup/list_users.html:8
-msgid "Available Users"
-msgstr ""
-
-#: UI/payments/use_overpayment2.html:121
-msgid "Available overpayments"
-msgstr ""
-
-#: bin/ic.pl:451 UI/Reports/filters/search_goods.html:267
+#: old/bin/ic.pl:449
 msgid "Average Cost"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Inventory/Search.pm:238
+#: lib/LedgerSMB/Report/Inventory/Search.pm:239
 msgid "Avg. Cost"
 msgstr ""
 
-#: sql/Pg-database.sql:810
+#: sql/Pg-database.sql:824
 msgid "BCC"
 msgstr "CCI"
 
-#: t/data/04-complex_template.html:557 UI/Contact/divs/bank_act.html:20
-#: UI/Contact/divs/bank_act.html:52
-msgid "BIC/SWIFT Code"
-msgstr ""
-
-#: t/data/04-complex_template.html:592
-msgid "BIC/SWIFT Code:"
-msgstr ""
-
-#: bin/ic.pl:1274
+#: old/bin/ic.pl:1272
 msgid "BOM"
 msgstr "Nomenclature composantes"
 
-#: UI/setup/confirm_operation.html:82
-msgid "Backup"
-msgstr "Sauvegarder"
-
-#: UI/setup/confirm_operation.html:89
-msgid "Backup DB"
-msgstr ""
-
-#: UI/setup/confirm_operation.html:96
-msgid "Backup Roles"
-msgstr ""
-
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:94 lib/LedgerSMB/Report/GL.pm:162
-#: UI/Reports/filters/gl.html:266
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:95 lib/LedgerSMB/Report/GL.pm:163
+#: UI/Reports/custom/reports.pl:185 UI/Reports/custom/reports.pl:5352
 msgid "Balance"
 msgstr "Solde"
 
-#: templates/demo/invoice.html:203 templates/demo/invoice.tex:170
-#: templates/demo_with_images/invoice.html:203
-#: templates/demo_with_images/invoice.tex:169 templates/xedemo/invoice.html:203
-#: templates/xedemo/invoice.tex:168
-msgid "Balance Due"
-msgstr "Solde dû"
-
-#: UI/Reports/balance_sheet.html:25 UI/Reports/balance_sheet.tex:28
-#: UI/Reports/filters/balance_sheet.html:2
-#: UI/Reports/filters/balance_sheet.html:10 sql/Pg-database.sql:2835
+#: sql/Pg-database.sql:2839
 msgid "Balance Sheet"
 msgstr "Bilan"
 
-#: lib/LedgerSMB/Report/Balance_Sheet.pm:303
+#: UI/Reports/custom/reports.pl:175 UI/Reports/custom/reports.pl:186
+#, fuzzy
+msgid "Balance Sheets"
+msgstr "Bilan"
+
+#: lib/LedgerSMB/Report/Balance_Sheet.pm:287
 msgid "Balance sheet"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:120
-msgid "Balance y Mayor"
-msgstr ""
+#: UI/Reports/custom/reports.pl:73
+#, fuzzy
+msgid "Balance sheets"
+msgstr "Bilan"
 
-#: UI/Reports/filters/trial_balance.html:73
-msgid "Balances as"
-msgstr ""
-
-#: UI/Contact/divs/bank_act.html:62
-msgid "Bank Account"
-msgstr ""
-
-#: t/data/04-complex_template.html:601
-msgid "Bank Account:"
-msgstr ""
-
-#: lib/LedgerSMB/Scripts/contact.pm:182 t/data/04-complex_template.html:32
-#: t/data/04-complex_template.html:554 UI/Contact/divs/bank_act.html:2
-#: UI/Contact/divs/bank_act.html:6
+#: lib/LedgerSMB/Scripts/contact.pm:195
 msgid "Bank Accounts"
 msgstr ""
 
-#: UI/ca-list-selector.html:37
-msgid "Bank Register Mode"
-msgstr ""
-
-#: bin/ic.pl:983
+#: old/bin/ic.pl:981
 msgid "Bar Code"
 msgstr ""
 
-#: bin/ir.pl:672 bin/is.pl:756 lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:92
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:93 old/bin/ir.pl:663
+#: old/bin/is.pl:753
 msgid "Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Payments.pm:153
+#: lib/LedgerSMB/Report/Invoices/Payments.pm:154
 msgid "Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:98
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:99
 msgid "Batch Class"
 msgstr ""
 
-#: bin/aa.pl:569
+#: old/bin/aa.pl:568
 msgid "Batch Control Code"
 msgstr ""
 
-#: UI/create_batch.html:36
-msgid "Batch Date"
-msgstr ""
-
-#: lib/LedgerSMB/Report/Invoices/Payments.pm:150
+#: lib/LedgerSMB/Report/Invoices/Payments.pm:151
 msgid "Batch Description"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:146
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:147
 msgid "Batch ID"
 msgstr ""
 
-#: lib/LedgerSMB/GL.pm:148 lib/LedgerSMB/IR.pm:386 lib/LedgerSMB/IS.pm:1065
+#: old/lib/LedgerSMB/GL.pm:148
 msgid "Batch ID Missing"
 msgstr ""
 
-#: UI/import_csv/import_csv.html:22
-msgid "Batch Information"
-msgstr ""
-
-#: bin/aa.pl:574
+#: old/bin/aa.pl:573
 msgid "Batch Name"
 msgstr ""
 
-#: UI/create_batch.html:15
-msgid "Batch Number"
-msgstr ""
-
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:140
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:141
 msgid "Batch Search"
 msgstr ""
 
-#: UI/Reports/filters/unapproved.html:6
-msgid "Batch Selection"
-msgstr ""
-
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:152
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:153
 msgid "Batch Type"
 msgstr ""
 
-#: sql/Pg-database.sql:2785
+#: sql/Pg-database.sql:2789
 msgid "Batches"
 msgstr ""
 
-#: UI/io-email.html:24 UI/rp-email.html:23
+#: UI/Reports/custom/reports.pl:2421
 msgid "Bcc"
 msgstr "Copie cachée"
 
-#: bin/arap.pl:795 bin/io.pl:1444
+#: old/bin/arap.pl:793 old/bin/io.pl:1463
 msgid "Bcc: [_1]"
 msgstr "Cci: [_1]"
 
-#: UI/reconciliation/report.html:26
-msgid "Beginning Statement Balance:"
-msgstr ""
+#: UI/Reports/custom/reports.pl:2000 UI/Reports/custom/reports.pl:5399
+#, fuzzy
+msgid "Beginning Balance"
+msgstr "Balance Globale"
 
-#: lib/LedgerSMB/Entity/Location.pm:112 UI/Contact/divs/address.html:40
-#: sql/Pg-database.sql:659
+#: UI/Reports/custom/reports.pl:79
+#, fuzzy
+msgid "Billable"
+msgstr "Disponible"
+
+#: lib/LedgerSMB/Entity/Location.pm:113 sql/Pg-database.sql:673
 msgid "Billing"
 msgstr ""
 
-#: sql/Pg-database.sql:813
+#: sql/Pg-database.sql:827
 msgid "Billing BCC"
 msgstr ""
 
-#: sql/Pg-database.sql:812
+#: sql/Pg-database.sql:826
 msgid "Billing CC"
 msgstr ""
 
-#: sql/Pg-database.sql:811
+#: sql/Pg-database.sql:825
 msgid "Billing Email"
 msgstr ""
 
-#: lib/LedgerSMB/Num2text.pm:119
+#: old/lib/LedgerSMB/Num2text.pm:119
 msgid "Billion"
 msgstr "Milliard"
 
-#: bin/ic.pl:493 bin/ic.pl:2097 bin/io.pl:247 bin/oe.pl:1859
-#: lib/LedgerSMB/Report/Inventory/History.pm:134
-#: lib/LedgerSMB/Report/Inventory/Search.pm:214
-#: templates/demo/bin_list.html:154 templates/demo/bin_list.tex:109
-#: templates/demo/pick_list.html:116 templates/demo/pick_list.tex:102
-#: templates/demo_with_images/bin_list.html:154
-#: templates/demo_with_images/bin_list.tex:109
-#: templates/demo_with_images/pick_list.html:116
-#: templates/demo_with_images/pick_list.tex:102
-#: templates/demo_with_images/work_order.html:133
-#: templates/demo/work_order.html:133 templates/xedemo/bin_list.html:154
-#: templates/xedemo/bin_list.tex:109 templates/xedemo/pick_list.html:116
-#: templates/xedemo/pick_list.tex:102 templates/xedemo/work_order.html:133
-#: UI/io-email.html:105 UI/Reports/filters/search_goods.html:288
+#: lib/LedgerSMB/Report/Inventory/History.pm:135
+#: lib/LedgerSMB/Report/Inventory/Search.pm:215 old/bin/ic.pl:491
+#: old/bin/ic.pl:2091 old/bin/io.pl:242 old/bin/oe.pl:1863
 msgid "Bin"
 msgstr "Lieu stockage"
 
-#: bin/am.pl:1505 bin/io.pl:1202 bin/oe.pl:265 bin/oe.pl:277 bin/printer.pl:88
-#: bin/printer.pl:102 templates/demo/bin_list.html:4
-#: templates/demo/bin_list.html:18 templates/demo/bin_list.tex:74
-#: templates/demo_with_images/bin_list.html:4
-#: templates/demo_with_images/bin_list.html:18
-#: templates/demo_with_images/bin_list.tex:74 templates/xedemo/bin_list.html:4
-#: templates/xedemo/bin_list.html:18 templates/xedemo/bin_list.tex:74
-#: sql/Pg-database.sql:2953 sql/Pg-database.sql:2966
+#: old/bin/am.pl:1464 old/bin/io.pl:1222 old/bin/oe.pl:266 old/bin/oe.pl:278
+#: old/bin/printer.pl:88 old/bin/printer.pl:102 sql/Pg-database.sql:2957
+#: sql/Pg-database.sql:2970
 msgid "Bin List"
 msgstr "Liste des emplacements"
 
-#: UI/Contact/divs/person.html:167
-msgid "Birthdate"
-msgstr ""
-
-#: UI/accounts/yearend.html:132
-msgid "Books closed on"
-msgstr ""
-
-#: UI/accounts/yearend.html:93
-msgid "Books closed up to"
-msgstr ""
-
-#: sql/Pg-database.sql:2140
+#: sql/Pg-database.sql:2144
 msgid "Budget"
 msgstr "Budget"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:114
+#: lib/LedgerSMB/Report/Budget/Variance.pm:115
 msgid "Budget Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:109
+#: lib/LedgerSMB/Report/Budget/Search.pm:110
 msgid "Budget Search Results"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:103
+#: lib/LedgerSMB/Report/Budget/Variance.pm:104
 msgid "Budget Variance Report"
 msgstr ""
 
-#: sql/Pg-database.sql:2915
+#: sql/Pg-database.sql:2919
 msgid "Budgets"
 msgstr ""
 
@@ -1347,28 +1057,19 @@ msgstr ""
 msgid "Bug: No such account"
 msgstr ""
 
-#: bin/is.pl:359 bin/oe.pl:373
+#: old/bin/is.pl:356 old/bin/oe.pl:374
 msgid "Business"
 msgstr "Type d'affaire"
-
-#: UI/payments/payments_filter.html:79
-msgid "Business Class"
-msgstr ""
 
 #: lib/LedgerSMB/Scripts/configuration.pm:32
 msgid "Business Number"
 msgstr "Numéro d'enregistrement société"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:78 UI/Contact/divs/credit.html:235
-#: UI/Contact/divs/credit.html:236
+#: lib/LedgerSMB/Report/Contact/Search.pm:79
 msgid "Business Type"
 msgstr ""
 
-#: t/data/04-complex_template.html:294
-msgid "Business Type:"
-msgstr ""
-
-#: lib/LedgerSMB/Report/Listings/Business_Unit.pm:86
+#: lib/LedgerSMB/Report/Listings/Business_Unit.pm:87
 msgid "Business Unit List"
 msgstr ""
 
@@ -1376,217 +1077,182 @@ msgstr ""
 msgid "Business Unit Number"
 msgstr ""
 
-#: UI/Reports/filters/invoice_outstanding.html:170
-#: UI/Reports/filters/invoice_search.html:260
-msgid "Business Units"
-msgstr ""
-
-#: bin/am.pl:297
+#: old/bin/am.pl:291
 msgid "Business deleted!"
 msgstr "Type d'affaire effacé!"
 
-#: bin/am.pl:290
+#: old/bin/am.pl:284
 msgid "Business saved!"
 msgstr "Type d'affaire enregistré!"
 
-#: UI/payments/payments_detail.html:169
-msgid "Business:"
-msgstr ""
-
-#: sql/Pg-database.sql:809
+#: sql/Pg-database.sql:823
 msgid "CC"
 msgstr ""
 
-#: bin/ic.pl:530 bin/ic.pl:699 lib/LedgerSMB/Report/Invoices/COGS.pm:130
-#: UI/accounts/edit.html:361
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:130 old/bin/ic.pl:528 old/bin/ic.pl:697
 msgid "COGS"
 msgstr "Coût des produits vendus"
 
-#: UI/Reports/filters/cogs_lines.html:5
-msgid "COGS Lots Report"
-msgstr ""
-
-#: UI/Contact/pricelist.html:114 UI/Reports/aging_report.html:117
-#: UI/Reports/balance_sheet.html:121 UI/Reports/display_report.html:70
-#: UI/Reports/PNL.html:98
-msgid "CSV"
-msgstr "CSV"
-
-#: UI/reconciliation/report.html:62 UI/reconciliation/upload.html:17
-msgid "CSV File:"
-msgstr ""
-
-#: lib/LedgerSMB/Report/co/Caja_Diaria.pm:114
-msgid "Caja Diaria"
-msgstr ""
-
-#: bin/ir.pl:807 bin/is.pl:412 bin/is.pl:883
+#: old/bin/ir.pl:798 old/bin/is.pl:409 old/bin/is.pl:880
 msgid "Calculate Taxes"
 msgstr ""
 
-#: bin/is.pl:672
+#: old/bin/is.pl:669
 msgid "Can't void a voided invoice!"
 msgstr ""
 
-#: bin/io.pl:1813 lib/LedgerSMB/Scripts/setup.pm:137
+#: lib/LedgerSMB/Scripts/setup.pm:156 lib/LedgerSMB/Scripts/setup.pm:187
+#: lib/LedgerSMB/Scripts/setup.pm:791 old/bin/io.pl:1833
 msgid "Cancel"
-msgstr ""
+msgstr "Annuler"
 
-#: lib/LedgerSMB/Scripts/setup.pm:163
-msgid "Cancel."
-msgstr ""
+#: lib/LedgerSMB/Upgrade_Tests.pm:222 lib/LedgerSMB/Upgrade_Tests.pm:634
+msgid "Cancel the <b>migration</b>"
+msgstr "Annuler la <b>migration</b>"
 
-#: lib/LedgerSMB/Scripts/setup.pm:209
+#: lib/LedgerSMB/Scripts/setup.pm:232
 msgid "Cancel?"
-msgstr ""
+msgstr "Annuler?"
 
-#: bin/gl.pl:647
+#: old/bin/gl.pl:627
 msgid "Cannot Repost Transaction"
 msgstr ""
 
-#: bin/ic.pl:162
+#: old/bin/ic.pl:160
 msgid "Cannot create Labor; COGS account does not exist!"
 msgstr ""
 
-#: bin/ic.pl:159
+#: old/bin/ic.pl:157
 msgid "Cannot create Labor; Inventory account does not exist!"
 msgstr ""
 
-#: bin/ic.pl:137
+#: old/bin/ic.pl:135
 msgid "Cannot create Part; COGS account does not exist!"
 msgstr ""
 
-#: bin/ic.pl:134
+#: old/bin/ic.pl:132
 msgid "Cannot create Part; Income account does not exist!"
 msgstr ""
 
-#: bin/ic.pl:131
+#: old/bin/ic.pl:129
 msgid "Cannot create Part; Inventory account does not exist!"
 msgstr ""
 
-#: bin/ic.pl:150
+#: old/bin/ic.pl:148
 msgid "Cannot create Service; Expense account does not exist!"
 msgstr ""
 
-#: bin/ic.pl:146
+#: old/bin/ic.pl:144
 msgid "Cannot create Service; Income account does not exist!"
 msgstr ""
 
-#: bin/ic.pl:1995
+#: old/bin/ic.pl:1989
 msgid "Cannot delete item!"
 msgstr "Impossible de supprimer l'objet!"
 
-#: bin/oe.pl:1341
+#: old/bin/oe.pl:1343
 msgid "Cannot delete order!"
 msgstr "Impossible de supprimer la commande!"
 
-#: bin/gl.pl:676
+#: old/bin/gl.pl:656
 msgid "Cannot delete posted transaction"
 msgstr ""
 
-#: bin/oe.pl:1345
+#: old/bin/oe.pl:1347
 msgid "Cannot delete quotation!"
 msgstr "Impossible de supprimer le devis!"
 
-#: bin/ir.pl:1281 bin/is.pl:1370
+#: old/bin/ir.pl:1274 old/bin/is.pl:1368
 msgid "Cannot post invoice for a closed period!"
 msgstr "Impossible d'enregistrer la facture sur un exercice clos!"
 
-#: bin/aa.pl:1342 bin/ir.pl:1296 bin/is.pl:1385
+#: old/bin/aa.pl:1328 old/bin/ir.pl:1289 old/bin/is.pl:1383
 msgid "Cannot post payment for a closed period!"
 msgstr "Impossible d'enregistrer le paiement sur un exercice clos!"
 
-#: bin/aa.pl:1328 bin/gl.pl:659
+#: old/bin/aa.pl:1314 old/bin/gl.pl:639 UI/Reports/custom/reports.pl:3568
 msgid "Cannot post transaction for a closed period!"
 msgstr "Impossible d'enregistrer l'écriture sur un exercice clos!"
 
-#: bin/gl.pl:700
+#: old/bin/gl.pl:678 UI/Reports/custom/reports.pl:3578
 msgid ""
 "Cannot post transaction with a debit and credit entry for the same account!"
 msgstr ""
 "Impossible d'enregistrer l'écriture avec un débit et un crédit sur le même "
 "compte!"
 
-#: bin/aa.pl:1390
+#: old/bin/aa.pl:1372 UI/Reports/custom/reports.pl:3612
 msgid "Cannot post transaction!"
 msgstr "Impossible d'enregistrer l'écriture!"
 
-#: bin/oe.pl:1232
+#: old/bin/oe.pl:1235
 msgid "Cannot save order!"
 msgstr "Impossible d'enregistrer la commande!"
 
-#: bin/oe.pl:1249
+#: old/bin/oe.pl:1252
 msgid "Cannot save quotation!"
 msgstr "Impossible d'enregistrer le devis!"
 
-#: bin/am.pl:710
+#: old/bin/am.pl:656
 msgid "Cannot save taxes!"
 msgstr ""
 
-#: lib/LedgerSMB/Budget.pm:240
+#: lib/LedgerSMB/Budget.pm:241
 msgid "Cannot specify both debits and credits for budget line [_1]"
 msgstr ""
 
-#: bin/ic.pl:2227
+#: old/bin/ic.pl:2221
 msgid "Cannot stock assemblies!"
 msgstr "Impossible de stocker l'assemblage!"
 
-#: templates/demo/timecard.html:44 templates/demo/timecard.tex:27
-#: templates/demo_with_images/timecard.html:44
-#: templates/demo_with_images/timecard.tex:27 templates/xedemo/timecard.html:44
-#: templates/xedemo/timecard.tex:27
-msgid "Card ID"
-msgstr ""
-
-#: UI/Reports/filters/income_statement.html:40 sql/Pg-database.sql:2850
+#: UI/Reports/custom/reports.pl:4333 UI/Reports/custom/reports.pl:4514
+#: UI/Reports/custom/reports.pl:5186 sql/Pg-database.sql:2854
 msgid "Cash"
 msgstr "Financier"
 
-#: UI/payments/payment2.html:305 UI/Reports/filters/payments.html:65
-msgid "Cash Account"
+#: UI/Reports/custom/reports.pl:128
+#, fuzzy
+msgid "Cash Accounts"
 msgstr "Compte comptant"
 
-#: UI/timecards/timecard.html:17
+#: UI/Reports/custom/reports.pl:139 UI/Reports/custom/reports.pl:187
+#, fuzzy
+msgid "Cash Accounts with Balances"
+msgstr "Compte comptant"
+
+#: UI/Reports/custom/reports.pl:172
 msgid "Category"
 msgstr "Catégorie"
 
-#: UI/io-email.html:18 UI/rp-email.html:17
+#: UI/Reports/custom/reports.pl:2444
 msgid "Cc"
 msgstr "Copie"
 
-#: bin/arap.pl:794 bin/io.pl:1443
+#: old/bin/arap.pl:792 old/bin/io.pl:1462
 msgid "Cc: [_1]"
 msgstr ""
 
-#: sql/Pg-database.sql:797
+#: sql/Pg-database.sql:811
 msgid "Cell Phone"
 msgstr "Cellulaire"
 
-#: UI/users/preferences.html:34 UI/users/preferences.html:65
-msgid "Change Password"
-msgstr "Modifier mot de passe"
-
-#: UI/timecards/timecard.html:105
-msgid "Chargeable"
+#: UI/Reports/custom/reports.pl:144 UI/Reports/custom/reports.pl:188
+msgid "Chart"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:142
+#: lib/LedgerSMB/Report/GL.pm:143
 msgid "Chart ID"
 msgstr ""
 
-#: lib/LedgerSMB/Report/COA.pm:143 sql/Pg-database.sql:2790
+#: lib/LedgerSMB/Report/COA.pm:140 sql/Pg-database.sql:2794
 msgid "Chart of Accounts"
 msgstr "Plan Comptable"
 
-#: UI/setup/select_coa.html:24
-msgid "Chart of accounts"
-msgstr ""
-
-#: sql/Pg-database.sql:2968
+#: sql/Pg-database.sql:2972
 msgid "Check"
 msgstr "Chèque"
 
-#: bin/ic.pl:2033
+#: old/bin/ic.pl:2027
 msgid "Check Inventory"
 msgstr "Listing chèques"
 
@@ -1594,104 +1260,46 @@ msgstr "Listing chèques"
 msgid "Check Prefix"
 msgstr "Préfixe"
 
-#: UI/payments/check_job.html:7
-msgid "Checking Job"
-msgstr ""
-
-#: UI/payments/check_job.html:15
-msgid "Checking Job [_1]"
-msgstr ""
-
-#: UI/payments/payment1_5.html:23
-msgid "Choose a company"
-msgstr ""
-
-#: sql/Pg-database.sql:956
+#: sql/Pg-database.sql:970
 msgid "Chord"
 msgstr ""
 
-#: bin/arap.pl:177 t/data/04-complex_template.html:386
-#: UI/Contact/divs/address.html:81 UI/Contact/divs/address.html:154
-#: UI/Reports/filters/contact_search.html:95
-#: UI/Reports/filters/purchase_history.html:78
+#: old/bin/arap.pl:175
 msgid "City"
 msgstr "Ville"
 
-#: t/data/04-complex_template.html:445
-msgid "City:"
-msgstr "Ville"
-
-#: UI/Contact/divs/company.html:75 UI/Contact/divs/credit.html:72
-#: UI/Contact/divs/person.html:67
-msgid "Class"
-msgstr ""
-
-#: lib/LedgerSMB/Scripts/recon.pm:215 UI/reconciliation/report.html:83
-#: UI/reconciliation/report.html:158
+#: lib/LedgerSMB/Scripts/recon.pm:228
 msgid "Clear date"
 msgstr ""
 
-#: UI/reconciliation/report.html:120
-msgid "Clear date is [*,_1,day] in the future"
-msgstr ""
-
-#: UI/reconciliation/report.html:126
-msgid "Clear date over [*,_1,day]"
-msgstr ""
-
-#: lib/LedgerSMB/Report/GL.pm:132 UI/rc-reconciliation.html:80
-#: UI/reconciliation/report.html:81 UI/reconciliation/report.html:156
-#: UI/reconciliation/report.html:209 UI/Reports/filters/gl.html:233
+#: lib/LedgerSMB/Report/GL.pm:133
 msgid "Cleared"
 msgstr "Lettré"
 
-#: UI/reconciliation/report.html:78
-msgid "Cleared Transactions"
-msgstr "Transactions compensées"
-
-#: UI/timecards/timecard.html:101
-msgid "Clocked"
+#: UI/Reports/custom/reports.pl:189
+msgid "Client"
 msgstr ""
 
-#: UI/accounts/yearend.html:97
-msgid "Close As-Of"
-msgstr ""
+#: UI/Reports/custom/reports.pl:159 UI/Reports/custom/reports.pl:4268
+#, fuzzy
+msgid "Client / Vendor"
+msgstr "Modifier fournisseur"
 
-#: UI/am-audit-control.html:19
-msgid "Close Books up to"
-msgstr "Clôturer l'exercice jusqu'au"
-
-#: UI/accounts/yearend.html:86 UI/accounts/yearend.html:113
-msgid "Close Period"
-msgstr ""
-
-#: UI/accounts/yearend.html:12
-msgid "Close Year"
-msgstr ""
-
-#: UI/accounts/yearend.html:92
-msgid "Close books"
-msgstr ""
-
-#: bin/aa.pl:1535 bin/oe.pl:320 lib/LedgerSMB/Report/Orders.pm:243
-#: UI/Reports/filters/invoice_search.html:212
-#: UI/Reports/filters/orders.html:101
-#: UI/Reports/filters/purchase_history.html:212
-#: UI/Reports/filters/timecards.html:36
+#: lib/LedgerSMB/Report/Orders.pm:245 old/bin/aa.pl:1517 old/bin/oe.pl:321
 msgid "Closed"
 msgstr "Clôturé"
 
-#: UI/accounts/yearend.html:15
-msgid "Closing data"
-msgstr ""
+#: UI/Reports/custom/reports.pl:173
+#, fuzzy
+msgid "Closing"
+msgstr "Clôturé"
 
-#: lib/LedgerSMB/Report/Listings/Language.pm:46
-#: lib/LedgerSMB/Report/Listings/SIC.pm:44 UI/am-language-form.html:12
-#: UI/am-sic-form.html:12
+#: lib/LedgerSMB/Report/Listings/Language.pm:47
+#: lib/LedgerSMB/Report/Listings/SIC.pm:45
 msgid "Code"
 msgstr "Code"
 
-#: bin/am.pl:375 bin/am.pl:459
+#: old/bin/am.pl:367 old/bin/am.pl:449
 msgid "Code missing!"
 msgstr "Code manquant!"
 
@@ -1699,24 +1307,21 @@ msgstr "Code manquant!"
 msgid "Cold Lead"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:111 sql/Pg-database.sql:2863
+#: lib/LedgerSMB/Scripts/order.pm:112 sql/Pg-database.sql:2867
 msgid "Combine"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:71
+#: lib/LedgerSMB/Scripts/order.pm:72
 msgid "Combine Purchase Orders"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:63
+#: lib/LedgerSMB/Scripts/order.pm:64
 msgid "Combine Sales Orders"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/Details.pm:74
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:71
-#: lib/LedgerSMB/Scripts/contact.pm:174 UI/Contact/contact.html:17
-#: UI/Contact/divs/company.html:2 UI/login.html:70
-#: UI/Reports/aging_report.html:19 UI/Reports/display_report.html:19
-#: UI/Reports/display_report.tex:24
+#: lib/LedgerSMB/Report/Taxform/Details.pm:75
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:72
+#: lib/LedgerSMB/Scripts/contact.pm:187
 msgid "Company"
 msgstr "Société"
 
@@ -1736,9 +1341,8 @@ msgstr "Information"
 msgid "Company License Number"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Payments.pm:147
+#: lib/LedgerSMB/Report/Invoices/Payments.pm:148
 #: lib/LedgerSMB/Scripts/configuration.pm:26
-#: UI/Reports/filters/purchase_history.html:23
 msgid "Company Name"
 msgstr "Nom de société"
 
@@ -1750,321 +1354,173 @@ msgstr "Téléphone"
 msgid "Company Sales Tax ID"
 msgstr ""
 
-#: UI/am-company-logo.html:7
-msgid "Company: [_1]"
-msgstr "Société: [_1]"
-
-#: UI/rp-search-generate_balance_sheet.html:17
-#: UI/rp-search-generate_income_statement.html:57
-msgid "Compare to"
-msgstr "Comparer à"
-
-#: UI/Reports/filters/balance_sheet.html:120
-#: UI/Reports/filters/income_statement.html:174
-msgid "Comparison Periods"
-msgstr ""
-
-#: UI/Reports/filters/balance_sheet.html:91
-#: UI/Reports/filters/income_statement.html:146
-msgid "Comparison selection by"
-msgstr ""
-
-#: UI/payments/check_job.html:25
-msgid "Completed Successfully"
-msgstr ""
-
-#: UI/users/preferences.html:54
-msgid "Confirm"
-msgstr "Confirmer"
-
-#: UI/setup/confirm_operation.html:10
-msgid "Confirm Operation"
-msgstr ""
-
-#: bin/am.pl:507 bin/oe.pl:1322
+#: old/bin/am.pl:462 old/bin/oe.pl:1324
 msgid "Confirm!"
 msgstr "Confirmer!"
 
-#: lib/LedgerSMB.pm:615
+#: lib/LedgerSMB.pm:440
 msgid "Conflict with Existing Data.  Perhaps you already entered this?"
 msgstr ""
 
-#: bin/io.pl:1699 templates/demo/bin_list.html:110
-#: templates/demo/packing_list.html:81 templates/demo/pick_list.html:80
-#: templates/demo/product_receipt.html:104
-#: templates/demo/product_receipt.tex:106
-#: templates/demo/purchase_order.html:105
-#: templates/demo/request_quotation.html:106
-#: templates/demo/sales_quotation.html:74
-#: templates/demo_with_images/bin_list.html:110
-#: templates/demo_with_images/packing_list.html:81
-#: templates/demo_with_images/pick_list.html:80
-#: templates/demo_with_images/product_receipt.html:104
-#: templates/demo_with_images/product_receipt.tex:106
-#: templates/demo_with_images/purchase_order.html:105
-#: templates/demo_with_images/request_quotation.html:106
-#: templates/demo_with_images/sales_quotation.html:74
-#: templates/xedemo/bin_list.html:110 templates/xedemo/packing_list.html:81
-#: templates/xedemo/pick_list.html:80 templates/xedemo/product_receipt.html:105
-#: templates/xedemo/purchase_order.html:105
-#: templates/xedemo/request_quotation.html:106
-#: templates/xedemo/sales_quotation.html:74
-#: UI/Reports/filters/contact_search.html:57 sql/Pg-database.sql:545
+#: old/bin/io.pl:1719 UI/Reports/custom/reports.pl:114
+#: UI/Reports/custom/reports.pl:190 sql/Pg-database.sql:545
 msgid "Contact"
 msgstr "Contact"
 
-#: lib/LedgerSMB/Scripts/contact.pm:181 t/data/04-complex_template.html:31
-#: UI/Contact/divs/contact_info.html:2 UI/Contact/divs/contact_info.html:29
-#: UI/Contact/divs/contact_info.html:109
-#: UI/Reports/filters/purchase_history.html:31
+#: lib/LedgerSMB/Scripts/contact.pm:194
 msgid "Contact Info"
 msgstr ""
 
-#: t/data/04-complex_template.html:495 t/data/04-complex_template.html:536
-msgid "Contact Info:"
-msgstr ""
-
-#: t/data/04-complex_template.html:491 UI/Contact/divs/contact_info.html:6
-msgid "Contact Information"
-msgstr ""
-
-#: lib/LedgerSMB/Report/Contact/Search.pm:90
-#: UI/Reports/filters/contact_search.html:8
+#: lib/LedgerSMB/Report/Contact/Search.pm:91
 msgid "Contact Search"
 msgstr ""
 
-#: UI/payments/payments_detail.html:423
-msgid "Contact Total (if paying \"some\")"
-msgstr ""
-
-#: sql/Pg-database.sql:2851
+#: sql/Pg-database.sql:2855
 msgid "Contacts"
 msgstr "Contacts"
 
-#: UI/budgetting/budget_entry.html:165 UI/budgetting/budget_entry.html:188
-msgid "Content"
-msgstr ""
-
-#: bin/aa.pl:1758 bin/arap.pl:269 bin/arapprn.pl:417 bin/ic.pl:956
-#: bin/ic.pl:1770 bin/ic.pl:2052 bin/ic.pl:2201 bin/io.pl:620 bin/io.pl:1061
-#: bin/oe.pl:1547 bin/oe.pl:2075 bin/oe.pl:2586 bin/pe.pl:330 bin/pe.pl:749
-#: bin/pe.pl:919 bin/pe.pl:1186 lib/LedgerSMB/Scripts/payment.pm:604
-#: lib/LedgerSMB/Scripts/payment.pm:671 lib/LedgerSMB/Scripts/payment.pm:1330
-#: UI/am-audit-control.html:49 UI/asset/begin_approval.html:67
-#: UI/asset/begin_depreciation_all.html:26 UI/asset/begin_report.html:61
-#: UI/Contact/divs/credit.html:401 UI/create_batch.html:52
-#: UI/inventory/adjustment_setup.html:37 UI/oe-save_warn.html:19
-#: UI/payments/payments_filter.html:186 UI/Reports/co/filter_bm.html:140
-#: UI/Reports/co/filter_cd.html:115 UI/Reports/filters/aging.html:148
-#: UI/Reports/filters/gl.html:302 UI/Reports/filters/inventory_activity.html:32
-#: UI/Reports/filters/invoice_outstanding.html:293
-#: UI/Reports/filters/invoice_search.html:383
-#: UI/Reports/filters/orders.html:203
-#: UI/Reports/filters/purchase_history.html:353
-#: UI/Reports/filters/taxforms.html:64
-#: UI/Reports/filters/trial_balance.html:133 UI/search_results.html:33
-#: UI/timecards/entry_filter.html:41
+#: lib/LedgerSMB/Scripts/payment.pm:626 lib/LedgerSMB/Scripts/payment.pm:693
+#: lib/LedgerSMB/Scripts/payment.pm:1367 old/bin/aa.pl:1740 old/bin/arap.pl:267
+#: old/bin/ic.pl:954 old/bin/ic.pl:1764 old/bin/ic.pl:2046 old/bin/ic.pl:2195
+#: old/bin/io.pl:614 old/bin/io.pl:1087 old/bin/oe.pl:1549 old/bin/oe.pl:2074
+#: old/bin/oe.pl:2570 old/bin/pe.pl:328 old/bin/pe.pl:747 old/bin/pe.pl:917
+#: old/bin/pe.pl:1184 UI/Reports/custom/reports.pl:74
+#: UI/Reports/custom/reports.pl:901 UI/Reports/custom/reports.pl:2488
+#: UI/Reports/custom/reports.pl:5263
 msgid "Continue"
 msgstr "Continuer"
 
-#: bin/ic.pl:870
+#: old/bin/ic.pl:868
 msgid "Continue Previous Workflow"
 msgstr ""
 
-#: UI/accounts/edit.html:207
-msgid "Contra"
-msgstr "Contrepartie"
+#: lib/LedgerSMB/Upgrade_Tests.pm:916
+msgid ""
+"Contrary to SQL-ledger, LedgerSMB invoices numbers must be unique. Please "
+"review suggestions to make all AP invoice numbers unique. Conflicting entries "
+"are presented by pairs, with a suffix added to the invoice number"
+msgstr ""
 
-#: bin/arap.pl:171 lib/LedgerSMB/Report/Contact/Search.pm:65
-#: lib/LedgerSMB/Report/Listings/Business_Unit.pm:56
-#: lib/LedgerSMB/Report/PNL/ECA.pm:94
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:83
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:104
-#: UI/business_units/edit.html:31 UI/business_units/filter.html:19
-#: UI/Contact/divs/company.html:52 UI/Contact/divs/person.html:47
-#: UI/payroll/income.html:63 UI/Reports/filters/contact_search.html:40
-#: UI/Reports/filters/overpayments.html:10
+#: lib/LedgerSMB/Report/Contact/Search.pm:66
+#: lib/LedgerSMB/Report/Listings/Business_Unit.pm:57
+#: lib/LedgerSMB/Report/PNL/ECA.pm:95 lib/LedgerSMB/Report/Taxform/Summary.pm:84
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:105 old/bin/arap.pl:169
 msgid "Control Code"
 msgstr ""
 
-#: UI/create_batch.html:78
-msgid "Control Number"
-msgstr "Numéro de contrôle"
-
-#: UI/io-email.html:65
+#: UI/Reports/custom/reports.pl:2385
 msgid "Copies"
 msgstr "Copies"
 
-#: UI/setup/confirm_operation.html:46
-msgid "Copy"
-msgstr "Copier"
-
-#: bin/am.pl:174 bin/am.pl:190
+#: old/bin/am.pl:170 old/bin/am.pl:186
 msgid "Copy to COA"
 msgstr "Copier dans le plan comptable"
 
-#: bin/aa.pl:944 bin/gl.pl:269 bin/ir.pl:537 bin/is.pl:578
+#: old/bin/aa.pl:932 old/bin/gl.pl:263 old/bin/ir.pl:528 old/bin/is.pl:575
 msgid "Copy to New"
 msgstr ""
 
-#: UI/setup/confirm_operation.html:39
-msgid "Copy to New Name"
-msgstr ""
-
-#: bin/ic.pl:1026 bin/ic.pl:1273 bin/oe.pl:2425
+#: lib/LedgerSMB/Report/Inventory/Activity.pm:109 old/bin/ic.pl:1024
+#: old/bin/ic.pl:1271 old/bin/oe.pl:2414
 msgid "Cost"
 msgstr "Coût"
-
-#: UI/am-department-form.html:29
-msgid "Cost Center"
-msgstr "Axé coûts"
 
 #: lib/LedgerSMB/Scripts/configuration.pm:93
 msgid "Cost of Goods Sold"
 msgstr "Coût des produits vendus"
 
-#: lib/LedgerSMB/Template/DB.pm:72 lib/LedgerSMB/Template/DB.pm:116
+#: lib/LedgerSMB/Template/DB.pm:73 lib/LedgerSMB/Template/DB.pm:117
 msgid "Could Not Load Template from DB"
 msgstr ""
 
-#: bin/ir.pl:1259 bin/is.pl:1349 bin/oe.pl:1267
+#: UI/Reports/custom/reports.pl:2177
+#, fuzzy
+msgid "Could not save reminder level!"
+msgstr "Enregistrement impossible!"
+
+#: old/bin/ir.pl:1252 old/bin/is.pl:1347 old/bin/oe.pl:1269
 msgid "Could not save the data.  Please try again"
 msgstr ""
 
-#: bin/oe.pl:2008
+#: old/bin/oe.pl:2007
 msgid "Could not save!"
 msgstr "Enregistrement impossible!"
 
-#: bin/oe.pl:2288
+#: old/bin/oe.pl:2277
 msgid "Could not transfer Inventory!"
 msgstr "Impossible de transférer l'inventaire!"
 
-#: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:93
-#: UI/inventory/adjustment_entry.html:29
+#: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:91
 msgid "Counted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Overpayments.pm:132
-#: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:69
+#: lib/LedgerSMB/Report/Listings/Overpayments.pm:133
+#: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:72
 msgid "Counterparty"
 msgstr "Contrepartie"
 
-#: lib/LedgerSMB/Report/Listings/Overpayments.pm:101
+#: lib/LedgerSMB/Report/Listings/Overpayments.pm:102
 msgid "Counterparty Code"
 msgstr ""
 
-#: bin/io.pl:1643 lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:31
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:31
-#: t/data/04-complex_template.html:389 UI/Contact/divs/address.html:84
-#: UI/Contact/divs/address.html:192 UI/Contact/divs/company.html:105
-#: UI/Contact/divs/employee.html:124 UI/Contact/divs/person.html:141
-#: UI/payroll/deduction.html:20 UI/payroll/income.html:22
-#: UI/Reports/filters/contact_search.html:110
-#: UI/Reports/filters/purchase_history.html:102
+#: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:32
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:32 old/bin/io.pl:1663
 msgid "Country"
 msgstr "Pays"
 
-#: UI/setup/select_coa.html:32
-msgid "Country Code"
-msgstr "Code de pays"
-
-#: lib/LedgerSMB/Report/Taxform/List.pm:52
+#: lib/LedgerSMB/Report/Taxform/List.pm:53
 msgid "Country Name"
 msgstr "Nom du pays"
 
-#: t/data/04-complex_template.html:477 UI/taxform/add_taxform.html:34
-msgid "Country:"
-msgstr "Pays:"
-
-#: UI/setup/credentials.html:60
-msgid "Create"
-msgstr ""
-
-#: UI/create_batch.html:2
-msgid "Create Batch"
-msgstr ""
-
-#: lib/LedgerSMB/Scripts/setup.pm:187
+#: lib/LedgerSMB/Scripts/setup.pm:212
 msgid "Create Database?"
 msgstr ""
 
-#: UI/create_batch.html:11
-msgid "Create New Batch"
-msgstr ""
-
-#: UI/reconciliation/upload.html:59
-msgid "Create New Report"
-msgstr ""
-
-#: UI/taxform/add_taxform.html:13
-msgid "Create New Tax Form"
-msgstr ""
-
-#: UI/setup/new_user.html:139
-msgid "Create User"
-msgstr ""
-
-#: UI/asset/search_reports.html:48 UI/create_batch.html:82
-#: UI/Reports/filters/unapproved.html:52
-msgid "Created By"
-msgstr ""
-
-#: UI/create_batch.html:83
-msgid "Created On"
-msgstr ""
-
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:89
-#: lib/LedgerSMB/Report/co/Caja_Diaria.pm:89 templates/demo/invoice.html:17
-#: templates/demo/invoice.tex:112 templates/demo_with_images/invoice.html:17
-#: templates/demo_with_images/invoice.tex:112 templates/xedemo/invoice.html:17
-#: templates/xedemo/invoice.tex:111 UI/budgetting/budget_entry.html:67
-#: UI/journal/journal_entry.html:116 UI/Reports/co/filter_bm.html:107
-#: UI/Reports/filters/gl.html:214 UI/Reports/filters/trial_balance.html:6
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:90
+#: lib/LedgerSMB/Report/co/Caja_Diaria.pm:90 UI/Reports/custom/reports.pl:191
+#: UI/Reports/custom/reports.pl:1999 UI/Reports/custom/reports.pl:3363
+#: UI/Reports/custom/reports.pl:5351
 msgid "Credit"
 msgstr "Crédit"
 
-#: lib/LedgerSMB/Scripts/contact.pm:301
+#: lib/LedgerSMB/Scripts/contact.pm:314
 msgid "Credit Account"
 msgstr "Compte de crédit"
 
-#: lib/LedgerSMB/Report/Contact/Search.pm:70
+#: lib/LedgerSMB/Report/Contact/Search.pm:71
 msgid "Credit Account Number"
 msgstr "Numéro de compte de crédit"
 
-#: lib/LedgerSMB/Scripts/contact.pm:179 UI/Contact/divs/credit.html:2
+#: lib/LedgerSMB/Scripts/contact.pm:192
 msgid "Credit Accounts"
 msgstr "Comptes de crédit"
 
-#: bin/am.pl:1498 sql/Pg-database.sql:2904
+#: old/bin/am.pl:1457 sql/Pg-database.sql:2908
 msgid "Credit Invoice"
 msgstr ""
 
-#: bin/aa.pl:550 bin/ir.pl:434 bin/is.pl:447 bin/oe.pl:416
-#: UI/Contact/divs/credit.html:29 UI/Contact/divs/credit.html:145
-#: UI/Contact/divs/credit.html:146 UI/orders/order.html:34
+#: old/bin/aa.pl:549 old/bin/ir.pl:425 old/bin/is.pl:444 old/bin/oe.pl:417
+#: UI/Reports/custom/reports.pl:115 UI/Reports/custom/reports.pl:192
 msgid "Credit Limit"
 msgstr "Encours autorisé"
 
-#: t/data/04-complex_template.html:201
-msgid "Credit Limit:"
-msgstr "Encours autorisé:"
-
-#: sql/Pg-database.sql:2903
+#: sql/Pg-database.sql:2907
 msgid "Credit Note"
 msgstr "Note de crédit"
 
-#: lib/LedgerSMB/Report/COA.pm:111 lib/LedgerSMB/Report/GL.pm:116
-#: lib/LedgerSMB/Report/Trial_Balance.pm:184
-#: lib/LedgerSMB/Scripts/payment.pm:158 UI/Reports/co/filter_cd.html:91
+#: lib/LedgerSMB/Report/COA.pm:113 lib/LedgerSMB/Report/GL.pm:117
+#: lib/LedgerSMB/Report/Trial_Balance.pm:185
+#: lib/LedgerSMB/Scripts/payment.pm:159
 msgid "Credits"
 msgstr ""
 
-#: UI/rc-till-closing.html:42
-msgid "Cumulative Error:"
+#: UI/Reports/custom/reports.pl:4358
+#, fuzzy
+msgid "Cumulative"
 msgstr "Erreur cumulative:"
 
-#: bin/ic.pl:1012 bin/ic.pl:1111 bin/oe.pl:2430
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:243
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:244 old/bin/ic.pl:1010
+#: old/bin/ic.pl:1109 old/bin/oe.pl:2419 UI/Reports/custom/reports.pl:4772
 msgid "Curr"
 msgstr "Dev."
 
@@ -2072,60 +1528,40 @@ msgstr "Dev."
 msgid "Currencies (colon-separated)"
 msgstr ""
 
-#: bin/aa.pl:426 bin/aa.pl:1644 bin/ir.pl:342 bin/is.pl:319 bin/oe.pl:331
-#: bin/oe.pl:1525 lib/LedgerSMB/Report/Contact/History.pm:72
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:77
-#: lib/LedgerSMB/Report/Contact/Search.pm:82
-#: lib/LedgerSMB/Report/Inventory/Search.pm:290
-#: lib/LedgerSMB/Report/Orders.pm:239 templates/demo/printPayment.html:75
-#: templates/demo_with_images/printPayment.html:75
-#: templates/xedemo/printPayment.html:75 UI/Contact/divs/credit.html:221
-#: UI/Contact/divs/credit.html:222 UI/Contact/pricelist.csv:46
-#: UI/Contact/pricelist.html:59 UI/Contact/pricelist.tex:62
-#: UI/orders/order.html:48 UI/payments/payment1.html:56
-#: UI/payments/payment2.html:131 UI/payments/payments_filter.html:123
-#: UI/payments/use_overpayment1.html:43 UI/payments/use_overpayment2.html:92
-#: UI/Reports/filters/invoice_outstanding.html:216
-#: UI/Reports/filters/invoice_search.html:306
-#: UI/Reports/filters/orders.html:187 UI/Reports/filters/overpayments.html:44
-#: UI/Reports/filters/payments.html:107
-#: UI/Reports/filters/purchase_history.html:275
-#: UI/Reports/filters/search_goods.html:360 UI/rp-aging.csv:6
-#: UI/timecards/timecard.html:121 UI/timecards/timecard-week.html:77
+#: lib/LedgerSMB/Report/Contact/History.pm:73
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:78
+#: lib/LedgerSMB/Report/Contact/Search.pm:83
+#: lib/LedgerSMB/Report/Inventory/Search.pm:291
+#: lib/LedgerSMB/Report/Orders.pm:241 old/bin/aa.pl:425 old/bin/aa.pl:1626
+#: old/bin/ir.pl:333 old/bin/is.pl:316 old/bin/oe.pl:332 old/bin/oe.pl:1527
+#: UI/Reports/custom/reports.pl:3271 UI/Reports/custom/reports.pl:5174
 msgid "Currency"
 msgstr "Devise"
 
-#: bin/aa.pl:1582 bin/pe.pl:820 lib/LedgerSMB/DBObject/Date.pm:79
-#: lib/LedgerSMB/Report/Aging.pm:126 templates/demo/statement.html:64
-#: templates/demo/statement.tex:38 templates/demo_with_images/statement.html:64
-#: templates/demo_with_images/statement.tex:38
-#: templates/xedemo/statement.html:64 templates/xedemo/statement.tex:38
-#: UI/bp-search.html:40 UI/lib/report_base.html:155 UI/lib/report_base.html:247
-#: UI/rc-reconciliation.html:40 UI/Reports/co/filter_bm.html:53
-#: UI/Reports/filters/aging.html:99
-#: UI/rp-search-generate_income_statement.html:33
-#: UI/rp-search-generate_tax_report.html:29
+#: lib/LedgerSMB/Report/Aging.pm:127 old/bin/aa.pl:1564 old/bin/pe.pl:818
+#: old/lib/LedgerSMB/DBObject/Date.pm:80 UI/Reports/custom/reports.pl:146
+#: UI/Reports/custom/reports.pl:193
 msgid "Current"
 msgstr "En cours"
 
-#: lib/LedgerSMB/Report/Balance_Sheet.pm:248
-#: lib/LedgerSMB/Report/Balance_Sheet.pm:250 lib/LedgerSMB/Report/PNL.pm:212
-#: lib/LedgerSMB/Report/PNL.pm:214 lib/LedgerSMB/Scripts/configuration.pm:84
+#: lib/LedgerSMB/Report/Balance_Sheet.pm:233
+#: lib/LedgerSMB/Report/Balance_Sheet.pm:235 lib/LedgerSMB/Report/PNL.pm:221
+#: lib/LedgerSMB/Report/PNL.pm:223 lib/LedgerSMB/Scripts/configuration.pm:84
 msgid "Current earnings"
 msgstr "Bénéfice de l'exercice"
 
-#: bin/aa.pl:513 bin/aa.pl:1594 bin/ic.pl:1124 bin/is.pl:435 bin/pe.pl:1015
-#: bin/pe.pl:1165 lib/LedgerSMB/Report/Aging.pm:83
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:178
+#: UI/Reports/custom/reports.pl:138
+#, fuzzy
+msgid "Custom Reports"
+msgstr "Client"
+
+#: lib/LedgerSMB/Report/Aging.pm:84
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:179
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:250
-#: lib/LedgerSMB/Report/Orders.pm:188 lib/LedgerSMB/Report/Orders.pm:194
-#: UI/business_units/edit.html:85 UI/Contact/divs/credit.html:14
-#: UI/Contact/divs/credit.html:15 UI/orders/order.html:21
-#: UI/payments/use_overpayment1.html:29 UI/payments/use_overpayment2.html:25
-#: UI/Reports/filters/aging.html:15
-#: UI/Reports/filters/invoice_outstanding.html:10
-#: UI/Reports/filters/invoice_search.html:10 UI/Reports/filters/orders.html:8
-#: UI/rp-search-generate_tax_report.html:139 sql/Pg-database.sql:543
+#: lib/LedgerSMB/Report/Orders.pm:190 lib/LedgerSMB/Report/Orders.pm:196
+#: old/bin/aa.pl:512 old/bin/aa.pl:1576 old/bin/ic.pl:1122 old/bin/is.pl:432
+#: old/bin/pe.pl:1013 old/bin/pe.pl:1163 UI/Reports/custom/reports.pl:145
+#: UI/Reports/custom/reports.pl:194 sql/Pg-database.sql:543
 msgid "Customer"
 msgstr "Client"
 
@@ -2133,334 +1569,191 @@ msgstr "Client"
 msgid "Customer Account"
 msgstr "Compte client"
 
-#: sql/Pg-database.sql:2788
+#: sql/Pg-database.sql:2792
 msgid "Customer History"
 msgstr "Historique client"
 
-#: UI/payments/payment1.html:36 UI/payments/payment2.html:30
-#: UI/Reports/filters/orders.html:9
-msgid "Customer Name"
-msgstr "Nom du client"
+#: UI/Reports/custom/reports.pl:129 UI/Reports/custom/reports.pl:195
+#, fuzzy
+msgid "Customer List"
+msgstr "Historique client"
 
-#: bin/aa.pl:1595 bin/io.pl:1581 lib/LedgerSMB/Report/Invoices/Payments.pm:115
-#: lib/LedgerSMB/Report/Invoices/Payments.pm:185
-#: lib/LedgerSMB/Scripts/configuration.pm:115
-#: UI/payments/payments_filter.html:66
-#: UI/Reports/filters/invoice_outstanding.html:11
-#: UI/Reports/filters/invoice_search.html:11
-#: UI/Reports/filters/overpayments.html:21 UI/Reports/filters/payments.html:21
-#: UI/Reports/filters/purchase_history.html:59
+#: lib/LedgerSMB/Report/Invoices/Payments.pm:116
+#: lib/LedgerSMB/Report/Invoices/Payments.pm:186
+#: lib/LedgerSMB/Scripts/configuration.pm:115 old/bin/aa.pl:1577
+#: old/bin/io.pl:1601 UI/Reports/custom/reports.pl:196
+#: UI/Reports/custom/reports.pl:4403
 msgid "Customer Number"
 msgstr "Numéro de client"
 
-#: UI/Reports/filters/contact_search.html:12
-msgid "Customer Search"
-msgstr "Recherche client"
-
-#: bin/aa.pl:1310 bin/is.pl:1358 bin/oe.pl:1200 bin/pe.pl:1244
+#: old/bin/aa.pl:1296 old/bin/is.pl:1356 old/bin/oe.pl:1203 old/bin/pe.pl:1242
 msgid "Customer missing!"
 msgstr "Client manquant!"
 
-#: bin/arap.pl:148 bin/pe.pl:1219
+#: lib/LedgerSMB/Upgrade_Tests.pm:670 lib/LedgerSMB/Upgrade_Tests.pm:716
+#, fuzzy
+msgid "Customer not in a business"
+msgstr "Client absent du fichier!"
+
+#: old/bin/arap.pl:146 old/bin/pe.pl:1217
 msgid "Customer not on file!"
 msgstr "Client absent du fichier!"
 
-#: UI/setup/complete.html:26 UI/setup/confirm_operation.html:113
-msgid "Customer/Vendor Accounts"
-msgstr "Comptes Clients/Fournisseurs"
-
-#: lib/LedgerSMB/App_State.pm:306
+#: lib/LedgerSMB/App_State.pm:212
 msgid "D"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:769
+#: lib/LedgerSMB/Scripts/asset.pm:772
 msgid "D M"
 msgstr ""
 
-#: UI/Contact/divs/employee.html:168
-msgid "DOB"
-msgstr "Date de naissance"
-
-#: t/data/04-complex_template.html:106
-msgid "DOB:"
-msgstr "Date de naissance:"
-
-#: bin/aa.pl:1300 lib/LedgerSMB/Scripts/payment.pm:332
+#: lib/LedgerSMB/Scripts/payment.pm:334 old/bin/aa.pl:1286
 msgid "Data not saved.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/recon.pm:144
+#: lib/LedgerSMB/Scripts/recon.pm:147
 msgid "Data not saved.  Please update again."
 msgstr ""
 
-#: UI/setup/credentials.html:48 UI/setup/list_databases.html:13
-msgid "Database"
-msgstr "Base de données"
-
-#: UI/setup/ui-db-credentials.html:6
-msgid "Database "
-msgstr ""
-
-#: UI/setup/ui-db-credentials.html:1
-msgid "Database Credentials"
-msgstr ""
-
-#: UI/am-company-logo.html:20
-msgid "Database Host"
-msgstr "Hôte de base de données"
-
-#: UI/setup/begin_backup.html:7 UI/setup/complete.html:8
-#: UI/setup/complete_migration_revert.html:8 UI/setup/confirm_operation.html:7
-#: UI/setup/credentials.html:7 UI/setup/new_user.html:7
-#: UI/setup/select_coa.html:7 UI/setup/template_info.html:7
-#: UI/setup/upgrade_info.html:7
-msgid "Database Management Console"
-msgstr ""
-
-#: UI/setup/complete.html:10 UI/setup/complete_migration_revert.html:9
-msgid "Database Operation Complete"
-msgstr ""
-
-#: lib/LedgerSMB/Scripts/setup.pm:186
+#: lib/LedgerSMB/Scripts/setup.pm:211
 msgid "Database does not exist."
 msgstr "Base de données inexistante."
 
-#: lib/LedgerSMB/Scripts/setup.pm:801
+#: lib/LedgerSMB/Scripts/setup.pm:915
 msgid "Database exists."
-msgstr ""
+msgstr "Base de données déjà inexistante."
 
-#: lib/LedgerSMB/DBH.pm:113
+#: lib/LedgerSMB/DBH.pm:103
 msgid ""
 "Database is not the expected version.  Was [_1], expected [_2].  Please re-"
 "run setup.pl against this database to correct.<a href='setup.pl'>setup.pl</a>"
 msgstr ""
 
-#: UI/am-company-logo.html:16
-msgid "Dataset"
-msgstr "Fichier de données"
-
-#: bin/aa.pl:816 bin/ir.pl:839 bin/is.pl:916 bin/oe.pl:1529 bin/pe.pl:1028
-#: lib/LedgerSMB/Report/Aging.pm:114 lib/LedgerSMB/Report/GL.pm:89
-#: lib/LedgerSMB/Report/Inventory/History.pm:142
-#: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:95
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:188
+#: lib/LedgerSMB/Report/Aging.pm:115 lib/LedgerSMB/Report/GL.pm:90
+#: lib/LedgerSMB/Report/Inventory/History.pm:143
+#: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:96
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:189
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:258
-#: lib/LedgerSMB/Report/Listings/Overpayments.pm:136
-#: lib/LedgerSMB/Report/Orders.pm:213
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:103
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:99
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:89
-#: lib/LedgerSMB/Scripts/asset.pm:532 lib/LedgerSMB/Scripts/payment.pm:154
-#: lib/LedgerSMB/Scripts/payment.pm:769 templates/demo/ap_transaction.html:73
-#: templates/demo/ap_transaction.html:192 templates/demo/ap_transaction.tex:60
-#: templates/demo/ap_transaction.tex:111 templates/demo/ar_transaction.html:72
-#: templates/demo/ar_transaction.html:191 templates/demo/ar_transaction.tex:77
-#: templates/demo/ar_transaction.tex:128 templates/demo/bin_list.html:109
-#: templates/demo/invoice.html:113 templates/demo/invoice.html:253
-#: templates/demo/invoice.tex:201 templates/demo/packing_list.html:80
-#: templates/demo/packing_list.tex:88 templates/demo/pick_list.html:79
-#: templates/demo/pick_list.tex:81 templates/demo/printPayment.html:78
-#: templates/demo/request_quotation.html:104
-#: templates/demo/sales_quotation.html:72 templates/demo/statement.html:62
-#: templates/demo/statement.tex:37 templates/demo/timecard.html:48
-#: templates/demo/timecard.tex:28
-#: templates/demo_with_images/ap_transaction.html:73
-#: templates/demo_with_images/ap_transaction.html:192
-#: templates/demo_with_images/ap_transaction.tex:60
-#: templates/demo_with_images/ap_transaction.tex:111
-#: templates/demo_with_images/ar_transaction.html:72
-#: templates/demo_with_images/ar_transaction.html:191
-#: templates/demo_with_images/ar_transaction.tex:77
-#: templates/demo_with_images/ar_transaction.tex:128
-#: templates/demo_with_images/bin_list.html:109
-#: templates/demo_with_images/invoice.html:113
-#: templates/demo_with_images/invoice.html:253
-#: templates/demo_with_images/invoice.tex:200
-#: templates/demo_with_images/packing_list.html:80
-#: templates/demo_with_images/packing_list.tex:88
-#: templates/demo_with_images/pick_list.html:79
-#: templates/demo_with_images/pick_list.tex:81
-#: templates/demo_with_images/printPayment.html:78
-#: templates/demo_with_images/request_quotation.html:104
-#: templates/demo_with_images/sales_quotation.html:72
-#: templates/demo_with_images/statement.html:62
-#: templates/demo_with_images/statement.tex:37
-#: templates/demo_with_images/timecard.html:48
-#: templates/demo_with_images/timecard.tex:28
-#: templates/xedemo/ap_transaction.html:73
-#: templates/xedemo/ap_transaction.html:192
-#: templates/xedemo/ap_transaction.tex:60
-#: templates/xedemo/ap_transaction.tex:111
-#: templates/xedemo/ar_transaction.html:72
-#: templates/xedemo/ar_transaction.html:191
-#: templates/xedemo/ar_transaction.tex:77
-#: templates/xedemo/ar_transaction.tex:128 templates/xedemo/bin_list.html:109
-#: templates/xedemo/invoice.html:113 templates/xedemo/invoice.html:253
-#: templates/xedemo/invoice.tex:200 templates/xedemo/packing_list.html:80
-#: templates/xedemo/packing_list.tex:88 templates/xedemo/pick_list.html:79
-#: templates/xedemo/pick_list.tex:81 templates/xedemo/printPayment.html:78
-#: templates/xedemo/product_receipt.html:103
-#: templates/xedemo/request_quotation.html:104
-#: templates/xedemo/sales_quotation.html:72 templates/xedemo/statement.html:62
-#: templates/xedemo/statement.tex:37 templates/xedemo/timecard.html:48
-#: templates/xedemo/timecard.tex:28 UI/asset/begin_depreciation_all.html:13
-#: UI/asset/begin_report.html:23 UI/inventory/adjustment_setup.html:19
-#: UI/journal/journal_entry.html:40 UI/orders/order.html:246
-#: UI/payments/payment2.html:99 UI/payments/payments_detail.html:321
-#: UI/payments/use_overpayment2.html:87 UI/Reports/filters/gl.html:183
-#: UI/Reports/filters/orders.html:129 UI/rp-search-generate_tax_report.html:127
+#: lib/LedgerSMB/Report/Listings/Overpayments.pm:137
+#: lib/LedgerSMB/Report/Orders.pm:215
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:104
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:100
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:91
+#: lib/LedgerSMB/Scripts/asset.pm:535 lib/LedgerSMB/Scripts/payment.pm:155
+#: lib/LedgerSMB/Scripts/payment.pm:791 old/bin/aa.pl:810 old/bin/ir.pl:830
+#: old/bin/is.pl:913 old/bin/oe.pl:1531 old/bin/pe.pl:1026
+#: UI/Reports/custom/reports.pl:197 UI/Reports/custom/reports.pl:3334
+#: UI/Reports/custom/reports.pl:4342 UI/Reports/custom/reports.pl:4559
+#: UI/Reports/custom/reports.pl:4770 UI/Reports/custom/reports.pl:5348
 msgid "Date"
 msgstr "Date"
 
-#: UI/users/preferences.html:78
-msgid "Date Format"
-msgstr "Format de date"
-
-#: bin/ic.pl:948 lib/LedgerSMB/Report/Listings/Overpayments.pm:102
-#: UI/Reports/filters/reconciliation_search.html:11
+#: lib/LedgerSMB/Report/Listings/Overpayments.pm:103 old/bin/ic.pl:946
 msgid "Date From"
 msgstr "De"
 
-#: UI/payments/payments_filter.html:106
-msgid "Date From:"
-msgstr "De:"
-
-#: bin/aa.pl:1646 lib/LedgerSMB/Report/Contact/Purchase.pm:101
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:247
-#: lib/LedgerSMB/Report/Invoices/Payments.pm:135
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:286
-#: UI/Reports/filters/invoice_outstanding.html:222
-#: UI/Reports/filters/invoice_search.html:312
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:102
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:248
+#: lib/LedgerSMB/Report/Invoices/Payments.pm:136
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:286 old/bin/aa.pl:1628
 msgid "Date Paid"
 msgstr "Date de paiement"
 
-#: bin/oe.pl:1735
+#: old/bin/oe.pl:1739
 msgid "Date Received"
 msgstr "Date de réception"
 
-#: UI/Reports/filters/payments.html:81 UI/Reports/filters/payments.html:97
-msgid "Date Reversed"
-msgstr ""
-
-#: bin/ic.pl:951 lib/LedgerSMB/Report/Listings/Overpayments.pm:103
+#: lib/LedgerSMB/Report/Listings/Overpayments.pm:104 old/bin/ic.pl:949
 msgid "Date To"
 msgstr "À"
 
-#: UI/payments/payments_filter.html:114
-msgid "Date To:"
-msgstr "À:"
-
-#: UI/timecards/timecard.html:56
-msgid "Date Worked"
-msgstr ""
-
-#: UI/payments/payment1.html:62
-msgid "Date from"
-msgstr "De"
-
-#: UI/Admin/user_search.html:51 UI/setup/new_user.html:102
-msgid "Date of Birth"
-msgstr "Date de naissance"
-
-#: bin/oe.pl:1993
+#: old/bin/oe.pl:1992
 msgid "Date received missing!"
 msgstr "Date de réception manquante!"
 
-#: bin/aa.pl:1699 UI/payments/payment1.html:73
-#: UI/Reports/filters/contact_search.html:123
+#: old/bin/aa.pl:1681
 msgid "Date to"
 msgstr "À"
 
-#: UI/payments/payment2.html:104
-msgid "Date to register payment"
-msgstr ""
-
-#: bin/arap.pl:801 bin/io.pl:1462
+#: old/bin/arap.pl:799 old/bin/io.pl:1481
 msgid "Date: [_1]"
 msgstr "Date: [_1]"
 
-#: UI/Reports/filters/balance_sheet.html:109
-#: UI/Reports/filters/income_statement.html:164
-msgid "Dates"
-msgstr ""
-
-#: bin/am.pl:804 UI/lib/report_base.html:161 UI/timecards/entry_filter.html:23
+#: old/bin/am.pl:742
 msgid "Day"
 msgstr "Jour"
 
-#: bin/arap.pl:531
+#: old/bin/arap.pl:529
 msgid "Day(s)"
 msgstr "JOur(s)"
 
-#: bin/am.pl:805 lib/LedgerSMB/App_State.pm:306
+#: lib/LedgerSMB/App_State.pm:211 old/bin/am.pl:743
 msgid "Days"
 msgstr "Jours"
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:83
-#: lib/LedgerSMB/Report/co/Caja_Diaria.pm:83 UI/budgetting/budget_entry.html:66
-#: UI/journal/journal_entry.html:115 UI/Reports/filters/gl.html:207
-#: UI/Reports/filters/trial_balance.html:5
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:84
+#: lib/LedgerSMB/Report/co/Caja_Diaria.pm:84 UI/Reports/custom/reports.pl:198
+#: UI/Reports/custom/reports.pl:1998 UI/Reports/custom/reports.pl:3362
+#: UI/Reports/custom/reports.pl:5350
 msgid "Debit"
 msgstr "Débit"
 
-#: bin/am.pl:1499 sql/Pg-database.sql:2900
+#: old/bin/am.pl:1458 sql/Pg-database.sql:2904
 msgid "Debit Invoice"
 msgstr ""
 
-#: sql/Pg-database.sql:2899
+#: sql/Pg-database.sql:2903
 msgid "Debit Note"
 msgstr "Note de débit"
 
-#: lib/LedgerSMB/Report/COA.pm:105 lib/LedgerSMB/Report/GL.pm:110
-#: lib/LedgerSMB/Report/Trial_Balance.pm:178
-#: lib/LedgerSMB/Scripts/payment.pm:157 UI/Reports/co/filter_cd.html:83
+#: lib/LedgerSMB/Report/COA.pm:106 lib/LedgerSMB/Report/GL.pm:111
+#: lib/LedgerSMB/Report/Trial_Balance.pm:179
+#: lib/LedgerSMB/Scripts/payment.pm:158
 msgid "Debits"
 msgstr "Débits"
 
-#: bin/aa.pl:97 bin/gl.pl:90 bin/io.pl:91 lib/LedgerSMB/App_State.pm:366
+#: UI/Reports/custom/reports.pl:199
+msgid "DebugData"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:200
+msgid "DebugSQL"
+msgstr ""
+
+#: lib/LedgerSMB/App_State.pm:276 old/bin/aa.pl:98 old/bin/gl.pl:91
+#: old/bin/io.pl:90 UI/Reports/custom/reports.pl:109
+#: UI/Reports/custom/reports.pl:5312
 msgid "Dec"
 msgstr "Déc."
 
-#: bin/aa.pl:83 bin/gl.pl:76 bin/io.pl:77 lib/LedgerSMB/App_State.pm:366
-#: lib/LedgerSMB/DBObject/Date.pm:73
+#: lib/LedgerSMB/App_State.pm:276 old/bin/aa.pl:84 old/bin/gl.pl:77
+#: old/bin/io.pl:76 old/lib/LedgerSMB/DBObject/Date.pm:74
+#: UI/Reports/custom/reports.pl:95 UI/Reports/custom/reports.pl:5298
 msgid "December"
 msgstr "Décembre"
-
-#: UI/rp-search-generate_balance_sheet.html:43
-#: UI/rp-search-generate_income_statement.html:93
-msgid "Decimal Places"
-msgstr "Décimales"
 
 #: lib/LedgerSMB/Scripts/configuration.pm:130
 msgid "Decimal Places for Money"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:35
-#: UI/payroll/deduction.html:33
+#: UI/Reports/custom/reports.pl:201 UI/Reports/custom/reports.pl:5228
+#, fuzzy
+msgid "Decimalplaces"
+msgstr "Décimales"
+
+#: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:36
 msgid "Deduction Class"
 msgstr ""
 
-#: UI/payroll/deduction.html:8
-msgid "Deduction Type"
-msgstr ""
-
-#: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:56
+#: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:57
 msgid "Deduction Types"
-msgstr ""
-
-#: UI/setup/upgrade_info.html:64
-msgid "Default AP"
-msgstr ""
-
-#: UI/setup/upgrade_info.html:48
-msgid "Default AR"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/configuration.pm:80
 msgid "Default Accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/configuration.pm:49 UI/setup/upgrade_info.html:35
+#: lib/LedgerSMB/Scripts/configuration.pm:49
 msgid "Default Country"
 msgstr "Pays par défaut"
 
@@ -2488,271 +1781,174 @@ msgstr "Format par défaut"
 msgid "Default Language"
 msgstr "Langue par défaut"
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:56
+#: lib/LedgerSMB/Report/Taxform/List.pm:57
 msgid "Default Reportable"
 msgstr ""
 
-#: UI/payroll/income.html:85
-msgid "Default amount"
-msgstr ""
-
-#: sql/Pg-database.sql:2837
+#: sql/Pg-database.sql:2841
 msgid "Defaults"
 msgstr "Valeurs par défaut"
 
-#: bin/aa.pl:914 bin/aa.pl:952 bin/am.pl:69 bin/am.pl:81 bin/am.pl:175
-#: bin/am.pl:184 bin/ic.pl:835 bin/ic.pl:857 bin/ir.pl:946 bin/is.pl:1028
-#: bin/oe.pl:672 bin/oe.pl:861 bin/pe.pl:174 bin/pe.pl:246 bin/pe.pl:608
-#: lib/LedgerSMB/Report/COA.pm:128 lib/LedgerSMB/Report/COA.pm:193
-#: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:122
-#: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:90
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:250
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:211
-#: lib/LedgerSMB/Scripts/account.pm:177 t/data/04-complex_template.html:510
-#: UI/business_units/list_classes.html:97 UI/Contact/divs/address.html:52
-#: UI/Contact/divs/bank_act.html:14 UI/Contact/divs/contact_info.html:11
-#: UI/Contact/pricelist.html:68 UI/reconciliation/report.html:309
+#: lib/LedgerSMB/Report/COA.pm:125 lib/LedgerSMB/Report/COA.pm:189
+#: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:120
+#: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:93
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:259
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:213
+#: lib/LedgerSMB/Scripts/account.pm:178 old/bin/aa.pl:908 old/bin/aa.pl:940
+#: old/bin/am.pl:67 old/bin/am.pl:79 old/bin/am.pl:171 old/bin/am.pl:180
+#: old/bin/ic.pl:833 old/bin/ic.pl:855 old/bin/ir.pl:939 old/bin/is.pl:1027
+#: old/bin/oe.pl:673 old/bin/oe.pl:864 old/bin/pe.pl:172 old/bin/pe.pl:244
+#: old/bin/pe.pl:606 UI/Reports/custom/reports.pl:3450
 msgid "Delete"
 msgstr "Supprimer"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:218
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:219
 msgid "Delete Batch"
 msgstr ""
 
-#: bin/am.pl:515
+#: old/bin/am.pl:470
 msgid "Delete Language"
 msgstr "Supprimer la langue"
 
-#: bin/arap.pl:633 bin/arap.pl:639
+#: old/bin/arap.pl:631 old/bin/arap.pl:637
 msgid "Delete Schedule"
 msgstr "Effacer transaction planifiée"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:224
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:225
 msgid "Delete Vouchers"
 msgstr ""
 
-#: bin/am.pl:526
+#: old/bin/am.pl:480
 msgid "Deleting a language will also delete the templates for the language [_1]"
 msgstr "Supprimer une langue effacera aussi les squelettes pour la langue [_1]"
 
-#: templates/demo/invoice.tex:136 templates/demo/request_quotation.html:144
-#: templates/demo_with_images/invoice.tex:136
-#: templates/demo_with_images/request_quotation.html:144
-#: templates/xedemo/invoice.tex:135 templates/xedemo/request_quotation.html:144
-msgid "Delivery"
-msgstr "Livraison"
-
-#: bin/io.pl:266 lib/LedgerSMB/Report/Contact/History.pm:106
-#: UI/Reports/filters/purchase_history.html:317
+#: lib/LedgerSMB/Report/Contact/History.pm:107 old/bin/io.pl:261
 msgid "Delivery Date"
 msgstr "Date de livraison"
 
-#: lib/LedgerSMB/Scripts/asset.pm:638
+#: UI/Reports/custom/reports.pl:202
+msgid "Deltas"
+msgstr ""
+
+#: lib/LedgerSMB/Scripts/asset.pm:639
 msgid "Dep. Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:636
+#: lib/LedgerSMB/Scripts/asset.pm:637
 msgid "Dep. Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:634 lib/LedgerSMB/Scripts/asset.pm:698
-#: lib/LedgerSMB/Scripts/asset.pm:766
+#: lib/LedgerSMB/Scripts/asset.pm:635 lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:769
 msgid "Dep. Starts"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:100
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:101
 msgid "Dep. Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:642
+#: lib/LedgerSMB/Scripts/asset.pm:643
 msgid "Dep. YTD"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:641
+#: lib/LedgerSMB/Scripts/asset.pm:642
 msgid "Dep. this run"
 msgstr ""
 
-#: bin/aa.pl:452 bin/ir.pl:375 bin/is.pl:348 bin/oe.pl:515
-#: UI/asset/edit_asset.html:152 UI/asset/search_asset.html:136
-#: UI/ca-list-selector.html:51 UI/payments/payment2.html:77
-#: UI/payments/payments_detail.html:123 UI/payments/payments_filter.html:52
-#: UI/rp-search.html:13
+#: old/bin/aa.pl:451 old/bin/ir.pl:366 old/bin/is.pl:345 old/bin/oe.pl:516
+#: UI/Reports/custom/reports.pl:123 UI/Reports/custom/reports.pl:203
+#: UI/Reports/custom/reports.pl:1967 UI/Reports/custom/reports.pl:3290
+#: UI/Reports/custom/reports.pl:4651 UI/Reports/custom/reports.pl:4696
+#: UI/Reports/custom/reports.pl:5112
 msgid "Department"
 msgstr "Service"
 
-#: UI/payments/payment1.html:28
-msgid "Departments"
-msgstr "Services"
-
-#: sql/Pg-database.sql:2891
+#: sql/Pg-database.sql:2895
 msgid "Depreciate"
 msgstr ""
 
-#: UI/asset/begin_depreciation_all.html:6
-msgid "Depreciate All"
-msgstr ""
-
-#: UI/asset/import_asset.html:44
-msgid "Depreciate Through"
-msgstr ""
-
-#: lib/LedgerSMB/Scripts/asset.pm:575 UI/accounts/edit.html:430
-#: sql/Pg-database.sql:2895
+#: lib/LedgerSMB/Scripts/asset.pm:578 UI/Reports/custom/reports.pl:176
+#: UI/Reports/custom/reports.pl:204 sql/Pg-database.sql:2899
 msgid "Depreciation"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset_Class.pm:77 UI/asset/edit_asset.html:171
-#: UI/asset/edit_class.html:47 UI/asset/search_asset.html:153
-#: UI/asset/search_class.html:56
+#: lib/LedgerSMB/Report/Listings/Asset_Class.pm:78
 msgid "Depreciation Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Asset_Class.pm:71
-#: lib/LedgerSMB/Report/Listings/Asset_Class.pm:93 UI/asset/edit_class.html:25
-#: UI/asset/search_class.html:21
+#: lib/LedgerSMB/Report/Listings/Asset_Class.pm:72
+#: lib/LedgerSMB/Report/Listings/Asset_Class.pm:94
 msgid "Depreciation Method"
 msgstr ""
 
-#: UI/asset/edit_asset.html:125 UI/asset/search_asset.html:109
-msgid "Depreciation Starts"
-msgstr ""
-
-#: lib/LedgerSMB/Scripts/asset.pm:79
+#: lib/LedgerSMB/Scripts/asset.pm:80
 msgid "Depreciation Successful"
 msgstr ""
 
-#: bin/aa.pl:612 bin/aa.pl:663 bin/aa.pl:1520 bin/am.pl:841 bin/ic.pl:746
-#: bin/ic.pl:1267 bin/ic.pl:2026 bin/ic.pl:2093 bin/io.pl:235 bin/io.pl:1702
-#: bin/ir.pl:479 bin/is.pl:495 bin/oe.pl:1852 bin/oe.pl:2056 bin/oe.pl:2134
-#: bin/oe.pl:2168 bin/oe.pl:2417 bin/pe.pl:311 bin/pe.pl:357 bin/pe.pl:386
-#: bin/pe.pl:1038 lib/LedgerSMB/Report/Aging.pm:109
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:76
-#: lib/LedgerSMB/Report/Budget/Search.pm:85
-#: lib/LedgerSMB/Report/Budget/Variance.pm:69
-#: lib/LedgerSMB/Report/Budget/Variance.pm:116 lib/LedgerSMB/Report/COA.pm:94
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:72
-#: lib/LedgerSMB/Report/co/Caja_Diaria.pm:73
-#: lib/LedgerSMB/Report/Contact/History.pm:83
-#: lib/LedgerSMB/Report/Contact/Search.pm:74
-#: lib/LedgerSMB/Report/File/Incoming.pm:51
-#: lib/LedgerSMB/Report/File/Internal.pm:49 lib/LedgerSMB/Report/GL.pm:100
-#: lib/LedgerSMB/Report/Inventory/Activity.pm:80
-#: lib/LedgerSMB/Report/Inventory/Activity.pm:131
-#: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:90
-#: lib/LedgerSMB/Report/Inventory/History.pm:122
-#: lib/LedgerSMB/Report/Inventory/Search.pm:198
-#: lib/LedgerSMB/Report/Listings/Asset.pm:86
-#: lib/LedgerSMB/Report/Listings/Asset.pm:120
-#: lib/LedgerSMB/Report/Listings/Business_Type.pm:47
-#: lib/LedgerSMB/Report/Listings/Business_Unit.pm:60
-#: lib/LedgerSMB/Report/Listings/GIFI.pm:49
-#: lib/LedgerSMB/Report/Listings/Language.pm:50
-#: lib/LedgerSMB/Report/Listings/SIC.pm:48
-#: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:64
-#: lib/LedgerSMB/Report/Listings/Warehouse.pm:39
-#: lib/LedgerSMB/Report/PNL/Product.pm:83 lib/LedgerSMB/Report/Timecards.pm:105
-#: lib/LedgerSMB/Report/Timecards.pm:118
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:114
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:110
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:100
-#: lib/LedgerSMB/Scripts/asset.pm:397 lib/LedgerSMB/Scripts/asset.pm:697
-#: lib/LedgerSMB/Scripts/asset.pm:765 templates/demo/bin_list.html:148
-#: templates/demo/bin_list.tex:106 templates/demo/invoice.html:142
-#: templates/demo/invoice.tex:135 templates/demo/packing_list.html:120
-#: templates/demo/packing_list.tex:114 templates/demo/pick_list.html:112
-#: templates/demo/pick_list.tex:100 templates/demo/printPayment.html:47
-#: templates/demo/product_receipt.html:128
-#: templates/demo/purchase_order.html:128
-#: templates/demo/request_quotation.html:141
-#: templates/demo/sales_order.html:130 templates/demo/sales_order.tex:119
-#: templates/demo/sales_quotation.html:99 templates/demo/timecard.html:85
-#: templates/demo/timecard.html:93 templates/demo/timecard.tex:38
-#: templates/demo/timecard.tex:40 templates/demo_with_images/bin_list.html:148
-#: templates/demo_with_images/bin_list.tex:106
-#: templates/demo_with_images/invoice.html:142
-#: templates/demo_with_images/invoice.tex:135
-#: templates/demo_with_images/packing_list.html:120
-#: templates/demo_with_images/packing_list.tex:114
-#: templates/demo_with_images/pick_list.html:112
-#: templates/demo_with_images/pick_list.tex:100
-#: templates/demo_with_images/printPayment.html:47
-#: templates/demo_with_images/product_receipt.html:128
-#: templates/demo_with_images/purchase_order.html:128
-#: templates/demo_with_images/request_quotation.html:141
-#: templates/demo_with_images/sales_order.html:130
-#: templates/demo_with_images/sales_order.tex:119
-#: templates/demo_with_images/sales_quotation.html:99
-#: templates/demo_with_images/timecard.html:85
-#: templates/demo_with_images/timecard.html:93
-#: templates/demo_with_images/timecard.tex:38
-#: templates/demo_with_images/timecard.tex:40
-#: templates/demo_with_images/work_order.html:130
-#: templates/demo_with_images/work_order.tex:125
-#: templates/demo/work_order.html:130 templates/demo/work_order.tex:125
-#: templates/xedemo/bin_list.html:148 templates/xedemo/bin_list.tex:106
-#: templates/xedemo/invoice.html:142 templates/xedemo/invoice.tex:134
-#: templates/xedemo/packing_list.html:120 templates/xedemo/packing_list.tex:114
-#: templates/xedemo/pick_list.html:112 templates/xedemo/pick_list.tex:100
-#: templates/xedemo/printPayment.html:47
-#: templates/xedemo/product_receipt.html:130
-#: templates/xedemo/purchase_order.html:128
-#: templates/xedemo/request_quotation.html:141
-#: templates/xedemo/sales_order.html:130 templates/xedemo/sales_order.tex:119
-#: templates/xedemo/sales_quotation.html:99 templates/xedemo/timecard.html:85
-#: templates/xedemo/timecard.html:93 templates/xedemo/timecard.tex:38
-#: templates/xedemo/timecard.tex:40 templates/xedemo/work_order.html:130
-#: templates/xedemo/work_order.tex:125 UI/accounts/edit.html:46
-#: UI/accounts/edit.html:131 UI/accounts/yearend.html:42
-#: UI/am-department-form.html:12 UI/am-gifi-form.html:16
-#: UI/am-language-form.html:16 UI/am-sic-form.html:20
-#: UI/am-warehouse-form.html:12 UI/budgetting/budget_entry.html:29
-#: UI/budgetting/budget_entry.html:68 UI/Contact/divs/contact_info.html:28
-#: UI/Contact/divs/contact_info.html:98 UI/Contact/divs/credit.html:28
-#: UI/Contact/divs/credit.html:86 UI/Contact/divs/credit.html:87
-#: UI/Contact/pricelist.csv:11 UI/Contact/pricelist.html:26
-#: UI/Contact/pricelist.tex:17 UI/create_batch.html:25 UI/create_batch.html:81
-#: UI/import_csv/import_csv.html:42 UI/inventory/adjustment_entry.html:28
-#: UI/io-email.html:102 UI/journal/journal_entry.html:53
-#: UI/reconciliation/report.html:86 UI/reconciliation/report.html:161
-#: UI/reconciliation/report.html:212 UI/Reports/filters/budget_search.html:31
-#: UI/Reports/filters/cogs_lines.html:19 UI/Reports/filters/gl.html:83
-#: UI/Reports/filters/gl.html:197 UI/Reports/filters/inventory_activity.html:19
-#: UI/Reports/filters/invoice_search.html:138 UI/Reports/filters/orders.html:70
-#: UI/Reports/filters/purchase_history.html:256
-#: UI/Reports/filters/search_goods.html:19
-#: UI/Reports/filters/search_goods.html:205
-#: UI/rp-search-generate_tax_report.html:150 UI/timecards/timecard.html:46
-#: UI/timecards/timecard-week.html:113 sql/Pg-database.sql:2829
-#: sql/Pg-database.sql:2834
+#: lib/LedgerSMB/Report/Aging.pm:110
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:77
+#: lib/LedgerSMB/Report/Budget/Search.pm:86
+#: lib/LedgerSMB/Report/Budget/Variance.pm:70
+#: lib/LedgerSMB/Report/Budget/Variance.pm:117 lib/LedgerSMB/Report/COA.pm:95
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:73
+#: lib/LedgerSMB/Report/co/Caja_Diaria.pm:74
+#: lib/LedgerSMB/Report/Contact/History.pm:84
+#: lib/LedgerSMB/Report/Contact/Search.pm:75
+#: lib/LedgerSMB/Report/File/Incoming.pm:52
+#: lib/LedgerSMB/Report/File/Internal.pm:50 lib/LedgerSMB/Report/GL.pm:101
+#: lib/LedgerSMB/Report/Inventory/Activity.pm:81
+#: lib/LedgerSMB/Report/Inventory/Activity.pm:147
+#: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:88
+#: lib/LedgerSMB/Report/Inventory/History.pm:123
+#: lib/LedgerSMB/Report/Inventory/Search.pm:199
+#: lib/LedgerSMB/Report/Listings/Asset.pm:87
+#: lib/LedgerSMB/Report/Listings/Asset.pm:121
+#: lib/LedgerSMB/Report/Listings/Business_Type.pm:49
+#: lib/LedgerSMB/Report/Listings/Business_Unit.pm:61
+#: lib/LedgerSMB/Report/Listings/GIFI.pm:50
+#: lib/LedgerSMB/Report/Listings/Language.pm:51
+#: lib/LedgerSMB/Report/Listings/SIC.pm:49
+#: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:67
+#: lib/LedgerSMB/Report/Listings/Warehouse.pm:40
+#: lib/LedgerSMB/Report/PNL/Product.pm:84 lib/LedgerSMB/Report/Timecards.pm:106
+#: lib/LedgerSMB/Report/Timecards.pm:119
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:115
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:111
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:102
+#: lib/LedgerSMB/Scripts/asset.pm:399 lib/LedgerSMB/Scripts/asset.pm:699
+#: lib/LedgerSMB/Scripts/asset.pm:768 old/bin/aa.pl:611 old/bin/aa.pl:662
+#: old/bin/aa.pl:1502 old/bin/am.pl:779 old/bin/ic.pl:744 old/bin/ic.pl:1265
+#: old/bin/ic.pl:2020 old/bin/ic.pl:2087 old/bin/io.pl:230 old/bin/io.pl:1722
+#: old/bin/ir.pl:470 old/bin/is.pl:492 old/bin/oe.pl:1856 old/bin/oe.pl:2055
+#: old/bin/oe.pl:2128 old/bin/oe.pl:2162 old/bin/oe.pl:2406 old/bin/pe.pl:309
+#: old/bin/pe.pl:355 old/bin/pe.pl:384 old/bin/pe.pl:1036
+#: UI/Reports/custom/reports.pl:120 UI/Reports/custom/reports.pl:205
+#: UI/Reports/custom/reports.pl:1997 UI/Reports/custom/reports.pl:3342
+#: UI/Reports/custom/reports.pl:4364 UI/Reports/custom/reports.pl:4725
+#: UI/Reports/custom/reports.pl:4769 UI/Reports/custom/reports.pl:5347
+#: sql/Pg-database.sql:2833 sql/Pg-database.sql:2838
 msgid "Description"
 msgstr "Description"
 
-#: bin/pe.pl:263
+#: old/bin/pe.pl:261
 msgid "Description Translations"
 msgstr "Description traductions"
 
-#: bin/am.pl:288 bin/am.pl:376 bin/am.pl:460 bin/am.pl:783
+#: old/bin/am.pl:282 old/bin/am.pl:368 old/bin/am.pl:450 old/bin/am.pl:727
 msgid "Description missing!"
 msgstr "Description manquante!"
 
-#: UI/asset/edit_asset.html:67 UI/asset/search_asset.html:56
-#: UI/business_units/edit.html:75 UI/business_units/filter.html:26
-#: UI/taxform/add_taxform.html:47
-msgid "Description:"
+#: UI/Reports/custom/reports.pl:206 UI/Reports/custom/reports.pl:4192
+#: UI/Reports/custom/reports.pl:5558
+msgid "Deselect all"
 msgstr ""
 
-#: bin/aa.pl:1555 bin/pe.pl:901 UI/rc-reconciliation.html:99
-#: UI/Reports/filters/aging.html:64
-#: UI/Reports/filters/purchase_history.html:231
+#: old/bin/aa.pl:1537 old/bin/pe.pl:899 UI/Reports/custom/reports.pl:77
+#: UI/Reports/custom/reports.pl:5124
 msgid "Detail"
 msgstr "Détail"
 
-#: UI/payments/payments_detail.html:218
-#: UI/Reports/filters/invoice_outstanding.html:122
-msgid "Details"
-msgstr "Détails"
-
-#: UI/rc-display-form.html:98
+#: UI/Reports/custom/reports.pl:5537
 msgid "Difference"
 msgstr "Différence"
 
@@ -2760,230 +1956,168 @@ msgstr "Différence"
 msgid "Disable Back Button"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/History.pm:102
+#: lib/LedgerSMB/Report/Contact/History.pm:103
 msgid "Disc"
 msgstr ""
 
-#: templates/demo/invoice.html:147 templates/demo/invoice.tex:140
-#: templates/demo/sales_order.html:134 templates/demo/sales_order.tex:121
-#: templates/demo/sales_quotation.html:103
-#: templates/demo_with_images/invoice.html:147
-#: templates/demo_with_images/invoice.tex:140
-#: templates/demo_with_images/sales_order.html:134
-#: templates/demo_with_images/sales_order.tex:121
-#: templates/demo_with_images/sales_quotation.html:103
-#: templates/xedemo/invoice.html:147 templates/xedemo/invoice.tex:139
-#: templates/xedemo/sales_order.html:134 templates/xedemo/sales_order.tex:121
-#: templates/xedemo/sales_quotation.html:103
-msgid "Disc %"
-msgstr ""
-
-#: bin/ic.pl:1127 lib/LedgerSMB/Scripts/payment.pm:772
-#: UI/accounts/edit.html:300 UI/accounts/edit.html:340
-#: UI/am-business-form.html:16 UI/Contact/divs/credit.html:167
-#: UI/Contact/divs/credit.html:168 UI/payments/payments_detail.html:328
-#: UI/Reports/filters/purchase_history.html:306
+#: lib/LedgerSMB/Scripts/payment.pm:794 old/bin/ic.pl:1125
 msgid "Discount"
 msgstr "Remise"
 
-#: lib/LedgerSMB/Report/Listings/Business_Type.pm:54
+#: lib/LedgerSMB/Report/Listings/Business_Type.pm:56
 msgid "Discount (%)"
 msgstr ""
 
-#: t/data/04-complex_template.html:242
-msgid "Discount:"
-msgstr ""
-
-#: lib/LedgerSMB/Scripts/asset.pm:702
+#: lib/LedgerSMB/Scripts/asset.pm:704
 msgid "Disp. Aquired Value"
 msgstr ""
 
-#: UI/templates/preview.html:63
-msgid "Display"
-msgstr ""
-
-#: lib/LedgerSMB/Scripts/asset.pm:577 sql/Pg-database.sql:2893
-#: sql/Pg-database.sql:2896
+#: lib/LedgerSMB/Scripts/asset.pm:580 sql/Pg-database.sql:2897
+#: sql/Pg-database.sql:2900
 msgid "Disposal"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:767
+#: lib/LedgerSMB/Scripts/asset.pm:770
 msgid "Disposal Date"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:401
+#: lib/LedgerSMB/Scripts/asset.pm:403
 msgid "Disposal Method"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:761
+#: lib/LedgerSMB/Scripts/asset.pm:764
 msgid "Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB.pm:612
+#: lib/LedgerSMB.pm:437
 msgid "Division by 0 error"
 msgstr ""
 
-#: bin/io.pl:1927
+#: old/bin/io.pl:1947
 msgid "Do not keep field empty [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/co/Caja_Diaria.pm:78
+#: lib/LedgerSMB/Report/co/Caja_Diaria.pm:79
 msgid "Document"
 msgstr ""
 
-#: UI/Reports/co/filter_cd.html:76
-msgid "Document Type"
-msgstr ""
-
-#: lib/LedgerSMB/Scripts/setup.pm:429
+#: lib/LedgerSMB/Scripts/setup.pm:458
 msgid "Don't know what to do with backup"
 msgstr ""
 
-#: bin/oe.pl:1949 bin/oe.pl:1957
+#: old/bin/oe.pl:1953 old/bin/oe.pl:1961 UI/Reports/custom/reports.pl:5559
 msgid "Done"
 msgstr "Fait!"
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:602
+#: lib/LedgerSMB/Upgrade_Tests.pm:797
 msgid "Double customernumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:637
+#: lib/LedgerSMB/Upgrade_Tests.pm:832
 msgid "Double vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Entity/Person.pm:104 sql/Pg-database.sql:723
+#: lib/LedgerSMB/Entity/Person.pm:105 sql/Pg-database.sql:737
 msgid "Dr."
 msgstr ""
 
-#: bin/aa.pl:1168 bin/aa.pl:1434 bin/gl.pl:122 bin/ir.pl:98
+#: old/bin/aa.pl:1153 old/bin/aa.pl:1416 old/bin/gl.pl:114 old/bin/ir.pl:89
 msgid "Draft Posted"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:121
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:123
 msgid "Draft Search"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:132
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:134
 msgid "Draft Type"
 msgstr ""
 
-#: sql/Pg-database.sql:2870
+#: sql/Pg-database.sql:2874
 msgid "Drafts"
 msgstr ""
 
-#: bin/ic.pl:509 lib/LedgerSMB/Report/Inventory/Search.pm:262
-#: UI/Reports/filters/search_goods.html:65
-#: UI/Reports/filters/search_goods.html:324
+#: lib/LedgerSMB/Report/Inventory/Search.pm:263 old/bin/ic.pl:507
 msgid "Drawing"
 msgstr "Dessin"
 
-#: lib/LedgerSMB/Report/COA.pm:117
+#: lib/LedgerSMB/Report/COA.pm:120
 msgid "Dropdowns"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:97
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:98
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:283
-#: templates/demo/ap_transaction.html:77 templates/demo/ap_transaction.tex:61
-#: templates/demo/ar_transaction.html:76 templates/demo/ar_transaction.tex:78
-#: templates/demo/invoice.html:114 templates/demo/invoice.tex:119
-#: templates/demo/receipt.tex:64 templates/demo/statement.html:63
-#: templates/demo_with_images/ap_transaction.html:77
-#: templates/demo_with_images/ap_transaction.tex:61
-#: templates/demo_with_images/ar_transaction.html:76
-#: templates/demo_with_images/ar_transaction.tex:78
-#: templates/demo_with_images/invoice.html:114
-#: templates/demo_with_images/invoice.tex:119
-#: templates/demo_with_images/receipt.tex:64
-#: templates/demo_with_images/statement.html:63
-#: templates/xedemo/ap_transaction.html:77
-#: templates/xedemo/ap_transaction.tex:61
-#: templates/xedemo/ar_transaction.html:76
-#: templates/xedemo/ar_transaction.tex:78 templates/xedemo/invoice.html:114
-#: templates/xedemo/invoice.tex:118 templates/xedemo/receipt.tex:64
-#: templates/xedemo/statement.html:63
 msgid "Due"
 msgstr ""
 
-#: bin/aa.pl:640 bin/aa.pl:1653 bin/ir.pl:507 bin/is.pl:533
-#: lib/LedgerSMB/Report/Aging.pm:119
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:105
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:251
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:289 UI/orders/order.html:96
-#: UI/Reports/filters/invoice_outstanding.html:237
-#: UI/Reports/filters/invoice_search.html:327
+#: lib/LedgerSMB/Report/Aging.pm:120
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:106
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:252
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:289 old/bin/aa.pl:639
+#: old/bin/aa.pl:1635 old/bin/ir.pl:498 old/bin/is.pl:530
 msgid "Due Date"
 msgstr "Échéance"
 
-#: bin/aa.pl:1315
+#: old/bin/aa.pl:1301
 msgid "Due Date missing!"
 msgstr "Date d'échéance manquante!"
 
-#: UI/Contact/divs/user.html:10 UI/setup/edit_user.html:11
-msgid "Duplicate User Found: Importing User"
-msgstr ""
-
-#: lib/LedgerSMB/Upgrade_Tests.pm:251
+#: lib/LedgerSMB/Upgrade_Tests.pm:313
 msgid "Duplicate employee numbers"
 msgstr ""
 
-#: bin/am.pl:854 bin/arap.pl:411 bin/is.pl:586 bin/is.pl:1027 bin/oe.pl:637
-#: bin/oe.pl:860 bin/oe.pl:1956 UI/io-email.html:16
-#: UI/Reports/filters/contact_search.html:49 UI/rp-email.html:15
+#: old/bin/am.pl:792 old/bin/arap.pl:409 old/bin/is.pl:583 old/bin/is.pl:1026
+#: old/bin/oe.pl:638 old/bin/oe.pl:863 old/bin/oe.pl:1960
+#: UI/Reports/custom/reports.pl:2442 UI/Reports/custom/reports.pl:4194
 msgid "E-mail"
 msgstr "E-mail"
 
-#: UI/rp-email.html:8
-msgid "E-mail Statement to [_1]"
+#: UI/Reports/custom/reports.pl:2426
+#, fuzzy
+msgid "E-mail Statement to"
 msgstr "Message éléctronique à [_1]"
 
-#: UI/io-email.html:7
-msgid "E-mail [_1]"
-msgstr "E-mail [_1]"
-
-#: bin/am.pl:1467 bin/io.pl:1256
+#: old/bin/am.pl:1426 old/bin/io.pl:1276 UI/Reports/custom/reports.pl:2500
 msgid "E-mail address missing!"
 msgstr "Adresse e-mail manquante!"
 
-#: bin/arap.pl:453
+#: old/bin/arap.pl:451
 msgid "E-mail message"
 msgstr "Message e-mail"
 
-#: bin/printer.pl:174
+#: old/bin/printer.pl:174
 msgid "E-mailed"
 msgstr "E-mail envoyé"
 
-#: lib/LedgerSMB/Report/PNL/ECA.pm:81
+#: lib/LedgerSMB/Report/PNL/ECA.pm:82
 msgid "ECA Income Statement"
 msgstr ""
 
-#: sql/Pg-database.sql:815
+#: sql/Pg-database.sql:829
 msgid "EDI ID"
 msgstr ""
 
-#: sql/Pg-database.sql:814
+#: sql/Pg-database.sql:828
 msgid "EDI Interchange ID"
 msgstr ""
 
-#: bin/aa.pl:150 bin/arapprn.pl:66 lib/LedgerSMB/Report/COA.pm:122
-#: lib/LedgerSMB/Report/COA.pm:192 t/data/04-complex_template.html:506
-#: UI/Contact/divs/address.html:51 UI/Contact/divs/contact_info.html:10
-#: UI/templates/preview.html:69
+#: old/bin/aa.pl:150 old/bin/arapprn.pl:64
 msgid "Edit"
 msgstr "Modifier"
 
-#: bin/aa.pl:377 bin/aa.pl:415
+#: old/bin/aa.pl:376 old/bin/aa.pl:414
 msgid "Edit AP Transaction"
 msgstr "Modifier une dépense"
 
-#: bin/aa.pl:376
+#: old/bin/aa.pl:375
 msgid "Edit AR Transaction"
 msgstr "Modifier une recette"
 
-#: lib/LedgerSMB/Scripts/account.pm:70
+#: lib/LedgerSMB/Scripts/account.pm:71
 msgid "Edit Account"
 msgstr "Modifier le compte"
 
-#: bin/ic.pl:98 bin/ic.pl:720
+#: old/bin/ic.pl:96 old/bin/ic.pl:718
 msgid "Edit Assembly"
 msgstr "Modifier produit fini / transformé"
 
@@ -2991,624 +2125,432 @@ msgstr "Modifier produit fini / transformé"
 msgid "Edit Asset Class"
 msgstr ""
 
-#: bin/am.pl:274
+#: old/bin/am.pl:268
 msgid "Edit Business"
 msgstr "Modifier type d'affaire"
 
-#: bin/is.pl:132
+#: old/bin/is.pl:129
 msgid "Edit Credit Invoice"
 msgstr ""
 
-#: bin/aa.pl:413
+#: old/bin/aa.pl:412
 msgid "Edit Credit Note"
 msgstr ""
 
-#: t/data/04-complex_template.html:17 UI/Contact/contact.html:32
-msgid "Edit Customer"
-msgstr "Modifier client"
-
-#: bin/is.pl:129
+#: old/bin/is.pl:126
 msgid "Edit Customer Return"
 msgstr ""
 
-#: bin/aa.pl:411
+#: old/bin/aa.pl:410
 msgid "Edit Debit Note"
 msgstr ""
 
-#: bin/pe.pl:510
+#: old/bin/pe.pl:508
 msgid "Edit Description Translations"
 msgstr "Modifier traductions description"
 
-#: t/data/04-complex_template.html:21 UI/Contact/contact.html:36
-msgid "Edit Employee"
-msgstr "Modifier employé"
-
-#: bin/am.pl:157
+#: old/bin/am.pl:153
 msgid "Edit GIFI"
 msgstr "Modifier code d'identification comptable ou fiscale"
 
-#: bin/pe.pl:107
+#: UI/Reports/custom/reports.pl:3100
+#, fuzzy
+msgid "Edit General Ledger Transaction"
+msgstr "Modifier une dépense"
+
+#: old/bin/pe.pl:105
 msgid "Edit Group"
 msgstr "Modifier groupe"
 
-#: bin/ic.pl:99
+#: old/bin/ic.pl:97
 msgid "Edit Labor/Overhead"
 msgstr "Modifier coût de production"
 
-#: bin/am.pl:448
+#: old/bin/am.pl:438
 msgid "Edit Language"
 msgstr "Modifier langue"
 
-#: bin/ic.pl:96 bin/ic.pl:718
+#: old/bin/ic.pl:94 old/bin/ic.pl:716
 msgid "Edit Part"
 msgstr "Modifier marchandise"
 
-#: bin/pe.pl:192
+#: old/bin/pe.pl:190
 msgid "Edit Pricegroup"
 msgstr "Modifier groupe de prix"
 
-#: bin/oe.pl:95
+#: old/bin/oe.pl:93
 msgid "Edit Purchase Order"
 msgstr "Modifier commande d'achat"
 
-#: bin/oe.pl:109
+#: old/bin/oe.pl:107
 msgid "Edit Quotation"
 msgstr "Modifier devis"
 
-#: UI/business_units/edit.html:14
-msgid "Edit Reporting Unit"
-msgstr ""
-
-#: bin/oe.pl:105
+#: old/bin/oe.pl:103
 msgid "Edit Request for Quotation"
 msgstr "Modifier demande de devis"
 
-#: bin/am.pl:360
+#: old/bin/am.pl:352
 msgid "Edit SIC"
 msgstr "Modifier code de secteur économique"
 
-#: bin/is.pl:135
+#: old/bin/is.pl:132
 msgid "Edit Sales Invoice"
 msgstr "Modifier facture de vente"
 
-#: bin/oe.pl:100
+#: old/bin/oe.pl:98
 msgid "Edit Sales Order"
 msgstr "Modifier commande de vente"
 
-#: bin/ic.pl:97 bin/ic.pl:719
+#: old/bin/ic.pl:95 old/bin/ic.pl:717
 msgid "Edit Service"
 msgstr "Modifier service"
 
-#: UI/taxform/add_taxform.html:11
-msgid "Edit Tax Form"
-msgstr ""
-
-#: UI/Contact/divs/employee.html:214
-msgid "Edit User"
-msgstr "Modifier utilisateur"
-
-#: t/data/04-complex_template.html:19 UI/Contact/contact.html:34
-msgid "Edit Vendor"
-msgstr "Modifier fournisseur"
-
-#: bin/ir.pl:147
+#: old/bin/ir.pl:141
 msgid "Edit Vendor Invoice"
 msgstr "Modifier facture de fournisseur"
 
-#: bin/ir.pl:141
+#: old/bin/ir.pl:135
 msgid "Edit Vendor Return"
 msgstr ""
 
-#: bin/am.pl:769
+#: old/bin/am.pl:713
 msgid "Edit Warehouse"
 msgstr "Modifier entrepôt"
 
-#: UI/Contact/divs/user.html:13 UI/setup/edit_user.html:14
-msgid "Editing User"
-msgstr ""
-
-#: lib/LedgerSMB/Num2text.pm:82
+#: old/lib/LedgerSMB/Num2text.pm:82
 msgid "Eight"
 msgstr "Huit"
 
-#: lib/LedgerSMB/Num2text.pm:93
+#: old/lib/LedgerSMB/Num2text.pm:93
 msgid "Eighteen"
 msgstr "Dix-huit"
 
-#: lib/LedgerSMB/Num2text.pm:111
+#: old/lib/LedgerSMB/Num2text.pm:111
 msgid "Eighty"
 msgstr "Quatre-vingt"
 
-#: lib/LedgerSMB/Num2text.pm:85
+#: old/lib/LedgerSMB/Num2text.pm:85
 msgid "Eleven"
 msgstr "Onze"
 
-#: lib/LedgerSMB/Num2text.pm:86
+#: old/lib/LedgerSMB/Num2text.pm:86
 msgid "Eleven-o"
 msgstr ""
 
-#: UI/Reports/aging_report.html:70 sql/Pg-database.sql:808
+#: sql/Pg-database.sql:822
 msgid "Email"
 msgstr ""
 
-#: bin/aa.pl:478 bin/aa.pl:1480 bin/oe.pl:539 bin/pe.pl:865
-#: lib/LedgerSMB/Report/Orders.pm:263 lib/LedgerSMB/Scripts/contact.pm:176
-#: templates/demo/ap_transaction.html:93 templates/demo/ap_transaction.tex:68
-#: templates/demo/ar_transaction.tex:85 templates/demo/timecard.html:31
-#: templates/demo/timecard.tex:22
-#: templates/demo_with_images/ap_transaction.html:93
-#: templates/demo_with_images/ap_transaction.tex:68
-#: templates/demo_with_images/ar_transaction.tex:85
-#: templates/demo_with_images/timecard.html:31
-#: templates/demo_with_images/timecard.tex:22
-#: templates/xedemo/ap_transaction.html:93
-#: templates/xedemo/ap_transaction.tex:68
-#: templates/xedemo/ar_transaction.tex:85 templates/xedemo/timecard.html:31
-#: templates/xedemo/timecard.tex:22 UI/Contact/divs/employee.html:2
-#: UI/Reports/filters/contact_search.html:65 UI/timecards/entry_filter.html:13
-#: sql/Pg-database.sql:544
+#: lib/LedgerSMB/Report/Orders.pm:265 lib/LedgerSMB/Scripts/contact.pm:189
+#: old/bin/aa.pl:477 old/bin/aa.pl:1462 old/bin/oe.pl:540 old/bin/pe.pl:863
+#: UI/Reports/custom/reports.pl:4776 sql/Pg-database.sql:544
 msgid "Employee"
 msgstr "Employé"
 
 #: lib/LedgerSMB/Scripts/configuration.pm:114
-#: t/data/04-complex_template.html:92 UI/Contact/divs/employee.html:132
-#: UI/setup/new_user.html:92
 msgid "Employee Number"
 msgstr "Numéro d'employé"
 
-#: UI/Reports/filters/contact_search.html:14
-msgid "Employee Search"
+#: UI/Reports/custom/reports.pl:1566
+msgid "Employee contribution"
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:233
+#: lib/LedgerSMB/Upgrade_Tests.pm:295
 msgid ""
 "Employee name doesn't meet minimal requirements (e.g. non-empty, alphanumeric)"
 msgstr ""
 
-#: UI/lib/report_base.html:314 sql/Pg-database.sql:2807
+#: sql/Pg-database.sql:2811
 msgid "Employees"
 msgstr "Employés"
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:449
+#: UI/Reports/custom/reports.pl:1567
+msgid "Employer contribution"
+msgstr ""
+
+#: lib/LedgerSMB/Upgrade_Tests.pm:512
 msgid "Empty AP account"
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:438
+#: lib/LedgerSMB/Upgrade_Tests.pm:501
 msgid "Empty AR account"
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:524
+#: lib/LedgerSMB/Upgrade_Tests.pm:610
+#, fuzzy
+msgid "Empty businesses"
+msgstr "Liste types d'affaire"
+
+#: lib/LedgerSMB/Upgrade_Tests.pm:587
 msgid "Empty customernumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:618
+#: lib/LedgerSMB/Upgrade_Tests.pm:813
 msgid "Empty vendornumbers"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:75
-#: lib/LedgerSMB/Report/Budget/Search.pm:122
-#: lib/LedgerSMB/Report/Budget/Variance.pm:120
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:133
-#: lib/LedgerSMB/Report/co/Caja_Diaria.pm:127
-#: lib/LedgerSMB/Report/Contact/History.pm:146 lib/LedgerSMB/Report/GL.pm:209
-#: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:79
+#: lib/LedgerSMB/Report/Budget/Search.pm:76
+#: lib/LedgerSMB/Report/Budget/Search.pm:123
+#: lib/LedgerSMB/Report/Budget/Variance.pm:121
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:136
+#: lib/LedgerSMB/Report/co/Caja_Diaria.pm:128
+#: lib/LedgerSMB/Report/Contact/History.pm:147 lib/LedgerSMB/Report/GL.pm:210
+#: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:80
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:157
-#: lib/LedgerSMB/Report/Listings/Business_Unit.pm:68
-#: UI/budgetting/budget_entry.html:51 UI/business_units/edit.html:67
-#: UI/Contact/divs/credit.html:31 UI/Contact/divs/credit.html:122
-#: UI/Contact/divs/credit.html:123 UI/Contact/divs/employee.html:191
-#: UI/Reports/filters/budget_search.html:54
+#: lib/LedgerSMB/Report/Listings/Business_Unit.pm:69
 msgid "End Date"
 msgstr ""
 
-#: t/data/04-complex_template.html:122 t/data/04-complex_template.html:188
-msgid "End Date:"
-msgstr ""
-
-#: UI/Reports/filters/trial_balance.html:11
+#: UI/Reports/custom/reports.pl:207
 msgid "Ending"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Trial_Balance.pm:190
+#: lib/LedgerSMB/Report/Trial_Balance.pm:191 UI/Reports/custom/reports.pl:2001
 msgid "Ending Balance"
 msgstr ""
 
-#: UI/reconciliation/report.html:56
-msgid "Ending GL Balance:"
-msgstr ""
-
-#: UI/reconciliation/report.html:30 UI/reconciliation/report.html:48
-msgid "Ending Statement Balance:"
-msgstr ""
-
-#: bin/am.pl:847
+#: old/bin/am.pl:785
 msgid "Ends"
 msgstr "Se termine"
 
-#: UI/am-audit-control.html:12
-msgid "Enforce transaction reversal for all dates"
-msgstr "Activer la clôture des écritures pour toutes les dates"
-
-#: UI/inventory/adjustment_entry.html:11 sql/Pg-database.sql:2784
+#: sql/Pg-database.sql:2788
 msgid "Enter Inventory"
 msgstr ""
 
-#: UI/setup/new_user.html:8
-msgid "Enter User"
-msgstr ""
-
-#: UI/Reports/filters/balance_sheet.html:140
-#: UI/Reports/filters/income_statement.html:211
-msgid "Enter date ranges for comparison"
-msgstr ""
-
-#: lib/LedgerSMB/Upgrade_Tests.pm:219
+#: lib/LedgerSMB/Upgrade_Tests.pm:281
 msgid "Enter employee numbers where they are missing"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:89
-#: lib/LedgerSMB/Report/Reconciliation/Summary.pm:152
+#: lib/LedgerSMB/Report/Budget/Search.pm:90
+#: lib/LedgerSMB/Report/Reconciliation/Summary.pm:153
 msgid "Entered By"
 msgstr ""
 
-#: UI/timecards/timecard.html:21
-msgid "Entered For"
-msgstr ""
-
-#: lib/LedgerSMB/Scripts/asset.pm:535
+#: lib/LedgerSMB/Scripts/asset.pm:538
 msgid "Entered at"
 msgstr ""
 
-#: t/data/04-complex_template.html:629 UI/Contact/divs/notes.html:78
-msgid "Entered at: [_1]"
-msgstr ""
-
-#: lib/LedgerSMB/Scripts/contact.pm:299 sql/Pg-database.sql:1054
+#: lib/LedgerSMB/Scripts/contact.pm:312 sql/Pg-database.sql:1068
 msgid "Entity"
 msgstr ""
 
-#: UI/lib/report_base.html:41
-msgid "Entity Class"
-msgstr ""
-
-#: bin/ir.pl:451 bin/is.pl:464 bin/oe.pl:433
+#: old/bin/ir.pl:442 old/bin/is.pl:461 old/bin/oe.pl:434
 msgid "Entity Code"
 msgstr ""
 
-#: bin/aa.pl:588
+#: old/bin/aa.pl:587
 msgid "Entity Control Code"
 msgstr ""
 
-#: sql/Pg-database.sql:1056
+#: sql/Pg-database.sql:1070
 msgid "Entity Credit Account"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:105
+#: UI/Reports/custom/reports.pl:4357
+msgid "Entries"
+msgstr ""
+
+#: lib/LedgerSMB/Report/GL.pm:106
 msgid "Entry ID"
 msgstr ""
 
-#: bin/is.pl:1003 bin/printer.pl:107
+#: old/bin/is.pl:1000 old/bin/printer.pl:107
 msgid "Envelope"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Balance_Sheet.pm:239
-#: lib/LedgerSMB/Report/Balance_Sheet.pm:241 lib/LedgerSMB/Report/PNL.pm:204
-#: lib/LedgerSMB/Report/PNL.pm:206 UI/accounts/edit.html:185
-#: UI/Reports/filters/gl.html:150
+#: lib/LedgerSMB/Report/Balance_Sheet.pm:224
+#: lib/LedgerSMB/Report/Balance_Sheet.pm:226 lib/LedgerSMB/Report/PNL.pm:213
+#: lib/LedgerSMB/Report/PNL.pm:215 UI/Reports/custom/reports.pl:168
 msgid "Equity"
 msgstr "Capital"
 
-#: lib/LedgerSMB/Report/Balance_Sheet.pm:221
-#: lib/LedgerSMB/Report/Balance_Sheet.pm:223
+#: lib/LedgerSMB/Report/Balance_Sheet.pm:206
+#: lib/LedgerSMB/Report/Balance_Sheet.pm:208
 msgid "Equity & Liabilities"
 msgstr ""
 
-#: UI/accounts/edit.html:186
-msgid "Equity (Temporary)"
-msgstr ""
-
-#: UI/Reports/balance_sheet.html:108
-msgid "Equity to Liabilities"
-msgstr ""
-
-#: lib/LedgerSMB/Scripts/setup.pm:386
+#: lib/LedgerSMB/Scripts/setup.pm:417
 msgid "Error creating backup file"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/vouchers.pm:94
+#: lib/LedgerSMB/Scripts/vouchers.pm:106
 msgid "Error creating batch.  Please try again."
 msgstr ""
 
-#: lib/LedgerSMB.pm:616
+#: lib/LedgerSMB.pm:441
 msgid "Error from Function:"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:473
+#: lib/LedgerSMB/Scripts/setup.pm:502
 msgid "Error while opening directory: [_1]"
 msgstr ""
 
-#: UI/payments/check_job.html:31
-msgid "Error:"
-msgstr ""
-
-#: lib/LedgerSMB/DBObject/Account.pm:90
+#: old/lib/LedgerSMB/DBObject/Account.pm:91
 msgid "Error: Cannot include summary account in other dropdown menus"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:637
+#: lib/LedgerSMB/Scripts/asset.pm:638
 msgid "Est. Life"
 msgstr ""
 
-#: bin/am.pl:852 bin/arap.pl:554
+#: old/bin/am.pl:790 old/bin/arap.pl:552
 msgid "Every"
 msgstr "Chaque"
 
-#: bin/aa.pl:818 bin/ir.pl:841 bin/is.pl:918 UI/orders/order.html:251
+#: old/bin/aa.pl:812 old/bin/ir.pl:832 old/bin/is.pl:915
 msgid "Exch"
 msgstr "Change"
 
-#: bin/aa.pl:434 bin/ir.pl:351 bin/is.pl:328 bin/oe.pl:341 bin/oe.pl:349
-#: bin/oe.pl:1533 lib/LedgerSMB/Report/Contact/History.pm:116
-#: lib/LedgerSMB/Scripts/payment.pm:780 UI/orders/order.html:54
-#: UI/payments/payment2.html:139 UI/payments/payments_detail.html:146
-#: UI/payments/payments_detail.html:155 UI/payments/use_overpayment2.html:100
-#: UI/Reports/filters/overpayments.html:51 UI/Reports/filters/payments.html:110
+#: lib/LedgerSMB/Report/Contact/History.pm:117
+#: lib/LedgerSMB/Scripts/payment.pm:802 old/bin/aa.pl:433 old/bin/ir.pl:342
+#: old/bin/is.pl:325 old/bin/oe.pl:342 old/bin/oe.pl:350 old/bin/oe.pl:1535
+#: UI/Reports/custom/reports.pl:3283
 msgid "Exchange Rate"
 msgstr "Taux de change"
 
-#: bin/aa.pl:1349 bin/ir.pl:1303 bin/is.pl:1392
+#: old/bin/aa.pl:1335 old/bin/ir.pl:1296 old/bin/is.pl:1390
 msgid "Exchange rate for payment missing!"
 msgstr "Taux de change manquant pour le paiement!"
 
-#: lib/LedgerSMB/Scripts/payment.pm:1086
+#: lib/LedgerSMB/Scripts/payment.pm:1113
 msgid "Exchange rate hasn't been defined!"
 msgstr ""
 
-#: lib/LedgerSMB/DBObject/Payment.pm:750
+#: old/lib/LedgerSMB/DBObject/Payment.pm:752
 msgid "Exchange rate inconsistency with database.  Got [_1], expected [_2]"
 msgstr ""
 
-#: bin/aa.pl:1331 bin/ir.pl:1284 bin/is.pl:1373 bin/oe.pl:1204 bin/oe.pl:1560
+#: old/bin/aa.pl:1317 old/bin/ir.pl:1277 old/bin/is.pl:1371 old/bin/oe.pl:1207
+#: old/bin/oe.pl:1562
 msgid "Exchange rate missing!"
 msgstr "Taux de change manquant!"
 
-#: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:96
+#: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:94
 msgid "Expected"
 msgstr ""
 
-#: bin/ic.pl:663 UI/accounts/edit.html:188 UI/accounts/edit.html:400
-#: UI/accounts/edit.html:439 UI/Reports/filters/gl.html:164
+#: old/bin/ic.pl:661 UI/Reports/custom/reports.pl:170
 msgid "Expense"
 msgstr "Dépenses"
 
-#: UI/asset/edit_asset.html:191
-msgid "Expense Account"
-msgstr ""
-
-#: UI/accounts/edit.html:313
-msgid "Expense/Asset"
-msgstr "Dépenses/actif"
-
-#: lib/LedgerSMB/Report/Balance_Sheet.pm:198
-#: lib/LedgerSMB/Report/Balance_Sheet.pm:200 lib/LedgerSMB/Report/PNL.pm:175
-#: lib/LedgerSMB/Report/PNL.pm:177
+#: lib/LedgerSMB/Report/Balance_Sheet.pm:183
+#: lib/LedgerSMB/Report/Balance_Sheet.pm:185 lib/LedgerSMB/Report/PNL.pm:184
+#: lib/LedgerSMB/Report/PNL.pm:186
 msgid "Expenses"
 msgstr ""
 
-#: bin/io.pl:245 templates/demo/invoice.html:148
-#: templates/demo/request_quotation.html:146
-#: templates/demo_with_images/invoice.html:148
-#: templates/demo_with_images/request_quotation.html:146
-#: templates/xedemo/invoice.html:148
-#: templates/xedemo/request_quotation.html:146
+#: UI/Reports/custom/reports.pl:253 UI/Reports/custom/reports.pl:383
+#: UI/Reports/custom/reports.pl:2801
+#, fuzzy
+msgid "Expenses account"
+msgstr "Dépenses/actif"
+
+#: UI/Reports/custom/reports.pl:178 UI/Reports/custom/reports.pl:208
+msgid "Expenses per employee"
+msgstr ""
+
+#: old/bin/io.pl:240
 msgid "Extended"
 msgstr "Prix total"
 
-#: UI/timecards/timecard-week.html:107
-msgid "Extra Used"
+#: UI/Reports/custom/reports.pl:80
+msgid "FPZ-34/VDZ-471"
 msgstr ""
 
-#: UI/budgetting/budget_entry.html:64 UI/journal/journal_entry.html:114
+#: UI/Reports/custom/reports.pl:81
+msgid "FPZ-34/VDZ-471 Courtesy"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:3298
 msgid "FX"
 msgstr "Devises"
 
-#: bin/pe.pl:1312
+#: UI/Reports/custom/reports.pl:4018 UI/Reports/custom/reports.pl:4343
+msgid "FY"
+msgstr ""
+
+#: old/bin/pe.pl:1310
 msgid "Failed to save order!"
 msgstr ""
 
-#: sql/Pg-database.sql:803
+#: sql/Pg-database.sql:817
 msgid "Fax"
 msgstr "Fax"
 
-#: templates/demo/ar_transaction.html:53 templates/demo/ar_transaction.tex:27
-#: templates/demo/letterhead.tex:14
-#: templates/demo_with_images/ar_transaction.html:53
-#: templates/demo_with_images/ar_transaction.tex:27
-#: templates/demo_with_images/letterhead.tex:14
-#: templates/xedemo/ar_transaction.html:53
-#: templates/xedemo/ar_transaction.tex:27 templates/xedemo/letterhead.tex:14
-msgid "Fax:"
-msgstr ""
-
-#: templates/demo/ap_transaction.html:54 templates/demo/ar_transaction.tex:65
-#: templates/demo/bin_list.html:59 templates/demo/bin_list.html:92
-#: templates/demo/invoice.html:59 templates/demo/invoice.html:92
-#: templates/demo/letterhead.html:22 templates/demo/packing_list.html:60
-#: templates/demo/pick_list.html:59 templates/demo/product_receipt.html:58
-#: templates/demo/product_receipt.html:86 templates/demo/product_receipt.tex:56
-#: templates/demo/product_receipt.tex:91 templates/demo/purchase_order.html:58
-#: templates/demo/purchase_order.html:86 templates/demo/purchase_order.tex:56
-#: templates/demo/purchase_order.tex:91
-#: templates/demo/request_quotation.html:59
-#: templates/demo/request_quotation.html:87
-#: templates/demo/request_quotation.tex:56
-#: templates/demo/request_quotation.tex:91 templates/demo/sales_order.html:55
-#: templates/demo/sales_order.html:83 templates/demo/sales_order.tex:55
-#: templates/demo/sales_order.tex:90 templates/demo/sales_quotation.html:52
-#: templates/demo/sales_quotation.tex:61
-#: templates/demo_with_images/ap_transaction.html:54
-#: templates/demo_with_images/ar_transaction.tex:65
-#: templates/demo_with_images/bin_list.html:59
-#: templates/demo_with_images/bin_list.html:92
-#: templates/demo_with_images/invoice.html:59
-#: templates/demo_with_images/invoice.html:92
-#: templates/demo_with_images/letterhead.html:22
-#: templates/demo_with_images/packing_list.html:60
-#: templates/demo_with_images/pick_list.html:59
-#: templates/demo_with_images/product_receipt.html:58
-#: templates/demo_with_images/product_receipt.html:86
-#: templates/demo_with_images/product_receipt.tex:56
-#: templates/demo_with_images/product_receipt.tex:91
-#: templates/demo_with_images/purchase_order.html:58
-#: templates/demo_with_images/purchase_order.html:86
-#: templates/demo_with_images/purchase_order.tex:56
-#: templates/demo_with_images/purchase_order.tex:91
-#: templates/demo_with_images/request_quotation.html:59
-#: templates/demo_with_images/request_quotation.html:87
-#: templates/demo_with_images/request_quotation.tex:56
-#: templates/demo_with_images/request_quotation.tex:91
-#: templates/demo_with_images/sales_order.html:55
-#: templates/demo_with_images/sales_order.html:83
-#: templates/demo_with_images/sales_order.tex:55
-#: templates/demo_with_images/sales_order.tex:90
-#: templates/demo_with_images/sales_quotation.html:52
-#: templates/demo_with_images/sales_quotation.tex:61
-#: templates/demo_with_images/work_order.html:55
-#: templates/demo_with_images/work_order.html:83
-#: templates/demo_with_images/work_order.tex:65
-#: templates/demo_with_images/work_order.tex:100
-#: templates/demo/work_order.html:55 templates/demo/work_order.html:83
-#: templates/demo/work_order.tex:65 templates/demo/work_order.tex:100
-#: templates/xedemo/ap_transaction.html:54
-#: templates/xedemo/ar_transaction.tex:65 templates/xedemo/bin_list.html:59
-#: templates/xedemo/bin_list.html:92 templates/xedemo/invoice.html:59
-#: templates/xedemo/invoice.html:92 templates/xedemo/letterhead.html:22
-#: templates/xedemo/packing_list.html:60 templates/xedemo/pick_list.html:59
-#: templates/xedemo/product_receipt.html:58
-#: templates/xedemo/product_receipt.html:86
-#: templates/xedemo/product_receipt.tex:56
-#: templates/xedemo/product_receipt.tex:91
-#: templates/xedemo/purchase_order.html:58
-#: templates/xedemo/purchase_order.html:86
-#: templates/xedemo/purchase_order.tex:56
-#: templates/xedemo/purchase_order.tex:91
-#: templates/xedemo/request_quotation.html:59
-#: templates/xedemo/request_quotation.html:87
-#: templates/xedemo/request_quotation.tex:56
-#: templates/xedemo/request_quotation.tex:91
-#: templates/xedemo/sales_order.html:55 templates/xedemo/sales_order.html:83
-#: templates/xedemo/sales_order.tex:55 templates/xedemo/sales_order.tex:90
-#: templates/xedemo/sales_quotation.html:52
-#: templates/xedemo/sales_quotation.tex:62 templates/xedemo/work_order.html:55
-#: templates/xedemo/work_order.html:83 templates/xedemo/work_order.tex:65
-#: templates/xedemo/work_order.tex:100
-msgid "Fax: [_1]"
-msgstr ""
-
-#: bin/aa.pl:87 bin/gl.pl:80 bin/io.pl:81 lib/LedgerSMB/App_State.pm:354
+#: lib/LedgerSMB/App_State.pm:264 old/bin/aa.pl:88 old/bin/gl.pl:81
+#: old/bin/io.pl:80 UI/Reports/custom/reports.pl:99
+#: UI/Reports/custom/reports.pl:5302
 msgid "Feb"
 msgstr "Fév."
 
-#: bin/aa.pl:73 bin/gl.pl:66 bin/io.pl:67 lib/LedgerSMB/App_State.pm:354
-#: lib/LedgerSMB/DBObject/Date.pm:63
+#: lib/LedgerSMB/App_State.pm:264 old/bin/aa.pl:74 old/bin/gl.pl:67
+#: old/bin/io.pl:66 old/lib/LedgerSMB/DBObject/Date.pm:64
+#: UI/Reports/custom/reports.pl:85 UI/Reports/custom/reports.pl:5288
 msgid "February"
 msgstr "Février"
 
-#: lib/LedgerSMB/Num2text.pm:90
+#: UI/Reports/custom/reports.pl:1562 UI/Reports/custom/reports.pl:1708
+msgid "Federal income tax"
+msgstr ""
+
+#: old/lib/LedgerSMB/Num2text.pm:90
 msgid "Fifteen"
 msgstr "Quinze"
 
-#: lib/LedgerSMB/Num2text.pm:108
+#: old/lib/LedgerSMB/Num2text.pm:108
 msgid "Fifty"
 msgstr "Cinquante"
 
-#: UI/file/attachment_screen.html:39
+#: UI/Reports/custom/reports.pl:4948
 msgid "File"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:993
+#: lib/LedgerSMB/Scripts/asset.pm:1009
 msgid "File Imported"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:48
-#: lib/LedgerSMB/Report/File/Internal.pm:46
-#: lib/LedgerSMB/Report/Listings/Templates.pm:50
+#: lib/LedgerSMB/Report/File/Incoming.pm:49
+#: lib/LedgerSMB/Report/File/Internal.pm:47
+#: lib/LedgerSMB/Report/Listings/Templates.pm:51
 msgid "File Name"
 msgstr ""
 
-#: UI/Contact/divs/files.html:11
-msgid "File Type"
-msgstr ""
-
-#: bin/aa.pl:1022 bin/aa.pl:1042 bin/ic.pl:879 bin/ic.pl:898 bin/ir.pl:963
-#: bin/ir.pl:982 bin/is.pl:1046 bin/is.pl:1065 bin/oe.pl:879 bin/oe.pl:898
-#: UI/Contact/divs/files.html:9 UI/journal/journal_entry.html:316
-#: UI/journal/journal_entry.html:334
+#: old/bin/aa.pl:1019 old/bin/aa.pl:1038 old/bin/ic.pl:877 old/bin/ic.pl:896
+#: old/bin/ir.pl:956 old/bin/ir.pl:975 old/bin/is.pl:1045 old/bin/is.pl:1064
+#: old/bin/oe.pl:882 old/bin/oe.pl:901
 msgid "File name"
 msgstr ""
 
-#: bin/aa.pl:1023 bin/aa.pl:1043 bin/ic.pl:880 bin/ic.pl:899 bin/ir.pl:964
-#: bin/ir.pl:983 bin/is.pl:1047 bin/is.pl:1066 bin/oe.pl:880 bin/oe.pl:899
-#: UI/journal/journal_entry.html:317 UI/journal/journal_entry.html:335
+#: old/bin/aa.pl:1020 old/bin/aa.pl:1039 old/bin/ic.pl:878 old/bin/ic.pl:897
+#: old/bin/ir.pl:957 old/bin/ir.pl:976 old/bin/is.pl:1046 old/bin/is.pl:1065
+#: old/bin/oe.pl:883 old/bin/oe.pl:902
 msgid "File type"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/contact.pm:184 UI/Contact/divs/files.html:2
+#: lib/LedgerSMB/Scripts/contact.pm:197 UI/Reports/custom/reports.pl:179
 msgid "Files"
 msgstr ""
 
-#: UI/Contact/divs/files.html:35
-msgid "Files attached to Credit Account"
-msgstr ""
-
-#: UI/Contact/divs/files.html:17
-msgid "Files attached to Entity"
-msgstr ""
-
-#: UI/payments/payments_detail.html:114
-msgid "Filtering From:"
-msgstr ""
-
-#: UI/payments/payments_filter.html:11
-msgid "Filtering Payments"
-msgstr ""
-
-#: UI/payments/payments_filter.html:10
-msgid "Filtering Receipts"
-msgstr ""
-
-#: t/data/04-complex_template.html:53
-msgid "First"
-msgstr ""
-
-#: UI/Admin/user_search.html:21 UI/Contact/divs/employee.html:43
-#: UI/setup/new_user.html:72
-msgid "First Name"
-msgstr "Prénom"
-
-#: UI/Reports/balance_sheet.html:100
-msgid "First column only"
-msgstr ""
-
-#: lib/LedgerSMB/Num2text.pm:79
+#: old/lib/LedgerSMB/Num2text.pm:79
 msgid "Five"
 msgstr "Cinq"
 
-#: lib/LedgerSMB/Num2text.pm:114
+#: old/lib/LedgerSMB/Num2text.pm:114
 msgid "Five Hundred"
 msgstr ""
 
-#: UI/accounts/edit.html:421
-msgid "Fixed Asset"
-msgstr ""
-
-#: UI/accounts/edit.html:415 sql/Pg-database.sql:2925
+#: sql/Pg-database.sql:2929
 msgid "Fixed Assets"
 msgstr ""
 
-#: bin/arap.pl:559
+#: old/bin/arap.pl:557
 msgid "For"
 msgstr "Pour"
+
+#: lib/LedgerSMB/Scripts/setup.pm:802
+msgid "Force"
+msgstr "Forcer"
 
 #: lib/LedgerSMB/Scripts/configuration.pm:96
 msgid "Foreign Exchange Gain"
@@ -3618,122 +2560,93 @@ msgstr "Produit conversion devises"
 msgid "Foreign Exchange Loss"
 msgstr "Perte conversion devises"
 
-#: UI/Reports/filters/taxforms.html:28
+#: UI/Reports/custom/reports.pl:78
 msgid "Form"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:48
+#: lib/LedgerSMB/Report/Taxform/List.pm:49
 msgid "Form Name"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Templates.pm:54
+#: lib/LedgerSMB/Report/Listings/Templates.pm:55
 msgid "Format"
 msgstr ""
 
-#: lib/LedgerSMB/Num2text.pm:107
+#: old/lib/LedgerSMB/Num2text.pm:107
 msgid "Forty"
 msgstr "Quarante"
 
-#: lib/LedgerSMB/Num2text.pm:78
+#: old/lib/LedgerSMB/Num2text.pm:78
 msgid "Four"
 msgstr "Quatre"
 
-#: lib/LedgerSMB/Num2text.pm:89
+#: old/lib/LedgerSMB/Num2text.pm:89
 msgid "Fourteen"
 msgstr "Quatorze"
 
-#: lib/LedgerSMB/Report/Timecards.pm:142
+#: lib/LedgerSMB/Report/Timecards.pm:143
 msgid "Fri"
 msgstr ""
 
-#: bin/aa.pl:1697 bin/ic.pl:1130 bin/oe.pl:2142 bin/pe.pl:836
-#: templates/demo/bin_list.html:28 templates/demo/bin_list.tex:35
-#: templates/demo_with_images/bin_list.html:28
-#: templates/demo_with_images/bin_list.tex:35 templates/xedemo/bin_list.html:28
-#: templates/xedemo/bin_list.tex:35 UI/asset/begin_approval.html:24
-#: UI/asset/search_reports.html:26 UI/bp-search.html:27
-#: UI/ca-list-selector.html:31 UI/lib/report_base.html:107
-#: UI/lib/report_base.html:202 UI/rc-reconciliation.html:16
-#: UI/Reports/co/filter_bm.html:21 UI/Reports/co/filter_cd.html:39
-#: UI/Reports/filters/contact_search.html:117
-#: UI/Reports/filters/income_statement.html:216
-#: UI/Reports/filters/purchase_history.html:119
-#: UI/Reports/filters/purchase_history.html:140
-#: UI/rp-search-generate_balance_sheet.html:19
-#: UI/rp-search-generate_income_statement.html:6
-#: UI/rp-search-generate_income_statement.html:59
-#: UI/rp-search-generate_tax_report.html:2
+#: old/bin/aa.pl:1679 old/bin/ic.pl:1128 old/bin/oe.pl:2136 old/bin/pe.pl:834
+#: UI/Reports/custom/reports.pl:141 UI/Reports/custom/reports.pl:209
+#: UI/Reports/custom/reports.pl:4743 UI/Reports/custom/reports.pl:5357
 msgid "From"
 msgstr "De"
 
-#: lib/LedgerSMB/Report/Reconciliation/Summary.pm:180
+#: lib/LedgerSMB/Report/Reconciliation/Summary.pm:181
 msgid "From Amount"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Inventory/Activity.pm:132
-#: lib/LedgerSMB/Report/Invoices/Payments.pm:193
-#: lib/LedgerSMB/Report/Reconciliation/Summary.pm:176
-#: lib/LedgerSMB/Report/Taxform/Details.pm:108
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:106
-#: lib/LedgerSMB/Report/Timecards.pm:159
+#: lib/LedgerSMB/Report/Inventory/Activity.pm:148
+#: lib/LedgerSMB/Report/Invoices/Payments.pm:194
+#: lib/LedgerSMB/Report/Reconciliation/Summary.pm:177
+#: lib/LedgerSMB/Report/Taxform/Details.pm:109
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:107
+#: lib/LedgerSMB/Report/Timecards.pm:160
 msgid "From Date"
 msgstr ""
 
-#: UI/asset/import_asset.html:52 UI/import_csv/import_csv.html:63
-#: UI/import_csv/import_inventory_csv.html:75
-msgid "From File"
-msgstr ""
-
-#: bin/oe.pl:2155
+#: old/bin/oe.pl:2149
 msgid "From Warehouse"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Trial_Balance.pm:204
+#: lib/LedgerSMB/Report/Trial_Balance.pm:205
 msgid "From date"
 msgstr ""
 
-#: UI/asset/begin_report.html:33 UI/Reports/filters/balance_sheet.html:51
-#: UI/Reports/filters/income_statement.html:106
-#: UI/Reports/filters/trial_balance.html:10
-msgid "Full"
-msgstr ""
-
-#: lib/LedgerSMB/Scripts/setup.pm:938 lib/LedgerSMB/Scripts/setup.pm:996
-#: lib/LedgerSMB/Scripts/setup.pm:1201
+#: lib/LedgerSMB/Scripts/setup.pm:1049 lib/LedgerSMB/Scripts/setup.pm:1105
+#: lib/LedgerSMB/Scripts/setup.pm:1309
 msgid "Full Permissions"
-msgstr ""
+msgstr "Permissions complètes"
 
-#: lib/LedgerSMB/Report/COA.pm:100 lib/LedgerSMB/Report/GL.pm:157
-#: lib/LedgerSMB/Report/Listings/GIFI.pm:45
-#: lib/LedgerSMB/Report/Listings/GIFI.pm:68
-#: lib/LedgerSMB/Report/Trial_Balance.pm:166 UI/accounts/edit.html:163
-#: UI/am-gifi-form.html:12 UI/lib/report_base.html:72
-#: UI/Reports/filters/balance_sheet.html:21 UI/Reports/filters/gl.html:254
-#: UI/Reports/filters/income_statement.html:76
-#: UI/rp-search-generate_tax_report.html:76 UI/rp-search.html:37
-#: sql/Pg-database.sql:2853
+#: lib/LedgerSMB/Report/COA.pm:101 lib/LedgerSMB/Report/GL.pm:158
+#: lib/LedgerSMB/Report/Listings/GIFI.pm:46
+#: lib/LedgerSMB/Report/Listings/GIFI.pm:69
+#: lib/LedgerSMB/Report/Trial_Balance.pm:167 UI/Reports/custom/reports.pl:210
+#: UI/Reports/custom/reports.pl:2004 UI/Reports/custom/reports.pl:4262
+#: UI/Reports/custom/reports.pl:5098 sql/Pg-database.sql:2857
 msgid "GIFI"
 msgstr "Code d'identification comptable ou fiscale"
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:384 lib/LedgerSMB/Upgrade_Tests.pm:401
-#: lib/LedgerSMB/Upgrade_Tests.pm:422
+#: lib/LedgerSMB/Upgrade_Tests.pm:447 lib/LedgerSMB/Upgrade_Tests.pm:464
+#: lib/LedgerSMB/Upgrade_Tests.pm:485
 msgid "GIFI accounts not in \"gifi\" table"
 msgstr ""
 
-#: bin/am.pl:216
+#: old/bin/am.pl:212
 msgid "GIFI deleted!"
 msgstr "Code d'identification comptable ou fiscale supprimé!"
 
-#: bin/am.pl:207
+#: old/bin/am.pl:203
 msgid "GIFI missing!"
 msgstr "Code d'identification comptable ou fiscale manquant!"
 
-#: bin/am.pl:209
+#: old/bin/am.pl:205
 msgid "GIFI saved!"
 msgstr "Code d'identification comptable ou fiscale enregistré!"
 
-#: bin/am.pl:861 UI/Reports/filters/unapproved.html:15
-#: UI/setup/complete.html:23 UI/setup/confirm_operation.html:110
+#: old/bin/am.pl:799 UI/Reports/custom/reports.pl:127
 msgid "GL"
 msgstr "Grand-livre"
 
@@ -3741,143 +2654,106 @@ msgstr "Grand-livre"
 msgid "GL Reference Number"
 msgstr ""
 
-#: UI/accounts/edit.html:448
-msgid "Gain"
+#: UI/Reports/custom/reports.pl:245
+msgid "GST"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:773
+#: lib/LedgerSMB/Scripts/asset.pm:776
 msgid "Gain (Loss)"
-msgstr ""
-
-#: UI/asset/begin_approval.html:47
-msgid "Gain Account"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/configuration.pm:77
 msgid "Gapless AR"
 msgstr ""
 
-#: sql/Pg-database.sql:2920
+#: sql/Pg-database.sql:2924
 msgid "General Journal"
 msgstr ""
 
-#: lib/LedgerSMB/Report/GL.pm:195
+#: lib/LedgerSMB/Report/GL.pm:196
 msgid "General Ledger Report"
 msgstr ""
 
-#: UI/Reports/filters/gl.html:17
-msgid "General Ledger Reports"
-msgstr ""
-
-#: lib/LedgerSMB/Scripts/order.pm:119 UI/Reports/aging_report.html:100
-#: UI/Reports/filters/balance_sheet.html:156
-#: UI/Reports/filters/income_statement.html:234 sql/Pg-database.sql:2779
-#: sql/Pg-database.sql:2817
+#: lib/LedgerSMB/Scripts/order.pm:120 sql/Pg-database.sql:2783
+#: sql/Pg-database.sql:2821
 msgid "Generate"
 msgstr ""
 
-#: UI/Contact/divs/company.html:165 UI/Contact/divs/person.html:181
-msgid "Generate Control Code"
-msgstr ""
-
-#: bin/oe.pl:2527
+#: old/bin/oe.pl:2516
 msgid "Generate Orders"
 msgstr ""
 
-#: bin/oe.pl:2432
+#: old/bin/oe.pl:2421
 msgid "Generate Purchase Orders"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:61
+#: lib/LedgerSMB/Scripts/order.pm:62
 msgid "Generate Purchase Orders from Sales Orders"
 msgstr ""
 
-#: bin/pe.pl:871 bin/pe.pl:1046 bin/pe.pl:1136
+#: old/bin/pe.pl:869 old/bin/pe.pl:1044 old/bin/pe.pl:1134
 msgid "Generate Sales Orders"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:74
+#: lib/LedgerSMB/Scripts/order.pm:75
 msgid "Generate Sales Orders from Purchase Orders"
 msgstr ""
 
-#: sql/Pg-database.sql:804
+#: sql/Pg-database.sql:818
 msgid "Generic Jabber"
 msgstr ""
 
-#: UI/Contact/divs/person.html:92
-msgid "Given Name"
-msgstr ""
-
-#: t/data/04-strings-for-translation.html:8
-msgid "Goods & Services"
-msgstr ""
-
-#: lib/LedgerSMB/Report/Inventory/Search.pm:325 sql/Pg-database.sql:2921
+#: lib/LedgerSMB/Report/Inventory/Search.pm:326 sql/Pg-database.sql:2925
 msgid "Goods and Services"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Inventory/History.pm:186
+#: lib/LedgerSMB/Report/Inventory/History.pm:187
 msgid "Goods and Services History"
 msgstr ""
 
-#: UI/payments/payments_detail.html:444
-msgid "Grand Total"
-msgstr ""
-
-#: bin/ic.pl:426 bin/ic.pl:1276 bin/io.pl:269 bin/oe.pl:2060 bin/oe.pl:2138
-#: bin/oe.pl:2173 bin/pe.pl:145
-#: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:48 UI/io-email.html:87
+#: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:49 old/bin/ic.pl:424
+#: old/bin/ic.pl:1274 old/bin/io.pl:264 old/bin/oe.pl:2059 old/bin/oe.pl:2132
+#: old/bin/oe.pl:2167 old/bin/pe.pl:143
 msgid "Group"
 msgstr "Groupe"
 
-#: bin/pe.pl:275
+#: old/bin/pe.pl:273
 msgid "Group Translations"
 msgstr "Grouper traductions"
 
-#: UI/io-email.html:81 UI/orders/order.html:297
-msgid "Group by"
-msgstr "Groupé par"
-
-#: bin/pe.pl:93
+#: old/bin/pe.pl:91
 msgid "Group deleted!"
 msgstr "Groupe effacé!"
 
-#: bin/pe.pl:70
+#: old/bin/pe.pl:68
 msgid "Group missing!"
 msgstr "Groupe absent!"
 
-#: bin/pe.pl:72
+#: old/bin/pe.pl:70
 msgid "Group saved!"
 msgstr "Groupe enregistré!"
 
-#: sql/Pg-database.sql:800
+#: sql/Pg-database.sql:814
 msgid "Gtalk"
 msgstr ""
 
-#: t/data/04-complex_template.html:25 sql/Pg-database.sql:2916
+#: sql/Pg-database.sql:2920
 msgid "HR"
 msgstr "Ressources humaines"
 
-#: sql/Pg-database.sql:2874
+#: UI/Reports/custom/reports.pl:1564 UI/Reports/custom/reports.pl:1710
+msgid "HSF"
+msgstr ""
+
+#: sql/Pg-database.sql:2878
 msgid "HTML Templates"
 msgstr "Squelettes HTML"
 
-#: UI/accounts/edit.html:14 UI/accounts/edit.html:60 UI/accounts/edit.html:144
-#: UI/am-sic-form.html:17 UI/rp-search-generate_balance_sheet.html:76
-#: UI/rp-search-generate_income_statement.html:126
+#: UI/Reports/custom/reports.pl:5242
 msgid "Heading"
 msgstr "En-tête"
 
-#: UI/Reports/filters/balance_sheet.html:38
-#: UI/Reports/filters/income_statement.html:93
-msgid "Hierarchy type"
-msgstr ""
-
-#: t/data/04-complex_template.html:35
-msgid "History"
-msgstr "Historique"
-
-#: sql/Pg-database.sql:805
+#: sql/Pg-database.sql:819
 msgid "Home Phone"
 msgstr "Téléphone privé"
 
@@ -3885,67 +2761,44 @@ msgstr "Téléphone privé"
 msgid "Hot Lead"
 msgstr ""
 
-#: sql/Pg-database.sql:955
+#: sql/Pg-database.sql:969
 msgid "Hourly"
 msgstr "Horaire"
 
-#: templates/demo/timecard.html:60 templates/demo/timecard.tex:31
-#: templates/demo_with_images/timecard.html:60
-#: templates/demo_with_images/timecard.tex:31 templates/xedemo/timecard.html:60
-#: templates/xedemo/timecard.tex:31
-msgid "Hours"
-msgstr "Heures"
-
-#: lib/LedgerSMB/Num2text.pm:113
+#: old/lib/LedgerSMB/Num2text.pm:113
 msgid "Hundred"
 msgstr "Cent"
 
-#: bin/aa.pl:1615 bin/am.pl:840
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:67
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:57 lib/LedgerSMB/Report/GL.pm:84
-#: lib/LedgerSMB/Report/Inventory/History.pm:113
-#: lib/LedgerSMB/Report/Inventory/Search.pm:189
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:192
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:68
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:58 lib/LedgerSMB/Report/GL.pm:85
+#: lib/LedgerSMB/Report/Inventory/History.pm:114
+#: lib/LedgerSMB/Report/Inventory/Search.pm:190
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:193
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:255
-#: lib/LedgerSMB/Report/Listings/Asset_Class.pm:64
-#: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:55
-#: lib/LedgerSMB/Report/Orders.pm:209 lib/LedgerSMB/Report/Timecards.pm:109
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:93
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:94
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:84
-#: lib/LedgerSMB/Scripts/asset.pm:531 templates/demo/timecard.html:35
-#: templates/demo/timecard.tex:23 templates/demo_with_images/timecard.html:35
-#: templates/demo_with_images/timecard.tex:23 templates/xedemo/timecard.html:35
-#: templates/xedemo/timecard.tex:23 UI/business_units/list_classes.html:11
-#: UI/Reports/filters/gl.html:176
-#: UI/Reports/filters/invoice_outstanding.html:136
-#: UI/Reports/filters/invoice_search.html:226
-#: UI/Reports/filters/orders.html:116 UI/rp-search-generate_tax_report.html:111
+#: lib/LedgerSMB/Report/Listings/Asset_Class.pm:65
+#: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:58
+#: lib/LedgerSMB/Report/Orders.pm:211 lib/LedgerSMB/Report/Timecards.pm:110
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:94
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:95
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:86
+#: lib/LedgerSMB/Scripts/asset.pm:534 old/bin/aa.pl:1597 old/bin/am.pl:778
+#: UI/Reports/custom/reports.pl:4340 UI/Reports/custom/reports.pl:4558
 msgid "ID"
 msgstr "ID"
 
-#: sql/Pg-database.sql:802
+#: sql/Pg-database.sql:816
 msgid "IRC"
 msgstr ""
 
-#: templates/demo/printPayment.html:87
-#: templates/demo_with_images/printPayment.html:87
-#: templates/xedemo/printPayment.html:87
-msgid "Identification"
+#: UI/Reports/custom/reports.pl:211
+msgid "Id"
 msgstr ""
 
-#: UI/form-dynatable.html:24
-msgid "If you would like to access this report again, please try this URL"
-msgstr ""
-
-#: lib/LedgerSMB/Report/Trial_Balance.pm:208 UI/lib/report_base.html:80
-#: UI/Reports/filters/income_statement.html:46
-#: UI/Reports/filters/trial_balance.html:49 UI/rp-search.html:44
+#: lib/LedgerSMB/Report/Trial_Balance.pm:209
 msgid "Ignore Year-ends"
 msgstr ""
 
-#: bin/ic.pl:503 lib/LedgerSMB/Report/Inventory/Search.pm:258
-#: UI/Reports/filters/search_goods.html:317
+#: lib/LedgerSMB/Report/Inventory/Search.pm:259 old/bin/ic.pl:501
 msgid "Image"
 msgstr "Image"
 
@@ -3953,823 +2806,521 @@ msgstr "Image"
 msgid "Images in Templates"
 msgstr ""
 
-#: UI/Contact/divs/user.html:59 UI/setup/edit_user.html:59
-#: UI/setup/new_user.html:38 sql/Pg-database.sql:2780 sql/Pg-database.sql:2890
-#: sql/Pg-database.sql:2905 sql/Pg-database.sql:2910
+#: sql/Pg-database.sql:2784 sql/Pg-database.sql:2894 sql/Pg-database.sql:2909
+#: sql/Pg-database.sql:2914
 msgid "Import"
 msgstr ""
 
-#: sql/Pg-database.sql:2783
+#: sql/Pg-database.sql:2787
 msgid "Import AP Batch"
 msgstr ""
 
-#: sql/Pg-database.sql:2782
+#: sql/Pg-database.sql:2786
 msgid "Import AR Batch"
 msgstr ""
 
-#: sql/Pg-database.sql:2897 sql/Pg-database.sql:2901
+#: sql/Pg-database.sql:2901 sql/Pg-database.sql:2905
 msgid "Import Batch"
 msgstr ""
 
-#: sql/Pg-database.sql:2852
+#: sql/Pg-database.sql:2856
 msgid "Import Chart"
 msgstr ""
 
-#: sql/Pg-database.sql:2909
+#: sql/Pg-database.sql:2913
 msgid "Import GIFI"
 msgstr ""
 
-#: sql/Pg-database.sql:2777
+#: sql/Pg-database.sql:2781
 msgid "Import Inventory"
 msgstr ""
 
-#: templates/demo/timecard.html:52 templates/demo/timecard.tex:29
-#: templates/demo_with_images/timecard.html:52
-#: templates/demo_with_images/timecard.tex:29 templates/xedemo/timecard.html:52
-#: templates/xedemo/timecard.tex:29
-msgid "In"
-msgstr ""
+#: UI/Reports/custom/reports.pl:3022
+#, fuzzy
+msgid "Imported from"
+msgstr "De"
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:80
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:81
 msgid "In Svc"
 msgstr ""
 
-#: bin/printer.pl:121
+#: old/bin/printer.pl:121 UI/Reports/custom/reports.pl:2329
 msgid "In-line"
 msgstr "En ligne"
 
-#: UI/rc-reconciliation.html:110
-msgid "Include Exchange Rate Difference"
-msgstr "Inclure différence conversion devises"
-
-#: bin/arap.pl:381
+#: old/bin/arap.pl:379
 msgid "Include Payment"
 msgstr "Inclure paiement"
 
-#: bin/aa.pl:1720 UI/ca-list-selector.html:70 UI/Reports/co/filter_bm.html:67
-#: UI/Reports/co/filter_cd.html:54 UI/Reports/filters/aging.html:71
-#: UI/Reports/filters/gl.html:116
-#: UI/Reports/filters/invoice_outstanding.html:102
-#: UI/Reports/filters/invoice_search.html:194 UI/Reports/filters/orders.html:82
-#: UI/Reports/filters/purchase_history.html:163
-#: UI/Reports/filters/search_goods.html:180
-#: UI/rp-search-generate_balance_sheet.html:70
-#: UI/rp-search-generate_income_statement.html:120
-#: UI/rp-search-generate_tax_report.html:104
+#: old/bin/aa.pl:1702 UI/Reports/custom/reports.pl:212
+#: UI/Reports/custom/reports.pl:5241
 msgid "Include in Report"
 msgstr "Inclure dans l'état"
 
-#: UI/accounts/edit.html:261
-msgid "Include in drop-down menus"
-msgstr "Inclure dans les menus déroulants"
-
-#: UI/Reports/filters/inventory_adj.html:20
-msgid "Includes Part"
-msgstr ""
-
-#: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:81
+#: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:82
 msgid "Including partnumber"
 msgstr ""
 
-#: bin/ic.pl:526 bin/ic.pl:659 lib/LedgerSMB/Report/Balance_Sheet.pm:205
-#: lib/LedgerSMB/Report/Balance_Sheet.pm:207 lib/LedgerSMB/Report/PNL.pm:183
-#: lib/LedgerSMB/Report/PNL.pm:185 lib/LedgerSMB/Scripts/configuration.pm:90
-#: UI/accounts/edit.html:187 UI/accounts/edit.html:270
-#: UI/accounts/edit.html:352 UI/accounts/edit.html:391
-#: UI/Reports/filters/gl.html:157
+#: lib/LedgerSMB/Report/Balance_Sheet.pm:190
+#: lib/LedgerSMB/Report/Balance_Sheet.pm:192 lib/LedgerSMB/Report/PNL.pm:192
+#: lib/LedgerSMB/Report/PNL.pm:194 lib/LedgerSMB/Scripts/configuration.pm:90
+#: old/bin/ic.pl:524 old/bin/ic.pl:657 UI/Reports/custom/reports.pl:169
 msgid "Income"
 msgstr "Recettes"
 
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:35 UI/payroll/income.html:35
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:36
 msgid "Income Class"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Income_Statement.pm:76
-#: UI/Reports/filters/income_statement.html:2
-#: UI/Reports/filters/income_statement.html:11 UI/Reports/PNL.tex:28
-#: sql/Pg-database.sql:2862
+#: lib/LedgerSMB/Report/PNL/Income_Statement.pm:60
+#: UI/Reports/custom/reports.pl:150 sql/Pg-database.sql:2866
 msgid "Income Statement"
 msgstr "Compte de résultat"
 
-#: UI/payroll/income.html:9
-msgid "Income Type"
-msgstr ""
-
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:56
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:57
 msgid "Income Types"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:78
+#: lib/LedgerSMB/Report/File/Incoming.pm:79
 msgid "Incoming Files"
 msgstr ""
 
-#: lib/LedgerSMB/DBObject/User.pm:107
+#: old/lib/LedgerSMB/DBObject/User.pm:108
 msgid "Incorrect Password"
 msgstr ""
 
-#: bin/ic.pl:1283
+#: old/bin/ic.pl:1281
 msgid "Individual Items"
 msgstr "Composition en marchandises individuelles"
 
-#: templates/demo/invoice.tex:31 templates/demo_with_images/invoice.tex:31
-#: templates/xedemo/invoice.tex:30
-msgid ""
-"Interest on overdue amounts will acrue at the rate of 12% per annum starting "
-"from [_1] until paid in full. Items returned are subject to a 10% restocking "
-"charge."
+#: UI/Reports/custom/reports.pl:238
+#, fuzzy
+msgid "Initial balance"
+msgstr "Balance Globale"
+
+#: UI/Reports/custom/reports.pl:3319 UI/Reports/custom/reports.pl:3358
+msgid "Input"
 msgstr ""
 
-#: lib/LedgerSMB.pm:608
+#: lib/LedgerSMB.pm:433
 msgid "Internal Database Error"
 msgstr ""
 
-#: lib/LedgerSMB/DBObject/Account.pm:94
+#: old/lib/LedgerSMB/DBObject/Account.pm:95
 msgid "Internal Database Error."
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Internal.pm:76
+#: lib/LedgerSMB/Report/File/Internal.pm:77
 msgid "Internal Files"
 msgstr ""
 
-#: bin/aa.pl:788 bin/ir.pl:783 bin/ir.pl:791 bin/is.pl:860 bin/is.pl:868
-#: bin/oe.pl:807 UI/orders/order.html:200
+#: old/bin/aa.pl:782 old/bin/ir.pl:774 old/bin/ir.pl:782 old/bin/is.pl:857
+#: old/bin/is.pl:865 old/bin/oe.pl:810
 msgid "Internal Notes"
 msgstr "Notes internes"
 
-#: lib/LedgerSMB/Report/PNL/Income_Statement.pm:104
+#: lib/LedgerSMB/Report/PNL/Income_Statement.pm:88
 msgid "Invalid Reporting Basis"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:383
+#: lib/LedgerSMB/Scripts/setup.pm:413
 msgid "Invalid backup request"
 msgstr ""
 
-#: lib/LedgerSMB.pm:611
+#: lib/LedgerSMB.pm:436
 msgid "Invalid date/time entered"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/import_csv.pm:452
-msgid "Invalid file"
+#: lib/LedgerSMB/Upgrade_Tests.pm:1097
+msgid "Invalid or suspect cleared delays"
 msgstr ""
 
-#: bin/am.pl:1425 bin/am.pl:1473
+#: old/bin/am.pl:1384 old/bin/am.pl:1432
 msgid "Invalid redirect"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/recon.pm:304
+#: lib/LedgerSMB/Scripts/recon.pm:346
 msgid "Invalid statement balance.  Hint: Try entering a number"
 msgstr ""
 
-#: bin/ic.pl:522 lib/LedgerSMB/Scripts/configuration.pm:87
-#: sql/Pg-database.sql:2943
+#: lib/LedgerSMB/Scripts/configuration.pm:87 old/bin/ic.pl:520
+#: sql/Pg-database.sql:2947
 msgid "Inventory"
 msgstr "Inventaire"
 
-#: UI/Reports/filters/inventory_activity.html:6 sql/Pg-database.sql:2781
+#: sql/Pg-database.sql:2785
 msgid "Inventory Activity"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Inventory/Activity.pm:145
+#: lib/LedgerSMB/Report/Inventory/Activity.pm:161
 msgid "Inventory Activity Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:68
+#: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:66
 msgid "Inventory Adjustment Details"
 msgstr ""
 
-#: UI/inventory/adjustment_entry.html:2
-msgid "Inventory Adjustment Entry"
-msgstr ""
-
-#: UI/inventory/adjustment_setup.html:2
-msgid "Inventory Adjustment Setup"
-msgstr ""
-
-#: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:69
+#: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:70
 msgid "Inventory Adjustments"
 msgstr ""
 
-#: sql/Pg-database.sql:2944
+#: sql/Pg-database.sql:2948
 msgid "Inventory and COGS"
 msgstr ""
 
-#: bin/ic.pl:1813
+#: old/bin/ic.pl:1807
 msgid ""
 "Inventory quantity must be zero before you can set this assembly obsolete!"
 msgstr ""
 "La quantité en stock doit être zéro avant de pouvoir annuler cet assemblage!"
 
-#: bin/ic.pl:1812
+#: old/bin/ic.pl:1806
 msgid "Inventory quantity must be zero before you can set this part obsolete!"
 msgstr ""
 "La quantité en stock doit être zero avant de pouvoir annuler cette pièce!"
 
-#: bin/oe.pl:2005
+#: old/bin/oe.pl:2004
 msgid "Inventory saved!"
 msgstr "Inventaire enregistré!"
 
-#: bin/oe.pl:2285
+#: old/bin/oe.pl:2274
 msgid "Inventory transferred!"
 msgstr "Inventaire transféré!"
 
-#: bin/am.pl:1497 bin/io.pl:1142 bin/is.pl:250 bin/is.pl:1396 bin/printer.pl:51
-#: lib/LedgerSMB/Report/Aging.pm:103
-#: lib/LedgerSMB/Report/Inventory/Search.pm:278
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:170
+#: lib/LedgerSMB/Report/Aging.pm:104
+#: lib/LedgerSMB/Report/Inventory/Search.pm:279
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:171
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:268
-#: lib/LedgerSMB/Scripts/payment.pm:768 templates/demo/invoice.html:4
-#: templates/demo/invoice.html:18 templates/demo/printPayment.html:41
-#: templates/demo_with_images/invoice.html:4
-#: templates/demo_with_images/invoice.html:18
-#: templates/demo_with_images/printPayment.html:41
-#: templates/xedemo/invoice.html:4 templates/xedemo/invoice.html:18
-#: templates/xedemo/printPayment.html:41
-#: UI/rp-search-generate_tax_report.html:119 sql/Pg-database.sql:1055
-#: sql/Pg-database.sql:2846 sql/Pg-database.sql:2945
+#: lib/LedgerSMB/Scripts/payment.pm:790 old/bin/am.pl:1456 old/bin/io.pl:1038
+#: old/bin/io.pl:1044 old/bin/io.pl:1162 old/bin/is.pl:245 old/bin/is.pl:1394
+#: old/bin/printer.pl:51 UI/Reports/custom/reports.pl:4341
+#: sql/Pg-database.sql:1069 sql/Pg-database.sql:2850 sql/Pg-database.sql:2949
 msgid "Invoice"
 msgstr "Facture"
 
-#: templates/demo/ap_transaction.html:69 templates/demo/ap_transaction.tex:59
-#: templates/demo/ar_transaction.html:68 templates/demo/ar_transaction.tex:76
-#: templates/demo/check_base.tex:52 templates/demo/invoice.html:112
-#: templates/demo/invoice.tex:118 templates/demo/packing_list.html:78
-#: templates/demo/packing_list.tex:87 templates/demo/pick_list.html:77
-#: templates/demo/pick_list.tex:80 templates/demo/product_receipt.html:102
-#: templates/demo/product_receipt.tex:105 templates/demo/statement.html:60
-#: templates/demo/statement.tex:36
-#: templates/demo_with_images/ap_transaction.html:69
-#: templates/demo_with_images/ap_transaction.tex:59
-#: templates/demo_with_images/ar_transaction.html:68
-#: templates/demo_with_images/ar_transaction.tex:76
-#: templates/demo_with_images/check_base.tex:52
-#: templates/demo_with_images/invoice.html:112
-#: templates/demo_with_images/invoice.tex:118
-#: templates/demo_with_images/packing_list.html:78
-#: templates/demo_with_images/packing_list.tex:87
-#: templates/demo_with_images/pick_list.html:77
-#: templates/demo_with_images/pick_list.tex:80
-#: templates/demo_with_images/product_receipt.html:102
-#: templates/demo_with_images/product_receipt.tex:105
-#: templates/demo_with_images/statement.html:60
-#: templates/demo_with_images/statement.tex:36
-#: templates/xedemo/ap_transaction.html:69
-#: templates/xedemo/ap_transaction.tex:59
-#: templates/xedemo/ar_transaction.html:68
-#: templates/xedemo/ar_transaction.tex:76 templates/xedemo/check_base.tex:52
-#: templates/xedemo/invoice.html:112 templates/xedemo/invoice.tex:117
-#: templates/xedemo/packing_list.html:78 templates/xedemo/packing_list.tex:87
-#: templates/xedemo/pick_list.html:77 templates/xedemo/pick_list.tex:80
-#: templates/xedemo/product_receipt.html:102
-#: templates/xedemo/product_receipt.tex:105 templates/xedemo/statement.html:60
-#: templates/xedemo/statement.tex:36
-msgid "Invoice #"
-msgstr "Facture #"
-
-#: bin/aa.pl:632 bin/aa.pl:1651 bin/ir.pl:499 bin/is.pl:525
+#: old/bin/aa.pl:631 old/bin/aa.pl:1633 old/bin/ir.pl:490 old/bin/is.pl:522
 msgid "Invoice Created"
 msgstr "Facture créée"
 
-#: bin/aa.pl:1316
+#: old/bin/aa.pl:1302
 msgid "Invoice Created Date missing!"
 msgstr "Date de création de facture manquante!"
 
-#: bin/aa.pl:636 bin/aa.pl:1625 bin/ir.pl:503 bin/is.pl:529
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:94
-#: templates/demo/product_receipt.html:103 UI/orders/order.html:90
-#: UI/Reports/filters/invoice_outstanding.html:163
-#: UI/Reports/filters/invoice_search.html:253
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:94 old/bin/aa.pl:635 old/bin/aa.pl:1607
+#: old/bin/ir.pl:494 old/bin/is.pl:526
 msgid "Invoice Date"
 msgstr "Date de facturation"
 
-#: bin/aa.pl:1314 bin/io.pl:1259 bin/ir.pl:1268 bin/is.pl:1357
+#: old/bin/aa.pl:1300 old/bin/io.pl:1279 old/bin/ir.pl:1261 old/bin/is.pl:1355
 msgid "Invoice Date missing!"
 msgstr "Date de facture manquante!"
 
-#: templates/demo/receipt.tex:63 templates/demo_with_images/receipt.tex:63
-#: templates/xedemo/receipt.tex:63
-msgid "Invoice No."
-msgstr "N° de Facture"
-
-#: bin/aa.pl:623 bin/aa.pl:1504 bin/aa.pl:1618 bin/ir.pl:489 bin/is.pl:516
-#: lib/LedgerSMB/Report/Contact/History.pm:68
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:65
+#: lib/LedgerSMB/Report/Contact/History.pm:69
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:66
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:88
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:87
-#: lib/LedgerSMB/Report/Taxform/Details.pm:86 UI/asset/edit_asset.html:207
-#: UI/asset/search_asset.html:175 UI/orders/order.html:78
-#: UI/payments/payments_detail.html:324 UI/payments/use_overpayment2.html:150
-#: UI/Reports/filters/invoice_outstanding.html:142
-#: UI/Reports/filters/invoice_search.html:87
-#: UI/Reports/filters/invoice_search.html:232
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:88
+#: lib/LedgerSMB/Report/Taxform/Details.pm:87 old/bin/aa.pl:622
+#: old/bin/aa.pl:1486 old/bin/aa.pl:1600 old/bin/ir.pl:480 old/bin/is.pl:513
 msgid "Invoice Number"
 msgstr "Numéro de facture"
 
-#: bin/io.pl:1269
+#: old/bin/io.pl:1289
 msgid "Invoice Number missing!"
 msgstr "Numéro de facture manquant!"
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:76
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:77
 msgid "Invoice Profit/Loss"
 msgstr ""
 
-#: UI/Reports/filters/invoice_outstanding.html:76
-#: UI/Reports/filters/invoice_search.html:169
-msgid "Invoice Status"
-msgstr ""
-
-#: lib/LedgerSMB/Report/Taxform/Details.pm:94
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:91
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:92
 msgid "Invoice Sum"
 msgstr ""
 
-#: UI/payments/payments_detail.html:216
-msgid "Invoice Total"
-msgstr ""
-
-#: sql/Pg-database.sql:2793 sql/Pg-database.sql:2796
+#: sql/Pg-database.sql:2797 sql/Pg-database.sql:2800
 msgid "Invoice Vouchers"
 msgstr ""
 
-#: UI/payments/use_overpayment2.html:152
-msgid "Invoice date"
-msgstr ""
-
-#: UI/payments/use_overpayment2.html:153
-msgid "Invoice due"
-msgstr ""
-
-#: lib/LedgerSMB/DBObject/Asset.pm:296
+#: old/lib/LedgerSMB/DBObject/Asset.pm:256
 msgid "Invoice not found"
 msgstr ""
 
-#: UI/Reports/filters/purchase_history.html:174
-msgid "Invoices"
+#: lib/LedgerSMB/Report/Taxform/Details.pm:95
+#, fuzzy
+msgid "Invoice sum"
 msgstr "Factures"
 
-#: bin/ic.pl:1257 bin/io.pl:230 templates/demo/bin_list.html:146
-#: templates/demo/bin_list.tex:105 templates/demo/invoice.html:140
-#: templates/demo/invoice.tex:133 templates/demo/packing_list.html:118
-#: templates/demo/packing_list.tex:113 templates/demo/pick_list.html:110
-#: templates/demo/pick_list.tex:99 templates/demo/product_receipt.html:126
-#: templates/demo/purchase_order.html:126
-#: templates/demo/request_quotation.html:139
-#: templates/demo/sales_order.html:128 templates/demo/sales_order.tex:118
-#: templates/demo/sales_quotation.html:97
-#: templates/demo_with_images/bin_list.html:146
-#: templates/demo_with_images/bin_list.tex:105
-#: templates/demo_with_images/invoice.html:140
-#: templates/demo_with_images/invoice.tex:133
-#: templates/demo_with_images/packing_list.html:118
-#: templates/demo_with_images/packing_list.tex:113
-#: templates/demo_with_images/pick_list.html:110
-#: templates/demo_with_images/pick_list.tex:99
-#: templates/demo_with_images/product_receipt.html:126
-#: templates/demo_with_images/purchase_order.html:126
-#: templates/demo_with_images/request_quotation.html:139
-#: templates/demo_with_images/sales_order.html:128
-#: templates/demo_with_images/sales_order.tex:118
-#: templates/demo_with_images/sales_quotation.html:97
-#: templates/demo_with_images/work_order.html:128
-#: templates/demo_with_images/work_order.tex:124
-#: templates/demo/work_order.html:128 templates/demo/work_order.tex:124
-#: templates/xedemo/bin_list.html:146 templates/xedemo/bin_list.tex:105
-#: templates/xedemo/invoice.html:140 templates/xedemo/invoice.tex:132
-#: templates/xedemo/packing_list.html:118 templates/xedemo/packing_list.tex:113
-#: templates/xedemo/pick_list.html:110 templates/xedemo/pick_list.tex:99
-#: templates/xedemo/product_receipt.html:128
-#: templates/xedemo/purchase_order.html:126
-#: templates/xedemo/request_quotation.html:139
-#: templates/xedemo/sales_order.html:128 templates/xedemo/sales_order.tex:118
-#: templates/xedemo/sales_quotation.html:97
-#: templates/xedemo/work_order.html:128 templates/xedemo/work_order.tex:124
-#: UI/io-email.html:96 UI/payments/payment2.html:303
+#: old/bin/ic.pl:1255 old/bin/io.pl:225
 msgid "Item"
 msgstr "Objet"
 
-#: bin/ic.pl:1992
+#: old/bin/ic.pl:1986
 msgid "Item deleted!"
 msgstr "Objet supprimé!"
 
-#: bin/io.pl:590
+#: old/bin/io.pl:584
 msgid "Item not on file!"
 msgstr "Objet non-listé!"
 
-#: UI/Reports/filters/search_goods.html:128
-msgid "Items Found In"
-msgstr ""
-
-#: templates/demo/packing_list.tex:21
-#: templates/demo_with_images/packing_list.tex:21
-#: templates/xedemo/packing_list.tex:21
-msgid "Items returned are subject to a 10% restocking charge."
-msgstr ""
-
-#: templates/demo/invoice.html:292 templates/demo/packing_list.html:176
-#: templates/demo_with_images/invoice.html:292
-#: templates/demo_with_images/packing_list.html:176
-#: templates/xedemo/invoice.html:292 templates/xedemo/packing_list.html:176
-msgid ""
-"Items returned are subject to a 10% restocking charge. A return authorization "
-"must be obtained from [_1] before goods are returned. Returns must be shipped "
-"prepaid and properly insured. [_1] will not be responsible for damages during "
-"transit."
-msgstr ""
-
-#: bin/aa.pl:86 bin/gl.pl:79 bin/io.pl:80 lib/LedgerSMB/App_State.pm:353
+#: lib/LedgerSMB/App_State.pm:263 old/bin/aa.pl:87 old/bin/gl.pl:80
+#: old/bin/io.pl:79 UI/Reports/custom/reports.pl:98
+#: UI/Reports/custom/reports.pl:5301
 msgid "Jan"
 msgstr "Jan."
 
-#: bin/aa.pl:72 bin/gl.pl:65 bin/io.pl:66 lib/LedgerSMB/App_State.pm:353
-#: lib/LedgerSMB/DBObject/Date.pm:62
+#: lib/LedgerSMB/App_State.pm:263 old/bin/aa.pl:73 old/bin/gl.pl:66
+#: old/bin/io.pl:65 old/lib/LedgerSMB/DBObject/Date.pm:63
+#: UI/Reports/custom/reports.pl:84 UI/Reports/custom/reports.pl:5287
 msgid "January"
 msgstr "Janvier"
 
-#: UI/payments/check_job.html:27
-msgid "Job Failed"
-msgstr ""
-
-#: UI/Contact/divs/employee.html:79
-msgid "Job Title"
-msgstr ""
-
-#: t/data/04-complex_template.html:78
-msgid "Job Title:"
-msgstr ""
-
-#: templates/demo/timecard.html:81 templates/demo/timecard.tex:37
-#: templates/demo_with_images/timecard.html:81
-#: templates/demo_with_images/timecard.tex:37 templates/xedemo/timecard.html:81
-#: templates/xedemo/timecard.tex:37
-msgid "Job/Project #"
-msgstr ""
-
-#: sql/Pg-database.sql:1057 sql/Pg-database.sql:2828
+#: sql/Pg-database.sql:1071 sql/Pg-database.sql:2832
 msgid "Journal Entry"
 msgstr ""
 
-#: UI/setup/complete.html:24 UI/setup/confirm_operation.html:111
-msgid "Journal Lines"
-msgstr ""
-
-#: bin/aa.pl:92 bin/gl.pl:85 bin/io.pl:86 lib/LedgerSMB/App_State.pm:361
+#: lib/LedgerSMB/App_State.pm:271 old/bin/aa.pl:93 old/bin/gl.pl:86
+#: old/bin/io.pl:85 UI/Reports/custom/reports.pl:104
+#: UI/Reports/custom/reports.pl:5307
 msgid "Jul"
 msgstr "Juill."
 
-#: bin/aa.pl:78 bin/gl.pl:71 bin/io.pl:72 lib/LedgerSMB/App_State.pm:361
-#: lib/LedgerSMB/DBObject/Date.pm:68
+#: lib/LedgerSMB/App_State.pm:271 old/bin/aa.pl:79 old/bin/gl.pl:72
+#: old/bin/io.pl:71 old/lib/LedgerSMB/DBObject/Date.pm:69
+#: UI/Reports/custom/reports.pl:90 UI/Reports/custom/reports.pl:5293
 msgid "July"
 msgstr "Juillet"
 
-#: bin/aa.pl:91 bin/gl.pl:84 bin/io.pl:85 lib/LedgerSMB/App_State.pm:360
+#: lib/LedgerSMB/App_State.pm:270 old/bin/aa.pl:92 old/bin/gl.pl:85
+#: old/bin/io.pl:84 UI/Reports/custom/reports.pl:103
+#: UI/Reports/custom/reports.pl:5306
 msgid "Jun"
 msgstr "Juin"
 
-#: bin/aa.pl:77 bin/gl.pl:70 bin/io.pl:71 lib/LedgerSMB/App_State.pm:360
-#: lib/LedgerSMB/DBObject/Date.pm:67 t/data/04-strings-for-translation.html:6
+#: lib/LedgerSMB/App_State.pm:270 old/bin/aa.pl:78 old/bin/gl.pl:71
+#: old/bin/io.pl:70 old/lib/LedgerSMB/DBObject/Date.pm:68
+#: UI/Reports/custom/reports.pl:89 UI/Reports/custom/reports.pl:5292
 msgid "June"
 msgstr "Juin"
 
-#: UI/Reports/balance_sheet.html:99
-msgid "Key Ratios"
-msgstr ""
-
-#: sql/Pg-database.sql:2873
+#: sql/Pg-database.sql:2877
 msgid "LaTeX Templates"
 msgstr "Squelettes LaTeX"
 
-#: lib/LedgerSMB/Report/Listings/Asset_Class.pm:67
-#: lib/LedgerSMB/Report/Listings/Asset_Class.pm:91
-#: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:38
-#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:38
-#: UI/business_units/list_classes.html:12
+#: lib/LedgerSMB/Report/Listings/Asset_Class.pm:68
+#: lib/LedgerSMB/Report/Listings/Asset_Class.pm:92
+#: lib/LedgerSMB/Report/Payroll/Deduction_Types.pm:39
+#: lib/LedgerSMB/Report/Payroll/Income_Types.pm:39
 msgid "Label"
 msgstr ""
 
-#: UI/asset/edit_class.html:19 UI/asset/search_class.html:14
-msgid "Label:"
-msgstr ""
-
-#: bin/ic.pl:694
+#: old/bin/ic.pl:692
 msgid "Labor/Overhead"
 msgstr "Coût de production"
 
-#: templates/demo/timecard.html:89 templates/demo/timecard.tex:39
-#: templates/demo_with_images/timecard.html:89
-#: templates/demo_with_images/timecard.tex:39 templates/xedemo/timecard.html:89
-#: templates/xedemo/timecard.tex:39
-msgid "Labor/Service Code"
-msgstr ""
-
-#: bin/pe.pl:390 bin/pe.pl:563 lib/LedgerSMB/Report/Aging.pm:96
-#: lib/LedgerSMB/Report/Listings/Language.pm:68
-#: lib/LedgerSMB/Report/Listings/Templates.pm:67
-#: UI/Contact/divs/credit.html:273 UI/Contact/divs/credit.html:274
-#: UI/Reports/filters/balance_sheet.html:79
-#: UI/Reports/filters/income_statement.html:134 UI/users/preferences.html:98
-#: sql/Pg-database.sql:2876
+#: lib/LedgerSMB/Report/Aging.pm:97 lib/LedgerSMB/Report/Listings/Language.pm:69
+#: lib/LedgerSMB/Report/Listings/Templates.pm:68 old/bin/pe.pl:388
+#: old/bin/pe.pl:561 UI/Reports/custom/reports.pl:5137 sql/Pg-database.sql:2880
 msgid "Language"
 msgstr "Langue"
 
-#: bin/am.pl:541
+#: old/bin/am.pl:489
 msgid "Language deleted!"
 msgstr "Langue effacée!"
 
-#: bin/am.pl:501
+#: old/bin/am.pl:456
 msgid "Language saved!"
 msgstr "Langue enregistrée!"
 
-#: bin/pe.pl:486
+#: old/bin/pe.pl:484
 msgid "Languages not defined!"
 msgstr "Langues non définis!"
 
-#: t/data/04-complex_template.html:67
-msgid "Last"
-msgstr ""
-
-#: bin/ic.pl:460 bin/ic.pl:638 lib/LedgerSMB/Report/Inventory/Search.pm:233
-#: UI/Contact/pricelist.csv:17 UI/Contact/pricelist.html:32
-#: UI/Contact/pricelist.tex:25 UI/Reports/filters/search_goods.html:259
+#: lib/LedgerSMB/Report/Inventory/Search.pm:234 old/bin/ic.pl:458
+#: old/bin/ic.pl:636
 msgid "Last Cost"
 msgstr ""
 
-#: UI/Admin/user_search.html:31 UI/Contact/divs/employee.html:66
-msgid "Last Name"
-msgstr ""
-
-#: lib/LedgerSMB/Report/Reconciliation/Summary.pm:149
+#: lib/LedgerSMB/Report/Reconciliation/Summary.pm:150
 msgid "Last Updated"
 msgstr ""
 
-#: UI/setup/new_user.html:82
-msgid "Last name"
-msgstr "Nom"
-
-#: bin/oe.pl:2428 sql/Pg-database.sql:546
+#: old/bin/oe.pl:2417 sql/Pg-database.sql:546
 msgid "Lead"
 msgstr ""
 
-#: UI/Contact/pricelist.csv:23 UI/Contact/pricelist.html:38
-#: UI/Contact/pricelist.tex:33
-msgid "Lead Time"
-msgstr ""
-
-#: bin/ic.pl:1028
+#: old/bin/ic.pl:1026
 msgid "Leadtime"
 msgstr "Délai"
 
-#: lib/LedgerSMB/Scripts/setup.pm:141
+#: UI/Reports/custom/reports.pl:136
+msgid "Ledger Browser"
+msgstr ""
+
+#: lib/LedgerSMB/Report/Taxform/Details.pm:91
+msgid "Ledger sum"
+msgstr ""
+
+#: lib/LedgerSMB/Scripts/setup.pm:160
 msgid "LedgerSMB 1.2 db found."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:146
+#: lib/LedgerSMB/Scripts/setup.pm:165
 msgid "LedgerSMB 1.3 db found."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:151
+#: lib/LedgerSMB/Scripts/setup.pm:170
 msgid "LedgerSMB 1.4 db found."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:157
+#: lib/LedgerSMB/Scripts/setup.pm:176
 msgid "LedgerSMB 1.5 db found."
 msgstr ""
 
-#: UI/setup/complete.html:17 UI/setup/confirm_operation.html:104
-msgid "LedgerSMB Database Statistics"
+#: lib/LedgerSMB/Scripts/setup.pm:181
+msgid "LedgerSMB 1.6 db found."
 msgstr ""
 
-#: UI/login.html:31 UI/menu/expanding.html:4
-msgid "LedgerSMB [_1]"
-msgstr ""
-
-#: UI/reconciliation/report.html:52
-msgid "Less Outstanding Checks:"
-msgstr ""
-
-#: sql/Pg-database.sql:2958 sql/Pg-database.sql:2973
+#: sql/Pg-database.sql:2962 sql/Pg-database.sql:2977
 msgid "Letterhead"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Balance_Sheet.pm:230
-#: lib/LedgerSMB/Report/Balance_Sheet.pm:232 lib/LedgerSMB/Report/PNL.pm:197
-#: lib/LedgerSMB/Report/PNL.pm:199
+#: lib/LedgerSMB/Report/Balance_Sheet.pm:215
+#: lib/LedgerSMB/Report/Balance_Sheet.pm:217 lib/LedgerSMB/Report/PNL.pm:206
+#: lib/LedgerSMB/Report/PNL.pm:208
 msgid "Liabilities"
 msgstr ""
 
-#: UI/accounts/edit.html:184 UI/Reports/filters/gl.html:143
+#: UI/Reports/custom/reports.pl:167
 msgid "Liability"
 msgstr "Passif"
-
-#: UI/Contact/divs/company.html:149
-msgid "License Number"
-msgstr ""
-
-#: UI/asset/search_class.html:32
-msgid "Lifetime Measured In"
-msgstr ""
 
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:171
 msgid "Line Item COGS Report"
 msgstr ""
 
-#: UI/Reports/filters/search_goods.html:274
-msgid "Line Total"
-msgstr "Total ligne"
-
-#: bin/ic.pl:766
+#: old/bin/ic.pl:764
 msgid "Link Accounts"
 msgstr "Lier comptes"
 
-#: bin/ic.pl:1271
+#: old/bin/ic.pl:1269 UI/Reports/custom/reports.pl:142
+#: UI/Reports/custom/reports.pl:213
 msgid "List"
 msgstr "Liste"
 
-#: sql/Pg-database.sql:2841
+#: sql/Pg-database.sql:2845
 msgid "List Businesses"
 msgstr "Liste types d'affaire"
 
-#: sql/Pg-database.sql:2887
+#: sql/Pg-database.sql:2891
 msgid "List Classes"
 msgstr ""
 
-#: sql/Pg-database.sql:2908
+#: sql/Pg-database.sql:2912
 msgid "List GIFI"
 msgstr "Afficher la liste des codes d'identification comptable ou fiscale"
 
-#: sql/Pg-database.sql:2843
+#: sql/Pg-database.sql:2847
 msgid "List Languages"
 msgstr "Liste des langues"
 
-#: UI/Reports/filters/overpayments.html:5
-msgid "List Overpayments"
-msgstr ""
-
-#: bin/ic.pl:443 lib/LedgerSMB/Report/Inventory/Search.pm:223
-#: UI/Reports/filters/search_goods.html:243
+#: lib/LedgerSMB/Report/Inventory/Search.pm:224 old/bin/ic.pl:441
 msgid "List Price"
 msgstr "Prix de revient"
 
-#: sql/Pg-database.sql:2845
+#: sql/Pg-database.sql:2849
 msgid "List SIC"
 msgstr "Liste des codes secteur économique"
 
-#: sql/Pg-database.sql:2881
+#: sql/Pg-database.sql:2885
 msgid "List Tax Forms"
 msgstr ""
 
-#: UI/ca-list-selector.html:97
-msgid "List Transactions"
-msgstr "Afficher écritures"
-
-#: UI/business_units/list_classes.html:116
-msgid "List Units"
-msgstr ""
-
-#: UI/setup/confirm_operation.html:63
-msgid "List Users"
-msgstr ""
-
-#: sql/Pg-database.sql:2839
+#: sql/Pg-database.sql:2843
 msgid "List Warehouse"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Listings/Business_Type.pm:73
+#: lib/LedgerSMB/Report/Listings/Business_Type.pm:75
 msgid "List of Business Types"
-msgstr ""
-
-#: UI/setup/confirm_operation.html:73 UI/setup/template_info.html:29
-msgid "Load Templates"
-msgstr ""
-
-#: UI/asset/edit_asset.html:142 UI/asset/search_asset.html:126
-#: UI/payments/payment2.html:38 UI/payments/use_overpayment2.html:34
-msgid "Location"
-msgstr ""
-
-#: t/data/04-complex_template.html:368 UI/Contact/divs/address.html:6
-msgid "Locations"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/configuration.pm:74
 msgid "Lock Item Description"
 msgstr ""
 
-#: UI/payments/payments_detail.html:409
-msgid "Locked by [_1]"
-msgstr ""
-
-#: UI/menu/expanding.html:6
-msgid "Logged in as [_1]"
-msgstr ""
-
-#: UI/menu/expanding.html:5
-msgid "Logged into [_1]"
-msgstr ""
-
-#: UI/logout.html:26
-msgid "Logged out due to inactivity"
-msgstr ""
-
-#: UI/login.html:85
-msgid "Logging in.  Please wait."
-msgstr ""
-
-#: UI/login.html:82 UI/setup/credentials.html:55
-msgid "Login"
-msgstr "Login"
-
-#: lib/LedgerSMB/Scripts/setup.pm:803
+#: lib/LedgerSMB/Scripts/setup.pm:917
 msgid "Login?"
 msgstr ""
 
-#: sql/Pg-database.sql:2926
+#: sql/Pg-database.sql:2930
 msgid "Logout"
 msgstr "Déconnexion"
 
-#: UI/logout.html:28
-msgid "Logout Successful"
-msgstr ""
-
-#: UI/accounts/edit.html:457
-msgid "Loss"
-msgstr ""
-
-#: UI/asset/begin_approval.html:57
-msgid "Loss Account"
-msgstr ""
-
-#: lib/LedgerSMB/App_State.pm:308
+#: lib/LedgerSMB/App_State.pm:216
 msgid "M"
 msgstr ""
 
-#: sql/Pg-database.sql:801
+#: sql/Pg-database.sql:815
 msgid "MSN"
 msgstr ""
 
-#: sql/Pg-database.sql:663
+#: sql/Pg-database.sql:677
 msgid "Mailing"
 msgstr ""
 
-#: bin/ic.pl:981 lib/LedgerSMB/Report/Inventory/Search.pm:250
-#: UI/Reports/filters/search_goods.html:47
-#: UI/Reports/filters/search_goods.html:339
+#: lib/LedgerSMB/Report/Inventory/Search.pm:251 old/bin/ic.pl:979
 msgid "Make"
 msgstr "Marque"
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:253
+#: lib/LedgerSMB/Upgrade_Tests.pm:315
 msgid "Make employee numbers unique"
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:287
+#: lib/LedgerSMB/Upgrade_Tests.pm:349
 msgid "Make invoice numbers unique"
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:272 lib/LedgerSMB/Upgrade_Tests.pm:737
+#: lib/LedgerSMB/Upgrade_Tests.pm:334 lib/LedgerSMB/Upgrade_Tests.pm:933
 msgid "Make non-obsolete partnumbers unique"
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:371
+#: lib/LedgerSMB/Upgrade_Tests.pm:434
 msgid "Make sure all meta numbers are unique."
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:235
+#: lib/LedgerSMB/Upgrade_Tests.pm:297
 msgid ""
 "Make sure every name consists of alphanumeric characters (and underscores) "
 "only and is at least one character long"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:937 lib/LedgerSMB/Scripts/setup.pm:995
-#: lib/LedgerSMB/Scripts/setup.pm:1200
+#: lib/LedgerSMB/Scripts/setup.pm:1048 lib/LedgerSMB/Scripts/setup.pm:1104
+#: lib/LedgerSMB/Scripts/setup.pm:1308
 msgid "Manage Users"
-msgstr ""
+msgstr "Gérer les usagers"
 
-#: bin/aa.pl:1494 lib/LedgerSMB/Report/Invoices/Outstanding.pm:267
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:268
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:301
-#: lib/LedgerSMB/Report/Orders.pm:267 UI/Contact/divs/employee.html:105
-#: UI/Contact/divs/employee.html:143
-#: UI/Reports/filters/invoice_outstanding.html:189
-#: UI/Reports/filters/invoice_search.html:279
+#: lib/LedgerSMB/Report/Orders.pm:269 old/bin/aa.pl:1476
 msgid "Manager"
 msgstr "Gestionnaire"
 
-#: t/data/04-complex_template.html:98
-msgid "Manager:"
-msgstr ""
-
-#: bin/ir.pl:636 bin/is.pl:418 bin/is.pl:716
+#: old/bin/ir.pl:627 old/bin/is.pl:415 old/bin/is.pl:713
 msgid "Manual"
 msgstr ""
 
-#: bin/aa.pl:88 bin/gl.pl:81 bin/io.pl:82 lib/LedgerSMB/App_State.pm:355
+#: lib/LedgerSMB/App_State.pm:265 old/bin/aa.pl:89 old/bin/gl.pl:82
+#: old/bin/io.pl:81 UI/Reports/custom/reports.pl:100
+#: UI/Reports/custom/reports.pl:5303
 msgid "Mar"
 msgstr "Mars"
 
-#: bin/aa.pl:74 bin/gl.pl:67 bin/io.pl:68 lib/LedgerSMB/App_State.pm:355
-#: lib/LedgerSMB/DBObject/Date.pm:64
+#: lib/LedgerSMB/App_State.pm:265 old/bin/aa.pl:75 old/bin/gl.pl:68
+#: old/bin/io.pl:67 old/lib/LedgerSMB/DBObject/Date.pm:65
+#: UI/Reports/custom/reports.pl:86 UI/Reports/custom/reports.pl:5289
 msgid "March"
 msgstr "Mars"
 
-#: bin/ic.pl:466 bin/ic.pl:644 lib/LedgerSMB/Report/Inventory/Search.pm:242
-#: UI/Reports/filters/search_goods.html:281
+#: lib/LedgerSMB/Report/Inventory/Search.pm:243 old/bin/ic.pl:464
+#: old/bin/ic.pl:642
 msgid "Markup"
 msgstr "Majoration"
 
@@ -4781,69 +3332,49 @@ msgstr ""
 msgid "Max per dropdown"
 msgstr ""
 
-#: bin/aa.pl:90 bin/gl.pl:83 bin/io.pl:84 lib/LedgerSMB/App_State.pm:359
-#: lib/LedgerSMB/DBObject/Date.pm:66
+#: lib/LedgerSMB/App_State.pm:269 old/bin/aa.pl:91 old/bin/gl.pl:84
+#: old/bin/io.pl:83 old/lib/LedgerSMB/DBObject/Date.pm:67
+#: UI/Reports/custom/reports.pl:102 UI/Reports/custom/reports.pl:5305
 msgid "May"
 msgstr "Mai"
 
-#: bin/aa.pl:76 bin/gl.pl:69 bin/io.pl:70
+#: old/bin/aa.pl:77 old/bin/gl.pl:70 old/bin/io.pl:69
+#: UI/Reports/custom/reports.pl:88 UI/Reports/custom/reports.pl:5291
 msgid "May "
 msgstr "Mai "
 
-#: bin/aa.pl:821 bin/ir.pl:674 bin/ir.pl:844 bin/is.pl:758 bin/is.pl:921
-#: lib/LedgerSMB/Report/GL.pm:127 lib/LedgerSMB/Scripts/payment.pm:156
-#: lib/LedgerSMB/Scripts/payment.pm:774 templates/demo/ap_transaction.html:195
-#: templates/demo_with_images/ap_transaction.html:195
-#: templates/xedemo/ap_transaction.html:195 UI/journal/journal_entry.html:118
-#: UI/orders/order.html:248 UI/payments/payment2.html:307
-#: UI/Reports/filters/gl.html:74 UI/Reports/filters/gl.html:227
+#: lib/LedgerSMB/Report/GL.pm:128 lib/LedgerSMB/Scripts/payment.pm:157
+#: lib/LedgerSMB/Scripts/payment.pm:796 old/bin/aa.pl:815 old/bin/ir.pl:665
+#: old/bin/ir.pl:835 old/bin/is.pl:755 old/bin/is.pl:918
+#: UI/Reports/custom/reports.pl:3365 UI/Reports/custom/reports.pl:3777
+#: UI/Reports/custom/reports.pl:3795 UI/Reports/custom/reports.pl:4737
+#: UI/Reports/custom/reports.pl:4774
 msgid "Memo"
 msgstr "Mémo"
 
-#: UI/payments/payment2.html:211
-msgid "Memo to help retrieval"
-msgstr ""
-
-#: bin/io.pl:1467 UI/io-email.html:34 UI/rp-email.html:33
+#: old/bin/io.pl:1486 UI/Reports/custom/reports.pl:2459
 msgid "Message"
 msgstr "Message"
 
-#: bin/arap.pl:806
+#: old/bin/arap.pl:804
 msgid "Message: "
 msgstr "Message: "
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:84
-#: UI/Reports/filters/income_statement.html:24
-#: UI/rp-search-generate_balance_sheet.html:58
-#: UI/rp-search-generate_income_statement.html:108
-#: UI/rp-search-generate_tax_report.html:86
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:85
+#: UI/Reports/custom/reports.pl:361 UI/Reports/custom/reports.pl:5184
 msgid "Method"
 msgstr "Méthode"
 
-#: UI/asset/edit_asset.html:108
-msgid "Method Default"
-msgstr ""
-
-#: bin/ic.pl:505 lib/LedgerSMB/Report/Inventory/Search.pm:266
-#: UI/Reports/filters/search_goods.html:73
-#: UI/Reports/filters/search_goods.html:331
+#: lib/LedgerSMB/Report/Inventory/Search.pm:267 old/bin/ic.pl:503
 msgid "Microfiche"
 msgstr "Microfiche"
 
-#: t/data/04-complex_template.html:60
-msgid "Middle"
-msgstr ""
-
-#: UI/Contact/divs/employee.html:54 UI/Contact/divs/person.html:105
-msgid "Middle Name"
-msgstr ""
-
-#: lib/LedgerSMB/Num2text.pm:118
+#: old/lib/LedgerSMB/Num2text.pm:118
 msgid "Million"
 msgstr "Million"
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:54
-#: lib/LedgerSMB/Report/File/Internal.pm:52
+#: lib/LedgerSMB/Report/File/Incoming.pm:55
+#: lib/LedgerSMB/Report/File/Internal.pm:53
 msgid "Mime Type"
 msgstr ""
 
@@ -4851,781 +3382,468 @@ msgstr ""
 msgid "Min Empty Lines"
 msgstr ""
 
-#: bin/ic.pl:1132 UI/Contact/pricelist.csv:40 UI/Contact/pricelist.html:53
-#: UI/Contact/pricelist.tex:54
+#: old/bin/ic.pl:1130
 msgid "Min Qty"
-msgstr ""
-
-#: UI/am-taxes.html:16
-msgid "Min Taxable"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/configuration.pm:118
 msgid "Misc Settings"
 msgstr ""
 
-#: UI/reconciliation/report.html:153
-msgid "Mismatched Transactions (From Upload)"
-msgstr ""
-
-#: lib/LedgerSMB/Entity/Person.pm:105 sql/Pg-database.sql:724
+#: lib/LedgerSMB/Entity/Person.pm:106 sql/Pg-database.sql:738
 msgid "Miss."
 msgstr ""
 
-#: bin/ic.pl:982 lib/LedgerSMB/Report/Inventory/Search.pm:254
-#: UI/Reports/filters/search_goods.html:55
-#: UI/Reports/filters/search_goods.html:346
+#: UI/Reports/custom/reports.pl:116 UI/Reports/custom/reports.pl:214
+#, fuzzy
+msgid "Mod"
+msgstr "Modèle"
+
+#: lib/LedgerSMB/Report/Inventory/Search.pm:255 old/bin/ic.pl:980
 msgid "Model"
 msgstr "Modèle"
 
-#: lib/LedgerSMB/Report/Timecards.pm:126
+#: lib/LedgerSMB/Report/Timecards.pm:127
 msgid "Mon"
 msgstr ""
 
-#: bin/aa.pl:1584 bin/am.pl:806 bin/pe.pl:822 lib/LedgerSMB/DBObject/Date.pm:84
-#: UI/bp-search.html:44 UI/lib/report_base.html:173 UI/lib/report_base.html:254
-#: UI/rc-reconciliation.html:47 UI/Reports/co/filter_bm.html:58
-#: UI/rp-search-generate_income_statement.html:40
-#: UI/rp-search-generate_tax_report.html:36
+#: old/bin/aa.pl:1566 old/bin/am.pl:744 old/bin/pe.pl:820
+#: old/lib/LedgerSMB/DBObject/Date.pm:85 UI/Reports/custom/reports.pl:122
+#: UI/Reports/custom/reports.pl:215
 msgid "Month"
 msgstr "Mois"
 
-#: bin/arap.pl:533
+#: old/bin/arap.pl:531
 msgid "Month(s)"
 msgstr "Mois"
 
-#: bin/am.pl:807 lib/LedgerSMB/App_State.pm:308
+#: lib/LedgerSMB/App_State.pm:215 old/bin/am.pl:745
 msgid "Months"
 msgstr "Mois"
 
-#: lib/LedgerSMB.pm:624
+#: lib/LedgerSMB.pm:449
 msgid "More information has been reported in the error logs"
 msgstr ""
 
-#: lib/LedgerSMB/Entity/Person.pm:106 sql/Pg-database.sql:725
+#: lib/LedgerSMB/Entity/Person.pm:107 sql/Pg-database.sql:739
 msgid "Mr."
 msgstr "M."
 
-#: lib/LedgerSMB/Entity/Person.pm:107 sql/Pg-database.sql:726
+#: lib/LedgerSMB/Entity/Person.pm:108 sql/Pg-database.sql:740
 msgid "Mrs."
 msgstr "Mme."
 
-#: lib/LedgerSMB/Entity/Person.pm:108 sql/Pg-database.sql:727
+#: lib/LedgerSMB/Entity/Person.pm:109 sql/Pg-database.sql:741
 msgid "Ms."
 msgstr "Mlle."
 
-#: UI/import_csv/import_inventory_csv.html:68
-msgid "Multiple dates"
-msgstr ""
-
-#: lib/LedgerSMB/Upgrade_Tests.pm:882
+#: lib/LedgerSMB/Upgrade_Tests.pm:1078
 msgid ""
 "Multiple tax rates with the same end date have been detected for a tax "
 "account;"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Payments.pm:224
+#: lib/LedgerSMB/Report/Invoices/Payments.pm:225
 msgid "Must have cash account in batch"
 msgstr ""
 
-#: lib/LedgerSMB/Entity/Contact.pm:165
+#: lib/LedgerSMB/Entity/Contact.pm:166
 msgid "Must have credit or entity id"
 msgstr ""
 
-#: bin/arap.pl:169 lib/LedgerSMB/Report/Contact/History.pm:56
-#: lib/LedgerSMB/Report/Contact/History.pm:138
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:60
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:141
-#: lib/LedgerSMB/Report/Contact/Search.pm:60
-#: lib/LedgerSMB/Report/Contact/Search.pm:99 lib/LedgerSMB/Report/Orders.pm:230
-#: lib/LedgerSMB/Report/PNL/ECA.pm:90 lib/LedgerSMB/Report/PNL/Invoice.pm:85
-#: UI/Contact/divs/company.html:83 UI/payments/payments_detail.html:215
-#: UI/Reports/filters/contact_search.html:34
-#: UI/Reports/filters/overpayments.html:32 UI/Reports/filters/payments.html:54
+#: UI/Reports/custom/reports.pl:2043
+msgid "N/A"
+msgstr ""
+
+#: lib/LedgerSMB/Report/Contact/History.pm:57
+#: lib/LedgerSMB/Report/Contact/History.pm:139
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:61
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:142
+#: lib/LedgerSMB/Report/Contact/Search.pm:61
+#: lib/LedgerSMB/Report/Contact/Search.pm:100 lib/LedgerSMB/Report/Orders.pm:232
+#: lib/LedgerSMB/Report/PNL/ECA.pm:91 lib/LedgerSMB/Report/PNL/Invoice.pm:86
+#: old/bin/arap.pl:167 UI/Reports/custom/reports.pl:113
+#: UI/Reports/custom/reports.pl:216
 msgid "Name"
 msgstr "Nom"
 
-#: t/data/04-complex_template.html:50 t/data/04-complex_template.html:160
-#: UI/Contact/divs/employee.html:40
-msgid "Name:"
-msgstr "Nom:"
-
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:134 sql/Pg-database.sql:2892
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:135 sql/Pg-database.sql:2896
 msgid "Net Book Value"
 msgstr ""
 
-#: UI/payments/payments_detail.html:329
-msgid "Net Due"
-msgstr ""
+#: UI/Reports/custom/reports.pl:1556 UI/Reports/custom/reports.pl:1704
+#, fuzzy
+msgid "Net Income"
+msgstr "Recettes"
 
-#: bin/aa.pl:468 bin/aa.pl:960 bin/gl.pl:267 bin/ir.pl:370 bin/ir.pl:556
-#: bin/is.pl:343 bin/is.pl:598 bin/oe.pl:510
+#: UI/Reports/custom/reports.pl:124 UI/Reports/custom/reports.pl:217
+#, fuzzy
+msgid "NetAmount"
+msgstr "Montant"
+
+#: old/bin/aa.pl:467 old/bin/aa.pl:948 old/bin/gl.pl:261 old/bin/ir.pl:361
+#: old/bin/ir.pl:547 old/bin/is.pl:340 old/bin/is.pl:595 old/bin/oe.pl:511
 msgid "New"
 msgstr "Nouveau"
 
-#: UI/asset/begin_report.html:7
-msgid "New Asset Report"
-msgstr ""
+#: UI/Reports/custom/reports.pl:3449
+#, fuzzy
+msgid "New Number"
+msgstr "Numéro"
 
-#: UI/asset/begin_approval.html:7
-msgid "New Asset Report Search"
-msgstr ""
-
-#: UI/reconciliation/upload.html:6
-msgid "New Reconciliation Report"
-msgstr ""
-
-#: UI/Contact/divs/user.html:16 UI/setup/edit_user.html:17
-msgid "New User"
-msgstr ""
-
-#: sql/Pg-database.sql:2927
+#: sql/Pg-database.sql:2931
 msgid "New Window"
 msgstr "Nouvelle fenêtre"
 
-#: bin/am.pl:843 UI/inventory/adjustment_entry.html:85
-#: UI/setup/select_coa.html:49
+#: old/bin/am.pl:781
 msgid "Next"
 msgstr "Prochain"
 
-#: bin/arap.pl:390
+#: old/bin/arap.pl:388
 msgid "Next Date"
 msgstr "Prochaine date"
 
-#: bin/am.pl:914
+#: old/bin/am.pl:852
 msgid "Next Number"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/configuration.pm:101
-#: lib/LedgerSMB/Scripts/configuration.pm:305
+#: lib/LedgerSMB/Scripts/configuration.pm:310
 msgid "Next in Sequence"
 msgstr ""
 
-#: lib/LedgerSMB/Num2text.pm:83
+#: old/lib/LedgerSMB/Num2text.pm:83
 msgid "Nine"
 msgstr "Neuf"
 
-#: lib/LedgerSMB/Num2text.pm:116
+#: old/lib/LedgerSMB/Num2text.pm:116
 msgid "Nine Hundred"
 msgstr ""
 
-#: lib/LedgerSMB/Num2text.pm:94
+#: old/lib/LedgerSMB/Num2text.pm:94
 msgid "Nineteen"
 msgstr "Dix-neuf"
 
-#: lib/LedgerSMB/Num2text.pm:112
+#: old/lib/LedgerSMB/Num2text.pm:112
 msgid "Ninety"
 msgstr "Quatre-vignt-dix"
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:101 UI/am-audit-control.html:15
-#: UI/am-audit-control.html:31 UI/Configuration/settings.html:37
+#: lib/LedgerSMB/Report/Taxform/List.pm:102
 msgid "No"
 msgstr "Non"
 
-#: lib/LedgerSMB/Scripts/contact.pm:631
+#: lib/LedgerSMB/Scripts/contact.pm:623
 msgid "No AR or AP Account Selected"
 msgstr ""
 
-#: lib/LedgerSMB/DBObject/TransTemplate.pm:64
+#: old/lib/LedgerSMB/DBObject/TransTemplate.pm:64
 msgid "No Account id for [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File.pm:49
+#: lib/LedgerSMB/Report/File.pm:50
 msgid "No File Class Specified"
 msgstr ""
 
-#: lib/LedgerSMB/DBObject/Draft.pm:60 lib/LedgerSMB/DBObject/Draft.pm:78
+#: old/lib/LedgerSMB/DBObject/Draft.pm:60 old/lib/LedgerSMB/DBObject/Draft.pm:78
 msgid "No ID Set"
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:301
+#: lib/LedgerSMB/Upgrade_Tests.pm:363
 msgid "No NULL Amounts"
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:217
+#: lib/LedgerSMB/Upgrade_Tests.pm:279
 msgid "No Null employeenumber"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:1202
+#: lib/LedgerSMB/Scripts/setup.pm:1310
 msgid "No changes"
-msgstr ""
+msgstr "Aucun changement"
 
-#: bin/aa.pl:212 bin/ir.pl:171 bin/is.pl:158
+#: old/bin/aa.pl:212 old/bin/ir.pl:161 old/bin/is.pl:153
 msgid "No currencies defined.  Please set these up under System/Defaults."
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:366
+#: lib/LedgerSMB/Upgrade_Tests.pm:429
 msgid "No duplicate meta_numbers"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/file.pm:114
+#: lib/LedgerSMB/Scripts/file.pm:116
 msgid "No file uploaded"
 msgstr ""
 
-#: UI/templates/edit.html:5 UI/templates/preview.html:45
-msgid "No language"
-msgstr ""
-
-#: bin/pe.pl:853
+#: old/bin/pe.pl:851
 msgid "No open Projects!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:1202
+#: lib/LedgerSMB/Scripts/payment.pm:1236
 msgid "No overpayment account selected.  Was one set up?"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File.pm:36
+#: lib/LedgerSMB/Report/File.pm:37
 msgid "No ref key set and no override provided"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/reports.pm:98
+#: lib/LedgerSMB/Scripts/reports.pm:97
 msgid "No report specified"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/taxform.pm:143
+#: lib/LedgerSMB/Scripts/taxform.pm:142
 msgid "No tax form selected"
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:340
+#: lib/LedgerSMB/Upgrade_Tests.pm:403
 msgid "No unassigned amounts in Transactions"
 msgstr ""
 
-#: bin/lsmb-request.pl:12
-msgid "No workflow script specified"
-msgstr ""
-
-#: bin/aa.pl:1613 UI/Reports/filters/invoice_outstanding.html:130
-#: UI/Reports/filters/invoice_search.html:220
-#: UI/Reports/filters/orders.html:110 UI/Reports/filters/search_goods.html:189
+#: old/bin/aa.pl:1595 UI/Reports/custom/reports.pl:111
+#: UI/Reports/custom/reports.pl:218
 msgid "No."
 msgstr "N°"
 
-#: UI/timecards/timecard.html:113
-msgid "Non-Chargeable"
-msgstr ""
-
-#: sql/Pg-database.sql:957
+#: sql/Pg-database.sql:971
 msgid "Non-cash"
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:788
+#: lib/LedgerSMB/Upgrade_Tests.pm:984
 msgid "Non-existing customer pricegroups in partscustomer"
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:898
+#: lib/LedgerSMB/Upgrade_Tests.pm:1116
 msgid "Non-existing vendor pricegroups in partsvendor"
 msgstr ""
 
-#: UI/accounts/edit.html:385
-msgid "Non-tracking Items"
+#: UI/Reports/custom/reports.pl:72
+msgid "Non-taxable Sales and Purchases"
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:692 lib/LedgerSMB/Upgrade_Tests.pm:714
+#: lib/LedgerSMB/Upgrade_Tests.pm:887
 msgid "Non-unique invoice numbers"
 msgstr ""
 
-#: UI/Reports/filters/invoice_search.html:66
-msgid "Nontaxable"
+#: lib/LedgerSMB/Upgrade_Tests.pm:910
+msgid "Non-unique invoice numbers detected"
 msgstr ""
 
-#: UI/Reports/filters/trial_balance.html:7
-msgid "Normal"
-msgstr ""
-
-#: UI/Reports/filters/reconciliation_search.html:61
-msgid "Not Approved"
-msgstr ""
-
-#: UI/Reports/filters/reconciliation_search.html:82
-msgid "Not Submitted"
-msgstr ""
-
-#: UI/Reports/filters/balance_sheet.html:72
-#: UI/Reports/filters/income_statement.html:127
-msgid "Not set up for hierarchy reporting, please see linked instructions"
-msgstr ""
-
-#: UI/Contact/divs/notes.html:46 UI/Contact/divs/notes.html:56
-msgid "Note Class"
-msgstr ""
-
-#: bin/aa.pl:787 bin/aa.pl:1524 bin/aa.pl:1657 bin/ic.pl:771 bin/ir.pl:780
-#: bin/is.pl:855 bin/oe.pl:806 lib/LedgerSMB/Report/Contact/Purchase.pm:109
-#: lib/LedgerSMB/Report/Inventory/Search.pm:270
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:255
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:110
+#: lib/LedgerSMB/Report/Inventory/Search.pm:271
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:256
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:292
-#: lib/LedgerSMB/Scripts/contact.pm:183 t/data/04-complex_template.html:33
-#: t/data/04-complex_template.html:626 templates/demo/printPayment.html:124
-#: templates/demo/product_receipt.html:219
-#: templates/demo/purchase_order.html:219
-#: templates/demo/request_quotation.html:175
-#: templates/demo/sales_order.html:205 templates/demo/sales_quotation.html:173
-#: templates/demo_with_images/printPayment.html:124
-#: templates/demo_with_images/product_receipt.html:219
-#: templates/demo_with_images/purchase_order.html:219
-#: templates/demo_with_images/request_quotation.html:175
-#: templates/demo_with_images/sales_order.html:205
-#: templates/demo_with_images/sales_quotation.html:173
-#: templates/xedemo/printPayment.html:124
-#: templates/xedemo/product_receipt.html:221
-#: templates/xedemo/purchase_order.html:219
-#: templates/xedemo/request_quotation.html:175
-#: templates/xedemo/sales_order.html:205
-#: templates/xedemo/sales_quotation.html:173 UI/Contact/divs/notes.html:2
-#: UI/Contact/divs/notes.html:6 UI/Contact/divs/notes.html:60
-#: UI/journal/journal_entry.html:79 UI/orders/order.html:199
-#: UI/payments/payment2.html:51 UI/payments/use_overpayment2.html:72
-#: UI/Reports/filters/contact_search.html:76 UI/Reports/filters/gl.html:91
-#: UI/Reports/filters/invoice_outstanding.html:250
-#: UI/Reports/filters/invoice_search.html:148
-#: UI/Reports/filters/invoice_search.html:340
-#: UI/Reports/filters/search_goods.html:310 UI/timecards/timecard.html:135
+#: lib/LedgerSMB/Scripts/contact.pm:196 old/bin/aa.pl:781 old/bin/aa.pl:1506
+#: old/bin/aa.pl:1639 old/bin/ic.pl:769 old/bin/ir.pl:771 old/bin/is.pl:852
+#: old/bin/oe.pl:809 UI/Reports/custom/reports.pl:3346
 msgid "Notes"
 msgstr "Notes"
 
-#: t/data/04-complex_template.html:639
-msgid "Notes:<br />"
-msgstr "Notes:<br />"
-
-#: bin/oe.pl:2002
+#: old/bin/oe.pl:2001
 msgid "Nothing entered!"
 msgstr "Rien n'a été saisi!"
 
-#: bin/oe.pl:2303 bin/oe.pl:2566 bin/pe.pl:1161
+#: old/bin/oe.pl:2292 old/bin/oe.pl:2550 old/bin/pe.pl:1159
+#: UI/Reports/custom/reports.pl:2416 UI/Reports/custom/reports.pl:2531
+#: UI/Reports/custom/reports.pl:5611
 msgid "Nothing selected!"
 msgstr "Pas de sélection!"
 
-#: bin/oe.pl:2019
+#: old/bin/oe.pl:2018
 msgid "Nothing to transfer!"
 msgstr "Rien à transférer!"
 
-#: bin/aa.pl:96 bin/gl.pl:89 bin/io.pl:90 lib/LedgerSMB/App_State.pm:365
+#: lib/LedgerSMB/App_State.pm:275 old/bin/aa.pl:97 old/bin/gl.pl:90
+#: old/bin/io.pl:89 UI/Reports/custom/reports.pl:108
+#: UI/Reports/custom/reports.pl:5311
 msgid "Nov"
 msgstr "Nov."
 
-#: bin/aa.pl:82 bin/gl.pl:75 bin/io.pl:76 lib/LedgerSMB/App_State.pm:365
-#: lib/LedgerSMB/DBObject/Date.pm:72
+#: lib/LedgerSMB/App_State.pm:275 old/bin/aa.pl:83 old/bin/gl.pl:76
+#: old/bin/io.pl:75 old/lib/LedgerSMB/DBObject/Date.pm:73
+#: UI/Reports/custom/reports.pl:94 UI/Reports/custom/reports.pl:5297
 msgid "November"
 msgstr "Novembre"
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:653 lib/LedgerSMB/Upgrade_Tests.pm:672
+#: lib/LedgerSMB/Upgrade_Tests.pm:848 lib/LedgerSMB/Upgrade_Tests.pm:867
 msgid "Null employee numbers"
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:768
+#: lib/LedgerSMB/Upgrade_Tests.pm:964
 msgid "Null make numbers"
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:751
+#: lib/LedgerSMB/Upgrade_Tests.pm:947
 msgid "Null model numbers"
 msgstr ""
 
-#: bin/ic.pl:745 bin/ic.pl:1264 bin/ic.pl:2020 bin/ic.pl:2089 bin/io.pl:232
-#: bin/oe.pl:1849 bin/pe.pl:268 bin/pe.pl:350 bin/pe.pl:382
-#: templates/demo/bin_list.html:147 templates/demo/invoice.html:141
-#: templates/demo/invoice.tex:134 templates/demo/packing_list.html:119
-#: templates/demo/pick_list.html:111 templates/demo/product_receipt.html:127
-#: templates/demo/product_receipt.tex:117
-#: templates/demo/purchase_order.html:127 templates/demo/purchase_order.tex:117
-#: templates/demo/request_quotation.html:140
-#: templates/demo/request_quotation.tex:122 templates/demo/sales_order.html:129
-#: templates/demo/sales_quotation.html:71
-#: templates/demo/sales_quotation.html:98 templates/demo/sales_quotation.tex:87
-#: templates/demo_with_images/bin_list.html:147
-#: templates/demo_with_images/invoice.html:141
-#: templates/demo_with_images/invoice.tex:134
-#: templates/demo_with_images/packing_list.html:119
-#: templates/demo_with_images/pick_list.html:111
-#: templates/demo_with_images/product_receipt.html:127
-#: templates/demo_with_images/product_receipt.tex:117
-#: templates/demo_with_images/purchase_order.html:127
-#: templates/demo_with_images/purchase_order.tex:117
-#: templates/demo_with_images/request_quotation.html:140
-#: templates/demo_with_images/request_quotation.tex:122
-#: templates/demo_with_images/sales_order.html:129
-#: templates/demo_with_images/sales_quotation.html:71
-#: templates/demo_with_images/sales_quotation.html:98
-#: templates/demo_with_images/sales_quotation.tex:87
-#: templates/demo_with_images/work_order.html:129
-#: templates/demo/work_order.html:129 templates/xedemo/bin_list.html:147
-#: templates/xedemo/invoice.html:141 templates/xedemo/invoice.tex:133
-#: templates/xedemo/packing_list.html:119 templates/xedemo/pick_list.html:111
-#: templates/xedemo/product_receipt.html:129
-#: templates/xedemo/product_receipt.tex:117
-#: templates/xedemo/purchase_order.html:127
-#: templates/xedemo/purchase_order.tex:117
-#: templates/xedemo/request_quotation.html:140
-#: templates/xedemo/request_quotation.tex:122
-#: templates/xedemo/sales_order.html:129
-#: templates/xedemo/sales_quotation.html:71
-#: templates/xedemo/sales_quotation.html:98
-#: templates/xedemo/sales_quotation.tex:88 templates/xedemo/work_order.html:129
-#: UI/am-taxes.html:17 UI/Contact/divs/credit.html:26 UI/io-email.html:99
+#: old/bin/ic.pl:743 old/bin/ic.pl:1262 old/bin/ic.pl:2014 old/bin/ic.pl:2083
+#: old/bin/io.pl:227 old/bin/oe.pl:1853 old/bin/pe.pl:266 old/bin/pe.pl:348
+#: old/bin/pe.pl:380 UI/Reports/custom/reports.pl:112
+#: UI/Reports/custom/reports.pl:219
 msgid "Number"
 msgstr "Numéro"
 
-#: UI/users/preferences.html:88
-msgid "Number Format"
-msgstr "Format des numéros"
-
-#: bin/io.pl:929
+#: old/bin/io.pl:923
 msgid "Number missing in Row [_1]"
 msgstr ""
 
-#: UI/Contact/pricelist.html:110 UI/Reports/aging_report.html:125
-#: UI/Reports/display_report.html:74
-msgid "ODS"
-msgstr ""
-
-#: bin/io.pl:249
+#: old/bin/io.pl:244
 msgid "OH"
 msgstr ""
 
-#: UI/payments/payment2.html:300
-msgid "OVERPAYMENT / ADVANCE PAYMENT / PREPAYMENT"
-msgstr ""
-
-#: bin/ic.pl:710 lib/LedgerSMB/Scripts/budgets.pm:127 UI/accounts/edit.html:116
-#: UI/Reports/filters/search_goods.html:113
+#: lib/LedgerSMB/Scripts/budgets.pm:127 old/bin/ic.pl:708
 msgid "Obsolete"
 msgstr "Obsolète"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:97
+#: lib/LedgerSMB/Report/Budget/Search.pm:98
 msgid "Obsolete By"
 msgstr ""
 
-#: bin/aa.pl:95 bin/gl.pl:88 bin/io.pl:89 lib/LedgerSMB/App_State.pm:364
+#: lib/LedgerSMB/App_State.pm:274 old/bin/aa.pl:96 old/bin/gl.pl:89
+#: old/bin/io.pl:88 UI/Reports/custom/reports.pl:107
+#: UI/Reports/custom/reports.pl:5310
 msgid "Oct"
 msgstr "Oct."
 
-#: bin/aa.pl:81 bin/gl.pl:74 bin/io.pl:75 lib/LedgerSMB/App_State.pm:364
-#: lib/LedgerSMB/DBObject/Date.pm:71
+#: lib/LedgerSMB/App_State.pm:274 old/bin/aa.pl:82 old/bin/gl.pl:75
+#: old/bin/io.pl:74 old/lib/LedgerSMB/DBObject/Date.pm:72
+#: UI/Reports/custom/reports.pl:93 UI/Reports/custom/reports.pl:5296
 msgid "October"
 msgstr "Octobre"
 
-#: bin/aa.pl:932 bin/ir.pl:525 bin/is.pl:566 bin/is.pl:841
+#: old/bin/aa.pl:920 old/bin/ir.pl:516 old/bin/is.pl:563 old/bin/is.pl:838
 msgid "Off Hold"
 msgstr ""
 
-#: UI/users/preferences.html:36
-msgid "Old Password"
-msgstr ""
-
-#: bin/ic.pl:477 bin/ic.pl:685 lib/LedgerSMB/Report/Inventory/History.pm:126
-#: lib/LedgerSMB/Report/Inventory/Search.pm:202
-#: lib/LedgerSMB/Report/Invoices/COGS.pm:110
-#: UI/inventory/adjustment_entry.html:30
-#: UI/Reports/filters/search_goods.html:99
+#: lib/LedgerSMB/Report/Inventory/History.pm:127
+#: lib/LedgerSMB/Report/Inventory/Search.pm:203
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:110 old/bin/ic.pl:475 old/bin/ic.pl:683
 msgid "On Hand"
 msgstr "En Stock / disponible"
 
-#: bin/aa.pl:934 bin/aa.pl:1711 bin/ir.pl:527 bin/is.pl:568 bin/is.pl:843
-#: UI/Reports/filters/invoice_outstanding.html:94
-#: UI/Reports/filters/invoice_search.html:186
+#: old/bin/aa.pl:922 old/bin/aa.pl:1693 old/bin/ir.pl:518 old/bin/is.pl:565
+#: old/bin/is.pl:840
 msgid "On Hold"
 msgstr ""
 
-#: UI/Reports/filters/search_goods.html:213
-msgid "On hand"
-msgstr ""
-
-#: lib/LedgerSMB/Num2text.pm:74
+#: old/lib/LedgerSMB/Num2text.pm:74
 msgid "One"
 msgstr "Un"
 
-#: lib/LedgerSMB/Num2text.pm:75
+#: old/lib/LedgerSMB/Num2text.pm:75
 msgid "One-o"
-msgstr ""
-
-#: UI/import_csv/import_inventory_csv.html:45
-msgid "Onhand amount"
-msgstr ""
-
-#: UI/import_csv/import_inventory_csv.html:52
-msgid "Onhand delta"
 msgstr ""
 
 #: lib/LedgerSMB/Scripts/configuration.pm:68
 msgid "Only Timeout Locks"
 msgstr ""
 
-#: UI/Reports/filters/contact_search.html:70
-msgid "Only Users"
-msgstr ""
-
-#: UI/Reports/filters/contact_search.html:73
-msgid "Only for Employees"
-msgstr ""
-
-#: UI/payments/payment2.html:120
-msgid "Only for documentation"
-msgstr ""
-
-#: UI/Reports/filters/balance_sheet.html:15
-#: UI/Reports/filters/balance_sheet.html:146
-#: UI/Reports/filters/income_statement.html:197
-#: UI/Reports/filters/income_statement.html:202
-#: UI/Reports/filters/income_statement.html:218
-#: UI/Reports/filters/income_statement.html:223
-msgid "Ooops! You forgot through date!"
-msgstr ""
-
-#: bin/aa.pl:1532 bin/oe.pl:317 UI/Reports/filters/invoice_search.html:206
-#: UI/Reports/filters/orders.html:95
-#: UI/Reports/filters/purchase_history.html:203
-#: UI/Reports/filters/timecards.html:29
+#: old/bin/aa.pl:1514 old/bin/oe.pl:318
 msgid "Open"
 msgstr "Ouvert"
 
-#: UI/logout.html:15
-msgid ""
-"Opera detected.  To complete this logout, please close your browser window or "
-"clear private/authentication information"
-msgstr ""
-
-#: UI/accounts/edit.html:198
-msgid "Options"
-msgstr ""
-
-#: UI/file/attachment_screen.html:35
-msgid "Or"
-msgstr ""
-
-#: UI/create_batch.html:67
-msgid "Or Add To Batch"
-msgstr ""
-
-#: bin/oe.pl:2421 lib/LedgerSMB/Report/Inventory/Search.pm:282
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:201
+#: lib/LedgerSMB/Report/Inventory/Search.pm:283
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:202 old/bin/io.pl:1041
+#: old/bin/io.pl:1045 old/bin/oe.pl:2410
 msgid "Order"
 msgstr "Commande"
 
-#: templates/demo/ap_transaction.html:88 templates/demo/ap_transaction.tex:66
-#: templates/demo/ar_transaction.html:87 templates/demo/ar_transaction.tex:83
-#: templates/demo/bin_list.html:108 templates/demo/invoice.html:115
-#: templates/demo/packing_list.html:79 templates/demo/pick_list.html:78
-#: templates/demo/purchase_order.html:102 templates/demo/purchase_order.tex:105
-#: templates/demo/sales_order.html:102 templates/demo/sales_order.tex:105
-#: templates/demo/statement.html:61
-#: templates/demo_with_images/ap_transaction.html:88
-#: templates/demo_with_images/ap_transaction.tex:66
-#: templates/demo_with_images/ar_transaction.html:87
-#: templates/demo_with_images/ar_transaction.tex:83
-#: templates/demo_with_images/bin_list.html:108
-#: templates/demo_with_images/invoice.html:115
-#: templates/demo_with_images/packing_list.html:79
-#: templates/demo_with_images/pick_list.html:78
-#: templates/demo_with_images/purchase_order.html:102
-#: templates/demo_with_images/purchase_order.tex:105
-#: templates/demo_with_images/sales_order.html:102
-#: templates/demo_with_images/sales_order.tex:105
-#: templates/demo_with_images/statement.html:61
-#: templates/demo_with_images/work_order.html:102
-#: templates/demo/work_order.html:102 templates/xedemo/ap_transaction.html:88
-#: templates/xedemo/ap_transaction.tex:66
-#: templates/xedemo/ar_transaction.html:87
-#: templates/xedemo/ar_transaction.tex:83 templates/xedemo/bin_list.html:108
-#: templates/xedemo/invoice.html:115 templates/xedemo/packing_list.html:79
-#: templates/xedemo/pick_list.html:78 templates/xedemo/purchase_order.html:102
-#: templates/xedemo/purchase_order.tex:105
-#: templates/xedemo/sales_order.html:102 templates/xedemo/sales_order.tex:105
-#: templates/xedemo/statement.html:61 templates/xedemo/work_order.html:102
-msgid "Order #"
-msgstr ""
-
-#: UI/reconciliation/report.html:258
-msgid "Order By"
-msgstr ""
-
-#: bin/oe.pl:394 bin/oe.pl:1805 templates/demo/purchase_order.html:103
-#: templates/demo/sales_order.html:103
-#: templates/demo_with_images/purchase_order.html:103
-#: templates/demo_with_images/sales_order.html:103
-#: templates/demo_with_images/work_order.html:103
-#: templates/demo/work_order.html:103 templates/xedemo/purchase_order.html:103
-#: templates/xedemo/sales_order.html:103 templates/xedemo/work_order.html:103
+#: old/bin/oe.pl:395 old/bin/oe.pl:1809
 msgid "Order Date"
 msgstr "Date de commande"
 
-#: bin/io.pl:1261 bin/oe.pl:1190 bin/oe.pl:1363
+#: old/bin/io.pl:1281 old/bin/oe.pl:1193 old/bin/oe.pl:1365
 msgid "Order Date missing!"
 msgstr "Date de commande manquante!"
 
-#: sql/Pg-database.sql:2917
+#: sql/Pg-database.sql:2921
 msgid "Order Entry"
 msgstr "Commandes"
 
-#: bin/aa.pl:628 bin/aa.pl:1508 bin/aa.pl:1621 bin/ir.pl:494 bin/is.pl:520
-#: bin/oe.pl:388 bin/oe.pl:1800 lib/LedgerSMB/Report/Contact/Purchase.pm:69
-#: UI/orders/order.html:84 UI/Reports/filters/invoice_outstanding.html:149
-#: UI/Reports/filters/invoice_search.html:97
-#: UI/Reports/filters/invoice_search.html:239 UI/Reports/filters/orders.html:40
-#: UI/Reports/filters/orders.html:123
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:70 old/bin/aa.pl:627
+#: old/bin/aa.pl:1490 old/bin/aa.pl:1603 old/bin/ir.pl:485 old/bin/is.pl:517
+#: old/bin/oe.pl:389 old/bin/oe.pl:1804
 msgid "Order Number"
 msgstr "Numéro de commande"
 
-#: bin/io.pl:1271 bin/oe.pl:1362
+#: old/bin/io.pl:1291 old/bin/oe.pl:1364
 msgid "Order Number missing!"
 msgstr "Numéro de commande manquant!"
 
-#: bin/oe.pl:1340
+#: old/bin/oe.pl:1342
 msgid "Order deleted!"
 msgstr "Commande supprimée!"
 
-#: bin/oe.pl:2555
+#: old/bin/oe.pl:2539
 msgid "Order generation failed!"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Inventory/History.pm:138
+#: lib/LedgerSMB/Report/Inventory/History.pm:139
 msgid "Order/Invoice"
 msgstr ""
 
-#: UI/am-taxes.html:19 UI/business_units/list_classes.html:14
-msgid "Ordering"
-msgstr ""
-
-#: UI/Reports/filters/purchase_history.html:183 UI/setup/complete.html:25
-#: UI/setup/confirm_operation.html:112
-msgid "Orders"
-msgstr ""
-
-#: bin/pe.pl:1319
+#: old/bin/pe.pl:1317
 msgid "Orders generated!"
 msgstr ""
 
-#: UI/setup/confirm_operation.html:32
-msgid "Other Actions"
-msgstr ""
-
-#: lib/LedgerSMB/Scripts/recon.pm:218
+#: lib/LedgerSMB/Scripts/recon.pm:231
 msgid "Our Balance"
 msgstr ""
 
-#: UI/reconciliation/report.html:88 UI/reconciliation/report.html:163
-#: UI/reconciliation/report.html:214
-msgid "Our Credits"
-msgstr ""
-
-#: UI/reconciliation/report.html:87 UI/reconciliation/report.html:162
-#: UI/reconciliation/report.html:213
-msgid "Our Debits"
-msgstr ""
-
-#: templates/demo/timecard.html:56 templates/demo/timecard.tex:30
-#: templates/demo_with_images/timecard.html:56
-#: templates/demo_with_images/timecard.tex:30 templates/xedemo/timecard.html:56
-#: templates/xedemo/timecard.tex:30
-msgid "Out"
-msgstr ""
-
-#: bin/gl.pl:710
+#: old/bin/gl.pl:687 UI/Reports/custom/reports.pl:3585
 msgid "Out of balance transaction!"
 msgstr "Écriture non-soldée!"
 
-#: UI/rc-reconciliation.html:71 sql/Pg-database.sql:2930
-#: sql/Pg-database.sql:2931
+#: sql/Pg-database.sql:2934 sql/Pg-database.sql:2935
 msgid "Outstanding"
 msgstr "En retard"
 
-#: UI/reconciliation/report.html:206
-msgid "Outstanding Transactions"
-msgstr ""
-
-#: UI/rc-display-form.html:79
-msgid "Over"
-msgstr ""
-
-#: UI/Reports/filters/aging.html:89
-msgid "Overdue"
-msgstr ""
-
-#: UI/accounts/edit.html:290 UI/accounts/edit.html:331
-msgid "Overpayment"
-msgstr ""
-
-#: UI/payments/use_overpayment2.html:154
-msgid "Overpayment Account"
-msgstr ""
-
-#: lib/LedgerSMB/Report/Listings/Overpayments.pm:78
+#: lib/LedgerSMB/Report/Listings/Overpayments.pm:79
 msgid "Overpayments"
 msgstr ""
 
-#: bin/am.pl:1063 lib/LedgerSMB/Form.pm:1347 UI/Contact/pricelist.html:104
-#: UI/Reports/aging_report.html:112 UI/Reports/balance_sheet.html:119
-#: UI/Reports/display_report.html:65 UI/Reports/PNL.html:96
+#: UI/Reports/custom/reports.pl:3778 UI/Reports/custom/reports.pl:3796
+msgid "Owed to the owner"
+msgstr ""
+
+#: old/bin/am.pl:1008 old/lib/LedgerSMB/Form.pm:1330
+#: UI/Reports/custom/reports.pl:2365 UI/Reports/custom/reports.pl:4959
 msgid "PDF"
 msgstr "PDF"
 
-#: templates/demo/ap_transaction.html:82 templates/demo/ap_transaction.tex:63
-#: templates/demo/ar_transaction.html:81
-#: templates/demo_with_images/ap_transaction.html:82
-#: templates/demo_with_images/ap_transaction.tex:63
-#: templates/demo_with_images/ar_transaction.html:81
-#: templates/xedemo/ap_transaction.html:82
-#: templates/xedemo/ap_transaction.tex:63
-#: templates/xedemo/ar_transaction.html:81
-msgid "PO #"
-msgstr ""
-
-#: bin/aa.pl:644 bin/aa.pl:1512 bin/aa.pl:1623 bin/ir.pl:511 bin/is.pl:537
-#: bin/oe.pl:402 bin/oe.pl:1810 lib/LedgerSMB/Report/Contact/Purchase.pm:73
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:205
-#: lib/LedgerSMB/Report/Orders.pm:247 UI/orders/order.html:102
-#: UI/Reports/filters/invoice_outstanding.html:155
-#: UI/Reports/filters/invoice_search.html:107
-#: UI/Reports/filters/invoice_search.html:245 UI/Reports/filters/orders.html:50
-#: UI/Reports/filters/orders.html:136
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:74
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:206
+#: lib/LedgerSMB/Report/Orders.pm:249 old/bin/aa.pl:643 old/bin/aa.pl:1494
+#: old/bin/aa.pl:1605 old/bin/ir.pl:502 old/bin/is.pl:534 old/bin/oe.pl:403
+#: old/bin/oe.pl:1814
 msgid "PO Number"
 msgstr "Numéro de référence"
 
-#: UI/payments/use_overpayment2.html:352
-msgid "POST"
-msgstr ""
-
-#: UI/payments/payment2.html:475 UI/payments/use_overpayment2.html:358
-msgid "POST AND PRINT"
-msgstr ""
-
-#: bin/am.pl:1500 bin/io.pl:1161 bin/is.pl:252 bin/is.pl:1002 bin/oe.pl:253
-#: bin/oe.pl:272 bin/printer.pl:79 bin/printer.pl:97
-#: templates/demo/packing_list.html:4 templates/demo/packing_list.html:18
-#: templates/demo/packing_list.tex:81
-#: templates/demo_with_images/packing_list.html:4
-#: templates/demo_with_images/packing_list.html:18
-#: templates/demo_with_images/packing_list.tex:81
-#: templates/xedemo/packing_list.html:4 templates/xedemo/packing_list.html:18
-#: templates/xedemo/packing_list.tex:81 sql/Pg-database.sql:2948
-#: sql/Pg-database.sql:2961
+#: old/bin/am.pl:1459 old/bin/io.pl:1181 old/bin/is.pl:247 old/bin/is.pl:999
+#: old/bin/oe.pl:254 old/bin/oe.pl:273 old/bin/printer.pl:79
+#: old/bin/printer.pl:97 sql/Pg-database.sql:2952 sql/Pg-database.sql:2965
 msgid "Packing List"
 msgstr "Liste d'envoi"
 
-#: bin/io.pl:1260
+#: old/bin/io.pl:1280
 msgid "Packing List Date missing!"
 msgstr "La liste d'envoi n'a pas de date!"
 
-#: bin/io.pl:1270
+#: old/bin/io.pl:1290
 msgid "Packing List Number missing!"
 msgstr "Le numéro de la liste d'envoi est manquant!"
 
-#: bin/aa.pl:1649 lib/LedgerSMB/Report/Contact/Purchase.pm:92
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:233
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:93
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:234
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:280
-#: lib/LedgerSMB/Report/Listings/Overpayments.pm:140
-#: lib/LedgerSMB/Scripts/payment.pm:771 templates/demo/invoice.html:190
-#: templates/demo/invoice.tex:165 templates/demo_with_images/invoice.html:190
-#: templates/demo_with_images/invoice.tex:164 templates/xedemo/invoice.html:190
-#: templates/xedemo/invoice.tex:163 UI/payments/payments_detail.html:327
-#: UI/Reports/filters/invoice_outstanding.html:230
-#: UI/Reports/filters/invoice_search.html:320
+#: lib/LedgerSMB/Report/Listings/Overpayments.pm:141
+#: lib/LedgerSMB/Scripts/payment.pm:793 old/bin/aa.pl:1631
 msgid "Paid"
 msgstr "Total payé"
 
-#: bin/pe.pl:133 UI/business_units/edit.html:45
+#: old/bin/pe.pl:131
 msgid "Parent"
 msgstr ""
 
-#: bin/io.pl:604 lib/LedgerSMB/Report/Invoices/COGS.pm:105
+#: lib/LedgerSMB/Report/Invoices/COGS.pm:105 old/bin/io.pl:598
+#: UI/Reports/custom/reports.pl:220
 msgid "Part"
 msgstr "Marchandise"
 
@@ -5633,631 +3851,426 @@ msgstr "Marchandise"
 msgid "Part Description"
 msgstr ""
 
-#: UI/Reports/filters/search_goods.html:29
-#: UI/Reports/filters/search_goods.html:236
-msgid "Part Group"
-msgstr ""
-
-#: bin/oe.pl:2052 bin/oe.pl:2130 bin/oe.pl:2164 bin/oe.pl:2415 bin/pe.pl:1033
-#: lib/LedgerSMB/Report/Contact/History.pm:79
-#: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:87
-#: lib/LedgerSMB/Report/Inventory/History.pm:118
-#: lib/LedgerSMB/Report/Inventory/Search.pm:194
+#: lib/LedgerSMB/Report/Contact/History.pm:80
+#: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:85
+#: lib/LedgerSMB/Report/Inventory/History.pm:119
+#: lib/LedgerSMB/Report/Inventory/Search.pm:195
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:99
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:159
-#: lib/LedgerSMB/Report/PNL/Product.pm:81
-#: lib/LedgerSMB/Scripts/configuration.pm:112
-#: UI/Reports/filters/cogs_lines.html:9
-#: UI/Reports/filters/inventory_activity.html:11
-#: UI/Reports/filters/purchase_history.html:246
-#: UI/Reports/filters/search_goods.html:9
-#: UI/Reports/filters/search_goods.html:197
+#: lib/LedgerSMB/Report/PNL/Product.pm:82
+#: lib/LedgerSMB/Scripts/configuration.pm:112 old/bin/oe.pl:2051
+#: old/bin/oe.pl:2124 old/bin/oe.pl:2158 old/bin/oe.pl:2404 old/bin/pe.pl:1031
 msgid "Part Number"
 msgstr "Numéro de marchandise"
 
-#: UI/asset/begin_report.html:45
-msgid "Partial"
-msgstr ""
-
-#: lib/LedgerSMB/Scripts/asset.pm:693
+#: lib/LedgerSMB/Scripts/asset.pm:695
 msgid "Partial Disposal Report [_1] on date [_2]"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Inventory/Activity.pm:76
-#: lib/LedgerSMB/Report/Inventory/Activity.pm:130
-#: lib/LedgerSMB/Report/Timecards.pm:114 lib/LedgerSMB/Report/Timecards.pm:163
-#: UI/Contact/pricelist.csv:7 UI/Contact/pricelist.html:22
-#: UI/Contact/pricelist.tex:12 UI/inventory/adjustment_entry.html:27
-#: UI/Reports/filters/invoice_search.html:117
-#: UI/Reports/filters/timecards.html:10 UI/timecards/timecard.html:33
-#: UI/timecards/timecard-week.html:89
+#: lib/LedgerSMB/Report/Inventory/Activity.pm:77
+#: lib/LedgerSMB/Report/Inventory/Activity.pm:146
+#: lib/LedgerSMB/Report/Timecards.pm:115 lib/LedgerSMB/Report/Timecards.pm:164
 msgid "Partnumber"
 msgstr "Numéro de marchandise"
 
-#: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:63
-#: lib/LedgerSMB/Report/Inventory/Search.pm:274
-#: UI/Reports/filters/search_partsgroups.html:12 sql/Pg-database.sql:2830
+#: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:64
+#: lib/LedgerSMB/Report/Inventory/Search.pm:275 sql/Pg-database.sql:2834
 msgid "Partsgroup"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:73
+#: lib/LedgerSMB/Report/Inventory/Partsgroups.pm:74
 msgid "Partsgroups"
 msgstr ""
-
-#: UI/Contact/divs/user.html:48 UI/login.html:58 UI/setup/credentials.html:37
-#: UI/setup/edit_user.html:49 UI/setup/new_user.html:30
-#: UI/users/preferences.html:45
-msgid "Password"
-msgstr "Mot de passe"
 
 #: lib/LedgerSMB/Scripts/configuration.pm:64
 msgid "Password Duration"
 msgstr ""
 
-#: lib/LedgerSMB/DBObject/User.pm:190
+#: old/lib/LedgerSMB/DBObject/User.pm:188
 msgid "Password required"
 msgstr "Mot de passe requis"
 
-#: lib/LedgerSMB/DBObject/User.pm:110
+#: old/lib/LedgerSMB/DBObject/User.pm:94
 msgid "Passwords must match."
 msgstr "Mots de passes non-identiques"
 
-#: UI/payments/payments_detail.html:191 UI/payments/payments_filter.html:140
-msgid "Pay From"
+#: UI/Reports/custom/reports.pl:152
+#, fuzzy
+msgid "Pay"
+msgstr "Jour"
+
+#: UI/Reports/custom/reports.pl:221 UI/Reports/custom/reports.pl:1474
+#, fuzzy
+msgid "Pay Report"
+msgstr "Rapports"
+
+#: UI/Reports/custom/reports.pl:222
+msgid "Pay Stub"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:151 UI/Contact/divs/credit.html:97
-#: UI/Contact/divs/credit.html:98 UI/payments/payments_filter.html:141
+#: lib/LedgerSMB/Scripts/payment.pm:152
 msgid "Pay To"
 msgstr ""
 
-#: templates/demo/printPayment.html:95
-#: templates/demo_with_images/printPayment.html:95
-#: templates/xedemo/printPayment.html:95
-msgid "Pay in behalf of"
-msgstr ""
-
-#: lib/LedgerSMB/Report/Inventory/Activity.pm:108
-msgid "Payable"
-msgstr ""
-
-#: UI/accounts/edit.html:307
-msgid "Payables"
-msgstr "À payer"
-
-#: lib/LedgerSMB/Scripts/payment.pm:998 t/data/04-complex_template.html:282
-#: UI/accounts/edit.html:280 UI/accounts/edit.html:322
-#: UI/Contact/divs/credit.html:209 UI/Contact/divs/credit.html:210
-#: UI/payments/payments_detail.html:217 sql/Pg-database.sql:2801
+#: lib/LedgerSMB/Scripts/payment.pm:1025 sql/Pg-database.sql:2805
 msgid "Payment"
 msgstr "Paiement"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:121
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:122
 msgid "Payment Amount"
 msgstr ""
 
-#: templates/demo/printPayment.html:32
-#: templates/demo_with_images/printPayment.html:32
-#: templates/xedemo/printPayment.html:32
-msgid "Payment Order Number [_1]"
-msgstr ""
-
-#: UI/payments/payments_filter.html:137
-msgid "Payment Processing"
-msgstr ""
-
-#: lib/LedgerSMB/Report/Invoices/Payments.pm:207
+#: lib/LedgerSMB/Report/Invoices/Payments.pm:208
 msgid "Payment Results"
 msgstr ""
 
-#: UI/Reports/filters/payments.html:79
-msgid "Payment Reversal Information"
-msgstr ""
-
-#: UI/Contact/divs/credit.html:157 UI/Contact/divs/credit.html:158
-msgid "Payment Terms"
-msgstr ""
-
-#: UI/payments/payments_detail.html:181 UI/payments/payments_filter.html:162
-msgid "Payment Type:"
-msgstr ""
-
-#: bin/aa.pl:1339 bin/ir.pl:1293 bin/is.pl:1382
+#: old/bin/aa.pl:1325 old/bin/ir.pl:1286 old/bin/is.pl:1380
 msgid "Payment date missing!"
 msgstr "Date de paiement manquante!"
 
-#: templates/demo/invoice.tex:30 templates/demo_with_images/invoice.tex:30
-#: templates/xedemo/invoice.tex:29
-msgid "Payment due NET [_1] Days from date of Invoice."
-msgstr ""
-
-#: templates/demo/invoice.html:291 templates/demo_with_images/invoice.html:291
-#: templates/xedemo/invoice.html:291
-msgid "Payment due by [_1]."
-msgstr ""
-
-#: bin/aa.pl:801 bin/ir.pl:828 bin/is.pl:905
-#: templates/demo/ap_transaction.html:179 templates/demo/ap_transaction.tex:109
-#: templates/demo/ar_transaction.html:178 templates/demo/ar_transaction.tex:126
-#: templates/demo/invoice.html:243 templates/demo/invoice.tex:199
-#: templates/demo_with_images/ap_transaction.html:179
-#: templates/demo_with_images/ap_transaction.tex:109
-#: templates/demo_with_images/ar_transaction.html:178
-#: templates/demo_with_images/ar_transaction.tex:126
-#: templates/demo_with_images/invoice.html:243
-#: templates/demo_with_images/invoice.tex:198
-#: templates/xedemo/ap_transaction.html:179
-#: templates/xedemo/ap_transaction.tex:109
-#: templates/xedemo/ar_transaction.html:178
-#: templates/xedemo/ar_transaction.tex:126 templates/xedemo/invoice.html:243
-#: templates/xedemo/invoice.tex:198 UI/orders/order.html:243
-#: UI/payments/payment1.html:20 UI/payments/payments_detail.html:10
-#: sql/Pg-database.sql:2805 sql/Pg-database.sql:2868
+#: old/bin/aa.pl:795 old/bin/ir.pl:819 old/bin/is.pl:902
+#: sql/Pg-database.sql:2809 sql/Pg-database.sql:2872
 msgid "Payments"
 msgstr "Paiements"
 
-#: bin/is.pl:683
+#: old/bin/is.pl:680
 msgid "Payments associated with voided invoice may need to be reversed."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:402
+#: lib/LedgerSMB/Scripts/asset.pm:404
 msgid "Percent"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:700
+#: lib/LedgerSMB/Scripts/asset.pm:702
 msgid "Percent Disposed"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:703
+#: lib/LedgerSMB/Scripts/asset.pm:705
 msgid "Percent Remaining"
 msgstr ""
 
-#: bin/aa.pl:1577 bin/pe.pl:815 UI/bp-search.html:34
-#: UI/ca-list-selector.html:58 UI/lib/report_base.html:130
-#: UI/lib/report_base.html:225 UI/rc-reconciliation.html:32
-#: UI/rp-search-generate_income_statement.html:25
-#: UI/rp-search-generate_income_statement.html:85
-#: UI/rp-search-generate_tax_report.html:21
+#: old/bin/aa.pl:1559 old/bin/pe.pl:813 UI/Reports/custom/reports.pl:223
+#: UI/Reports/custom/reports.pl:314
 msgid "Period"
 msgstr "Période"
 
-#: UI/lib/report_base.html:278
-msgid "Period type"
-msgstr ""
-
-#: UI/Reports/filters/balance_sheet.html:99
-#: UI/Reports/filters/income_statement.html:154
-msgid "Periods"
-msgstr ""
-
-#: lib/LedgerSMB/Scripts/contact.pm:175 UI/Contact/divs/person.html:2
+#: lib/LedgerSMB/Scripts/contact.pm:188
 msgid "Person"
 msgstr ""
 
-#: UI/Contact/divs/person.html:154
-msgid "Personal ID"
-msgstr ""
-
-#: UI/Reports/filters/contact_search.html:53
-msgid "Phone"
-msgstr "Tél."
-
-#: sql/Pg-database.sql:662
+#: sql/Pg-database.sql:676
 msgid "Physical"
 msgstr ""
 
-#: bin/am.pl:1501 bin/io.pl:1184 bin/is.pl:251 bin/oe.pl:252 bin/oe.pl:271
-#: bin/printer.pl:75 bin/printer.pl:93 templates/demo/pick_list.html:4
-#: templates/demo/pick_list.html:18 templates/demo/pick_list.tex:74
-#: templates/demo_with_images/pick_list.html:4
-#: templates/demo_with_images/pick_list.html:18
-#: templates/demo_with_images/pick_list.tex:74
-#: templates/xedemo/pick_list.html:4 templates/xedemo/pick_list.html:18
-#: templates/xedemo/pick_list.tex:74 sql/Pg-database.sql:2949
-#: sql/Pg-database.sql:2962
+#: old/bin/am.pl:1460 old/bin/io.pl:1204 old/bin/is.pl:246 old/bin/oe.pl:253
+#: old/bin/oe.pl:272 old/bin/printer.pl:75 old/bin/printer.pl:93
+#: sql/Pg-database.sql:2953 sql/Pg-database.sql:2966
 msgid "Pick List"
 msgstr "Liste de sélection"
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:862
+#: lib/LedgerSMB/Upgrade_Tests.pm:1058
 msgid ""
 "Please add a header to the CoA which sorts before the listed accounts "
 "(usually \"0000\" works) (in the standard SL UI)"
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:843
+#: lib/LedgerSMB/Upgrade_Tests.pm:1039
 msgid ""
 "Please add at least one header to your CoA which sorts before all other "
 "account numbers (in the standard SL UI)"
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:408
+#: lib/LedgerSMB/Upgrade_Tests.pm:471
 msgid "Please add the missing GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:452
+#: lib/LedgerSMB/Upgrade_Tests.pm:515
 msgid "Please correct the empty AP accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:441
+#: lib/LedgerSMB/Upgrade_Tests.pm:504
 msgid "Please correct the empty AR accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:808
+#: lib/LedgerSMB/Upgrade_Tests.pm:1004
 msgid "Please fix the presented rows to either be \"H\" or \"A\""
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:792 lib/LedgerSMB/Upgrade_Tests.pm:826
+#: lib/LedgerSMB/Upgrade_Tests.pm:988 lib/LedgerSMB/Upgrade_Tests.pm:1022
 msgid ""
 "Please fix the pricegroup data in your partscustomer table (no UI available)"
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:720
-msgid "Please make all AP invoice numbers unique"
-msgstr ""
-
-#: lib/LedgerSMB/Upgrade_Tests.pm:698
+#: lib/LedgerSMB/Upgrade_Tests.pm:893
 msgid "Please make all AR invoice numbers unique"
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:186 lib/LedgerSMB/Upgrade_Tests.pm:606
+#: lib/LedgerSMB/Upgrade_Tests.pm:248 lib/LedgerSMB/Upgrade_Tests.pm:801
 msgid "Please make all customer numbers unique"
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:677
+#: lib/LedgerSMB/Upgrade_Tests.pm:872
 msgid "Please make all employee numbers unique"
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:205 lib/LedgerSMB/Upgrade_Tests.pm:641
+#: lib/LedgerSMB/Upgrade_Tests.pm:267 lib/LedgerSMB/Upgrade_Tests.pm:836
 msgid "Please make all vendor numbers unique"
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:657
+#: lib/LedgerSMB/Upgrade_Tests.pm:852
 msgid "Please make sure all employees have an employee number"
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:773
+#: lib/LedgerSMB/Upgrade_Tests.pm:969
 msgid "Please make sure all make numbers are non-empty"
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:755
+#: lib/LedgerSMB/Upgrade_Tests.pm:951
 msgid "Please make sure all modelsnumbers are non-empty"
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:528
+#: lib/LedgerSMB/Upgrade_Tests.pm:591
 msgid "Please make sure there are no empty customer numbers."
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:622
+#: lib/LedgerSMB/Upgrade_Tests.pm:817
 msgid "Please make sure there are no empty vendor numbers."
 msgstr ""
 
-#: templates/demo/request_quotation.html:128
-#: templates/demo/request_quotation.tex:117
-#: templates/demo_with_images/request_quotation.html:128
-#: templates/demo_with_images/request_quotation.tex:117
-#: templates/xedemo/request_quotation.html:128
-#: templates/xedemo/request_quotation.tex:117
-msgid "Please provide price and delivery time for the following items:"
-msgstr ""
-
-#: UI/payments/use_overpayment1.html:18
-msgid "Please select a customer with unused overpayments"
-msgstr ""
-
-#: lib/LedgerSMB/Scripts/account.pm:98
+#: lib/LedgerSMB/Scripts/account.pm:99
 msgid "Please select a valid heading"
 msgstr ""
 
-#: UI/payments/use_overpayment1.html:16
-msgid "Please select a vendor with unused overpayments"
+#: lib/LedgerSMB/Scripts/timecard.pm:152
+msgid "Please submit a start/end time or a qty"
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:388
+#: lib/LedgerSMB/Upgrade_Tests.pm:451
 msgid "Please use the 1.2 UI to add the GIFI accounts"
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:426
+#: lib/LedgerSMB/Upgrade_Tests.pm:489
 msgid "Please use the 1.3/1.4 UI to add the GIFI accounts"
 msgstr ""
 
-#: bin/aa.pl:910 bin/aa.pl:948 bin/aa.pl:968 bin/gl.pl:255 bin/gl.pl:295
-#: bin/ir.pl:541 bin/ir.pl:575 bin/ir.pl:942 bin/is.pl:582 bin/is.pl:620
-#: bin/is.pl:1023 lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:244
-#: UI/payments/payment2.html:469
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:253 old/bin/aa.pl:904
+#: old/bin/aa.pl:936 old/bin/aa.pl:956 old/bin/gl.pl:249 old/bin/gl.pl:289
+#: old/bin/ir.pl:532 old/bin/ir.pl:566 old/bin/ir.pl:935 old/bin/is.pl:579
+#: old/bin/is.pl:617 old/bin/is.pl:1022 UI/Reports/custom/reports.pl:3446
 msgid "Post"
 msgstr "Enregistrer"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:212
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:213
 msgid "Post Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/recon.pm:217 UI/create_batch.html:84
+#: lib/LedgerSMB/Scripts/recon.pm:230
 msgid "Post Date"
 msgstr ""
 
-#: UI/accounts/yearend.html:76
-msgid "Post Yearend"
-msgstr ""
-
-#: bin/aa.pl:913 bin/ir.pl:543 bin/ir.pl:943 bin/is.pl:1026
+#: old/bin/aa.pl:907 old/bin/ir.pl:534 old/bin/ir.pl:936 old/bin/is.pl:1025
+#: UI/Reports/custom/reports.pl:3447
 msgid "Post as new"
 msgstr "Enregistrer comme nouveau"
 
-#: UI/reconciliation/report.html:85 UI/reconciliation/report.html:160
-#: UI/reconciliation/report.html:211
-msgid "Posted Date"
-msgstr ""
-
-#: UI/payments/payments_detail.html:99
-msgid "Posting Date:"
-msgstr ""
-
-#: bin/am.pl:1374
+#: old/bin/am.pl:1333
 msgid "Posting GL Transaction [_1]"
 msgstr ""
 
-#: bin/am.pl:1214
+#: old/bin/am.pl:1173
 msgid "Posting Sales Invoice [_1]"
 msgstr ""
 
-#: bin/am.pl:1236 bin/am.pl:1245
+#: old/bin/am.pl:1195 old/bin/am.pl:1204
 msgid "Posting Transaction [_1]"
 msgstr ""
 
-#: bin/am.pl:1224
+#: old/bin/am.pl:1183
 msgid "Posting Vendor Invoice [_1]"
 msgstr ""
 
-#: bin/am.pl:1062 bin/printer.pl:151 lib/LedgerSMB/Form.pm:1345
+#: old/bin/am.pl:1007 old/bin/printer.pl:151 old/lib/LedgerSMB/Form.pm:1328
+#: UI/Reports/custom/reports.pl:2366 UI/Reports/custom/reports.pl:4960
 msgid "Postscript"
 msgstr "Postcript"
 
-#: sql/Pg-database.sql:2928
+#: sql/Pg-database.sql:2932
 msgid "Preferences"
 msgstr "Préférences"
 
-#: UI/users/preferences.html:19
-msgid "Preferences Saved"
-msgstr "Préférences enregistrées"
-
-#: UI/users/preferences.html:17
-msgid "Preferences for "
+#: UI/Reports/custom/reports.pl:4195
+msgid "Preview"
 msgstr ""
 
-#: UI/Configuration/sequence.html:14
-msgid "Prefix"
-msgstr "Préfixe"
-
-#: bin/io.pl:242 templates/demo/invoice.tex:139
-#: templates/demo/product_receipt.html:131
-#: templates/demo/purchase_order.html:131 templates/demo/sales_order.html:133
-#: templates/demo/sales_quotation.html:102
-#: templates/demo/sales_quotation.tex:89
-#: templates/demo_with_images/invoice.tex:139
-#: templates/demo_with_images/product_receipt.html:131
-#: templates/demo_with_images/purchase_order.html:131
-#: templates/demo_with_images/sales_order.html:133
-#: templates/demo_with_images/sales_quotation.html:102
-#: templates/demo_with_images/sales_quotation.tex:89
-#: templates/xedemo/invoice.tex:138 templates/xedemo/product_receipt.html:133
-#: templates/xedemo/purchase_order.html:131
-#: templates/xedemo/sales_order.html:133
-#: templates/xedemo/sales_quotation.html:102
-#: templates/xedemo/sales_quotation.tex:90
+#: old/bin/io.pl:237
 msgid "Price"
 msgstr "Prix"
 
-#: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:48
-#: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:63
-#: UI/Reports/filters/search_pricegroups.html:12
+#: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:49
+#: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:64
 msgid "Price Group"
 msgstr "Groupe de prix"
 
-#: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:73
+#: lib/LedgerSMB/Report/Inventory/Pricegroups.pm:74
 msgid "Price Groups"
 msgstr "Groupes de prix"
 
-#: lib/LedgerSMB/Report/Inventory/Search.pm:246
-#: UI/Reports/filters/search_goods.html:229
+#: lib/LedgerSMB/Report/Inventory/Search.pm:247
 msgid "Price Updated"
 msgstr ""
 
-#: bin/ic.pl:1101 bin/pe.pl:217 UI/Contact/divs/credit.html:246
-#: UI/Contact/divs/credit.html:247
+#: old/bin/ic.pl:1099 old/bin/pe.pl:215
 msgid "Pricegroup"
 msgstr "Groupe de prix"
 
-#: bin/pe.pl:97
+#: old/bin/pe.pl:95
 msgid "Pricegroup deleted!"
 msgstr "Groupe de prix supprimé!"
 
-#: bin/pe.pl:76
+#: old/bin/pe.pl:74
 msgid "Pricegroup missing!"
 msgstr "Groupe de prix manquant!"
 
-#: bin/pe.pl:78
+#: old/bin/pe.pl:76
 msgid "Pricegroup saved!"
 msgstr "Groupe de prix enregistré!"
 
-#: t/data/04-complex_template.html:361 UI/Contact/divs/credit.html:379
-#: UI/Contact/pricelist.html:16
-msgid "Pricelist"
-msgstr "Liste de prix"
-
-#: UI/Contact/pricelist.tex:69
-msgid "Pricelist for [_1]"
-msgstr "Groupe de prix de [_1]"
-
-#: sql/Pg-database.sql:795
+#: sql/Pg-database.sql:809
 msgid "Primary Phone"
 msgstr "Téléphone principal"
 
-#: bin/aa.pl:909 bin/aa.pl:946 bin/am.pl:855 bin/arap.pl:486 bin/ir.pl:539
-#: bin/is.pl:580 bin/is.pl:1022 bin/oe.pl:631 bin/oe.pl:853 bin/oe.pl:1953
-#: lib/LedgerSMB/Report/Taxform/Details.pm:130
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:127
-#: UI/payments/payments_detail.html:495 UI/timecards/timecard.html:161
+#: lib/LedgerSMB/Report/Taxform/Details.pm:131
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:128 old/bin/aa.pl:903
+#: old/bin/aa.pl:934 old/bin/am.pl:793 old/bin/arap.pl:484 old/bin/ir.pl:530
+#: old/bin/is.pl:577 old/bin/is.pl:1021 old/bin/oe.pl:632 old/bin/oe.pl:856
+#: old/bin/oe.pl:1957 UI/Reports/custom/reports.pl:4196
 msgid "Print"
 msgstr "Imprimer"
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:238
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:239
 msgid "Print Batch"
 msgstr ""
 
-#: bin/oe.pl:641 bin/oe.pl:856
+#: UI/Reports/custom/reports.pl:4974
+#, fuzzy
+msgid "Print Report"
+msgstr "Imprimante"
+
+#: old/bin/oe.pl:642 old/bin/oe.pl:859
 msgid "Print and Save"
 msgstr "Imprimer et sauver"
 
-#: bin/oe.pl:649 bin/oe.pl:859
+#: old/bin/oe.pl:650 old/bin/oe.pl:862
 msgid "Print and Save as new"
 msgstr ""
 
-#: bin/printer.pl:173
+#: old/bin/printer.pl:173
 msgid "Printed"
 msgstr "Imprimé"
 
-#: UI/users/preferences.html:120
-msgid "Printer"
-msgstr "Imprimante"
-
-#: bin/am.pl:1409
+#: old/bin/am.pl:1368
 msgid "Printing Bin List [_1]"
 msgstr ""
 
-#: bin/am.pl:1402
+#: old/bin/am.pl:1361
 msgid "Printing Credit Invoice [_1]"
 msgstr ""
 
-#: bin/am.pl:1403
+#: old/bin/am.pl:1362
 msgid "Printing Debit Invoice [_1]"
 msgstr ""
 
-#: bin/am.pl:1401
+#: old/bin/am.pl:1360
 msgid "Printing Invoice [_1]"
 msgstr ""
 
-#: bin/am.pl:1404
+#: old/bin/am.pl:1363
 msgid "Printing Packing List [_1]"
 msgstr ""
 
-#: bin/am.pl:1405
+#: old/bin/am.pl:1364
 msgid "Printing Pick List [_1]"
 msgstr ""
 
-#: bin/am.pl:1408
+#: old/bin/am.pl:1367
 msgid "Printing Purchase Order [_1]"
 msgstr ""
 
-#: bin/am.pl:1406
+#: old/bin/am.pl:1365
 msgid "Printing Sales Order [_1]"
 msgstr ""
 
-#: bin/am.pl:1400
+#: old/bin/am.pl:1359
 msgid "Printing Transaction [_1]"
 msgstr ""
 
-#: bin/am.pl:1407
+#: old/bin/am.pl:1366
 msgid "Printing Work Order [_1]"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:640
+#: lib/LedgerSMB/Scripts/asset.pm:641
 msgid "Prior Dep."
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:639
+#: lib/LedgerSMB/Scripts/asset.pm:640
 msgid "Prior Through"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/asset.pm:400 lib/LedgerSMB/Scripts/asset.pm:771
+#: lib/LedgerSMB/Scripts/asset.pm:402 lib/LedgerSMB/Scripts/asset.pm:774
 msgid "Proceeds"
 msgstr ""
 
-#: bin/am.pl:985 UI/am-list-recurring.html:62
+#: old/bin/am.pl:922
 msgid "Process Transactions"
 msgstr "Traiter transactions"
 
-#: bin/ir.pl:922 templates/demo/product_receipt.html:4
-#: templates/demo/product_receipt.html:18
-#: templates/demo/product_receipt.tex:100
-#: templates/demo_with_images/product_receipt.html:4
-#: templates/demo_with_images/product_receipt.html:18
-#: templates/demo_with_images/product_receipt.tex:100
-#: templates/xedemo/product_receipt.html:4
-#: templates/xedemo/product_receipt.tex:100 sql/Pg-database.sql:2974
-#: sql/Pg-database.sql:2975
+#: old/bin/ir.pl:913 sql/Pg-database.sql:2978 sql/Pg-database.sql:2979
 msgid "Product Receipt"
 msgstr ""
 
-#: UI/am-department-form.html:36
-msgid "Profit Center"
-msgstr "Axé profit"
-
-#: UI/Contact/divs/credit.html:384
-msgid "Profit and Loss"
-msgstr ""
-
-#: bin/aa.pl:1017 bin/ic.pl:945 bin/ir.pl:958 bin/is.pl:1041
+#: old/bin/aa.pl:1014 old/bin/ic.pl:943 old/bin/ir.pl:951 old/bin/is.pl:1040
 msgid "Profit/Loss"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Product.pm:71
+#: lib/LedgerSMB/Report/PNL/Product.pm:72
 msgid "Proft/Loss on Inventory Sales"
 msgstr ""
 
-#: bin/io.pl:268 bin/pe.pl:891 UI/io-email.html:83
-#: UI/journal/journal_entry.html:120 UI/payments/payments_filter.html:40
-#: UI/rp-search-generate_income_statement.html:2
+#: old/bin/io.pl:263 old/bin/pe.pl:889 UI/Reports/custom/reports.pl:151
+#: UI/Reports/custom/reports.pl:224 UI/Reports/custom/reports.pl:3294
+#: UI/Reports/custom/reports.pl:3786
 msgid "Project"
 msgstr "Projet"
 
-#: bin/pe.pl:280
+#: old/bin/pe.pl:278
 msgid "Project Description Translations"
 msgstr "Traductions description de projet"
 
-#: bin/pe.pl:285 bin/pe.pl:1036 UI/Reports/filters/purchase_history.html:326
+#: old/bin/pe.pl:283 old/bin/pe.pl:1034 UI/Reports/custom/reports.pl:1972
 msgid "Project Number"
 msgstr "Numéro de projet"
 
-#: bin/aa.pl:1629
+#: old/bin/aa.pl:1611
 msgid "Project Numbers"
 msgstr "Numéros de projet"
 
-#: lib/LedgerSMB/Report/Timecards.pm:101
+#: lib/LedgerSMB/Report/Timecards.pm:102
 msgid "Project/Department Number"
 msgstr ""
 
-#: UI/payments/payment2.html:67
-msgid "Projects"
-msgstr "Projets"
-
-#: lib/LedgerSMB/Report/Listings/Asset.pm:89
-#: lib/LedgerSMB/Report/Listings/Asset.pm:121
-#: lib/LedgerSMB/Scripts/asset.pm:398
+#: lib/LedgerSMB/Report/Listings/Asset.pm:90
+#: lib/LedgerSMB/Report/Listings/Asset.pm:122 lib/LedgerSMB/Scripts/asset.pm:400
 msgid "Purchase Date"
 msgstr ""
 
-#: UI/asset/edit_asset.html:77 UI/asset/search_asset.html:66
-msgid "Purchase Date:"
-msgstr ""
-
-#: lib/LedgerSMB/Report/Contact/History.pm:129
-#: UI/Reports/filters/purchase_history.html:12
+#: lib/LedgerSMB/Report/Contact/History.pm:130
 msgid "Purchase History"
 msgstr ""
 
-#: bin/am.pl:1281 bin/am.pl:1504 bin/io.pl:1195 bin/ir.pl:547 bin/ir.pl:945
-#: bin/oe.pl:264 bin/oe.pl:666 bin/oe.pl:867 bin/oe.pl:1226 bin/printer.pl:84
-#: t/data/04-complex_template.html:343 templates/demo/purchase_order.html:4
-#: templates/demo/purchase_order.html:18 templates/demo/purchase_order.tex:100
-#: templates/demo_with_images/purchase_order.html:4
-#: templates/demo_with_images/purchase_order.html:18
-#: templates/demo_with_images/purchase_order.tex:100
-#: templates/xedemo/product_receipt.html:18
-#: templates/xedemo/purchase_order.html:4
-#: templates/xedemo/purchase_order.html:18
-#: templates/xedemo/purchase_order.tex:100 UI/Contact/divs/credit.html:367
-#: sql/Pg-database.sql:1933 sql/Pg-database.sql:2811 sql/Pg-database.sql:2952
-#: sql/Pg-database.sql:2965
+#: old/bin/am.pl:1240 old/bin/am.pl:1463 old/bin/io.pl:1215 old/bin/ir.pl:538
+#: old/bin/ir.pl:938 old/bin/oe.pl:265 old/bin/oe.pl:667 old/bin/oe.pl:870
+#: old/bin/oe.pl:1229 old/bin/printer.pl:84 sql/Pg-database.sql:1934
+#: sql/Pg-database.sql:2815 sql/Pg-database.sql:2956 sql/Pg-database.sql:2969
 msgid "Purchase Order"
 msgstr "Commande d'achat"
 
@@ -6265,78 +4278,51 @@ msgstr "Commande d'achat"
 msgid "Purchase Order Number"
 msgstr "Numéro de commande"
 
-#: bin/am.pl:863 lib/LedgerSMB/Report/Orders.pm:190
-#: lib/LedgerSMB/Report/Orders.pm:290 UI/Reports/filters/search_goods.html:167
-#: sql/Pg-database.sql:2814 sql/Pg-database.sql:2816 sql/Pg-database.sql:2819
+#: lib/LedgerSMB/Report/Orders.pm:192 lib/LedgerSMB/Report/Orders.pm:292
+#: old/bin/am.pl:801 sql/Pg-database.sql:2818 sql/Pg-database.sql:2820
+#: sql/Pg-database.sql:2823
 msgid "Purchase Orders"
 msgstr "Commandes d'achat"
 
-#: lib/LedgerSMB/Report/Listings/Asset.pm:92
-#: lib/LedgerSMB/Report/Listings/Asset.pm:123
-#: lib/LedgerSMB/Scripts/asset.pm:399
+#: lib/LedgerSMB/Report/Listings/Asset.pm:93
+#: lib/LedgerSMB/Report/Listings/Asset.pm:124 lib/LedgerSMB/Scripts/asset.pm:401
 msgid "Purchase Value"
 msgstr ""
 
-#: UI/asset/edit_asset.html:87 UI/asset/search_asset.html:76
-msgid "Purchase Value:"
-msgstr ""
-
-#: lib/LedgerSMB/Report/Inventory/Activity.pm:98
+#: lib/LedgerSMB/Report/Inventory/Activity.pm:99
 msgid "Purchased"
 msgstr ""
 
-#: lib/LedgerSMB/App_State.pm:309
+#: lib/LedgerSMB/App_State.pm:218
 msgid "Q"
 msgstr ""
 
-#: bin/ic.pl:1259 bin/ic.pl:2100 bin/io.pl:238 bin/oe.pl:1855 bin/oe.pl:2147
-#: bin/pe.pl:1041 lib/LedgerSMB/Report/Contact/History.pm:87
-#: lib/LedgerSMB/Report/Inventory/History.pm:155
-#: lib/LedgerSMB/Report/Inventory/Search.pm:294
-#: templates/demo/bin_list.html:151 templates/demo/bin_list.tex:108
-#: templates/demo/invoice.html:144 templates/demo/invoice.tex:137
-#: templates/demo/packing_list.html:123 templates/demo/packing_list.tex:116
-#: templates/demo/pick_list.html:113 templates/demo/pick_list.tex:101
-#: templates/demo/product_receipt.html:129
-#: templates/demo/product_receipt.tex:118
-#: templates/demo/purchase_order.html:129 templates/demo/purchase_order.tex:118
-#: templates/demo/request_quotation.html:142
-#: templates/demo/request_quotation.tex:123 templates/demo/sales_order.html:131
-#: templates/demo/sales_quotation.html:100
-#: templates/demo/sales_quotation.tex:88
-#: templates/demo_with_images/bin_list.html:151
-#: templates/demo_with_images/bin_list.tex:108
-#: templates/demo_with_images/invoice.html:144
-#: templates/demo_with_images/invoice.tex:137
-#: templates/demo_with_images/packing_list.html:123
-#: templates/demo_with_images/packing_list.tex:116
-#: templates/demo_with_images/pick_list.html:113
-#: templates/demo_with_images/pick_list.tex:101
-#: templates/demo_with_images/product_receipt.html:129
-#: templates/demo_with_images/product_receipt.tex:118
-#: templates/demo_with_images/purchase_order.html:129
-#: templates/demo_with_images/purchase_order.tex:118
-#: templates/demo_with_images/request_quotation.html:142
-#: templates/demo_with_images/request_quotation.tex:123
-#: templates/demo_with_images/sales_order.html:131
-#: templates/demo_with_images/sales_quotation.html:100
-#: templates/demo_with_images/sales_quotation.tex:88
-#: templates/demo_with_images/work_order.html:131
-#: templates/demo/work_order.html:131 templates/xedemo/bin_list.html:151
-#: templates/xedemo/bin_list.tex:108 templates/xedemo/invoice.html:144
-#: templates/xedemo/invoice.tex:136 templates/xedemo/packing_list.html:123
-#: templates/xedemo/packing_list.tex:116 templates/xedemo/pick_list.html:113
-#: templates/xedemo/pick_list.tex:101 templates/xedemo/product_receipt.html:131
-#: templates/xedemo/product_receipt.tex:118
-#: templates/xedemo/purchase_order.html:129
-#: templates/xedemo/purchase_order.tex:118
-#: templates/xedemo/request_quotation.html:142
-#: templates/xedemo/request_quotation.tex:123
-#: templates/xedemo/sales_order.html:131
-#: templates/xedemo/sales_quotation.html:100
-#: templates/xedemo/sales_quotation.tex:89 templates/xedemo/work_order.html:131
-#: UI/Reports/filters/purchase_history.html:286
-#: UI/timecards/timecard-week.html:101
+#: UI/Reports/custom/reports.pl:1559 UI/Reports/custom/reports.pl:1706
+msgid "QPIP"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:1560
+msgid "QPIP employer"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:1557 UI/Reports/custom/reports.pl:1705
+msgid "QPP"
+msgstr ""
+
+#: UI/Reports/custom/reports.pl:1558
+#, fuzzy
+msgid "QPP employer"
+msgstr "Employé"
+
+#: UI/Reports/custom/reports.pl:248
+msgid "QST"
+msgstr ""
+
+#: lib/LedgerSMB/Report/Contact/History.pm:88
+#: lib/LedgerSMB/Report/Inventory/History.pm:156
+#: lib/LedgerSMB/Report/Inventory/Search.pm:295 old/bin/ic.pl:1257
+#: old/bin/ic.pl:2094 old/bin/io.pl:233 old/bin/oe.pl:1859 old/bin/oe.pl:2141
+#: old/bin/pe.pl:1039
 msgid "Qty"
 msgstr "Qté"
 
@@ -6344,227 +4330,161 @@ msgstr "Qté"
 msgid "Quantity"
 msgstr ""
 
-#: bin/ic.pl:2217
+#: old/bin/ic.pl:2211
 msgid "Quantity exceeds available units to stock!"
 msgstr "La quantité dépasse le nombre d'unités en stock"
 
-#: bin/aa.pl:1586 bin/pe.pl:824 lib/LedgerSMB/DBObject/Date.pm:90
-#: UI/bp-search.html:47 UI/lib/report_base.html:179 UI/lib/report_base.html:261
-#: UI/rc-reconciliation.html:53 UI/Reports/co/filter_bm.html:63
-#: UI/rp-search-generate_income_statement.html:46
-#: UI/rp-search-generate_tax_report.html:42
+#: old/bin/aa.pl:1568 old/bin/pe.pl:822 old/lib/LedgerSMB/DBObject/Date.pm:91
+#: UI/Reports/custom/reports.pl:147 UI/Reports/custom/reports.pl:225
 msgid "Quarter"
 msgstr "Trimestre"
 
-#: lib/LedgerSMB/App_State.pm:309
+#: lib/LedgerSMB/App_State.pm:217
 msgid "Quarters"
 msgstr ""
 
-#: bin/io.pl:1209 bin/io.pl:1216 bin/oe.pl:230 bin/oe.pl:657 bin/oe.pl:864
-#: bin/oe.pl:1237 bin/printer.pl:57
-#: lib/LedgerSMB/Report/Inventory/Search.pm:286
-#: lib/LedgerSMB/Report/Orders.pm:251 templates/demo/sales_quotation.html:4
-#: templates/demo/sales_quotation.html:17 templates/demo/sales_quotation.tex:69
-#: templates/demo_with_images/sales_quotation.html:4
-#: templates/demo_with_images/sales_quotation.html:17
-#: templates/demo_with_images/sales_quotation.tex:69
-#: templates/xedemo/sales_quotation.html:4
-#: templates/xedemo/sales_quotation.html:17
-#: templates/xedemo/sales_quotation.tex:70 sql/Pg-database.sql:1934
-#: sql/Pg-database.sql:2823 sql/Pg-database.sql:2955 sql/Pg-database.sql:2970
+#: UI/Reports/custom/reports.pl:1563 UI/Reports/custom/reports.pl:1709
+msgid "Quebec income tax"
+msgstr ""
+
+#: lib/LedgerSMB/Report/Inventory/Search.pm:287
+#: lib/LedgerSMB/Report/Orders.pm:253 old/bin/io.pl:1229 old/bin/io.pl:1236
+#: old/bin/oe.pl:231 old/bin/oe.pl:658 old/bin/oe.pl:867 old/bin/oe.pl:1240
+#: old/bin/printer.pl:57 sql/Pg-database.sql:1935 sql/Pg-database.sql:2827
+#: sql/Pg-database.sql:2959 sql/Pg-database.sql:2974
 msgid "Quotation"
 msgstr "Devis"
 
-#: templates/demo/sales_quotation.tex:75
-#: templates/demo_with_images/sales_quotation.tex:75
-#: templates/xedemo/sales_quotation.tex:76
-msgid "Quotation #"
-msgstr ""
-
-#: bin/oe.pl:484
+#: old/bin/oe.pl:485
 msgid "Quotation Date"
 msgstr "Date de devis"
 
-#: bin/io.pl:1262 bin/oe.pl:1193 bin/oe.pl:1369
+#: old/bin/io.pl:1282 old/bin/oe.pl:1196 old/bin/oe.pl:1371
 msgid "Quotation Date missing!"
 msgstr "Date de devis manqante!"
 
-#: bin/oe.pl:461
+#: old/bin/oe.pl:462
 msgid "Quotation Number"
 msgstr "Numéro de devis"
 
-#: bin/io.pl:1272 bin/oe.pl:1368
+#: old/bin/io.pl:1292 old/bin/oe.pl:1370
 msgid "Quotation Number missing!"
 msgstr "Numéro de devis manquant!"
 
-#: bin/oe.pl:1344
+#: old/bin/oe.pl:1346
 msgid "Quotation deleted!"
 msgstr "Devis effacé!"
 
-#: lib/LedgerSMB/Report/Orders.pm:193 lib/LedgerSMB/Report/Orders.pm:292
-#: UI/Reports/filters/purchase_history.html:192
-#: UI/Reports/filters/search_goods.html:151 sql/Pg-database.sql:2826
-#: sql/Pg-database.sql:2919
+#: lib/LedgerSMB/Report/Orders.pm:195 lib/LedgerSMB/Report/Orders.pm:294
+#: sql/Pg-database.sql:2830 sql/Pg-database.sql:2923
 msgid "Quotations"
 msgstr "Devis"
 
-#: bin/oe.pl:239 bin/oe.pl:668 bin/oe.pl:865 bin/printer.pl:62
-#: t/data/04-complex_template.html:352 UI/Contact/divs/credit.html:376
-#: sql/Pg-database.sql:1935 sql/Pg-database.sql:2824 sql/Pg-database.sql:2956
-#: sql/Pg-database.sql:2971
+#: old/bin/oe.pl:240 old/bin/oe.pl:669 old/bin/oe.pl:868 old/bin/printer.pl:62
+#: sql/Pg-database.sql:1936 sql/Pg-database.sql:2828 sql/Pg-database.sql:2960
+#: sql/Pg-database.sql:2975
 msgid "RFQ"
 msgstr "Demande de devis"
 
-#: templates/demo/request_quotation.html:103
-#: templates/demo/request_quotation.tex:106
-#: templates/demo_with_images/request_quotation.html:103
-#: templates/demo_with_images/request_quotation.tex:106
-#: templates/xedemo/request_quotation.html:103
-#: templates/xedemo/request_quotation.tex:106
-msgid "RFQ #"
-msgstr "No. de demande de devis"
-
-#: bin/oe.pl:472 lib/LedgerSMB/Scripts/configuration.pm:111
+#: lib/LedgerSMB/Scripts/configuration.pm:111 old/bin/oe.pl:473
 msgid "RFQ Number"
 msgstr "Numéro de demande de devis"
 
-#: lib/LedgerSMB/Report/Orders.pm:196 lib/LedgerSMB/Report/Orders.pm:294
-#: UI/Reports/filters/search_goods.html:174 sql/Pg-database.sql:2827
+#: lib/LedgerSMB/Report/Orders.pm:198 lib/LedgerSMB/Report/Orders.pm:296
+#: sql/Pg-database.sql:2831
 msgid "RFQs"
 msgstr "Demandes de devis"
 
-#: bin/ic.pl:486 bin/ic.pl:2102 lib/LedgerSMB/Report/Inventory/Search.pm:210
-#: UI/Reports/filters/search_goods.html:295
+#: UI/Reports/custom/reports.pl:231
+msgid "RLZ-1.S"
+msgstr ""
+
+#: lib/LedgerSMB/Report/Inventory/Search.pm:211 old/bin/ic.pl:484
+#: old/bin/ic.pl:2096
 msgid "ROP"
 msgstr "Seuil réapprovisionnement"
 
-#: bin/ir.pl:671 bin/is.pl:755 templates/demo/timecard.html:101
-#: templates/demo/timecard.tex:44 templates/demo_with_images/timecard.html:101
-#: templates/demo_with_images/timecard.tex:44
-#: templates/xedemo/timecard.html:101 templates/xedemo/timecard.tex:44
+#: UI/Reports/custom/reports.pl:1561 UI/Reports/custom/reports.pl:1707
+msgid "RRSP"
+msgstr ""
+
+#: old/bin/ir.pl:662 old/bin/is.pl:752
 msgid "Rate"
 msgstr "Taux"
 
-#: UI/am-taxes.html:15
-msgid "Rate (%)"
-msgstr "Taux (%)"
-
-#: UI/accounts/yearend.html:136
-msgid "Re-Open As Of"
-msgstr ""
-
-#: UI/accounts/yearend.html:123 UI/accounts/yearend.html:130
-msgid "Re-open Books"
-msgstr ""
-
-#: UI/accounts/yearend.html:153
-msgid "Re-open Period"
-msgstr ""
-
-#: lib/LedgerSMB/Scripts/setup.pm:158
+#: lib/LedgerSMB/Scripts/setup.pm:177 lib/LedgerSMB/Scripts/setup.pm:182
 msgid "Rebuild/Upgrade?"
-msgstr ""
+msgstr "Reconstruire/Mettre à jour?"
 
-#: bin/io.pl:179 bin/oe.pl:1839 templates/demo/bin_list.html:152
-#: templates/demo_with_images/bin_list.html:152
-#: templates/xedemo/bin_list.html:152
+#: old/bin/io.pl:174 old/bin/oe.pl:1843
 msgid "Recd"
 msgstr "Reçu"
 
-#: lib/LedgerSMB/Scripts/payment.pm:998 sql/Pg-database.sql:2800
-#: sql/Pg-database.sql:2969
+#: lib/LedgerSMB/Scripts/payment.pm:1025 sql/Pg-database.sql:2804
+#: sql/Pg-database.sql:2973
 msgid "Receipt"
 msgstr "Reçu"
 
-#: templates/demo_with_images/product_receipt.html:103
-msgid "Receipt Date"
-msgstr ""
-
-#: lib/LedgerSMB/Report/Invoices/Payments.pm:208
+#: lib/LedgerSMB/Report/Invoices/Payments.pm:209
 msgid "Receipt Results"
 msgstr ""
 
-#: UI/payments/payment1.html:19 sql/Pg-database.sql:2804
-#: sql/Pg-database.sql:2882
+#: sql/Pg-database.sql:2808 sql/Pg-database.sql:2886
 msgid "Receipts"
 msgstr "Reçus"
 
-#: lib/LedgerSMB/Report/Inventory/Activity.pm:94
-msgid "Receivable"
-msgstr "À recevoir"
-
-#: UI/accounts/edit.html:264
-msgid "Receivables"
-msgstr "À recevoir"
-
-#: lib/LedgerSMB/Scripts/order.pm:76 sql/Pg-database.sql:2821
+#: lib/LedgerSMB/Scripts/order.pm:77 sql/Pg-database.sql:2825
 msgid "Receive"
 msgstr "Réception"
 
-#: bin/oe.pl:1734
+#: old/bin/oe.pl:1737
 msgid "Receive Merchandise"
 msgstr "Réception marchandise"
 
-#: lib/LedgerSMB/Scripts/payment.pm:825
+#: lib/LedgerSMB/Scripts/payment.pm:847
 msgid "Received"
 msgstr ""
 
-#: UI/accounts/edit.html:220
-msgid "Recon"
-msgstr ""
-
-#: UI/reconciliation/upload.html:45
-msgid "Reconcile as FX"
-msgstr ""
-
-#: sql/Pg-database.sql:2806 sql/Pg-database.sql:2859 sql/Pg-database.sql:2871
+#: sql/Pg-database.sql:2810 sql/Pg-database.sql:2863 sql/Pg-database.sql:2875
 msgid "Reconciliation"
 msgstr "Rapprochement"
 
-#: UI/reconciliation/report.html:22
-msgid "Reconciliation Date:"
+#: UI/Reports/custom/reports.pl:226
+#, fuzzy
+msgid "Reconciliation Date"
 msgstr "Date de Rapprochement"
 
-#: UI/reconciliation/report.html:13
-msgid "Reconciliation Report"
-msgstr "Rapport de rapprochement"
-
-#: lib/LedgerSMB/Report/Reconciliation/Summary.pm:193
+#: lib/LedgerSMB/Report/Reconciliation/Summary.pm:194
 msgid "Reconciliation Reports"
 msgstr "Rapports de rapprochement"
 
-#: bin/ir.pl:473 bin/is.pl:489 UI/orders/order.html:42
+#: old/bin/ir.pl:464 old/bin/is.pl:486
 msgid "Record in"
 msgstr "Enregistrer dans"
 
-#: UI/timecards/entry_filter.html:17
-msgid "Recording time for"
-msgstr ""
-
-#: bin/arap.pl:566
+#: old/bin/arap.pl:564
 msgid "Recurring Transaction for [_1]"
 msgstr ""
 
-#: bin/am.pl:817 UI/am-list-recurring.html:8 sql/Pg-database.sql:2923
+#: old/bin/am.pl:755 sql/Pg-database.sql:2927
 msgid "Recurring Transactions"
 msgstr "Transactions périodiques"
 
-#: bin/am.pl:836 bin/arap.pl:587 lib/LedgerSMB/Report/Budget/Search.pm:80
-#: lib/LedgerSMB/Report/Budget/Search.pm:126 lib/LedgerSMB/Report/GL.pm:94
-#: lib/LedgerSMB/Report/GL.pm:213
-#: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:99
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:108
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:154
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:94
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:134 UI/accounts/yearend.html:33
-#: UI/budgetting/budget_entry.html:19 UI/import_csv/import_csv.html:31
-#: UI/journal/journal_entry.html:19 UI/Reports/filters/budget_search.html:21
-#: UI/Reports/filters/gl.html:25 UI/Reports/filters/gl.html:190
-#: UI/Reports/filters/unapproved.html:80
+#: lib/LedgerSMB/Report/Budget/Search.pm:81
+#: lib/LedgerSMB/Report/Budget/Search.pm:127 lib/LedgerSMB/Report/GL.pm:95
+#: lib/LedgerSMB/Report/GL.pm:214
+#: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:100
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:109
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:155
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:96
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:136 old/bin/am.pl:774
+#: old/bin/arap.pl:585 UI/Reports/custom/reports.pl:117
+#: UI/Reports/custom/reports.pl:227 UI/Reports/custom/reports.pl:3332
+#: UI/Reports/custom/reports.pl:4719 UI/Reports/custom/reports.pl:4768
 msgid "Reference"
 msgstr "Référence"
 
-#: bin/io.pl:1273
+#: old/bin/io.pl:1293
 msgid "Reference Number Missing"
 msgstr ""
 
@@ -6572,275 +4492,175 @@ msgstr ""
 msgid "Referral"
 msgstr ""
 
-#: templates/demo/ar_transaction.html:224 templates/demo/ar_transaction.tex:143
-#: templates/demo_with_images/ar_transaction.html:224
-#: templates/demo_with_images/ar_transaction.tex:143
-#: templates/xedemo/ar_transaction.html:224
-#: templates/xedemo/ar_transaction.tex:143
-msgid "Registration"
-msgstr ""
-
-#: templates/demo/invoice.html:309 templates/demo_with_images/invoice.html:309
-#: templates/xedemo/invoice.html:309
-msgid "Registration [_1]"
-msgstr ""
-
-#: lib/LedgerSMB/Scripts/budgets.pm:118 UI/reconciliation/report.html:301
+#: lib/LedgerSMB/Scripts/budgets.pm:118
 msgid "Reject"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:88
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:89
 msgid "Rem. Life"
 msgstr ""
 
-#: bin/aa.pl:552 bin/ir.pl:439 bin/is.pl:452 bin/oe.pl:421
-#: UI/orders/order.html:36
+#: old/bin/aa.pl:551 old/bin/ir.pl:430 old/bin/is.pl:449 old/bin/oe.pl:422
 msgid "Remaining"
 msgstr "Restant"
 
-#: t/data/04-complex_template.html:559 UI/Contact/divs/bank_act.html:23
-#: UI/Contact/divs/bank_act.html:73
-msgid "Remark"
+#: UI/Reports/custom/reports.pl:2352
+msgid "Reminder"
 msgstr ""
 
-#: t/data/04-complex_template.html:610
-msgid "Remark:"
-msgstr ""
-
-#: bin/arap.pl:550
+#: old/bin/arap.pl:548
 msgid "Repeat"
 msgstr "Répéter"
 
-#: UI/reconciliation/approved.html:4
-msgid "Report Approved"
-msgstr ""
+#: UI/Reports/custom/reports.pl:153 UI/Reports/custom/reports.pl:5150
+#, fuzzy
+msgid "Report"
+msgstr "Rapports"
 
-#: UI/Reports/aging_report.html:15 UI/Reports/display_report.html:16
-#: UI/Reports/display_report.tex:22
-msgid "Report Name"
-msgstr ""
-
-#: lib/LedgerSMB/Scripts/asset.pm:525
+#: lib/LedgerSMB/Scripts/asset.pm:528
 msgid "Report Results"
 msgstr ""
 
-#: UI/reconciliation/submitted.html:4
-msgid "Report Submitted"
-msgstr ""
-
-#: UI/Reports/filters/trial_balance.html:81
-msgid "Report Type"
-msgstr ""
-
-#: lib/LedgerSMB/Scripts/asset.pm:630
+#: lib/LedgerSMB/Scripts/asset.pm:631
 msgid "Report [_1] on date [_2]"
 msgstr ""
 
-#: UI/rp-search-generate_tax_report.html:67
+#: UI/Reports/custom/reports.pl:75 UI/Reports/custom/reports.pl:228
 msgid "Report for"
 msgstr "Rapport de"
 
-#: UI/timecards/timecard-week.html:66
-msgid "Report in"
-msgstr ""
+#: UI/Reports/custom/reports.pl:229
+#, fuzzy
+msgid "Report format"
+msgstr "Rapport de"
 
-#: lib/LedgerSMB/Report/PNL/Income_Statement.pm:85
+#: UI/Reports/custom/reports.pl:230
+#, fuzzy
+msgid "Report pages"
+msgstr "Rapports"
+
+#: lib/LedgerSMB/Report/PNL/Income_Statement.pm:69
 msgid "Reporting Basis"
 msgstr ""
 
-#: sql/Pg-database.sql:2878
+#: sql/Pg-database.sql:2882
 msgid "Reporting Units"
 msgstr ""
 
-#: sql/Pg-database.sql:2812 sql/Pg-database.sql:2825 sql/Pg-database.sql:2854
-#: sql/Pg-database.sql:2858 sql/Pg-database.sql:2883 sql/Pg-database.sql:2894
-#: sql/Pg-database.sql:2922 sql/Pg-database.sql:2937 sql/Pg-database.sql:2978
+#: sql/Pg-database.sql:2816 sql/Pg-database.sql:2829 sql/Pg-database.sql:2858
+#: sql/Pg-database.sql:2862 sql/Pg-database.sql:2887 sql/Pg-database.sql:2898
+#: sql/Pg-database.sql:2926 sql/Pg-database.sql:2941 sql/Pg-database.sql:2982
 msgid "Reports"
 msgstr "Rapports"
 
-#: bin/arap.pl:357
+#: old/bin/arap.pl:355
 msgid "Reposting Not Allowed"
 msgstr ""
 
-#: bin/oe.pl:2423
+#: old/bin/oe.pl:2412
 msgid "Req"
 msgstr ""
 
-#: bin/oe.pl:1243 templates/demo/request_quotation.html:4
-#: templates/demo/request_quotation.html:18
-#: templates/demo/request_quotation.tex:100
-#: templates/demo_with_images/request_quotation.html:4
-#: templates/demo_with_images/request_quotation.html:18
-#: templates/demo_with_images/request_quotation.tex:100
-#: templates/xedemo/request_quotation.html:4
-#: templates/xedemo/request_quotation.html:18
-#: templates/xedemo/request_quotation.tex:100
+#: old/bin/oe.pl:1246
 msgid "Request for Quotation"
 msgstr "Demande de devis"
 
-#: UI/io-email.html:74 UI/rp-email.html:58
-msgid "Request read receipt"
-msgstr ""
-
-#: UI/Reports/filters/orders.html:145
-msgid "Required By"
-msgstr "Requis pour"
-
-#: lib/LedgerSMB/Report/Orders.pm:222
+#: lib/LedgerSMB/Report/Orders.pm:224
 msgid "Required Date"
 msgstr ""
 
-#: lib/LedgerSMB/Request.pm:59
+#: lib/LedgerSMB/Request.pm:57
 msgid "Required attribute not provided: [_1]"
 msgstr ""
 
-#: bin/io.pl:275 bin/oe.pl:398 bin/oe.pl:456
-#: templates/demo/purchase_order.html:104 templates/demo/purchase_order.tex:106
-#: templates/demo/request_quotation.html:105
-#: templates/demo/request_quotation.tex:107 templates/demo/sales_order.html:104
-#: templates/demo/sales_order.tex:106
-#: templates/demo_with_images/purchase_order.html:104
-#: templates/demo_with_images/purchase_order.tex:106
-#: templates/demo_with_images/request_quotation.html:105
-#: templates/demo_with_images/request_quotation.tex:107
-#: templates/demo_with_images/sales_order.html:104
-#: templates/demo_with_images/sales_order.tex:106
-#: templates/demo_with_images/work_order.html:104
-#: templates/demo/work_order.html:104 templates/xedemo/product_receipt.html:104
-#: templates/xedemo/product_receipt.tex:106
-#: templates/xedemo/purchase_order.html:104
-#: templates/xedemo/purchase_order.tex:106
-#: templates/xedemo/request_quotation.html:105
-#: templates/xedemo/request_quotation.tex:107
-#: templates/xedemo/sales_order.html:104 templates/xedemo/sales_order.tex:106
-#: templates/xedemo/work_order.html:104
+#: old/bin/io.pl:270 old/bin/oe.pl:399 old/bin/oe.pl:457
 msgid "Required by"
 msgstr "Requis pour"
 
-#: lib/LedgerSMB.pm:613 lib/LedgerSMB.pm:614
+#: lib/LedgerSMB.pm:438 lib/LedgerSMB.pm:439
 msgid "Required input not provided"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Balance_Sheet.pm:92
-#: lib/LedgerSMB/Report/PNL/Income_Statement.pm:106
+#: lib/LedgerSMB/Report/Balance_Sheet.pm:77
+#: lib/LedgerSMB/Report/PNL/Income_Statement.pm:90
 msgid "Required period type"
 msgstr ""
 
-#: UI/Contact/divs/user.html:90 UI/setup/edit_user.html:88
-msgid "Reset Password"
-msgstr ""
-
-#: UI/accounts/yearend.html:50
-msgid "Retained Earnings"
-msgstr "Éxcédents non distribués"
-
-#: UI/Contact/divs/company.html:174 UI/Contact/divs/person.html:189
-#: UI/templates/edit.html:44
-msgid "Retrieve"
-msgstr ""
-
-#: UI/setup/complete.html:12 UI/setup/complete_migration_revert.html:11
-msgid "Return to setup"
-msgstr ""
-
-#: UI/logout.html:30
-msgid "Return to the login screen."
-msgstr ""
-
-#: bin/ic.pl:534 UI/accounts/edit.html:370
+#: old/bin/ic.pl:532
 msgid "Returns"
 msgstr ""
 
-#: UI/Reports/filters/overpayments.html:42
-msgid "Reversal Information"
-msgstr ""
+#: lib/LedgerSMB/Report/Inventory/Activity.pm:95
+#, fuzzy
+msgid "Revenue"
+msgstr "Sept"
 
-#: lib/LedgerSMB/Report/Listings/Overpayments.pm:159
+#: lib/LedgerSMB/Report/Listings/Overpayments.pm:160
 msgid "Reverse"
 msgstr ""
 
-#: sql/Pg-database.sql:2942
+#: sql/Pg-database.sql:2946
 msgid "Reverse AR Overpay"
 msgstr ""
 
-#: sql/Pg-database.sql:2941
+#: sql/Pg-database.sql:2945
 msgid "Reverse Overpay"
 msgstr ""
 
-#: sql/Pg-database.sql:2869
+#: sql/Pg-database.sql:2873
 msgid "Reverse Payment"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Invoices/Payments.pm:236
+#: lib/LedgerSMB/Report/Invoices/Payments.pm:237
 msgid "Reverse Payments"
 msgstr ""
 
-#: sql/Pg-database.sql:2940
+#: sql/Pg-database.sql:2944
 msgid "Reverse Receipts"
 msgstr ""
 
-#: sql/Pg-database.sql:2481
+#: sql/Pg-database.sql:2485
 msgid "Rounded"
 msgstr ""
 
-#: UI/setup/complete.html:18 UI/setup/confirm_operation.html:105
-msgid "Row counts"
-msgstr ""
-
-#: UI/setup/begin_backup.html:50
-msgid "Run Backup"
-msgstr ""
-
-#: UI/Reports/filters/inventory_adj.html:35
-msgid "Run Report"
-msgstr ""
-
-#: UI/Contact/divs/company.html:125 sql/Pg-database.sql:2875
+#: sql/Pg-database.sql:2879
 msgid "SIC"
 msgstr "Code secteur économique"
 
-#: bin/am.pl:385
+#: old/bin/am.pl:377
 msgid "SIC deleted!"
 msgstr "Code secteur économique effacé!"
 
-#: bin/am.pl:378
+#: old/bin/am.pl:370
 msgid "SIC saved!"
 msgstr "Code secteur économique enregistré!"
 
-#: t/data/04-complex_template.html:259
-msgid "SIC:"
-msgstr ""
-
-#: bin/io.pl:270 bin/oe.pl:1841 bin/oe.pl:2413
+#: old/bin/io.pl:265 old/bin/oe.pl:1845 old/bin/oe.pl:2402
 msgid "SKU"
 msgstr "SKU"
 
-#: lib/LedgerSMB/Scripts/setup.pm:128
+#: lib/LedgerSMB/Scripts/setup.pm:147
 msgid "SQL-Ledger 3.0 database detected."
-msgstr ""
+msgstr "Banque de données SQL-Ledger 3.0 détectée."
 
-#: lib/LedgerSMB/Scripts/setup.pm:107
+#: lib/LedgerSMB/Scripts/setup.pm:126
 msgid "SQL-Ledger database detected."
-msgstr ""
+msgstr "Banque de données SQL-Ledger détectée."
 
-#: UI/payments/payment1.html:46
-msgid "SSN"
-msgstr "Numéro d'assurance sociale"
-
-#: sql/Pg-database.sql:954
+#: sql/Pg-database.sql:968
 msgid "Salary"
 msgstr "Salaire"
 
-#: sql/Pg-database.sql:3789
+#: sql/Pg-database.sql:3793
 msgid "Sale"
 msgstr "Vente"
 
-#: lib/LedgerSMB/Entity/Location.pm:113 UI/Contact/divs/address.html:42
-#: UI/Contact/divs/employee.html:93 sql/Pg-database.sql:660
+#: lib/LedgerSMB/Entity/Location.pm:114 sql/Pg-database.sql:674
 msgid "Sales"
 msgstr "Ventes"
 
-#: bin/is.pl:1001 bin/oe.pl:653 bin/oe.pl:862 sql/Pg-database.sql:2902
+#: old/bin/is.pl:998 old/bin/oe.pl:654 old/bin/oe.pl:865
+#: sql/Pg-database.sql:2906
 msgid "Sales Invoice"
 msgstr "Facture de vente"
 
@@ -6848,16 +4668,10 @@ msgstr "Facture de vente"
 msgid "Sales Invoice/AR Transaction Number"
 msgstr ""
 
-#: bin/am.pl:1275 bin/am.pl:1502 bin/io.pl:1147 bin/is.pl:588 bin/is.pl:1029
-#: bin/oe.pl:250 bin/oe.pl:655 bin/oe.pl:866 bin/oe.pl:1220 bin/printer.pl:67
-#: templates/demo/sales_order.html:4 templates/demo/sales_order.html:18
-#: templates/demo/sales_order.tex:99
-#: templates/demo_with_images/sales_order.html:4
-#: templates/demo_with_images/sales_order.html:18
-#: templates/demo_with_images/sales_order.tex:99
-#: templates/xedemo/sales_order.html:4 templates/xedemo/sales_order.html:18
-#: templates/xedemo/sales_order.tex:99 sql/Pg-database.sql:1932
-#: sql/Pg-database.sql:2810 sql/Pg-database.sql:2950 sql/Pg-database.sql:2963
+#: old/bin/am.pl:1234 old/bin/am.pl:1461 old/bin/io.pl:1167 old/bin/is.pl:585
+#: old/bin/is.pl:1028 old/bin/oe.pl:251 old/bin/oe.pl:656 old/bin/oe.pl:869
+#: old/bin/oe.pl:1223 old/bin/printer.pl:67 sql/Pg-database.sql:1933
+#: sql/Pg-database.sql:2814 sql/Pg-database.sql:2954 sql/Pg-database.sql:2967
 msgid "Sales Order"
 msgstr "Commande de vente"
 
@@ -6865,10 +4679,9 @@ msgstr "Commande de vente"
 msgid "Sales Order Number"
 msgstr "Numéro de commande de vente"
 
-#: bin/am.pl:862 lib/LedgerSMB/Report/Orders.pm:187
-#: lib/LedgerSMB/Report/Orders.pm:288 UI/Reports/filters/search_goods.html:144
-#: sql/Pg-database.sql:2813 sql/Pg-database.sql:2815 sql/Pg-database.sql:2818
-#: sql/Pg-database.sql:2832
+#: lib/LedgerSMB/Report/Orders.pm:189 lib/LedgerSMB/Report/Orders.pm:290
+#: old/bin/am.pl:800 sql/Pg-database.sql:2817 sql/Pg-database.sql:2819
+#: sql/Pg-database.sql:2822 sql/Pg-database.sql:2836
 msgid "Sales Orders"
 msgstr "Commandes de vente"
 
@@ -6876,170 +4689,121 @@ msgstr "Commandes de vente"
 msgid "Sales Quotation Number"
 msgstr "Numéro de devis de vente"
 
-#: UI/Contact/divs/company.html:139
-msgid "Sales Tax ID"
+#: UI/Reports/custom/reports.pl:232
+msgid "Sales Summary by month"
 msgstr ""
 
-#: t/data/04-complex_template.html:85
-msgid "Sales:"
-msgstr "Ventes:"
+#: UI/Reports/custom/reports.pl:233
+msgid "Sales Summary by month and customer"
+msgstr ""
 
-#: bin/aa.pl:477 bin/aa.pl:1479 bin/is.pl:376 bin/oe.pl:529
-#: lib/LedgerSMB/Report/Contact/History.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:263
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:298
-#: templates/demo/ar_transaction.html:92 templates/demo/invoice.html:116
-#: templates/demo/invoice.tex:120 templates/demo/sales_order.html:105
-#: templates/demo/sales_order.tex:107
-#: templates/demo_with_images/ar_transaction.html:92
-#: templates/demo_with_images/invoice.html:116
-#: templates/demo_with_images/invoice.tex:120
-#: templates/demo_with_images/sales_order.html:105
-#: templates/demo_with_images/sales_order.tex:107
-#: templates/demo_with_images/work_order.html:105
-#: templates/demo/work_order.html:105 templates/xedemo/ar_transaction.html:92
-#: templates/xedemo/invoice.html:116 templates/xedemo/invoice.tex:119
-#: templates/xedemo/sales_order.html:105 templates/xedemo/sales_order.tex:107
-#: templates/xedemo/work_order.html:105
-#: UI/Reports/filters/contact_search.html:62
-#: UI/Reports/filters/invoice_outstanding.html:183
-#: UI/Reports/filters/invoice_search.html:273
+#: UI/Reports/custom/reports.pl:234
+msgid "Sales Summary by month and group"
+msgstr ""
+
+#: lib/LedgerSMB/Report/Contact/History.pm:121
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:264
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:298 old/bin/aa.pl:476
+#: old/bin/aa.pl:1461 old/bin/is.pl:373 old/bin/oe.pl:530
+#: UI/Reports/custom/reports.pl:4776
 msgid "Salesperson"
 msgstr "Vendeur"
 
-#: UI/Contact/divs/employee.html:28 UI/Contact/divs/person.html:76
-msgid "Salutation"
-msgstr ""
+#: UI/Reports/custom/reports.pl:137
+#, fuzzy
+msgid "Sample Form"
+msgstr "Format de date"
 
-#: UI/asset/edit_asset.html:113 UI/asset/search_asset.html:97
-msgid "Salvage Value:"
-msgstr ""
-
-#: lib/LedgerSMB/Report/Timecards.pm:146
+#: lib/LedgerSMB/Report/Timecards.pm:147
 msgid "Sat"
 msgstr "Sam."
 
-#: bin/aa.pl:980 bin/am.pl:67 bin/am.pl:75 bin/am.pl:86 bin/am.pl:173
-#: bin/am.pl:179 bin/gl.pl:274 bin/ic.pl:833 bin/ic.pl:842 bin/ir.pl:560
-#: bin/is.pl:604 bin/oe.pl:633 bin/oe.pl:855 bin/pe.pl:167 bin/pe.pl:239
-#: bin/pe.pl:607 lib/LedgerSMB/Scripts/account.pm:169
-#: lib/LedgerSMB/Scripts/account.pm:182 lib/LedgerSMB/Scripts/asset.pm:447
-#: lib/LedgerSMB/Scripts/budgets.pm:103 t/data/04-complex_template.html:131
-#: t/data/04-complex_template.html:310 t/data/04-complex_template.html:620
-#: t/data/04-complex_template.html:644 UI/accounts/edit.html:527
-#: UI/am-taxes.html:77 UI/asset/edit_asset.html:218 UI/asset/edit_class.html:58
-#: UI/asset/import_asset.html:58 UI/business_units/edit.html:96
-#: UI/business_units/list_classes.html:89 UI/Configuration/sequence.html:10
-#: UI/Configuration/sequence.html:119 UI/Configuration/settings.html:74
-#: UI/Contact/divs/bank_act.html:85 UI/Contact/divs/company.html:181
-#: UI/Contact/divs/employee.html:204 UI/Contact/divs/notes.html:68
-#: UI/Contact/divs/person.html:196 UI/Contact/pricelist.html:96
-#: UI/import_csv/import_csv.html:74 UI/import_csv/import_inventory_csv.html:81
-#: UI/inventory/adjustment_entry.html:92 UI/payroll/deduction.html:98
-#: UI/payroll/income.html:104 UI/reconciliation/report.html:279
-#: UI/taxform/add_taxform.html:88 UI/templates/edit.html:38
-#: UI/timecards/timecard.html:169 UI/timecards/timecard-week.html:127
-#: UI/users/preferences.html:152
+#: lib/LedgerSMB/Scripts/account.pm:170 lib/LedgerSMB/Scripts/account.pm:183
+#: lib/LedgerSMB/Scripts/asset.pm:449 lib/LedgerSMB/Scripts/budgets.pm:103
+#: old/bin/aa.pl:968 old/bin/am.pl:65 old/bin/am.pl:73 old/bin/am.pl:84
+#: old/bin/am.pl:169 old/bin/am.pl:175 old/bin/gl.pl:268 old/bin/ic.pl:831
+#: old/bin/ic.pl:840 old/bin/ir.pl:551 old/bin/is.pl:601 old/bin/oe.pl:634
+#: old/bin/oe.pl:858 old/bin/pe.pl:165 old/bin/pe.pl:237 old/bin/pe.pl:605
 msgid "Save"
 msgstr "Enregistrer"
 
-#: UI/Contact/divs/contact_info.html:128
-msgid "Save As New"
-msgstr ""
-
-#: lib/LedgerSMB/Scripts/payment.pm:220
+#: lib/LedgerSMB/Scripts/payment.pm:222
 msgid "Save Batch"
 msgstr ""
 
-#: UI/Contact/divs/credit.html:324
-msgid "Save Changes"
-msgstr ""
-
-#: t/data/04-complex_template.html:546 UI/Contact/divs/contact_info.html:121
-msgid "Save Contact"
-msgstr ""
-
-#: bin/aa.pl:973 bin/gl.pl:257 bin/gl.pl:303 bin/ir.pl:580 bin/is.pl:625
+#: old/bin/aa.pl:961 old/bin/gl.pl:251 old/bin/gl.pl:297 old/bin/ir.pl:571
+#: old/bin/is.pl:622
 msgid "Save Draft"
 msgstr ""
 
-#: UI/Contact/divs/user.html:159 UI/setup/edit_user.html:156
-msgid "Save Groups"
-msgstr ""
-
-#: bin/aa.pl:956 bin/ir.pl:554 bin/is.pl:596
+#: old/bin/aa.pl:944 old/bin/ir.pl:545 old/bin/is.pl:593
 msgid "Save Info"
 msgstr ""
 
-#: t/data/04-complex_template.html:485 UI/Contact/divs/address.html:205
-msgid "Save Location"
-msgstr ""
+#: UI/Reports/custom/reports.pl:4198
+#, fuzzy
+msgid "Save Level"
+msgstr "Enregistrer transaction planifiée"
 
-#: UI/Contact/divs/credit.html:334
-msgid "Save New"
-msgstr ""
+#: UI/Reports/custom/reports.pl:235 UI/Reports/custom/reports.pl:4206
+#, fuzzy
+msgid "Save Report"
+msgstr "Rapports"
 
-#: UI/Contact/divs/address.html:213
-msgid "Save New Location"
-msgstr ""
-
-#: bin/arap.pl:632 bin/arap.pl:637
+#: old/bin/arap.pl:630 old/bin/arap.pl:635
 msgid "Save Schedule"
 msgstr "Enregistrer transaction planifiée"
 
-#: bin/aa.pl:958 bin/gl.pl:261
+#: old/bin/aa.pl:946 old/bin/gl.pl:255
 msgid "Save Template"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:738
+#: lib/LedgerSMB/Scripts/setup.pm:780
 msgid "Save and Retry"
-msgstr ""
+msgstr "Saugevarder et Reprendre"
 
-#: bin/aa.pl:981
+#: old/bin/aa.pl:969
 msgid "Save as New"
 msgstr ""
 
-#: bin/am.pl:68 bin/am.pl:77 bin/gl.pl:263 bin/ic.pl:834 bin/ic.pl:851
-#: bin/oe.pl:645 bin/oe.pl:858 lib/LedgerSMB/Scripts/account.pm:172
+#: lib/LedgerSMB/Scripts/account.pm:173 old/bin/am.pl:66 old/bin/am.pl:75
+#: old/bin/gl.pl:257 old/bin/ic.pl:832 old/bin/ic.pl:849 old/bin/oe.pl:646
+#: old/bin/oe.pl:861
 msgid "Save as new"
 msgstr "Enregistrer comme nouveau"
 
-#: bin/am.pl:1320
+#: lib/LedgerSMB/Upgrade_Tests.pm:221 lib/LedgerSMB/Upgrade_Tests.pm:633
+msgid "Save the fixes provided and attempt to continue migration"
+msgstr "Sauvegarder les corrections et tenter de reprendre la migration"
+
+#: lib/LedgerSMB/Scripts/business_unit.pm:195
+#, fuzzy
+msgid "Saved id [_1]"
+msgstr "Date: [_1]"
+
+#: old/bin/am.pl:1279
 msgid "Saving [_1] [_2]"
 msgstr ""
 
-#: UI/oe-save_warn.html:13
-msgid "Saving over an existing document.  Continue?"
-msgstr ""
-
-#: bin/aa.pl:911 bin/aa.pl:950 bin/gl.pl:265 bin/ir.pl:550 bin/ir.pl:944
-#: bin/is.pl:590 bin/is.pl:1024 bin/oe.pl:670 bin/oe.pl:854
+#: old/bin/aa.pl:905 old/bin/aa.pl:938 old/bin/gl.pl:259 old/bin/ir.pl:541
+#: old/bin/ir.pl:937 old/bin/is.pl:587 old/bin/is.pl:1023 old/bin/oe.pl:671
+#: old/bin/oe.pl:857 UI/Reports/custom/reports.pl:3448
 msgid "Schedule"
 msgstr "Planification"
 
-#: bin/printer.pl:175 UI/journal/journal_entry.html:306
+#: old/bin/printer.pl:175 UI/Reports/custom/reports.pl:3478
 msgid "Scheduled"
 msgstr "Planifié"
 
-#: bin/printer.pl:131 lib/LedgerSMB/Scripts/payment.pm:516
-#: lib/LedgerSMB/Template.pm:309 UI/lib/utilities.html:44
+#: lib/LedgerSMB/Scripts/payment.pm:538 lib/LedgerSMB/Template.pm:560
+#: old/bin/printer.pl:131 UI/Reports/custom/reports.pl:2337
+#: UI/Reports/custom/reports.pl:4947
 msgid "Screen"
 msgstr "Écran"
 
-#: UI/Admin/user_search.html:60 UI/asset/search_asset.html:186
-#: UI/asset/search_class.html:67 UI/asset/search_reports.html:70
-#: UI/business_units/filter.html:45 UI/Reports/filters/budget_search.html:78
-#: UI/Reports/filters/cogs_lines.html:36
-#: UI/Reports/filters/contact_search.html:141
-#: UI/Reports/filters/overpayments.html:61 UI/Reports/filters/payments.html:126
-#: UI/Reports/filters/reconciliation_search.html:103
-#: UI/Reports/filters/search_goods.html:385
-#: UI/Reports/filters/search_partsgroups.html:18
-#: UI/Reports/filters/search_pricegroups.html:18
-#: UI/Reports/filters/timecards.html:42 UI/Reports/filters/unapproved.html:107
-#: sql/Pg-database.sql:2778 sql/Pg-database.sql:2786 sql/Pg-database.sql:2799
-#: sql/Pg-database.sql:2809 sql/Pg-database.sql:2867 sql/Pg-database.sql:2914
-#: sql/Pg-database.sql:2977
+#: sql/Pg-database.sql:2782 sql/Pg-database.sql:2790 sql/Pg-database.sql:2803
+#: sql/Pg-database.sql:2813 sql/Pg-database.sql:2871 sql/Pg-database.sql:2918
+#: sql/Pg-database.sql:2981
 msgid "Search"
 msgstr "Recherche"
 
@@ -7047,99 +4811,47 @@ msgstr "Recherche"
 msgid "Search AP"
 msgstr ""
 
-#: UI/Reports/filters/invoice_search.html:5
-msgid "Search AP Invoices"
-msgstr ""
-
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:332
 msgid "Search AR"
 msgstr ""
 
-#: UI/Reports/filters/invoice_search.html:9
-msgid "Search AR Invoices"
-msgstr ""
-
-#: UI/asset/search_class.html:5
-msgid "Search Asset Class"
-msgstr ""
-
-#: sql/Pg-database.sql:2889
+#: sql/Pg-database.sql:2893
 msgid "Search Assets"
 msgstr ""
 
-#: UI/Reports/filters/budget_search.html:11
-msgid "Search Budgets"
-msgstr ""
-
-#: UI/Reports/filters/search_goods.html:5
-msgid "Search Goods and Services"
-msgstr ""
-
-#: sql/Pg-database.sql:2775
+#: sql/Pg-database.sql:2779
 msgid "Search Groups"
 msgstr ""
 
-#: UI/Reports/filters/inventory_adj.html:6
-msgid "Search Inventory Entry"
-msgstr ""
-
-#: UI/Reports/filters/search_partsgroups.html:4
-msgid "Search Partsgroups"
-msgstr ""
-
-#: UI/Reports/filters/payments.html:7 UI/Reports/filters/payments.html:17
-msgid "Search Payments"
-msgstr ""
-
-#: UI/Reports/filters/search_pricegroups.html:4
-msgid "Search Price Groups"
-msgstr ""
-
-#: sql/Pg-database.sql:2776
+#: sql/Pg-database.sql:2780
 msgid "Search Pricegroups"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:69
+#: lib/LedgerSMB/Scripts/order.pm:70
 msgid "Search Purchase Orders"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:80
+#: lib/LedgerSMB/Scripts/order.pm:81
 msgid "Search Quotations"
 msgstr ""
 
-#: UI/Reports/filters/payments.html:14
-msgid "Search Receipts"
-msgstr ""
-
-#: UI/Reports/filters/reconciliation_search.html:5
-msgid "Search Reconciliation Reports"
-msgstr ""
-
-#: lib/LedgerSMB/Scripts/order.pm:84
+#: lib/LedgerSMB/Scripts/order.pm:85
 msgid "Search Requests for Quotation"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/order.pm:58
+#: lib/LedgerSMB/Scripts/order.pm:59
 msgid "Search Sales Orders"
 msgstr ""
 
-#: UI/Reports/filters/unapproved.html:35
-msgid "Search Unapproved Transactions"
-msgstr ""
-
-#: sql/Pg-database.sql:2906
+#: sql/Pg-database.sql:2910
 msgid "Search and GL"
 msgstr ""
 
-#: UI/Admin/user_search.html:5
-msgid "Search for Users"
-msgstr ""
-
-#: lib/LedgerSMB/Scripts/asset.pm:498
+#: lib/LedgerSMB/Scripts/asset.pm:501
 msgid "Search reports"
 msgstr ""
 
-#: sql/Pg-database.sql:796
+#: sql/Pg-database.sql:810
 msgid "Secondary Phone"
 msgstr ""
 
@@ -7147,116 +4859,99 @@ msgstr ""
 msgid "Security Settings"
 msgstr ""
 
-#: UI/reconciliation/report.html:273 UI/Reports/aging_report.html:58
-msgid "Select All"
-msgstr ""
-
-#: bin/pe.pl:1141
+#: old/bin/pe.pl:1139
 msgid "Select Customer"
 msgstr ""
 
-#: UI/setup/template_info.html:9
-msgid "Select Templates to Load"
-msgstr ""
-
-#: bin/oe.pl:2532
+#: old/bin/oe.pl:2521
 msgid "Select Vendor"
 msgstr ""
 
-#: bin/arapprn.pl:450 bin/is.pl:1417 bin/oe.pl:1286
+#: old/bin/arapprn.pl:367 old/bin/is.pl:1415 old/bin/oe.pl:1288
 msgid "Select a Printer!"
 msgstr ""
 
-#: UI/taxform/add_taxform.html:62
-msgid "Select by Default:"
+#: UI/tmp/index.pl:20
+msgid "Select a User to View Their Details"
 msgstr ""
 
-#: bin/arap.pl:184 bin/ic.pl:1687 bin/pe.pl:672
+#: UI/Reports/custom/reports.pl:236 UI/Reports/custom/reports.pl:4191
+#: UI/Reports/custom/reports.pl:5557
+#, fuzzy
+msgid "Select all"
+msgstr "Sélectionner le payement"
+
+#: old/bin/arap.pl:182 old/bin/ic.pl:1681 old/bin/pe.pl:670
 msgid "Select from one of the names below"
 msgstr "Sélectionner un des noms ci-dessous"
 
-#: UI/payments/use_overpayment2.html:148
-msgid "Select invoices"
-msgstr ""
-
-#: UI/setup/credentials.html:16
-msgid "Select or Enter User"
-msgstr ""
-
-#: bin/arapprn.pl:369
-msgid "Select payment"
-msgstr "Sélectionner le payement"
-
-#: bin/arapprn.pl:89 bin/arapprn.pl:448 bin/is.pl:1415 bin/oe.pl:1284
+#: old/bin/arapprn.pl:87 old/bin/arapprn.pl:365 old/bin/is.pl:1413
+#: old/bin/oe.pl:1286 UI/Reports/custom/reports.pl:2515
 msgid "Select postscript or PDF!"
 msgstr "Sélectionner Postscript ou PDF!"
 
-#: bin/io.pl:1112
+#: old/bin/io.pl:1137
 msgid "Select txt, postscript or PDF!"
 msgstr "Sélectionner Txt, Postscript ou PDF!"
 
-#: lib/LedgerSMB/Report/Invoices/Payments.pm:121
+#: lib/LedgerSMB/Report/Invoices/Payments.pm:122
 msgid "Selected"
 msgstr ""
 
-#: UI/payments/payments_filter.html:3
-msgid "Selection"
-msgstr ""
-
-#: bin/ic.pl:1269
+#: old/bin/ic.pl:1267
 msgid "Sell"
 msgstr "Vente"
 
-#: bin/ic.pl:439 bin/ic.pl:1128 lib/LedgerSMB/Report/Contact/History.pm:97
-#: lib/LedgerSMB/Report/Inventory/History.pm:151
-#: lib/LedgerSMB/Report/Inventory/Search.pm:228 UI/Contact/pricelist.csv:31
-#: UI/Contact/pricelist.html:44 UI/Contact/pricelist.tex:42
-#: UI/Reports/filters/purchase_history.html:266
-#: UI/Reports/filters/search_goods.html:251
+#: lib/LedgerSMB/Report/Contact/History.pm:98
+#: lib/LedgerSMB/Report/Inventory/History.pm:152
+#: lib/LedgerSMB/Report/Inventory/Search.pm:229 old/bin/ic.pl:437
+#: old/bin/ic.pl:1126
 msgid "Sell Price"
 msgstr "Prix de vente"
 
-#: bin/am.pl:1454
+#: old/bin/am.pl:1413
 msgid "Sending Bin List [_1]"
 msgstr ""
 
-#: bin/am.pl:1447
+#: old/bin/am.pl:1406
 msgid "Sending Credit Invoice [_1]"
 msgstr ""
 
-#: bin/am.pl:1448
+#: old/bin/am.pl:1407
 msgid "Sending Debit Invoice [_1]"
 msgstr ""
 
-#: bin/am.pl:1446
+#: old/bin/am.pl:1405
 msgid "Sending Invoice [_1]"
 msgstr ""
 
-#: bin/am.pl:1449
+#: old/bin/am.pl:1408
 msgid "Sending Packing List [_1]"
 msgstr ""
 
-#: bin/am.pl:1450
+#: old/bin/am.pl:1409
 msgid "Sending Pick List [_1]"
 msgstr ""
 
-#: bin/am.pl:1453
+#: old/bin/am.pl:1412
 msgid "Sending Purchase Order [_1]"
 msgstr ""
 
-#: bin/am.pl:1451
+#: old/bin/am.pl:1410
 msgid "Sending Sales Order [_1]"
 msgstr ""
 
-#: bin/am.pl:1445
+#: old/bin/am.pl:1404
 msgid "Sending Transaction [_1]"
 msgstr ""
 
-#: bin/am.pl:1452
+#: old/bin/am.pl:1411
 msgid "Sending Work Order [_1]"
 msgstr ""
 
-#: bin/aa.pl:94 bin/gl.pl:87 bin/io.pl:88 lib/LedgerSMB/App_State.pm:363
+#: lib/LedgerSMB/App_State.pm:273 old/bin/aa.pl:95 old/bin/gl.pl:88
+#: old/bin/io.pl:87 UI/Reports/custom/reports.pl:106
+#: UI/Reports/custom/reports.pl:5309
 msgid "Sep"
 msgstr "Sept."
 
@@ -7264,57 +4959,31 @@ msgstr "Sept."
 msgid "Separate Duties"
 msgstr ""
 
-#: bin/aa.pl:80 bin/gl.pl:73 bin/io.pl:74 lib/LedgerSMB/App_State.pm:363
-#: lib/LedgerSMB/DBObject/Date.pm:70
+#: lib/LedgerSMB/App_State.pm:273 old/bin/aa.pl:81 old/bin/gl.pl:74
+#: old/bin/io.pl:73 old/lib/LedgerSMB/DBObject/Date.pm:71
+#: UI/Reports/custom/reports.pl:92 UI/Reports/custom/reports.pl:5295
 msgid "September"
 msgstr "Septembre"
 
-#: UI/Configuration/sequence.html:15
-msgid "Sequence"
-msgstr ""
-
-#: UI/Configuration/sequence.html:6 sql/Pg-database.sql:2939
+#: sql/Pg-database.sql:2943
 msgid "Sequences"
 msgstr ""
 
-#: templates/demo/packing_list.html:121
-#: templates/demo_with_images/packing_list.html:121
-#: templates/demo_with_images/work_order.html:134
-#: templates/demo/work_order.html:134 templates/xedemo/packing_list.html:121
-#: templates/xedemo/work_order.html:134
-msgid "Serial #"
-msgstr ""
-
-#: bin/io.pl:267 bin/oe.pl:1862
+#: old/bin/io.pl:262 old/bin/oe.pl:1866
 msgid "Serial No."
 msgstr "N° série"
 
-#: lib/LedgerSMB/Report/Contact/History.pm:110
-#: lib/LedgerSMB/Report/Inventory/History.pm:164
-#: lib/LedgerSMB/Report/Inventory/Search.pm:303 templates/demo/bin_list.tex:107
-#: templates/demo/packing_list.tex:115
-#: templates/demo_with_images/bin_list.tex:107
-#: templates/demo_with_images/packing_list.tex:115
-#: templates/demo_with_images/work_order.tex:126
-#: templates/demo/work_order.tex:126 templates/xedemo/bin_list.tex:107
-#: templates/xedemo/packing_list.tex:115 templates/xedemo/work_order.tex:126
-#: UI/Reports/filters/purchase_history.html:335
-#: UI/Reports/filters/search_goods.html:37
-#: UI/Reports/filters/search_goods.html:367
+#: lib/LedgerSMB/Report/Contact/History.pm:111
+#: lib/LedgerSMB/Report/Inventory/History.pm:165
+#: lib/LedgerSMB/Report/Inventory/Search.pm:304
 msgid "Serial Number"
 msgstr "Numéro de série"
 
-#: templates/demo/bin_list.html:149
-#: templates/demo_with_images/bin_list.html:149
-#: templates/xedemo/bin_list.html:149
-msgid "Serialnumber"
-msgstr ""
-
-#: bin/io.pl:606
+#: old/bin/io.pl:600
 msgid "Service"
 msgstr "Prestation de service"
 
-#: bin/pe.pl:1031
+#: old/bin/pe.pl:1029
 msgid "Service Code"
 msgstr ""
 
@@ -7322,1594 +4991,805 @@ msgstr ""
 msgid "Session Timeout"
 msgstr "Fin de session"
 
-#: sql/Pg-database.sql:2880
+#: sql/Pg-database.sql:2884
 msgid "Sessions"
 msgstr "Sessions"
 
-#: UI/Configuration/sequence.html:13
-msgid "Setting"
-msgstr ""
-
-#: UI/users/preferences.html:76
-msgid "Settings"
-msgstr ""
-
-#: lib/LedgerSMB/Num2text.pm:81
+#: old/lib/LedgerSMB/Num2text.pm:81
 msgid "Seven"
 msgstr "Sept"
 
-#: lib/LedgerSMB/Num2text.pm:115
+#: old/lib/LedgerSMB/Num2text.pm:115
 msgid "Seven Hundred"
 msgstr ""
 
-#: lib/LedgerSMB/Num2text.pm:92
+#: old/lib/LedgerSMB/Num2text.pm:92
 msgid "Seventeen"
 msgstr "Dix-sept"
 
-#: lib/LedgerSMB/Num2text.pm:110
+#: old/lib/LedgerSMB/Num2text.pm:110
 msgid "Seventy"
 msgstr "Soixante-dix"
 
-#: bin/io.pl:172 bin/oe.pl:1835 lib/LedgerSMB/Scripts/order.pm:65
-#: templates/demo/packing_list.html:124 templates/demo/pick_list.html:114
-#: templates/demo_with_images/packing_list.html:124
-#: templates/demo_with_images/pick_list.html:114
-#: templates/xedemo/packing_list.html:124 templates/xedemo/pick_list.html:114
-#: sql/Pg-database.sql:2820
+#: lib/LedgerSMB/Scripts/order.pm:66 old/bin/io.pl:167 old/bin/oe.pl:1839
+#: sql/Pg-database.sql:2824
 msgid "Ship"
 msgstr "Expédier"
 
-#: bin/oe.pl:1730
+#: old/bin/oe.pl:1732
 msgid "Ship Merchandise"
 msgstr "Expédier marchandise"
 
-#: templates/demo/bin_list.html:30 templates/demo/bin_list.tex:53
-#: templates/demo/invoice.html:29 templates/demo/invoice.tex:76
-#: templates/demo/sales_order.html:29
-#: templates/demo_with_images/bin_list.html:30
-#: templates/demo_with_images/bin_list.tex:53
-#: templates/demo_with_images/invoice.html:29
-#: templates/demo_with_images/invoice.tex:76
-#: templates/demo_with_images/sales_order.html:29
-#: templates/demo_with_images/work_order.html:29
-#: templates/demo/work_order.html:29 templates/xedemo/bin_list.html:30
-#: templates/xedemo/bin_list.tex:53 templates/xedemo/invoice.html:29
-#: templates/xedemo/invoice.tex:75 templates/xedemo/sales_order.html:29
-#: templates/xedemo/work_order.html:29
-msgid "Ship To"
-msgstr ""
-
-#: templates/demo/packing_list.html:29 templates/demo/pick_list.html:28
-#: templates/demo/product_receipt.html:30 templates/demo/purchase_order.html:30
-#: templates/demo/request_quotation.html:30
-#: templates/demo_with_images/packing_list.html:29
-#: templates/demo_with_images/pick_list.html:28
-#: templates/demo_with_images/product_receipt.html:30
-#: templates/demo_with_images/purchase_order.html:30
-#: templates/demo_with_images/request_quotation.html:30
-#: templates/xedemo/packing_list.html:29 templates/xedemo/pick_list.html:28
-#: templates/xedemo/product_receipt.html:30
-#: templates/xedemo/purchase_order.html:30
-#: templates/xedemo/request_quotation.html:30
-msgid "Ship To:"
-msgstr "Expédier à:"
-
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:117
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:275
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:118
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:276
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:307
-#: lib/LedgerSMB/Report/Orders.pm:259 templates/demo/product_receipt.html:106
-#: templates/demo/purchase_order.html:107 templates/demo/sales_order.html:107
-#: templates/demo/sales_order.tex:109
-#: templates/demo_with_images/product_receipt.html:106
-#: templates/demo_with_images/purchase_order.html:107
-#: templates/demo_with_images/sales_order.html:107
-#: templates/demo_with_images/sales_order.tex:109
-#: templates/demo_with_images/work_order.html:107
-#: templates/demo/work_order.html:107 templates/xedemo/product_receipt.html:107
-#: templates/xedemo/purchase_order.html:107
-#: templates/xedemo/sales_order.html:107 templates/xedemo/sales_order.tex:109
-#: templates/xedemo/work_order.html:107
-#: UI/Reports/filters/invoice_outstanding.html:65
-#: UI/Reports/filters/invoice_outstanding.html:270
-#: UI/Reports/filters/invoice_search.html:158
-#: UI/Reports/filters/invoice_search.html:360 UI/Reports/filters/orders.html:60
-#: UI/Reports/filters/orders.html:165
+#: lib/LedgerSMB/Report/Orders.pm:261
 msgid "Ship Via"
 msgstr "Expédier via"
 
-#: bin/aa.pl:912 bin/io.pl:1567 bin/is.pl:584 bin/is.pl:1025 bin/oe.pl:635
-#: bin/oe.pl:857 bin/oe.pl:1955
+#: old/bin/aa.pl:906 old/bin/io.pl:1587 old/bin/is.pl:581 old/bin/is.pl:1024
+#: old/bin/oe.pl:636 old/bin/oe.pl:860 old/bin/oe.pl:1959
 msgid "Ship to"
 msgstr "Expédier à"
 
-#: bin/aa.pl:1663 bin/aa.pl:1693 bin/is.pl:505 bin/oe.pl:594 bin/oe.pl:1789
-#: templates/demo/bin_list.html:115 templates/demo/invoice.html:118
-#: templates/demo/invoice.tex:122 templates/demo/packing_list.html:86
-#: templates/demo/packing_list.tex:93 templates/demo/pick_list.html:83
-#: templates/demo/pick_list.tex:84 templates/demo/product_receipt.tex:108
-#: templates/demo/purchase_order.tex:108
-#: templates/demo/request_quotation.html:108
-#: templates/demo/request_quotation.tex:109
-#: templates/demo/sales_quotation.html:76 templates/demo/sales_quotation.tex:78
-#: templates/demo_with_images/bin_list.html:115
-#: templates/demo_with_images/invoice.html:118
-#: templates/demo_with_images/invoice.tex:122
-#: templates/demo_with_images/packing_list.html:86
-#: templates/demo_with_images/packing_list.tex:93
-#: templates/demo_with_images/pick_list.html:83
-#: templates/demo_with_images/pick_list.tex:84
-#: templates/demo_with_images/product_receipt.tex:108
-#: templates/demo_with_images/purchase_order.tex:108
-#: templates/demo_with_images/request_quotation.html:108
-#: templates/demo_with_images/request_quotation.tex:109
-#: templates/demo_with_images/sales_quotation.html:76
-#: templates/demo_with_images/sales_quotation.tex:78
-#: templates/xedemo/bin_list.html:115 templates/xedemo/invoice.html:118
-#: templates/xedemo/invoice.tex:121 templates/xedemo/packing_list.html:86
-#: templates/xedemo/packing_list.tex:93 templates/xedemo/pick_list.html:83
-#: templates/xedemo/pick_list.tex:84 templates/xedemo/product_receipt.tex:108
-#: templates/xedemo/purchase_order.tex:108
-#: templates/xedemo/request_quotation.html:108
-#: templates/xedemo/request_quotation.tex:109
-#: templates/xedemo/sales_quotation.html:76
-#: templates/xedemo/sales_quotation.tex:79 UI/orders/order.html:68
+#: old/bin/aa.pl:1645 old/bin/aa.pl:1675 old/bin/is.pl:502 old/bin/oe.pl:595
+#: old/bin/oe.pl:1793
 msgid "Ship via"
 msgstr "Expédier via"
 
-#: lib/LedgerSMB/Entity/Location.pm:114 UI/Contact/divs/address.html:44
-#: sql/Pg-database.sql:661 sql/Pg-database.sql:2918
+#: lib/LedgerSMB/Entity/Location.pm:115 sql/Pg-database.sql:675
+#: sql/Pg-database.sql:2922
 msgid "Shipping"
 msgstr "Expédition"
 
-#: bin/oe.pl:1731
+#: old/bin/oe.pl:1734
 msgid "Shipping Date"
 msgstr "Date d'expédition"
 
-#: bin/oe.pl:1989
+#: old/bin/oe.pl:1988
 msgid "Shipping Date missing!"
 msgstr "Date d'expédition manquante!"
 
-#: bin/is.pl:1004 bin/printer.pl:111
+#: old/bin/is.pl:1001 old/bin/printer.pl:111
 msgid "Shipping Label"
 msgstr ""
 
-#: bin/aa.pl:1661 bin/is.pl:501 bin/oe.pl:590 bin/oe.pl:1784
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:113
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:271
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:114
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:272
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:304
-#: lib/LedgerSMB/Report/Orders.pm:255 templates/demo/bin_list.html:114
-#: templates/demo/bin_list.tex:84 templates/demo/invoice.html:117
-#: templates/demo/invoice.tex:121 templates/demo/packing_list.html:85
-#: templates/demo/packing_list.tex:92 templates/demo/pick_list.html:82
-#: templates/demo/pick_list.tex:83 templates/demo/product_receipt.html:105
-#: templates/demo/product_receipt.tex:107
-#: templates/demo/purchase_order.html:106 templates/demo/purchase_order.tex:107
-#: templates/demo/request_quotation.html:107
-#: templates/demo/request_quotation.tex:108 templates/demo/sales_order.html:106
-#: templates/demo/sales_order.tex:108 templates/demo/sales_quotation.html:75
-#: templates/demo/sales_quotation.tex:77
-#: templates/demo_with_images/bin_list.html:114
-#: templates/demo_with_images/bin_list.tex:84
-#: templates/demo_with_images/invoice.html:117
-#: templates/demo_with_images/invoice.tex:121
-#: templates/demo_with_images/packing_list.html:85
-#: templates/demo_with_images/packing_list.tex:92
-#: templates/demo_with_images/pick_list.html:82
-#: templates/demo_with_images/pick_list.tex:83
-#: templates/demo_with_images/product_receipt.html:105
-#: templates/demo_with_images/product_receipt.tex:107
-#: templates/demo_with_images/purchase_order.html:106
-#: templates/demo_with_images/purchase_order.tex:107
-#: templates/demo_with_images/request_quotation.html:107
-#: templates/demo_with_images/request_quotation.tex:108
-#: templates/demo_with_images/sales_order.html:106
-#: templates/demo_with_images/sales_order.tex:108
-#: templates/demo_with_images/sales_quotation.html:75
-#: templates/demo_with_images/sales_quotation.tex:77
-#: templates/demo_with_images/work_order.html:106
-#: templates/demo/work_order.html:106 templates/xedemo/bin_list.html:114
-#: templates/xedemo/bin_list.tex:84 templates/xedemo/invoice.html:117
-#: templates/xedemo/invoice.tex:120 templates/xedemo/packing_list.html:85
-#: templates/xedemo/packing_list.tex:92 templates/xedemo/pick_list.html:82
-#: templates/xedemo/pick_list.tex:83 templates/xedemo/product_receipt.html:106
-#: templates/xedemo/product_receipt.tex:107
-#: templates/xedemo/purchase_order.html:106
-#: templates/xedemo/purchase_order.tex:107
-#: templates/xedemo/request_quotation.html:107
-#: templates/xedemo/request_quotation.tex:108
-#: templates/xedemo/sales_order.html:106 templates/xedemo/sales_order.tex:108
-#: templates/xedemo/sales_quotation.html:75
-#: templates/xedemo/sales_quotation.tex:78 templates/xedemo/work_order.html:106
-#: UI/orders/order.html:62 UI/Reports/filters/invoice_outstanding.html:264
-#: UI/Reports/filters/invoice_search.html:354
+#: lib/LedgerSMB/Report/Orders.pm:257 old/bin/aa.pl:1643 old/bin/is.pl:498
+#: old/bin/oe.pl:591 old/bin/oe.pl:1788
 msgid "Shipping Point"
 msgstr "Expéditeur"
-
-#: UI/Reports/filters/search_goods.html:106
-msgid "Short"
-msgstr "Court"
 
 #: lib/LedgerSMB/Scripts/configuration.pm:121
 msgid "Show Credit Limit"
 msgstr ""
 
-#: templates/demo/printPayment.html:82
-#: templates/demo_with_images/printPayment.html:82
-#: templates/xedemo/printPayment.html:82
-msgid "Signature"
-msgstr "Signature"
+#: UI/Reports/custom/reports.pl:237
+msgid "Signed report"
+msgstr ""
 
-#: sql/Pg-database.sql:2480
+#: sql/Pg-database.sql:2484
 msgid "Simple"
 msgstr ""
 
-#: UI/import_csv/import_inventory_csv.html:61
-msgid "Single date"
-msgstr ""
-
-#: lib/LedgerSMB/Entity/Person.pm:109 sql/Pg-database.sql:728
+#: lib/LedgerSMB/Entity/Person.pm:110 sql/Pg-database.sql:742
 msgid "Sir."
 msgstr ""
 
-#: lib/LedgerSMB/Num2text.pm:80
+#: old/lib/LedgerSMB/Num2text.pm:80
 msgid "Six"
 msgstr "Six"
 
-#: lib/LedgerSMB/Num2text.pm:91
+#: old/lib/LedgerSMB/Num2text.pm:91
 msgid "Sixteen"
 msgstr "Seize"
 
-#: lib/LedgerSMB/Num2text.pm:109
+#: old/lib/LedgerSMB/Num2text.pm:109
 msgid "Sixty"
 msgstr "Soixante"
 
-#: UI/setup/select_coa.html:58
-msgid "Skip"
-msgstr ""
-
-#: lib/LedgerSMB/Report/Inventory/Activity.pm:84
+#: lib/LedgerSMB/Report/Inventory/Activity.pm:85
 msgid "Sold"
 msgstr ""
 
-#: UI/payments/payments_detail.html:274
-msgid "Some"
-msgstr ""
-
-#: UI/io-email.html:94 UI/orders/order.html:306
-msgid "Sort by"
-msgstr "Trier par"
-
-#: bin/aa.pl:820 bin/aa.pl:1516 bin/ir.pl:843 bin/is.pl:920
-#: lib/LedgerSMB/Report/Budget/Search.pm:128 lib/LedgerSMB/Report/GL.pm:122
-#: lib/LedgerSMB/Report/GL.pm:215
-#: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:75
-#: lib/LedgerSMB/Report/Invoices/Payments.pm:141
-#: lib/LedgerSMB/Scripts/payment.pm:155 lib/LedgerSMB/Scripts/recon.pm:216
-#: templates/demo/ap_transaction.html:194
-#: templates/demo/ar_transaction.html:193 templates/demo/invoice.html:255
-#: templates/demo/printPayment.html:50
-#: templates/demo_with_images/ap_transaction.html:194
-#: templates/demo_with_images/ar_transaction.html:193
-#: templates/demo_with_images/invoice.html:255
-#: templates/demo_with_images/printPayment.html:50
-#: templates/xedemo/ap_transaction.html:194
-#: templates/xedemo/ar_transaction.html:193 templates/xedemo/invoice.html:255
-#: templates/xedemo/printPayment.html:50 UI/inventory/adjustment_setup.html:29
-#: UI/journal/journal_entry.html:117 UI/orders/order.html:247
-#: UI/payments/payment2.html:109 UI/payments/payment2.html:253
-#: UI/payments/payment2.html:306 UI/payments/payments_detail.html:304
-#: UI/reconciliation/report.html:84 UI/reconciliation/report.html:159
-#: UI/reconciliation/report.html:210 UI/Reports/filters/gl.html:68
-#: UI/Reports/filters/gl.html:221 UI/Reports/filters/inventory_adj.html:11
-#: UI/Reports/filters/invoice_search.html:128
-#: UI/Reports/filters/payments.html:74
+#: lib/LedgerSMB/Report/Budget/Search.pm:129 lib/LedgerSMB/Report/GL.pm:123
+#: lib/LedgerSMB/Report/GL.pm:216
+#: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:73
+#: lib/LedgerSMB/Report/Invoices/Payments.pm:142
+#: lib/LedgerSMB/Scripts/payment.pm:156 lib/LedgerSMB/Scripts/recon.pm:229
+#: old/bin/aa.pl:814 old/bin/aa.pl:1498 old/bin/ir.pl:834 old/bin/is.pl:917
+#: UI/Reports/custom/reports.pl:3364 UI/Reports/custom/reports.pl:3787
+#: UI/Reports/custom/reports.pl:4731 UI/Reports/custom/reports.pl:4773
+#: UI/Reports/custom/reports.pl:5346
 msgid "Source"
 msgstr "Source"
 
-#: UI/payments/payment2.html:126
-msgid "Source documentation"
-msgstr ""
-
-#: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:83
+#: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:84
 msgid "Source starting with"
 msgstr ""
 
-#: templates/demo/sales_quotation.html:194
-#: templates/demo_with_images/sales_quotation.html:194
-#: templates/xedemo/sales_quotation.html:194
-msgid "Special order items are subject to a 10% cancellation fee."
-msgstr ""
-
-#: templates/demo/sales_order.html:225
-#: templates/demo_with_images/sales_order.html:225
-#: templates/xedemo/sales_order.html:225
-msgid "Special order items are subject to a 10% order cancellation fee."
-msgstr ""
-
-#: templates/demo/sales_quotation.tex:23
-#: templates/demo_with_images/sales_quotation.tex:23
-#: templates/xedemo/sales_quotation.tex:23
-msgid "Special order items are subject to a 10\\% cancellation fee."
-msgstr ""
-
-#: UI/lib/report_base.html:64 UI/rp-search.html:30
+#: UI/Reports/custom/reports.pl:5096
 msgid "Standard"
 msgstr "Standard"
 
-#: lib/LedgerSMB/Report/Listings/SIC.pm:66
+#: lib/LedgerSMB/Report/Listings/SIC.pm:67
 msgid "Standard Industrial Codes"
 msgstr "Code secteur économique"
 
-#: lib/LedgerSMB/Report/Budget/Search.pm:70
-#: lib/LedgerSMB/Report/Budget/Search.pm:120
-#: lib/LedgerSMB/Report/Budget/Variance.pm:118
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:131
-#: lib/LedgerSMB/Report/co/Caja_Diaria.pm:125
-#: lib/LedgerSMB/Report/Contact/History.pm:143 lib/LedgerSMB/Report/GL.pm:207
-#: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:77
+#: lib/LedgerSMB/Report/Budget/Search.pm:71
+#: lib/LedgerSMB/Report/Budget/Search.pm:121
+#: lib/LedgerSMB/Report/Budget/Variance.pm:119
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:134
+#: lib/LedgerSMB/Report/co/Caja_Diaria.pm:126
+#: lib/LedgerSMB/Report/Contact/History.pm:144 lib/LedgerSMB/Report/GL.pm:208
+#: lib/LedgerSMB/Report/Inventory/Search_Adj.pm:78
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:155
-#: lib/LedgerSMB/Report/Listings/Business_Unit.pm:64
-#: UI/budgetting/budget_entry.html:41 UI/business_units/edit.html:59
-#: UI/Contact/divs/credit.html:30 UI/Contact/divs/employee.html:180
-#: UI/Reports/filters/budget_search.html:44
+#: lib/LedgerSMB/Report/Listings/Business_Unit.pm:65
 msgid "Start Date"
 msgstr "Date de début"
 
-#: t/data/04-complex_template.html:114
-msgid "Start Date:"
-msgstr "Date de début:"
-
-#: UI/payments/payments_filter.html:179
-msgid "Start Source Numbering At:"
-msgstr ""
-
-#: UI/setup/complete.html:13
-msgid "Start Using LedgerSMB"
-msgstr ""
-
-#: bin/arap.pl:591 UI/Reports/filters/purchase_history.html:112
+#: old/bin/arap.pl:589
 msgid "Startdate"
 msgstr "Date de début"
 
-#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:77
-#: lib/LedgerSMB/Report/Trial_Balance.pm:172
+#: lib/LedgerSMB/Report/co/Balance_y_Mayor.pm:78
+#: lib/LedgerSMB/Report/Trial_Balance.pm:173
 msgid "Starting Balance"
 msgstr ""
 
-#: UI/Contact/divs/credit.html:110 UI/Contact/divs/credit.html:111
-#: UI/timecards/entry_filter.html:33
-msgid "Starting Date"
-msgstr ""
-
-#: t/data/04-complex_template.html:177
-msgid "Starting Date:"
-msgstr ""
-
-#: bin/io.pl:1637
+#: old/bin/io.pl:1657
 msgid "State"
 msgstr "Etat"
 
-#: t/data/04-complex_template.html:387 UI/Contact/divs/address.html:82
-#: UI/Contact/divs/address.html:165 UI/Reports/filters/contact_search.html:100
-#: UI/Reports/filters/purchase_history.html:86
-msgid "State/Province"
-msgstr "Région/État"
-
-#: t/data/04-complex_template.html:454
-msgid "State/Province:"
-msgstr ""
-
-#: templates/demo/statement.html:4 templates/demo/statement.html:19
-#: templates/demo/statement.tex:29 templates/demo_with_images/statement.html:4
-#: templates/demo_with_images/statement.html:19
-#: templates/demo_with_images/statement.tex:29
-#: templates/xedemo/statement.html:4 templates/xedemo/statement.html:19
-#: templates/xedemo/statement.tex:29 sql/Pg-database.sql:2954
-#: sql/Pg-database.sql:2967
+#: UI/Reports/custom/reports.pl:2351 UI/Reports/custom/reports.pl:2499
+#: sql/Pg-database.sql:2958 sql/Pg-database.sql:2971
 msgid "Statement"
 msgstr "Relevé"
 
-#: lib/LedgerSMB/Report/Reconciliation/Summary.pm:139
-#: UI/rc-display-form.html:66 UI/reconciliation/upload.html:30
+#: lib/LedgerSMB/Report/Reconciliation/Summary.pm:140
+#: UI/Reports/custom/reports.pl:5531
 msgid "Statement Balance"
 msgstr "Solde relevé de compte"
 
-#: lib/LedgerSMB/Report/Reconciliation/Summary.pm:135
+#: lib/LedgerSMB/Report/Reconciliation/Summary.pm:136
 msgid "Statement Date"
 msgstr ""
 
-#: UI/payments/check_job.html:20
-msgid "Status: Complete"
+#: UI/Reports/custom/reports.pl:2506
+#, fuzzy
+msgid "Statement sent to"
+msgstr "Relevé"
+
+#: UI/Reports/custom/reports.pl:2578 UI/Reports/custom/reports.pl:5642
+msgid "Statements sent to printer!"
 msgstr ""
 
-#: UI/payments/check_job.html:18
-msgid "Status: Still Running"
-msgstr ""
-
-#: bin/ic.pl:630
+#: old/bin/ic.pl:628
 msgid "Stock"
 msgstr "Stock"
 
-#: bin/ic.pl:2002 bin/ic.pl:2109 sql/Pg-database.sql:2935
+#: old/bin/ic.pl:1996 old/bin/ic.pl:2103 sql/Pg-database.sql:2939
 msgid "Stock Assembly"
 msgstr "Stock de produits"
 
-#: UI/users/preferences.html:109
-msgid "Stylesheet"
-msgstr "Feuille de style"
+#: UI/Reports/custom/reports.pl:154
+msgid "Stub"
+msgstr ""
 
-#: t/data/04-complex_template.html:231
-msgid "Subcontract GIFI:"
-msgstr "Code d'identification comptable ou fiscale - Sous-traitance"
-
-#: UI/budgetting/budget_entry.html:155 UI/budgetting/budget_entry.html:183
-#: UI/Contact/divs/notes.html:31 UI/io-email.html:22 UI/rp-email.html:21
+#: UI/Reports/custom/reports.pl:2448
 msgid "Subject"
 msgstr "Objet"
 
-#: bin/arap.pl:804 bin/io.pl:1465 UI/Contact/divs/notes.html:77
+#: old/bin/arap.pl:802 old/bin/io.pl:1484
 msgid "Subject: [_1]"
 msgstr "Objet: [_1]"
 
-#: UI/Reports/filters/reconciliation_search.html:86
-msgid "Submission Status"
-msgstr ""
-
-#: UI/reconciliation/report.html:285
-msgid "Submit"
-msgstr ""
-
-#: lib/LedgerSMB/Report/Reconciliation/Summary.pm:146
-#: UI/Reports/filters/reconciliation_search.html:81
+#: lib/LedgerSMB/Report/Reconciliation/Summary.pm:147
 msgid "Submitted"
 msgstr ""
 
-#: bin/aa.pl:1741 bin/io.pl:1315 bin/ir.pl:752 bin/is.pl:825 bin/oe.pl:788
-#: templates/demo/ap_transaction.html:130
-#: templates/demo/ar_transaction.html:129 templates/demo/invoice.html:175
-#: templates/demo/invoice.tex:157 templates/demo/product_receipt.html:159
-#: templates/demo/purchase_order.html:159 templates/demo/sales_order.html:161
-#: templates/demo/sales_quotation.html:130
-#: templates/demo/sales_quotation.tex:107
-#: templates/demo_with_images/ap_transaction.html:130
-#: templates/demo_with_images/ar_transaction.html:129
-#: templates/demo_with_images/invoice.html:175
-#: templates/demo_with_images/invoice.tex:156
-#: templates/demo_with_images/product_receipt.html:159
-#: templates/demo_with_images/purchase_order.html:159
-#: templates/demo_with_images/sales_order.html:161
-#: templates/demo_with_images/sales_quotation.html:130
-#: templates/demo_with_images/sales_quotation.tex:107
-#: templates/xedemo/ap_transaction.html:130
-#: templates/xedemo/ar_transaction.html:129 templates/xedemo/invoice.html:175
-#: templates/xedemo/invoice.tex:155 templates/xedemo/product_receipt.html:161
-#: templates/xedemo/purchase_order.html:159
-#: templates/xedemo/sales_order.html:161
-#: templates/xedemo/sales_quotation.html:130 UI/orders/order.html:215
-#: UI/payments/payment2.html:294 UI/payments/payment2.html:448
-#: UI/payments/use_overpayment2.html:140 UI/payments/use_overpayment2.html:326
-#: UI/Reports/filters/gl.html:274
-#: UI/Reports/filters/invoice_outstanding.html:279
-#: UI/Reports/filters/invoice_search.html:369
-#: UI/Reports/filters/orders.html:195
-#: UI/rp-search-generate_balance_sheet.html:82
-#: UI/rp-search-generate_income_statement.html:132
-#: UI/rp-search-generate_tax_report.html:186
+#: old/bin/aa.pl:1723 old/bin/io.pl:1335 old/bin/ir.pl:743 old/bin/is.pl:822
+#: old/bin/oe.pl:791 UI/Reports/custom/reports.pl:156
+#: UI/Reports/custom/reports.pl:5243
 msgid "Subtotal"
 msgstr "Sous total"
 
-#: UI/rc-till-closing.html:69
-msgid "Subtotal:"
-msgstr "Sous total:"
-
-#: UI/Configuration/sequence.html:16
-msgid "Suffix"
-msgstr ""
-
-#: bin/aa.pl:1552 bin/pe.pl:899 UI/rc-reconciliation.html:92
-#: UI/Reports/filters/aging.html:57
-#: UI/Reports/filters/invoice_outstanding.html:115
-#: UI/Reports/filters/purchase_history.html:221
-#: UI/rp-search-generate_tax_report.html:60
+#: old/bin/aa.pl:1534 old/bin/pe.pl:897 UI/Reports/custom/reports.pl:76
+#: UI/Reports/custom/reports.pl:239 UI/Reports/custom/reports.pl:5123
 msgid "Summary"
 msgstr "Résumé"
 
-#: UI/accounts/edit.html:237
-msgid "Summary account for"
-msgstr ""
-
-#: lib/LedgerSMB/Report/Timecards.pm:122
+#: lib/LedgerSMB/Report/Timecards.pm:123
 msgid "Sun"
 msgstr "Dim."
 
-#: UI/setup/credentials.html:24
-msgid "Super-user login"
+#: lib/LedgerSMB/Upgrade_Tests.pm:1101
+msgid ""
+"Suspect or invalid cleared delays have been detected. Please review the dates "
+"in the original application"
 msgstr ""
 
-#: UI/setup/credentials.html:8
-msgid "Superuser Credentials"
-msgstr ""
-
-#: UI/Contact/divs/person.html:117
-msgid "Surname"
-msgstr ""
-
-#: UI/ca-list-selector.html:46
-msgid "Swaps debits and credits to match bank statements"
-msgstr ""
-
-#: sql/Pg-database.sql:2929
+#: sql/Pg-database.sql:2933
 msgid "System"
 msgstr "Système"
 
-#: UI/Configuration/settings.html:9
-msgid "System Defaults"
-msgstr "Préférences système"
-
-#: templates/demo/printPayment.html:66
-#: templates/demo_with_images/printPayment.html:66
-#: templates/xedemo/printPayment.html:66
-msgid "TOTAL"
-msgstr "TOTAL"
-
-#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:72
-#: lib/LedgerSMB/Report/Listings/Asset.pm:82
-#: lib/LedgerSMB/Report/Listings/Asset.pm:119
-#: lib/LedgerSMB/Scripts/asset.pm:633 lib/LedgerSMB/Scripts/asset.pm:696
-#: lib/LedgerSMB/Scripts/asset.pm:764
+#: lib/LedgerSMB/Report/Assets/Net_Book_Value.pm:73
+#: lib/LedgerSMB/Report/Listings/Asset.pm:83
+#: lib/LedgerSMB/Report/Listings/Asset.pm:120 lib/LedgerSMB/Scripts/asset.pm:634
+#: lib/LedgerSMB/Scripts/asset.pm:698 lib/LedgerSMB/Scripts/asset.pm:767
 msgid "Tag"
 msgstr ""
 
-#: UI/asset/edit_asset.html:48 UI/asset/search_asset.html:39
-msgid "Tag:"
-msgstr ""
-
-#: bin/aa.pl:1639 bin/ic.pl:542 bin/ic.pl:671
-#: lib/LedgerSMB/Report/Contact/Purchase.pm:87
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:223
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:274 UI/accounts/edit.html:231
-#: UI/accounts/edit.html:379 UI/accounts/edit.html:409
-#: UI/Reports/filters/invoice_outstanding.html:203
-#: UI/Reports/filters/invoice_search.html:293
-#: UI/Reports/filters/orders.html:180 UI/rp-search-generate_tax_report.html:167
+#: lib/LedgerSMB/Report/Contact/Purchase.pm:88
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:224
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:274 old/bin/aa.pl:1621
+#: old/bin/ic.pl:540 old/bin/ic.pl:669
 msgid "Tax"
 msgstr "Taxe"
 
-#: UI/Reports/filters/invoice_search.html:71
-msgid "Tax Account"
-msgstr "Compte de taxe"
-
-#: bin/ir.pl:673 bin/is.pl:757
+#: old/bin/ir.pl:664 old/bin/is.pl:754
 msgid "Tax Code"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/Details.pm:110
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:108 UI/Contact/divs/credit.html:263
-#: UI/Contact/divs/credit.html:264
+#: UI/Reports/custom/reports.pl:70 UI/Reports/custom/reports.pl:242
+#: UI/Reports/custom/reports.pl:2353 UI/Reports/custom/reports.pl:3769
+#: UI/Reports/custom/reports.pl:3848
+#, fuzzy
+msgid "Tax Declaration"
+msgstr "Traduction"
+
+#: lib/LedgerSMB/Report/Taxform/Details.pm:111
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:109
 msgid "Tax Form"
 msgstr ""
 
-#: bin/aa.pl:664
+#: old/bin/aa.pl:663
 msgid "Tax Form Applied"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/Details.pm:120
+#: lib/LedgerSMB/Report/Taxform/Details.pm:121
 msgid "Tax Form Details Report"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/List.pm:72
+#: lib/LedgerSMB/Report/Taxform/List.pm:73
 msgid "Tax Form List"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:117
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:118
 msgid "Tax Form Report"
 msgstr ""
 
-#: UI/Reports/filters/taxforms.html:21
-msgid "Tax Form Reports"
-msgstr ""
-
-#: sql/Pg-database.sql:2924
+#: sql/Pg-database.sql:2928
 msgid "Tax Forms"
 msgstr ""
 
-#: bin/aa.pl:593 bin/ir.pl:459 bin/is.pl:472 UI/Admin/user_search.html:41
+#: old/bin/aa.pl:592 old/bin/ir.pl:450 old/bin/is.pl:469
 msgid "Tax ID"
 msgstr ""
 
-#: UI/Contact/divs/employee.html:154 UI/setup/new_user.html:112
-msgid "Tax ID/SSN"
-msgstr ""
-
-#: bin/ir.pl:661 bin/is.pl:744 bin/oe.pl:763 UI/Contact/divs/credit.html:313
-#: UI/Contact/divs/credit.html:314 UI/orders/order.html:233
+#: old/bin/ir.pl:652 old/bin/is.pl:741 old/bin/oe.pl:764
 msgid "Tax Included"
 msgstr "Taxe incluse"
 
-#: UI/Contact/divs/company.html:115
-msgid "Tax Number/SSN"
-msgstr "Numéro de taxe"
-
-#: t/data/04-complex_template.html:222
-msgid "Tax Number/SSN:"
-msgstr "Numéro de taxe/Assurance sociale"
-
-#: templates/demo/ar_transaction.tex:71
-#: templates/demo_with_images/ar_transaction.tex:71
-#: templates/xedemo/ar_transaction.tex:71
-msgid "Tax Number: [_1]"
-msgstr "Numéro de taxe: [_1]"
-
-#: UI/am-taxes.html:20
-msgid "Tax Rules"
+#: UI/Reports/custom/reports.pl:71 UI/Reports/custom/reports.pl:240
+msgid "Tax collected and paid"
 msgstr ""
 
-#: UI/Reports/filters/invoice_search.html:61
-msgid "Tax Status"
+#: UI/Reports/custom/reports.pl:241
+msgid "Tax collected and paid2"
 msgstr ""
 
-#: templates/demo/product_receipt.html:192
-#: templates/demo/purchase_order.html:192
-#: templates/demo_with_images/product_receipt.html:192
-#: templates/demo_with_images/purchase_order.html:192
-#: templates/xedemo/product_receipt.html:194
-#: templates/xedemo/purchase_order.html:192
-msgid "Tax included"
-msgstr "Taxes incluses"
-
-#: bin/io.pl:251
+#: old/bin/io.pl:246
 msgid "TaxForm"
 msgstr ""
 
-#: UI/Reports/filters/invoice_search.html:65
-msgid "Taxable"
-msgstr "Imposable"
-
-#: bin/am.pl:575 UI/Contact/divs/credit.html:286 sql/Pg-database.sql:2836
+#: old/bin/am.pl:523 sql/Pg-database.sql:2840
 msgid "Taxes"
 msgstr "Taxes"
 
-#: bin/am.pl:707
+#: old/bin/am.pl:653
 msgid "Taxes saved!"
 msgstr "Taxes enregistrées!"
 
-#: templates/demo/ap_transaction.html:229
-#: templates/demo/ar_transaction.html:235 templates/demo/invoice.html:320
-#: templates/demo_with_images/ap_transaction.html:229
-#: templates/demo_with_images/ar_transaction.html:235
-#: templates/demo_with_images/invoice.html:320
-#: templates/xedemo/ap_transaction.html:229
-#: templates/xedemo/ar_transaction.html:235 templates/xedemo/invoice.html:320
-msgid "Taxes shown are included in price."
-msgstr ""
-
-#: templates/demo/ar_transaction.html:61
-#: templates/demo_with_images/ar_transaction.html:61
-#: templates/xedemo/ar_transaction.html:61
-msgid "Taxnumber:"
-msgstr "Numéro de taxe:"
-
-#: templates/demo/ap_transaction.html:62
-#: templates/demo_with_images/ap_transaction.html:62
-#: templates/xedemo/ap_transaction.html:62
-msgid "Taxnumber: [_1]"
-msgstr "Numéro de taxe: [_1]"
-
-#: templates/demo/ar_transaction.html:49 templates/demo/ar_transaction.tex:26
-#: templates/demo/letterhead.tex:13
-#: templates/demo_with_images/ar_transaction.html:49
-#: templates/demo_with_images/ar_transaction.tex:26
-#: templates/demo_with_images/letterhead.tex:13
-#: templates/xedemo/ar_transaction.html:49
-#: templates/xedemo/ar_transaction.tex:26 templates/xedemo/letterhead.tex:13
-msgid "Tel:"
-msgstr "Tél:"
-
-#: templates/demo/ap_transaction.html:50 templates/demo/ar_transaction.tex:61
-#: templates/demo/bin_list.html:55 templates/demo/bin_list.html:88
-#: templates/demo/invoice.html:55 templates/demo/invoice.html:88
-#: templates/demo/letterhead.html:21 templates/demo/packing_list.html:56
-#: templates/demo/pick_list.html:55 templates/demo/printPayment.html:27
-#: templates/demo/product_receipt.html:54
-#: templates/demo/product_receipt.html:82 templates/demo/product_receipt.tex:52
-#: templates/demo/product_receipt.tex:87 templates/demo/purchase_order.html:54
-#: templates/demo/purchase_order.html:82 templates/demo/purchase_order.tex:52
-#: templates/demo/purchase_order.tex:87
-#: templates/demo/request_quotation.html:55
-#: templates/demo/request_quotation.html:83
-#: templates/demo/request_quotation.tex:52
-#: templates/demo/request_quotation.tex:87 templates/demo/sales_order.html:52
-#: templates/demo/sales_order.html:80 templates/demo/sales_order.tex:51
-#: templates/demo/sales_order.tex:86 templates/demo/sales_quotation.html:48
-#: templates/demo/sales_quotation.tex:57
-#: templates/demo_with_images/ap_transaction.html:50
-#: templates/demo_with_images/ar_transaction.tex:61
-#: templates/demo_with_images/bin_list.html:55
-#: templates/demo_with_images/bin_list.html:88
-#: templates/demo_with_images/invoice.html:55
-#: templates/demo_with_images/invoice.html:88
-#: templates/demo_with_images/letterhead.html:21
-#: templates/demo_with_images/packing_list.html:56
-#: templates/demo_with_images/pick_list.html:55
-#: templates/demo_with_images/printPayment.html:27
-#: templates/demo_with_images/product_receipt.html:54
-#: templates/demo_with_images/product_receipt.html:82
-#: templates/demo_with_images/product_receipt.tex:52
-#: templates/demo_with_images/product_receipt.tex:87
-#: templates/demo_with_images/purchase_order.html:54
-#: templates/demo_with_images/purchase_order.html:82
-#: templates/demo_with_images/purchase_order.tex:52
-#: templates/demo_with_images/purchase_order.tex:87
-#: templates/demo_with_images/request_quotation.html:55
-#: templates/demo_with_images/request_quotation.html:83
-#: templates/demo_with_images/request_quotation.tex:52
-#: templates/demo_with_images/request_quotation.tex:87
-#: templates/demo_with_images/sales_order.html:52
-#: templates/demo_with_images/sales_order.html:80
-#: templates/demo_with_images/sales_order.tex:51
-#: templates/demo_with_images/sales_order.tex:86
-#: templates/demo_with_images/sales_quotation.html:48
-#: templates/demo_with_images/sales_quotation.tex:57
-#: templates/demo_with_images/work_order.html:52
-#: templates/demo_with_images/work_order.html:80
-#: templates/demo_with_images/work_order.tex:61
-#: templates/demo_with_images/work_order.tex:96
-#: templates/demo/work_order.html:52 templates/demo/work_order.html:80
-#: templates/demo/work_order.tex:61 templates/demo/work_order.tex:96
-#: templates/xedemo/ap_transaction.html:50
-#: templates/xedemo/ar_transaction.tex:61 templates/xedemo/bin_list.html:55
-#: templates/xedemo/bin_list.html:88 templates/xedemo/invoice.html:55
-#: templates/xedemo/invoice.html:88 templates/xedemo/letterhead.html:21
-#: templates/xedemo/packing_list.html:56 templates/xedemo/pick_list.html:55
-#: templates/xedemo/printPayment.html:27
-#: templates/xedemo/product_receipt.html:54
-#: templates/xedemo/product_receipt.html:82
-#: templates/xedemo/product_receipt.tex:52
-#: templates/xedemo/product_receipt.tex:87
-#: templates/xedemo/purchase_order.html:54
-#: templates/xedemo/purchase_order.html:82
-#: templates/xedemo/purchase_order.tex:52
-#: templates/xedemo/purchase_order.tex:87
-#: templates/xedemo/request_quotation.html:55
-#: templates/xedemo/request_quotation.html:83
-#: templates/xedemo/request_quotation.tex:52
-#: templates/xedemo/request_quotation.tex:87
-#: templates/xedemo/sales_order.html:52 templates/xedemo/sales_order.html:80
-#: templates/xedemo/sales_order.tex:51 templates/xedemo/sales_order.tex:86
-#: templates/xedemo/sales_quotation.html:48
-#: templates/xedemo/sales_quotation.tex:58 templates/xedemo/work_order.html:52
-#: templates/xedemo/work_order.html:80 templates/xedemo/work_order.tex:61
-#: templates/xedemo/work_order.tex:96
-msgid "Tel: [_1]"
-msgstr "Tél: [_1]"
-
-#: lib/LedgerSMB/Report/Listings/Templates.pm:75
+#: lib/LedgerSMB/Report/Listings/Templates.pm:76
 msgid "Template Listing"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/template.pm:86
+#: lib/LedgerSMB/Scripts/template.pm:87
 msgid "Template Not Found"
 msgstr ""
 
-#: bin/aa.pl:1133 bin/gl.pl:379
+#: old/bin/aa.pl:1126 old/bin/gl.pl:370
 msgid "Template Saved!"
 msgstr "Squelette enregistré!"
 
-#: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:106
+#: lib/LedgerSMB/Report/Listings/TemplateTrans.pm:109
 msgid "Template Transactions"
 msgstr ""
 
-#: UI/setup/confirm_operation.html:67 UI/setup/template_info.html:24
-msgid "Templates"
-msgstr "Squelettes"
-
-#: lib/LedgerSMB/Num2text.pm:84
+#: old/lib/LedgerSMB/Num2text.pm:84
 msgid "Ten"
 msgstr "Dix"
 
-#: bin/oe.pl:363
+#: old/bin/oe.pl:364
 msgid "Terms"
 msgstr "Crédit limité à"
 
-#: templates/demo/product_receipt.html:184
-#: templates/demo/purchase_order.html:184 templates/demo/sales_order.html:183
-#: templates/demo/sales_quotation.html:151
-#: templates/demo_with_images/product_receipt.html:184
-#: templates/demo_with_images/purchase_order.html:184
-#: templates/demo_with_images/sales_order.html:183
-#: templates/demo_with_images/sales_quotation.html:151
-#: templates/xedemo/product_receipt.html:186
-#: templates/xedemo/purchase_order.html:184
-#: templates/xedemo/sales_order.html:183
-#: templates/xedemo/sales_quotation.html:151
-msgid "Terms Net [_1] days"
+#: UI/Reports/custom/reports.pl:2348
+msgid "Text"
 msgstr ""
 
-#: t/data/04-complex_template.html:210
-msgid "Terms:"
-msgstr ""
-
-#: templates/demo/sales_order.tex:161
-#: templates/demo_with_images/sales_order.tex:161
-#: templates/xedemo/sales_order.tex:161
-msgid "Terms: Net [_1]  days"
-msgstr ""
-
-#: templates/demo/sales_quotation.tex:126
-#: templates/demo_with_images/sales_quotation.tex:126
-#: templates/xedemo/sales_quotation.tex:128
-msgid "Terms: [_1] days"
-msgstr ""
-
-#: templates/demo/invoice.tex:214 templates/demo/sales_order.tex:175
-#: templates/demo_with_images/invoice.tex:217
-#: templates/demo_with_images/sales_order.tex:175
-#: templates/xedemo/invoice.tex:213 templates/xedemo/sales_order.tex:175
-msgid "Thank You for your valued business!"
-msgstr ""
-
-#: templates/demo/invoice.html:280 templates/demo_with_images/invoice.html:280
-#: templates/xedemo/invoice.html:280
-msgid "Thank you for your valued business!"
-msgstr ""
-
-#: templates/demo/printPayment.html:102
-#: templates/demo_with_images/printPayment.html:102
-#: templates/xedemo/printPayment.html:102
-msgid "The amount of"
-msgstr ""
-
-#: lib/LedgerSMB/Scripts/payment.pm:1480 lib/LedgerSMB/Scripts/payment.pm:1486
+#: lib/LedgerSMB/Scripts/payment.pm:1518 lib/LedgerSMB/Scripts/payment.pm:1524
 msgid "The amount of the invoice number"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:1734
+#: lib/LedgerSMB/Scripts/payment.pm:1775
 msgid "The amount to be pay from the accno"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:1702
+#: lib/LedgerSMB/Scripts/payment.pm:1744
 msgid "The amount to be pay of the invoice number"
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:344
+#: lib/LedgerSMB/Upgrade_Tests.pm:407
 msgid "The following transactions have unassigned amounts"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/recon.pm:219
+#: lib/LedgerSMB/Scripts/recon.pm:232
 msgid "Their Balance"
 msgstr ""
 
-#: UI/reconciliation/report.html:90 UI/reconciliation/report.html:165
-msgid "Their Credits"
-msgstr ""
-
-#: UI/reconciliation/report.html:89 UI/reconciliation/report.html:164
-msgid "Their Debits"
-msgstr ""
-
-#: UI/reconciliation/report.html:9
-msgid "There are unapproved reconciliations before the end date of this report."
-msgstr ""
-
-#: UI/reconciliation/report.html:7
-msgid "There are unapproved transactions before the end date of this report."
-msgstr ""
-
-#: UI/payments/use_overpayment1.html:59
-msgid "There is no customer with overpayments"
-msgstr ""
-
-#: UI/payments/use_overpayment1.html:57
-msgid "There is no vendor with overpayments"
-msgstr ""
-
-#: lib/LedgerSMB/Num2text.pm:88
+#: old/lib/LedgerSMB/Num2text.pm:88
 msgid "Thirteen"
 msgstr "Treize"
 
-#: lib/LedgerSMB/Num2text.pm:106
+#: old/lib/LedgerSMB/Num2text.pm:106
 msgid "Thirty"
 msgstr "Trente"
 
-#: UI/Contact/divs/address.html:78 UI/Contact/divs/contact_info.html:26
-msgid "This Account"
-msgstr ""
-
-#: UI/setup/complete_migration_revert.html:10
-msgid "This database operation has completed successfully."
-msgstr ""
-
-#: UI/setup/complete.html:11
-msgid ""
-"This database operation has completed successfully.  LedgerSMB may now be "
-"used."
-msgstr ""
-
-#: templates/demo/printPayment.html:109
-#: templates/demo_with_images/printPayment.html:109
-#: templates/xedemo/printPayment.html:109
-msgid "This document has been approved by"
-msgstr ""
-
-#: lib/LedgerSMB/Scripts/payment.pm:1100
+#: lib/LedgerSMB/Scripts/payment.pm:1129
 msgid "This gl movement, is a consecuence of a payment transaction"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:1787
+#: lib/LedgerSMB/Scripts/payment.pm:1828
 msgid "This gl movement, is the result of a overpayment transaction"
 msgstr ""
 
-#: lib/LedgerSMB/Num2text.pm:117
+#: lib/LedgerSMB/Upgrade_Tests.pm:635
+msgid ""
+"This will <b>remove</b> the business references in <u>vendor</u> and "
+"<u>customer</u> tables"
+msgstr ""
+"Ceci <b>enlèvera</b> toutes ces références des tables <u>vendor</u> et "
+"<u>customer</u>"
+
+#: old/lib/LedgerSMB/Num2text.pm:117
 msgid "Thousand"
 msgstr "Mille"
 
-#: lib/LedgerSMB/Num2text.pm:77
+#: old/lib/LedgerSMB/Num2text.pm:77
 msgid "Three"
 msgstr "Trois"
 
-#: t/data/04-complex_template.html:302 UI/Contact/divs/credit.html:139
-#: UI/Contact/divs/credit.html:140
-msgid "Threshold"
-msgstr ""
-
-#: UI/Reports/filters/balance_sheet.html:13
-#: UI/Reports/filters/balance_sheet.html:144
-msgid "Through date"
-msgstr ""
-
-#: lib/LedgerSMB/Report/Timecards.pm:138
+#: lib/LedgerSMB/Report/Timecards.pm:139
 msgid "Thu"
 msgstr "Jeu."
 
-#: bin/aa.pl:1600 lib/LedgerSMB/Report/GL.pm:137
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:259
-#: lib/LedgerSMB/Report/Invoices/Transactions.pm:295
-#: UI/Reports/filters/gl.html:241
-#: UI/Reports/filters/invoice_outstanding.html:256
-#: UI/Reports/filters/invoice_search.html:346
+#: lib/LedgerSMB/Report/GL.pm:138
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:260
+#: lib/LedgerSMB/Report/Invoices/Transactions.pm:295 old/bin/aa.pl:1582
+#: UI/Reports/custom/reports.pl:4778
 msgid "Till"
 msgstr "Caisse"
 
-#: templates/demo/timecard.html:4 templates/demo/timecard.html:18
-#: templates/demo/timecard.tex:17 templates/demo_with_images/timecard.html:4
-#: templates/demo_with_images/timecard.html:18
-#: templates/demo_with_images/timecard.tex:17 templates/xedemo/timecard.html:4
-#: templates/xedemo/timecard.html:18 templates/xedemo/timecard.tex:17
-msgid "Time Card"
-msgstr "Carte de temps"
-
-#: UI/timecards/entry_filter.html:26
-msgid "Time Frame"
-msgstr ""
-
-#: UI/timecards/timecard.html:68
-msgid "Time In"
-msgstr ""
-
-#: UI/timecards/timecard.html:84
-msgid "Time Out"
-msgstr ""
-
-#: UI/Reports/filters/timecards.html:6
-msgid "Time and Material Cards"
-msgstr ""
-
-#: UI/timecards/timecard.html:15
-msgid "Time or Materials Card"
-msgstr ""
-
-#: sql/Pg-database.sql:2957 sql/Pg-database.sql:2972
+#: sql/Pg-database.sql:2961 sql/Pg-database.sql:2976
 msgid "Timecard"
 msgstr "Carte de temps"
 
-#: UI/timecards/entry_filter.html:6 UI/timecards/entry_filter.html:7
-msgid "Timecard Criteria"
-msgstr ""
-
-#: lib/LedgerSMB/Report/Timecards.pm:173 sql/Pg-database.sql:2938
+#: lib/LedgerSMB/Report/Timecards.pm:174 sql/Pg-database.sql:2942
 msgid "Timecards"
 msgstr "Cartes de temps"
 
-#: bin/am.pl:853
+#: old/bin/am.pl:791
 msgid "Times"
 msgstr ""
 
-#: bin/ic.pl:1131 bin/oe.pl:2145 bin/pe.pl:839 templates/demo/invoice.html:28
-#: templates/demo/request_quotation.tex:27 templates/demo/sales_order.html:28
-#: templates/demo_with_images/invoice.html:28
-#: templates/demo_with_images/request_quotation.tex:27
-#: templates/demo_with_images/sales_order.html:28
-#: templates/demo_with_images/work_order.html:28
-#: templates/demo/work_order.html:28 templates/xedemo/invoice.html:28
-#: templates/xedemo/request_quotation.tex:27
-#: templates/xedemo/sales_order.html:28 templates/xedemo/work_order.html:28
-#: UI/asset/begin_approval.html:32 UI/asset/search_reports.html:35
-#: UI/bp-search.html:29 UI/ca-list-selector.html:33 UI/lib/report_base.html:119
-#: UI/lib/report_base.html:213 UI/rc-reconciliation.html:22
-#: UI/Reports/co/filter_bm.html:27 UI/Reports/co/filter_cd.html:45
-#: UI/Reports/filters/aging.html:34
-#: UI/Reports/filters/income_statement.html:221
-#: UI/Reports/filters/purchase_history.html:127
-#: UI/Reports/filters/purchase_history.html:148
-#: UI/rp-search-generate_income_statement.html:14
-#: UI/rp-search-generate_income_statement.html:66
-#: UI/rp-search-generate_tax_report.html:10
+#: old/bin/ic.pl:1129 old/bin/oe.pl:2139 old/bin/pe.pl:837
+#: UI/Reports/custom/reports.pl:143 UI/Reports/custom/reports.pl:243
+#: UI/Reports/custom/reports.pl:475 UI/Reports/custom/reports.pl:498
+#: UI/Reports/custom/reports.pl:595 UI/Reports/custom/reports.pl:4749
+#: UI/Reports/custom/reports.pl:5361
 msgid "To"
 msgstr "À"
 
-#: lib/LedgerSMB/Report/Reconciliation/Summary.pm:182
+#: lib/LedgerSMB/Report/Reconciliation/Summary.pm:183
 msgid "To Amount"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Inventory/Activity.pm:133
-#: lib/LedgerSMB/Report/Invoices/Payments.pm:195
-#: lib/LedgerSMB/Report/Reconciliation/Summary.pm:178
-#: lib/LedgerSMB/Report/Taxform/Details.pm:109
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:107
-#: lib/LedgerSMB/Report/Timecards.pm:161
-#: lib/LedgerSMB/Report/Trial_Balance.pm:206 UI/reconciliation/upload.html:37
+#: lib/LedgerSMB/Report/Inventory/Activity.pm:149
+#: lib/LedgerSMB/Report/Invoices/Payments.pm:196
+#: lib/LedgerSMB/Report/Reconciliation/Summary.pm:179
+#: lib/LedgerSMB/Report/Taxform/Details.pm:110
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:108
+#: lib/LedgerSMB/Report/Timecards.pm:162
+#: lib/LedgerSMB/Report/Trial_Balance.pm:207
 msgid "To Date"
 msgstr ""
 
-#: UI/payments/payments_detail.html:330
-msgid "To Pay"
-msgstr ""
-
-#: bin/oe.pl:2160
+#: old/bin/oe.pl:2154
 msgid "To Warehouse"
 msgstr ""
 
-#: t/data/04-strings-for-translation.html:7
-msgid "To [_1]"
-msgstr "À [_1]"
-
-#: UI/payments/use_overpayment2.html:126
-msgid "To be used"
-msgstr ""
-
-#: UI/setup/begin_backup.html:26
-msgid "To email"
-msgstr ""
-
-#: UI/setup/begin_backup.html:40
-msgid "To my browser"
-msgstr ""
-
-#: lib/LedgerSMB/Scripts/payment.pm:822
+#: lib/LedgerSMB/Scripts/payment.pm:844
 msgid "To pay"
 msgstr ""
 
-#: templates/demo/product_receipt.html:29 templates/demo/purchase_order.html:29
-#: templates/demo/request_quotation.html:28
-#: templates/demo_with_images/product_receipt.html:29
-#: templates/demo_with_images/purchase_order.html:29
-#: templates/demo_with_images/request_quotation.html:28
-#: templates/xedemo/product_receipt.html:29
-#: templates/xedemo/purchase_order.html:29
-#: templates/xedemo/request_quotation.html:28
-#: UI/payments/payments_detail.html:116
-#: UI/Reports/filters/reconciliation_search.html:19
-#: UI/Reports/filters/reconciliation_search.html:37
-msgid "To:"
-msgstr "À:"
-
-#: bin/arap.pl:802 bin/io.pl:1463
+#: old/bin/arap.pl:800 old/bin/io.pl:1482
 msgid "To: [_1]"
 msgstr "À [_1]"
 
-#: UI/payments/payment2.html:173
-msgid "Toggle all removal checkboxes"
-msgstr ""
-
-#: UI/payments/payment2.html:288
-msgid "Toggle removal of entry in current payment"
-msgstr ""
-
-#: lib/LedgerSMB/DBObject/Account.pm:256
+#: old/lib/LedgerSMB/DBObject/Account.pm:259
 msgid "Too many links on summary account!"
 msgstr ""
 
-#: sql/Pg-database.sql:2792
+#: sql/Pg-database.sql:2796
 msgid "Top-level"
 msgstr "Description principale"
 
-#: bin/aa.pl:1642 bin/ir.pl:815 bin/is.pl:891 bin/oe.pl:820
-#: lib/LedgerSMB/Report/Aging.pm:150
-#: lib/LedgerSMB/Report/Inventory/History.pm:160
-#: lib/LedgerSMB/Report/Inventory/Search.pm:299
+#: lib/LedgerSMB/Report/Aging.pm:151
+#: lib/LedgerSMB/Report/Inventory/History.pm:161
+#: lib/LedgerSMB/Report/Inventory/Search.pm:300
 #: lib/LedgerSMB/Report/Invoices/COGS.pm:120
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:228
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:229
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:277
-#: lib/LedgerSMB/Report/Taxform/Details.pm:98
-#: lib/LedgerSMB/Report/Taxform/Summary.pm:96
-#: lib/LedgerSMB/Scripts/asset.pm:537 lib/LedgerSMB/Scripts/payment.pm:199
-#: lib/LedgerSMB/Scripts/payment.pm:770 templates/demo/ap_transaction.html:126
-#: templates/demo/ap_transaction.html:147
-#: templates/demo/ar_transaction.html:125
-#: templates/demo/ar_transaction.html:146 templates/demo/invoice.html:172
-#: templates/demo/product_receipt.html:156
-#: templates/demo/product_receipt.html:178
-#: templates/demo/product_receipt.html:185
-#: templates/demo/purchase_order.html:156
-#: templates/demo/purchase_order.html:178
-#: templates/demo/purchase_order.html:185 templates/demo/sales_order.html:158
-#: templates/demo/sales_order.html:186 templates/demo/sales_quotation.html:127
-#: templates/demo/sales_quotation.html:154 templates/demo/timecard.html:105
-#: templates/demo/timecard.tex:45
-#: templates/demo_with_images/ap_transaction.html:126
-#: templates/demo_with_images/ap_transaction.html:147
-#: templates/demo_with_images/ar_transaction.html:125
-#: templates/demo_with_images/ar_transaction.html:146
-#: templates/demo_with_images/invoice.html:172
-#: templates/demo_with_images/product_receipt.html:156
-#: templates/demo_with_images/product_receipt.html:178
-#: templates/demo_with_images/product_receipt.html:185
-#: templates/demo_with_images/purchase_order.html:156
-#: templates/demo_with_images/purchase_order.html:178
-#: templates/demo_with_images/purchase_order.html:185
-#: templates/demo_with_images/sales_order.html:158
-#: templates/demo_with_images/sales_order.html:186
-#: templates/demo_with_images/sales_quotation.html:127
-#: templates/demo_with_images/sales_quotation.html:154
-#: templates/demo_with_images/timecard.html:105
-#: templates/demo_with_images/timecard.tex:45
-#: templates/xedemo/ap_transaction.html:126
-#: templates/xedemo/ap_transaction.html:147
-#: templates/xedemo/ar_transaction.html:125
-#: templates/xedemo/ar_transaction.html:146 templates/xedemo/invoice.html:172
-#: templates/xedemo/product_receipt.html:158
-#: templates/xedemo/product_receipt.html:180
-#: templates/xedemo/product_receipt.html:187
-#: templates/xedemo/purchase_order.html:156
-#: templates/xedemo/purchase_order.html:178
-#: templates/xedemo/purchase_order.html:185
-#: templates/xedemo/sales_order.html:158 templates/xedemo/sales_order.html:186
-#: templates/xedemo/sales_quotation.html:127
-#: templates/xedemo/sales_quotation.html:154 templates/xedemo/timecard.html:105
-#: templates/xedemo/timecard.tex:45 UI/orders/order.html:225
-#: UI/payments/payment1.html:86 UI/payments/payment1.html:95
-#: UI/payments/payment2.html:453 UI/payments/payments_detail.html:326
-#: UI/reconciliation/report.html:146 UI/reconciliation/report.html:197
-#: UI/reconciliation/report.html:241
-#: UI/Reports/filters/invoice_outstanding.html:209
-#: UI/Reports/filters/invoice_search.html:299
-#: UI/rp-search-generate_tax_report.html:175
+#: lib/LedgerSMB/Report/Taxform/Details.pm:99
+#: lib/LedgerSMB/Report/Taxform/Summary.pm:97 lib/LedgerSMB/Scripts/asset.pm:540
+#: lib/LedgerSMB/Scripts/payment.pm:201 lib/LedgerSMB/Scripts/payment.pm:792
+#: old/bin/aa.pl:1624 old/bin/ir.pl:806 old/bin/is.pl:888 old/bin/oe.pl:823
+#: UI/Reports/custom/reports.pl:244
 msgid "Total"
 msgstr "Total"
 
-#: lib/LedgerSMB/Scripts/asset.pm:643
+#: lib/LedgerSMB/Scripts/asset.pm:644
 msgid "Total Accum. Dep."
 msgstr ""
 
-#: templates/demo/statement.html:109
-#: templates/demo_with_images/statement.html:109
-#: templates/xedemo/statement.html:109
-msgid "Total Outstanding"
-msgstr ""
+#: UI/Reports/custom/reports.pl:1565 UI/Reports/custom/reports.pl:1711
+#, fuzzy
+msgid "Total Income"
+msgstr "Recettes"
 
-#: lib/LedgerSMB/Report/Invoices/Payments.pm:138
+#: lib/LedgerSMB/Report/Invoices/Payments.pm:139
 msgid "Total Paid"
 msgstr ""
 
-#: UI/accounts/edit.html:346
-msgid "Tracking Items"
+#: UI/Reports/custom/reports.pl:1568
+msgid "Total contribution"
 msgstr ""
 
-#: bin/is.pl:362 bin/oe.pl:377
+#: UI/Reports/custom/reports.pl:164 UI/Reports/custom/reports.pl:1606
+#, fuzzy
+msgid "Totals"
+msgstr "Total"
+
+#: old/bin/is.pl:359 old/bin/oe.pl:378
 msgid "Trade Discount"
 msgstr "Escompte commercial"
 
-#: bin/aa.pl:920 bin/am.pl:1496
+#: old/bin/aa.pl:914 old/bin/am.pl:1455
 msgid "Transaction"
 msgstr "Écriture"
 
-#: sql/Pg-database.sql:2847
+#: sql/Pg-database.sql:2851
 msgid "Transaction Approval"
 msgstr ""
 
-#: lib/LedgerSMB/Report/PNL/Invoice.pm:89 UI/import_csv/import_csv.html:51
-#: UI/import_csv/import_inventory_csv.html:33
-#: UI/Reports/filters/purchase_history.html:132
+#: lib/LedgerSMB/Report/PNL/Invoice.pm:90
 msgid "Transaction Date"
 msgstr ""
 
-#: bin/gl.pl:653
+#: old/bin/gl.pl:633 UI/Reports/custom/reports.pl:3564
 msgid "Transaction Date missing!"
 msgstr "Date d'écriture manquante!"
 
-#: bin/pe.pl:834
+#: old/bin/pe.pl:832
 msgid "Transaction Dates"
 msgstr ""
 
-#: UI/reconciliation/report.html:82 UI/reconciliation/report.html:157
-#: UI/Reports/filters/unapproved.html:39
-msgid "Transaction Type"
+#: UI/Reports/custom/reports.pl:4405
+#, fuzzy
+msgid "Transaction Number"
+msgstr "Écriture"
+
+#: UI/Reports/custom/reports.pl:3610
+#, fuzzy
+msgid "Transaction posted!"
+msgstr "Traductions enregistrées"
+
+#: UI/Reports/custom/reports.pl:133 UI/Reports/custom/reports.pl:246
+msgid "Transactions without Departments"
 msgstr ""
 
-#: UI/setup/confirm_operation.html:114
-msgid "Transactions"
-msgstr "Mouvements"
-
-#: bin/oe.pl:2149 bin/oe.pl:2265 sql/Pg-database.sql:2822
-#: sql/Pg-database.sql:2857
+#: old/bin/oe.pl:2143 old/bin/oe.pl:2259 sql/Pg-database.sql:2826
+#: sql/Pg-database.sql:2861
 msgid "Transfer"
 msgstr "Transfert"
 
-#: bin/oe.pl:2026 bin/oe.pl:2176
+#: old/bin/oe.pl:2025 old/bin/oe.pl:2170
 msgid "Transfer Inventory"
 msgstr "Transfert inventaire"
 
-#: bin/oe.pl:2044
+#: old/bin/oe.pl:2043
 msgid "Transfer from"
 msgstr "Transférer de"
 
-#: bin/oe.pl:2048
+#: old/bin/oe.pl:2047
 msgid "Transfer to"
 msgstr "Transférer vers"
 
-#: bin/pe.pl:394 bin/pe.pl:564
+#: old/bin/pe.pl:392 old/bin/pe.pl:562
 msgid "Translation"
 msgstr "Traduction"
 
-#: bin/pe.pl:86
+#: old/bin/pe.pl:84
 msgid "Translation deleted!"
 msgstr "Traduction supprimée!"
 
-#: UI/accounts/edit.html:479 sql/Pg-database.sql:2833 sql/Pg-database.sql:2936
+#: sql/Pg-database.sql:2837 sql/Pg-database.sql:2940
 msgid "Translations"
 msgstr "Traductions"
 
-#: bin/pe.pl:65
+#: old/bin/pe.pl:63
 msgid "Translations saved!"
 msgstr "Traductions enregistrées"
 
-#: lib/LedgerSMB/Report/Trial_Balance.pm:141 sql/Pg-database.sql:2861
+#: lib/LedgerSMB/Report/Trial_Balance.pm:142 sql/Pg-database.sql:2865
 msgid "Trial Balance"
 msgstr "Balance Globale"
 
-#: lib/LedgerSMB/Num2text.pm:120
+#: UI/Reports/custom/reports.pl:134
+#, fuzzy
+msgid "Trial Balance by month"
+msgstr "Balance Globale"
+
+#: UI/Reports/custom/reports.pl:140 UI/Reports/custom/reports.pl:247
+msgid "Trial Balance with Month Headings"
+msgstr ""
+
+#: old/lib/LedgerSMB/Num2text.pm:120
 msgid "Trillion"
 msgstr "Billion"
 
-#: lib/LedgerSMB/Report/Timecards.pm:130
+#: lib/LedgerSMB/Report/Timecards.pm:131
 msgid "Tue"
 msgstr "Mar."
 
-#: lib/LedgerSMB/Num2text.pm:87
+#: old/lib/LedgerSMB/Num2text.pm:87
 msgid "Twelve"
 msgstr "Douze"
 
-#: lib/LedgerSMB/Num2text.pm:95
+#: old/lib/LedgerSMB/Num2text.pm:95
 msgid "Twenty"
 msgstr "Vingt"
 
-#: lib/LedgerSMB/Num2text.pm:104
+#: old/lib/LedgerSMB/Num2text.pm:104
 msgid "Twenty Eight"
 msgstr "Vingt-huit"
 
-#: lib/LedgerSMB/Num2text.pm:101
+#: old/lib/LedgerSMB/Num2text.pm:101
 msgid "Twenty Five"
 msgstr "Vingt-cinq"
 
-#: lib/LedgerSMB/Num2text.pm:100
+#: old/lib/LedgerSMB/Num2text.pm:100
 msgid "Twenty Four"
 msgstr "Vingt-quatre"
 
-#: lib/LedgerSMB/Num2text.pm:105
+#: old/lib/LedgerSMB/Num2text.pm:105
 msgid "Twenty Nine"
 msgstr "Vingt-neuf"
 
-#: lib/LedgerSMB/Num2text.pm:96
+#: old/lib/LedgerSMB/Num2text.pm:96
 msgid "Twenty One"
 msgstr "Vingt-et-un"
 
-#: lib/LedgerSMB/Num2text.pm:97
+#: old/lib/LedgerSMB/Num2text.pm:97
 msgid "Twenty One-o"
 msgstr ""
 
-#: lib/LedgerSMB/Num2text.pm:103
+#: old/lib/LedgerSMB/Num2text.pm:103
 msgid "Twenty Seven"
 msgstr "Vingt-sept"
 
-#: lib/LedgerSMB/Num2text.pm:102
+#: old/lib/LedgerSMB/Num2text.pm:102
 msgid "Twenty Six"
 msgstr "Vingt-six"
 
-#: lib/LedgerSMB/Num2text.pm:99
+#: old/lib/LedgerSMB/Num2text.pm:99
 msgid "Twenty Three"
 msgstr "Vingt-trois"
 
-#: lib/LedgerSMB/Num2text.pm:98
+#: old/lib/LedgerSMB/Num2text.pm:98
 msgid "Twenty Two"
 msgstr "Vingt-deux"
 
-#: lib/LedgerSMB/Num2text.pm:76
+#: old/lib/LedgerSMB/Num2text.pm:76
 msgid "Two"
 msgstr "Deux"
 
-#: bin/io.pl:1696 lib/LedgerSMB/Report/Inventory/History.pm:146
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:90
-#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:80
-#: lib/LedgerSMB/Scripts/asset.pm:533 t/data/04-complex_template.html:384
-#: UI/Contact/divs/address.html:79 UI/Contact/divs/address.html:119
-#: UI/Contact/divs/contact_info.html:27 UI/Contact/divs/credit.html:25
-#: UI/Contact/divs/wage.html:7
+#: lib/LedgerSMB/Report/Inventory/History.pm:147
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:91
+#: lib/LedgerSMB/Report/Unapproved/Drafts.pm:82
+#: lib/LedgerSMB/Scripts/asset.pm:536 old/bin/io.pl:1716
+#: UI/Reports/custom/reports.pl:158 UI/Reports/custom/reports.pl:4344
 msgid "Type"
 msgstr ""
 
-#: UI/am-business-form.html:12 sql/Pg-database.sql:2877
+#: sql/Pg-database.sql:2881
 msgid "Type of Business"
 msgstr "Type d'affaire"
 
-#: t/data/04-complex_template.html:411 t/data/04-complex_template.html:494
-#: t/data/04-complex_template.html:526
-msgid "Type:"
+#: UI/Reports/custom/reports.pl:135 UI/Reports/custom/reports.pl:249
+msgid "Unbalanced Journal"
 msgstr ""
 
-#: UI/payments/use_overpayment2.html:346
-msgid "UPDATE"
-msgstr ""
-
-#: bin/lsmb-request.pl:80
-msgid "Unable to open script"
-msgstr ""
-
-#: lib/LedgerSMB/Contact.pm:63
-msgid "Unable to save contact information"
-msgstr ""
-
-#: UI/Reports/filters/unapproved.html:72
-msgid "Unapproved"
-msgstr ""
-
-#: UI/rc-display-form.html:78
-msgid "Under"
-msgstr ""
-
-#: lib/LedgerSMB/Scripts/template.pm:132
+#: lib/LedgerSMB/Scripts/template.pm:133
 msgid "Unexpected file name, expected [_1], got [_2]"
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:285
+#: lib/LedgerSMB/Upgrade_Tests.pm:347
 msgid "Unique AR Invoice numbers"
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:184
+#: lib/LedgerSMB/Upgrade_Tests.pm:246
 msgid "Unique Customernumber"
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:203
+#: lib/LedgerSMB/Upgrade_Tests.pm:265
 msgid "Unique Vendornumber"
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:270 lib/LedgerSMB/Upgrade_Tests.pm:735
+#: lib/LedgerSMB/Upgrade_Tests.pm:332 lib/LedgerSMB/Upgrade_Tests.pm:931
 msgid "Unique nonobsolete partnumbers"
 msgstr ""
 
-#: bin/ic.pl:790 bin/ic.pl:1261 bin/io.pl:240 bin/oe.pl:1857
-#: lib/LedgerSMB/Report/Contact/History.pm:91
-#: lib/LedgerSMB/Report/Inventory/History.pm:130
-#: lib/LedgerSMB/Report/Inventory/Search.pm:206 templates/demo/invoice.tex:138
-#: templates/demo/product_receipt.tex:119 templates/demo/purchase_order.tex:119
-#: templates/demo/sales_order.tex:120
-#: templates/demo_with_images/invoice.tex:138
-#: templates/demo_with_images/product_receipt.tex:119
-#: templates/demo_with_images/purchase_order.tex:119
-#: templates/demo_with_images/sales_order.tex:120
-#: templates/xedemo/invoice.tex:137 templates/xedemo/product_receipt.tex:119
-#: templates/xedemo/purchase_order.tex:119 templates/xedemo/sales_order.tex:120
-#: UI/payroll/income.html:74 UI/Reports/filters/purchase_history.html:296
-#: UI/Reports/filters/search_goods.html:221
+#: lib/LedgerSMB/Report/Contact/History.pm:92
+#: lib/LedgerSMB/Report/Inventory/History.pm:131
+#: lib/LedgerSMB/Report/Inventory/Search.pm:207 old/bin/ic.pl:788
+#: old/bin/ic.pl:1259 old/bin/io.pl:235 old/bin/oe.pl:1861
 msgid "Unit"
 msgstr "Unité"
 
-#: templates/demo/invoice.html:146 templates/demo/request_quotation.html:145
-#: templates/demo/request_quotation.tex:124
-#: templates/demo_with_images/invoice.html:146
-#: templates/demo_with_images/request_quotation.html:145
-#: templates/demo_with_images/request_quotation.tex:124
-#: templates/xedemo/invoice.html:146
-#: templates/xedemo/request_quotation.html:145
-#: templates/xedemo/request_quotation.tex:124
-msgid "Unit Price"
-msgstr "Prix unitaire"
-
-#: lib/LedgerSMB/Upgrade_Tests.pm:839
+#: lib/LedgerSMB/Upgrade_Tests.pm:1035
 msgid "Unknown "
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:821
+#: lib/LedgerSMB/Upgrade_Tests.pm:1017
 msgid ""
 "Unknown account category (should be A(sset)/L(iability)/E(xpense)/I(ncome)/"
 "(e)Q(uity))"
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:803
+#: lib/LedgerSMB/Upgrade_Tests.pm:999
 msgid "Unknown charttype; should be H(eader)/A(ccount)"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:207
+#: lib/LedgerSMB/Scripts/setup.pm:230
 msgid "Unknown database found."
-msgstr ""
+msgstr "Banque de données inconnue."
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:256
+#: lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm:265
 msgid "Unlock"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:231
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:232
 msgid "Unlock Batch"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:162
+#: lib/LedgerSMB/Scripts/setup.pm:186
 msgid "Unsupported LedgerSMB version detected."
-msgstr ""
+msgstr "Version de LedgerSMB non-supportée."
 
-#: UI/Reports/filters/payments.html:23
-msgid "Unsupported Number"
-msgstr ""
-
-#: lib/LedgerSMB/Scripts/setup.pm:135
+#: lib/LedgerSMB/Scripts/setup.pm:154
 msgid "Unsupported SQL-Ledger version detected."
-msgstr ""
+msgstr "Version de SQL-Ledger non-supportée."
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:467 lib/LedgerSMB/Upgrade_Tests.pm:542
+#: lib/LedgerSMB/Upgrade_Tests.pm:530 lib/LedgerSMB/Upgrade_Tests.pm:737
 msgid "Unsupported account categories"
 msgstr ""
 
-#: lib/LedgerSMB/Upgrade_Tests.pm:486 lib/LedgerSMB/Upgrade_Tests.pm:560
+#: lib/LedgerSMB/Upgrade_Tests.pm:549 lib/LedgerSMB/Upgrade_Tests.pm:755
 msgid "Unsupported account link combinations"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/contact.pm:457
+#: lib/LedgerSMB/Scripts/contact.pm:470
 msgid "Unsupported account type"
 msgstr ""
 
-#: UI/Reports/filters/contact_search.html:16
-msgid "Unsupported.  Expect errors"
-msgstr ""
-
-#: UI/Reports/filters/search_goods.html:120
-msgid "Unused"
-msgstr ""
-
-#: bin/aa.pl:908 bin/aa.pl:940 bin/gl.pl:254 bin/ic.pl:832 bin/ic.pl:841
-#: bin/ir.pl:533 bin/ir.pl:941 bin/is.pl:574 bin/is.pl:1021 bin/oe.pl:629
-#: bin/oe.pl:852 bin/oe.pl:1952 bin/pe.pl:606
-#: lib/LedgerSMB/Scripts/budgets.pm:97 UI/am-taxes.html:72
-#: UI/payments/payment2.html:463 UI/payments/payments_detail.html:469
-#: UI/payroll/deduction.html:90 UI/payroll/income.html:96
-#: UI/reconciliation/report.html:267
+#: lib/LedgerSMB/Scripts/budgets.pm:97 old/bin/aa.pl:902 old/bin/aa.pl:928
+#: old/bin/gl.pl:248 old/bin/ic.pl:830 old/bin/ic.pl:839 old/bin/ir.pl:524
+#: old/bin/ir.pl:934 old/bin/is.pl:571 old/bin/is.pl:1020 old/bin/oe.pl:630
+#: old/bin/oe.pl:855 old/bin/oe.pl:1956 old/bin/pe.pl:604
+#: UI/Reports/custom/reports.pl:3445 UI/Reports/custom/reports.pl:5556
 msgid "Update"
 msgstr "Mettre à jour"
 
-#: bin/ic.pl:783
+#: UI/Reports/custom/reports.pl:4197
+msgid "Update Courtesies"
+msgstr ""
+
+#: old/bin/ic.pl:781
 msgid "Updated"
 msgstr "Mis à jour"
 
-#: UI/setup/upgrade_info.html:78
-msgid "Upgrade"
-msgstr "Mise à jour"
-
-#: UI/setup/upgrade_info.html:8
-msgid "Upgrade Info"
-msgstr "Information de mise à jour"
-
-#: UI/file/attachment_screen.html:48 UI/templates/preview.html:38
-msgid "Upload"
-msgstr ""
-
-#: lib/LedgerSMB/Report/File/Incoming.pm:57
-#: lib/LedgerSMB/Report/File/Internal.pm:55
+#: lib/LedgerSMB/Report/File/Incoming.pm:58
+#: lib/LedgerSMB/Report/File/Internal.pm:56
 msgid "Uploaded At"
 msgstr ""
 
-#: lib/LedgerSMB/Report/File/Incoming.pm:60
-#: lib/LedgerSMB/Report/File/Internal.pm:58
+#: lib/LedgerSMB/Report/File/Incoming.pm:61
+#: lib/LedgerSMB/Report/File/Internal.pm:59
 msgid "Uploaded By"
 msgstr ""
 
-#: UI/file/attachment_screen.html:26
-msgid "Url"
-msgstr "Url"
-
-#: lib/LedgerSMB/Report/Listings/Asset.pm:95 UI/asset/edit_asset.html:99
-#: UI/asset/search_asset.html:88
+#: lib/LedgerSMB/Report/Listings/Asset.pm:96
 msgid "Usable Life"
 msgstr ""
 
-#: sql/Pg-database.sql:2803
+#: sql/Pg-database.sql:2807
 msgid "Use AR Overpayment"
 msgstr ""
 
-#: UI/payments/use_overpayment1.html:9 sql/Pg-database.sql:2802
+#: sql/Pg-database.sql:2806
 msgid "Use Overpayment"
 msgstr ""
 
-#: bin/io.pl:1805
+#: old/bin/io.pl:1825
 msgid "Use Shipto"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:1609
+#: lib/LedgerSMB/Scripts/payment.pm:1650
 msgid "Use overpayment/prepayment"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:87
+#: lib/LedgerSMB/Scripts/configuration.pm:137
+msgid "Use web service for current Buy Exchange Rates"
+msgstr ""
+
+#: lib/LedgerSMB/Report/Budget/Variance.pm:88
+#: lib/LedgerSMB/Report/Inventory/Activity.pm:114
 msgid "Used"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/contact.pm:177 t/data/04-complex_template.html:36
-#: UI/am-company-logo.html:12 UI/Contact/divs/user.html:3
+#: lib/LedgerSMB/Scripts/contact.pm:190
 msgid "User"
 msgstr "Utilisateur"
 
-#: UI/login.html:46
-msgid "User Name"
-msgstr ""
-
-#: lib/LedgerSMB/Scripts/setup.pm:982
+#: lib/LedgerSMB/Scripts/setup.pm:1091
 msgid "User already exists. Import?"
-msgstr ""
+msgstr "Usager existant. Importer?"
 
-#: UI/Contact/divs/user.html:28 UI/Contact/divs/user.html:41
-#: UI/setup/edit_user.html:29 UI/setup/edit_user.html:42
-#: UI/setup/list_users.html:12 UI/setup/new_user.html:23
-msgid "Username"
-msgstr ""
-
-#: UI/setup/ui-db-credentials.html:4
-msgid "Username "
-msgstr ""
-
-#: UI/Admin/user_search.html:11
-msgid "Username:"
-msgstr ""
-
-#: UI/setup/complete.html:27 UI/setup/confirm_operation.html:50
-#: UI/setup/confirm_operation.html:115
-msgid "Users"
-msgstr ""
-
-#: UI/Contact/pricelist.csv:34 UI/Contact/pricelist.html:47
-#: UI/Contact/pricelist.tex:46
-msgid "Valid From"
-msgstr "Valable depuis"
-
-#: UI/am-taxes.html:18 UI/Contact/pricelist.csv:37 UI/Contact/pricelist.html:50
-#: UI/Contact/pricelist.tex:50
-msgid "Valid To"
-msgstr "Valable au"
-
-#: bin/oe.pl:455 templates/demo/sales_quotation.html:73
-#: templates/demo/sales_quotation.tex:76
-#: templates/demo_with_images/sales_quotation.html:73
-#: templates/demo_with_images/sales_quotation.tex:76
-#: templates/xedemo/sales_quotation.html:73
-#: templates/xedemo/sales_quotation.tex:77
+#: old/bin/oe.pl:456
 msgid "Valid until"
 msgstr "Valable jusqu'au"
 
-#: lib/LedgerSMB/Report/Budget/Variance.pm:92
-#: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:99
+#: UI/Reports/custom/reports.pl:163
+msgid "Validation totals"
+msgstr ""
+
+#: lib/LedgerSMB/Report/Budget/Variance.pm:93
+#: lib/LedgerSMB/Report/Inventory/Adj_Details.pm:97
 msgid "Variance"
 msgstr ""
 
-#: UI/reconciliation/report.html:44
-msgid "Variance:"
-msgstr ""
-
-#: bin/aa.pl:516 bin/aa.pl:1603 bin/ic.pl:1023 bin/ir.pl:420 bin/oe.pl:2419
-#: bin/oe.pl:2575 bin/pe.pl:1016 bin/pe.pl:1166
-#: lib/LedgerSMB/Report/Aging.pm:80
-#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:176
+#: lib/LedgerSMB/Report/Aging.pm:81
+#: lib/LedgerSMB/Report/Invoices/Outstanding.pm:177
 #: lib/LedgerSMB/Report/Invoices/Transactions.pm:247
-#: lib/LedgerSMB/Report/Orders.pm:191 lib/LedgerSMB/Report/Orders.pm:197
-#: UI/Contact/divs/credit.html:11 UI/Contact/divs/credit.html:12
-#: UI/payments/payments_detail.html:8 UI/payments/use_overpayment1.html:27
-#: UI/payments/use_overpayment2.html:23 UI/payments/use_overpayment2.html:151
-#: UI/Reports/filters/aging.html:14
-#: UI/Reports/filters/invoice_outstanding.html:6
-#: UI/Reports/filters/invoice_search.html:6 UI/Reports/filters/orders.html:5
-#: UI/rp-search-generate_tax_report.html:141 sql/Pg-database.sql:542
+#: lib/LedgerSMB/Report/Orders.pm:193 lib/LedgerSMB/Report/Orders.pm:199
+#: old/bin/aa.pl:515 old/bin/aa.pl:1585 old/bin/ic.pl:1021 old/bin/ir.pl:411
+#: old/bin/oe.pl:2408 old/bin/oe.pl:2559 old/bin/pe.pl:1014 old/bin/pe.pl:1164
+#: sql/Pg-database.sql:542
 msgid "Vendor"
 msgstr "Fournisseur"
 
@@ -8917,12 +5797,11 @@ msgstr "Fournisseur"
 msgid "Vendor Account"
 msgstr ""
 
-#: sql/Pg-database.sql:2789
+#: sql/Pg-database.sql:2793
 msgid "Vendor History"
 msgstr "Historique fournisseurs"
 
-#: bin/oe.pl:661 bin/oe.pl:863 t/data/04-complex_template.html:334
-#: UI/Contact/divs/credit.html:358 sql/Pg-database.sql:2898
+#: old/bin/oe.pl:662 old/bin/oe.pl:866 sql/Pg-database.sql:2902
 msgid "Vendor Invoice"
 msgstr "Facture d'achat"
 
@@ -8930,131 +5809,95 @@ msgstr "Facture d'achat"
 msgid "Vendor Invoice/AP Transaction Number"
 msgstr ""
 
-#: UI/payments/payment1.html:37 UI/payments/payment2.html:31
-#: UI/Reports/filters/orders.html:6
-msgid "Vendor Name"
-msgstr "Nom du fournisseur"
-
-#: bin/aa.pl:1604 bin/io.pl:1582 lib/LedgerSMB/Report/Invoices/Payments.pm:113
-#: lib/LedgerSMB/Report/Invoices/Payments.pm:183
-#: lib/LedgerSMB/Scripts/configuration.pm:116 UI/asset/edit_asset.html:197
-#: UI/asset/search_asset.html:165 UI/payments/payments_filter.html:64
-#: UI/Reports/filters/invoice_outstanding.html:7
-#: UI/Reports/filters/invoice_search.html:7
-#: UI/Reports/filters/overpayments.html:20 UI/Reports/filters/payments.html:22
-#: UI/Reports/filters/purchase_history.html:57
-#: UI/Reports/filters/taxforms.html:41
+#: lib/LedgerSMB/Report/Invoices/Payments.pm:114
+#: lib/LedgerSMB/Report/Invoices/Payments.pm:184
+#: lib/LedgerSMB/Scripts/configuration.pm:116 old/bin/aa.pl:1586
+#: old/bin/io.pl:1602 UI/Reports/custom/reports.pl:250
+#: UI/Reports/custom/reports.pl:4404
 msgid "Vendor Number"
 msgstr "Numéro de fournisseur"
 
-#: UI/Contact/pricelist.csv:20 UI/Contact/pricelist.html:35
-#: UI/Contact/pricelist.tex:29
-msgid "Vendor Partnumber"
-msgstr ""
-
-#: bin/ic.pl:1025
+#: old/bin/ic.pl:1023
 msgid "Vendor Reference Number"
 msgstr ""
 
-#: UI/Reports/filters/contact_search.html:10
-msgid "Vendor Search"
-msgstr ""
-
-#: bin/aa.pl:1311 bin/ir.pl:1269 bin/oe.pl:1201
+#: old/bin/aa.pl:1297 old/bin/ir.pl:1262 old/bin/oe.pl:1204
 msgid "Vendor missing!"
 msgstr "Fournisseur manquant!"
 
-#: bin/arap.pl:149 bin/pe.pl:1220
+#: lib/LedgerSMB/Upgrade_Tests.pm:647 lib/LedgerSMB/Upgrade_Tests.pm:693
+#, fuzzy
+msgid "Vendor not in a business"
+msgstr "Fournisseur absent du fichier!"
+
+#: old/bin/arap.pl:147 old/bin/pe.pl:1218
 msgid "Vendor not on file!"
 msgstr "Fournisseur absent du fichier!"
 
-#: bin/old-handler.pl:163
+#: old/bin/old-handler.pl:139
 msgid "Version"
 msgstr "Version"
 
-#: UI/am-company-logo.html:6
-msgid "Version [_1]"
-msgstr "Version [_1]"
-
-#: bin/is.pl:594
+#: old/bin/is.pl:591
 msgid "Void"
 msgstr ""
 
-#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:135
+#: lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm:136
 msgid "Voucher List"
 msgstr ""
 
-#: sql/Pg-database.sql:2855 sql/Pg-database.sql:2856 sql/Pg-database.sql:2979
+#: sql/Pg-database.sql:2859 sql/Pg-database.sql:2860 sql/Pg-database.sql:2983
 msgid "Vouchers"
 msgstr ""
 
-#: lib/LedgerSMB/App_State.pm:307
+#: lib/LedgerSMB/App_State.pm:214
 msgid "W"
 msgstr ""
 
-#: UI/Contact/divs/wage.html:2
-msgid "Wages and Deductions"
-msgstr ""
-
-#: lib/LedgerSMB/Scripts/contact.pm:178
+#: lib/LedgerSMB/Scripts/contact.pm:191
 msgid "Wages/Deductions"
 msgstr ""
 
-#: bin/oe.pl:1740 templates/demo/bin_list.html:112
-#: templates/demo/bin_list.tex:82 templates/demo/packing_list.html:83
-#: templates/demo/packing_list.tex:90 templates/demo/pick_list.html:81
-#: templates/demo/pick_list.tex:82 templates/demo_with_images/bin_list.html:112
-#: templates/demo_with_images/bin_list.tex:82
-#: templates/demo_with_images/packing_list.html:83
-#: templates/demo_with_images/packing_list.tex:90
-#: templates/demo_with_images/pick_list.html:81
-#: templates/demo_with_images/pick_list.tex:82
-#: templates/xedemo/bin_list.html:112 templates/xedemo/bin_list.tex:82
-#: templates/xedemo/packing_list.html:83 templates/xedemo/packing_list.tex:90
-#: templates/xedemo/pick_list.html:81 templates/xedemo/pick_list.tex:82
-#: UI/Reports/filters/search_goods.html:353
+#: old/bin/oe.pl:1744
 msgid "Warehouse"
 msgstr "Entrepôt"
 
-#: lib/LedgerSMB/Report/Listings/Warehouse.pm:57 sql/Pg-database.sql:2879
+#: old/bin/am.pl:737
+#, fuzzy
+msgid "Warehouse deleted!"
+msgstr "Groupe effacé!"
+
+#: old/bin/am.pl:730
+#, fuzzy
+msgid "Warehouse saved!"
+msgstr "Entrepôts"
+
+#: lib/LedgerSMB/Report/Listings/Warehouse.pm:58 sql/Pg-database.sql:2883
 msgid "Warehouses"
 msgstr "Entrepôts"
 
-#: UI/oe-save_warn.html:5
-msgid "Warning!"
-msgstr "Attention!"
-
-#: UI/lib/ui-header.html:39
-msgid "Warning:  Your password will expire in [_1]"
-msgstr "Attention:  Votre mot de passe expirera dans [_1]"
-
-#: lib/LedgerSMB/Report/Timecards.pm:134
+#: lib/LedgerSMB/Report/Timecards.pm:135
 msgid "Wed"
 msgstr "Mer."
 
-#: bin/am.pl:808 UI/lib/report_base.html:167 UI/timecards/entry_filter.html:24
+#: old/bin/am.pl:746
 msgid "Week"
 msgstr "Semaine"
 
-#: lib/LedgerSMB/Report/Timecards.pm:97
+#: lib/LedgerSMB/Report/Timecards.pm:98
 msgid "Week Starting"
 msgstr "Semaine débutant le"
 
-#: bin/arap.pl:532
+#: old/bin/arap.pl:530
 msgid "Week(s)"
 msgstr "Semaine(s)"
 
-#: UI/timecards/timecard-week.html:50
-msgid "Weekly Time and Materials Entry"
-msgstr ""
-
-#: bin/am.pl:809 lib/LedgerSMB/App_State.pm:307
+#: lib/LedgerSMB/App_State.pm:213 old/bin/am.pl:747
 msgid "Weeks"
 msgstr "Semaines"
 
-#: bin/ic.pl:550 bin/ic.pl:577 bin/ic.pl:599
-#: lib/LedgerSMB/Report/Inventory/Search.pm:218
-#: UI/Reports/filters/search_goods.html:303
+#: lib/LedgerSMB/Report/Inventory/Search.pm:219 old/bin/ic.pl:548
+#: old/bin/ic.pl:575 old/bin/ic.pl:597
 msgid "Weight"
 msgstr "Poids"
 
@@ -9062,15 +5905,11 @@ msgstr "Poids"
 msgid "Weight Unit"
 msgstr "Unité de poids"
 
-#: bin/io.pl:597
+#: old/bin/io.pl:591
 msgid "What type of item is this?"
 msgstr "De quel type est cet objet?"
 
-#: UI/setup/begin_backup.html:8
-msgid "Where shall we send the backup?"
-msgstr ""
-
-#: sql/Pg-database.sql:3760
+#: sql/Pg-database.sql:3764
 msgid "Whole Month Straight Line"
 msgstr ""
 
@@ -9078,300 +5917,605 @@ msgstr ""
 msgid "Widgit Themes"
 msgstr ""
 
-#: bin/am.pl:1503 bin/io.pl:1154 bin/oe.pl:251 bin/printer.pl:71
-#: templates/demo_with_images/work_order.html:4
-#: templates/demo_with_images/work_order.html:18
-#: templates/demo_with_images/work_order.tex:109
-#: templates/demo/work_order.html:4 templates/demo/work_order.html:18
-#: templates/demo/work_order.tex:109 templates/xedemo/work_order.html:4
-#: templates/xedemo/work_order.html:18 templates/xedemo/work_order.tex:109
-#: sql/Pg-database.sql:2951 sql/Pg-database.sql:2964
+#: old/bin/am.pl:1462 old/bin/io.pl:1174 old/bin/oe.pl:252 old/bin/printer.pl:71
+#: sql/Pg-database.sql:2955 sql/Pg-database.sql:2968
 msgid "Work Order"
 msgstr "Fiche de traitement"
 
-#: lib/LedgerSMB/Scripts/setup.pm:109
+#: lib/LedgerSMB/Scripts/setup.pm:128
 msgid "Would you like to migrate the database?"
-msgstr ""
+msgstr "Voulez-vous migrer la banque de données?"
 
-#: lib/LedgerSMB/Scripts/setup.pm:112
+#: lib/LedgerSMB/Scripts/setup.pm:131
 msgid "Would you like to upgrade the database?"
-msgstr ""
+msgstr "Voulez-vous mettre à jour la banque de données?"
 
-#: UI/Reports/aging_report.html:121
-msgid "XLS"
+#: UI/Reports/custom/reports.pl:2347
+#, fuzzy
+msgid "XML"
 msgstr "XLS"
 
-#: lib/LedgerSMB/App_State.pm:310
+#: lib/LedgerSMB/App_State.pm:220
 msgid "Y"
 msgstr ""
 
-#: sql/Pg-database.sql:799
+#: sql/Pg-database.sql:813
 msgid "Yahoo"
 msgstr "Yahoo"
 
-#: bin/aa.pl:1588 bin/am.pl:810 bin/pe.pl:826 lib/LedgerSMB/DBObject/Date.pm:95
-#: UI/bp-search.html:50 UI/lib/report_base.html:185 UI/lib/report_base.html:269
-#: UI/rc-reconciliation.html:59 UI/rp-search-generate_income_statement.html:52
-#: UI/rp-search-generate_tax_report.html:48
+#: old/bin/aa.pl:1570 old/bin/am.pl:748 old/bin/pe.pl:824
+#: old/lib/LedgerSMB/DBObject/Date.pm:96 UI/Reports/custom/reports.pl:148
+#: UI/Reports/custom/reports.pl:251
 msgid "Year"
 msgstr "Année"
 
-#: sql/Pg-database.sql:2860
+#: sql/Pg-database.sql:2864
 msgid "Year End"
 msgstr ""
 
-#: bin/arap.pl:534
+#: old/bin/arap.pl:532
 msgid "Year(s)"
 msgstr "Année(s)"
 
-#: UI/accounts/yearend.html:22 UI/accounts/yearend.html:38
-msgid "Yearend"
-msgstr "Écriture de fin d'exercice"
-
-#: UI/accounts/yearend_complete.html:4
-msgid "Yearend complete"
-msgstr "Écriture de fin d'exercice complétée"
-
-#: bin/am.pl:811 lib/LedgerSMB/App_State.pm:310
+#: lib/LedgerSMB/App_State.pm:219 old/bin/am.pl:749
 msgid "Years"
 msgstr "Années"
 
-#: bin/oe.pl:1327 lib/LedgerSMB/Report/Taxform/List.pm:100
-#: UI/am-audit-control.html:14 UI/am-audit-control.html:30
-#: UI/Configuration/settings.html:29 UI/setup/confirm_operation.html:29
+#: UI/Reports/custom/reports.pl:5223
+#, fuzzy
+msgid "Years back"
+msgstr "Années"
+
+#: lib/LedgerSMB/Report/Taxform/List.pm:101 old/bin/oe.pl:1329
+#: UI/Reports/custom/reports.pl:252
 msgid "Yes"
 msgstr "Oui"
 
-#: UI/users/preferences.html:24
-msgid "Your password will expire in "
-msgstr ""
-
-#: t/data/04-complex_template.html:388
-msgid "ZIP/Post Code"
-msgstr "Code Postal"
-
-#: lib/LedgerSMB/Num2text.pm:73
+#: old/lib/LedgerSMB/Num2text.pm:73
 msgid "Zero"
 msgstr "Zéro"
 
-#: bin/io.pl:1640
+#: old/bin/io.pl:1660
 msgid "Zip Code"
 msgstr "Code Postal"
 
-#: UI/Contact/divs/address.html:83 UI/Contact/divs/address.html:175
-msgid "Zip/Post Code"
-msgstr "Code Postal"
-
-#: t/data/04-complex_template.html:463
-msgid "Zip/Post Code:"
-msgstr "Code Postal:"
-
-#: UI/Reports/filters/contact_search.html:105
-#: UI/Reports/filters/purchase_history.html:94
-msgid "Zip/Postal Code"
-msgstr "Code Postal"
-
-#: lib/LedgerSMB/Report/PNL.pm:146
+#: lib/LedgerSMB/Report/PNL.pm:155
 msgid ""
 "[_1]\n"
 "[_2]"
 msgstr ""
 
-#: bin/gl.pl:184
+#: old/bin/gl.pl:179
 msgid "[_1] Cash Transfer Transaction"
 msgstr ""
 
-#: bin/aa.pl:394
+#: old/bin/aa.pl:393
 msgid "[_1] Credit Note"
 msgstr "Note de crédit"
 
-#: bin/aa.pl:398
+#: old/bin/aa.pl:397
 msgid "[_1] Debit Note"
 msgstr "Note de débit"
 
-#: bin/gl.pl:187
+#: old/bin/gl.pl:182
 msgid "[_1] General Ledger Transaction"
 msgstr ""
 
-#: bin/arap.pl:173
+#: old/bin/arap.pl:171
 msgid "[_1] Number"
 msgstr ""
 
-#: bin/aa.pl:387
+#: old/bin/aa.pl:386
 msgid "[_1] [_2] Transaction"
 msgstr ""
 
-#: bin/ic.pl:1645
+#: old/bin/ic.pl:1639
 msgid "[_1]: Customer not on file!"
 msgstr ""
 
-#: bin/ic.pl:1567
+#: old/bin/ic.pl:1561
 msgid "[_1]: Vendor not on file!"
 msgstr ""
 
-#: lib/LedgerSMB/Form.pm:714
+#: old/lib/LedgerSMB/Form.pm:698
 msgid "[_1]:[_2]:[_3]: Invalid Redirect"
 msgstr ""
 
-#: bin/old-handler.pl:172
+#: UI/Reports/custom/reports.pl:182
+msgid "accno"
+msgstr ""
+
+#: old/bin/old-handler.pl:148
 msgid "action not defined!"
 msgstr ""
 
-#: UI/rp-search-generate_balance_sheet.html:2
+#: UI/Reports/custom/reports.pl:5219
 msgid "as at"
 msgstr "au"
 
-#: UI/Reports/co/filter_bm.html:114
-msgid "balance"
-msgstr ""
-
-#: lib/LedgerSMB/DBObject/Payment.pm:476
+#: old/lib/LedgerSMB/DBObject/Payment.pm:478
 msgid "cash"
 msgstr "comptant"
 
-#: lib/LedgerSMB/DBObject/Payment.pm:477
+#: old/lib/LedgerSMB/DBObject/Payment.pm:479
 msgid "check"
 msgstr "chèque"
 
-#: bin/io.pl:1634
+#: old/bin/io.pl:1654
 msgid "city"
 msgstr "ville"
 
-#: bin/ic.pl:1081 bin/oe.pl:365 t/data/04-complex_template.html:215
-#: t/data/04-complex_template.html:255 UI/Contact/divs/credit.html:163
-#: UI/Contact/divs/credit.html:181
+#: old/bin/ic.pl:1079 old/bin/oe.pl:366
 msgid "days"
 msgstr "jours"
 
-#: UI/Reports/co/filter_bm.html:99
-msgid "debits"
-msgstr "débits"
-
-#: lib/LedgerSMB/Scripts/admin.pm:141
+#: lib/LedgerSMB/Scripts/admin.pm:71
 msgid "delete"
 msgstr ""
 
-#: lib/LedgerSMB/DBObject/Payment.pm:478
+#: old/lib/LedgerSMB/DBObject/Payment.pm:480
 msgid "deposit"
 msgstr "dépôt"
 
-#: sql/Pg-database.sql:3834
+#: sql/Pg-database.sql:3838
 msgid "depreciation"
 msgstr "dépréciation"
 
-#: sql/Pg-database.sql:3835
+#: sql/Pg-database.sql:3839
 msgid "disposal"
 msgstr ""
 
-#: bin/am.pl:1254 bin/am.pl:1325 bin/am.pl:1379 bin/am.pl:1430 bin/am.pl:1480
+#: old/bin/am.pl:1213 old/bin/am.pl:1284 old/bin/am.pl:1338 old/bin/am.pl:1389
+#: old/bin/am.pl:1439
 msgid "done"
 msgstr "fait"
 
-#: bin/ir.pl:1242 bin/is.pl:1334 bin/oe.pl:1175
+#: old/bin/ir.pl:1235 old/bin/is.pl:1331 old/bin/oe.pl:1178
 msgid "ea"
 msgstr "pièce(s)"
 
-#: bin/am.pl:1328 bin/am.pl:1483
+#: old/bin/am.pl:1287 old/bin/am.pl:1442
 msgid "failed"
 msgstr "échec"
 
-#: t/data/04-gettext.tex:10
-msgid "fr"
-msgstr "fr"
-
-#: UI/lib/report_base.html:108 UI/lib/report_base.html:203
-msgid "from_date"
+#: UI/Reports/custom/reports.pl:2346
+msgid "html"
 msgstr ""
 
-#: sql/Pg-database.sql:3836
+#: sql/Pg-database.sql:3840
 msgid "import"
 msgstr ""
 
-#: sql/Pg-database.sql:3761
+#: sql/Pg-database.sql:3765
 msgid "in months"
 msgstr "en mois"
 
-#: sql/Pg-database.sql:3756 sql/Pg-database.sql:3764
+#: sql/Pg-database.sql:3760 sql/Pg-database.sql:3768
 msgid "in years"
 msgstr "en années"
 
-#: lib/LedgerSMB/Scripts/payment.pm:1734
+#: lib/LedgerSMB/Scripts/payment.pm:1775
 msgid "is bigger than the amount available"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:1486
+#: lib/LedgerSMB/Scripts/payment.pm:1524
 msgid "is lesser than 0"
 msgstr "est inférieur à 0"
 
-#: lib/LedgerSMB/Scripts/payment.pm:1480
+#: lib/LedgerSMB/Scripts/payment.pm:1518
 msgid "is lesser than the amount to be paid"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:1702
+#: lib/LedgerSMB/Scripts/payment.pm:1744
 msgid "is null"
 msgstr "est nul"
 
-#: UI/Configuration/sequence.html:12
-msgid "label"
-msgstr ""
-
-#: t/data/04-gettext.html:3 t/data/04-gettext.html:4
-msgid "nl"
-msgstr "nl"
-
-#: lib/LedgerSMB/DBObject/Payment.pm:479
+#: old/lib/LedgerSMB/DBObject/Payment.pm:481
 msgid "other"
 msgstr ""
 
-#: sql/Pg-database.sql:3837
+#: sql/Pg-database.sql:3841
 msgid "partial disposal"
 msgstr ""
 
-#: UI/Reports/aging_report.html:108 UI/Reports/display_report.html:61
-msgid "permalink"
-msgstr "lien permanent"
-
-#: sql/Pg-database.sql:3726
+#: sql/Pg-database.sql:3730
 msgid "production"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/setup.pm:245
+#: lib/LedgerSMB/Scripts/setup.pm:267
 msgid "psql not found."
 msgstr "psql non disponible."
 
-#: bin/arap.pl:809 bin/io.pl:1469
+#: old/bin/arap.pl:807 old/bin/io.pl:1488
 msgid "sent"
 msgstr "envoyé"
 
-#: UI/Reports/co/filter_bm.html:92
-msgid "starting_balance"
-msgstr ""
-
-#: UI/Reports/filters/search_goods.html:375
-msgid "subtotal"
-msgstr "sous total"
-
-#: sql/Pg-database.sql:3725
+#: sql/Pg-database.sql:3729
 msgid "time"
 msgstr ""
 
-#: bin/arap.pl:561
+#: old/bin/arap.pl:559
 msgid "time(s)"
 msgstr ""
 
-#: UI/lib/report_base.html:120 UI/lib/report_base.html:214
-msgid "to_date"
-msgstr ""
-
-#: bin/ic.pl:1436
+#: old/bin/ic.pl:1433
 msgid "unexpected error!"
 msgstr ""
 
-#: lib/LedgerSMB/Scripts/payment.pm:1742 lib/LedgerSMB/Scripts/payment.pm:1759
-#: lib/LedgerSMB/Scripts/payment.pm:1814 lib/LedgerSMB/Scripts/payment.pm:1831
+#: lib/LedgerSMB/Scripts/payment.pm:1783 lib/LedgerSMB/Scripts/payment.pm:1800
+#: lib/LedgerSMB/Scripts/payment.pm:1855 lib/LedgerSMB/Scripts/payment.pm:1872
 msgid "use of an overpayment"
 msgstr ""
 
-#: t/data/04-gettext.tex:8
-msgid "zh_CN"
-msgstr "zh_CN"
+#~ msgid "Account:"
+#~ msgstr "Compte:"
+
+#~ msgid "Activate Audit trail"
+#~ msgstr "Activer la journalisation des accès aux écritures clôturées"
+
+#~ msgid "Add Customer"
+#~ msgstr "Ajouter client"
+
+#~ msgid "Add User"
+#~ msgstr "Ajouter utilisateur"
+
+#~ msgid "Add Vendor"
+#~ msgstr "Ajouter fournisseur"
+
+#, fuzzy
+#~ msgid "Amount to pay"
+#~ msgstr "Montant"
+
+#~ msgid "Asset Class:"
+#~ msgstr "Classe d'actif:"
+
+#~ msgid "Backup"
+#~ msgstr "Sauvegarder"
+
+#~ msgid "Balance Due"
+#~ msgstr "Solde dû"
+
+#~ msgid "CSV"
+#~ msgstr "CSV"
+
+#~ msgid "Change Password"
+#~ msgstr "Modifier mot de passe"
+
+#~ msgid "City:"
+#~ msgstr "Ville"
+
+#~ msgid "Cleared Transactions"
+#~ msgstr "Transactions compensées"
+
+#~ msgid "Close Books up to"
+#~ msgstr "Clôturer l'exercice jusqu'au"
+
+#~ msgid "Company: [_1]"
+#~ msgstr "Société: [_1]"
+
+#~ msgid "Compare to"
+#~ msgstr "Comparer à"
+
+#~ msgid "Confirm"
+#~ msgstr "Confirmer"
+
+#~ msgid "Contra"
+#~ msgstr "Contrepartie"
+
+#~ msgid "Control Number"
+#~ msgstr "Numéro de contrôle"
+
+#~ msgid "Copy"
+#~ msgstr "Copier"
+
+#~ msgid "Cost Center"
+#~ msgstr "Axé coûts"
+
+#~ msgid "Country Code"
+#~ msgstr "Code de pays"
+
+#~ msgid "Country:"
+#~ msgstr "Pays:"
+
+#~ msgid "Credit Limit:"
+#~ msgstr "Encours autorisé:"
+
+#~ msgid "Customer Name"
+#~ msgstr "Nom du client"
+
+#~ msgid "Customer Search"
+#~ msgstr "Recherche client"
+
+#~ msgid "Customer/Vendor Accounts"
+#~ msgstr "Comptes Clients/Fournisseurs"
+
+#~ msgid "DOB"
+#~ msgstr "Date de naissance"
+
+#~ msgid "DOB:"
+#~ msgstr "Date de naissance:"
+
+#~ msgid "Database"
+#~ msgstr "Base de données"
+
+#~ msgid "Database Host"
+#~ msgstr "Hôte de base de données"
+
+#~ msgid "Dataset"
+#~ msgstr "Fichier de données"
+
+#~ msgid "Date From:"
+#~ msgstr "De:"
+
+#~ msgid "Date To:"
+#~ msgstr "À:"
+
+#~ msgid "Date of Birth"
+#~ msgstr "Date de naissance"
+
+#~ msgid "Delivery"
+#~ msgstr "Livraison"
+
+#~ msgid "Departments"
+#~ msgstr "Services"
+
+#~ msgid "Details"
+#~ msgstr "Détails"
+
+#~ msgid "E-mail [_1]"
+#~ msgstr "E-mail [_1]"
+
+#~ msgid "Edit Customer"
+#~ msgstr "Modifier client"
+
+#~ msgid "Edit Employee"
+#~ msgstr "Modifier employé"
+
+#~ msgid "Edit User"
+#~ msgstr "Modifier utilisateur"
+
+#~ msgid "Enforce transaction reversal for all dates"
+#~ msgstr "Activer la clôture des écritures pour toutes les dates"
+
+#~ msgid "First Name"
+#~ msgstr "Prénom"
+
+#~ msgid "Group by"
+#~ msgstr "Groupé par"
+
+#~ msgid "History"
+#~ msgstr "Historique"
+
+#~ msgid "Hours"
+#~ msgstr "Heures"
+
+#~ msgid "Include Exchange Rate Difference"
+#~ msgstr "Inclure différence conversion devises"
+
+#~ msgid "Include in drop-down menus"
+#~ msgstr "Inclure dans les menus déroulants"
+
+#~ msgid "Invoice #"
+#~ msgstr "Facture #"
+
+#~ msgid "Invoice No."
+#~ msgstr "N° de Facture"
+
+#~ msgid "Last name"
+#~ msgstr "Nom"
+
+#~ msgid "Line Total"
+#~ msgstr "Total ligne"
+
+#~ msgid "List Transactions"
+#~ msgstr "Afficher écritures"
+
+#~ msgid "Login"
+#~ msgstr "Login"
+
+#~ msgid "Name:"
+#~ msgstr "Nom:"
+
+#~ msgid "Notes:<br />"
+#~ msgstr "Notes:<br />"
+
+#~ msgid "Number Format"
+#~ msgstr "Format des numéros"
+
+msgid "Password"
+msgstr "Mot de passe"
+
+#~ msgid "Payables"
+#~ msgstr "À payer"
+
+#~ msgid "Phone"
+#~ msgstr "Tél."
+
+#~ msgid "Preferences Saved"
+#~ msgstr "Préférences enregistrées"
+
+#~ msgid "Prefix"
+#~ msgstr "Préfixe"
+
+#~ msgid "Pricelist"
+#~ msgstr "Liste de prix"
+
+#~ msgid "Pricelist for [_1]"
+#~ msgstr "Groupe de prix de [_1]"
+
+#~ msgid "Profit Center"
+#~ msgstr "Axé profit"
+
+#~ msgid "Projects"
+#~ msgstr "Projets"
+
+#~ msgid "RFQ #"
+#~ msgstr "No. de demande de devis"
+
+#~ msgid "Rate (%)"
+#~ msgstr "Taux (%)"
+
+#~ msgid "Receivable"
+#~ msgstr "À recevoir"
+
+#~ msgid "Receivables"
+#~ msgstr "À recevoir"
+
+#~ msgid "Reconciliation Report"
+#~ msgstr "Rapport de rapprochement"
+
+#~ msgid "Required By"
+#~ msgstr "Requis pour"
+
+#~ msgid "Retained Earnings"
+#~ msgstr "Éxcédents non distribués"
+
+#~ msgid "SSN"
+#~ msgstr "Numéro d'assurance sociale"
+
+#~ msgid "Sales:"
+#~ msgstr "Ventes:"
+
+#~ msgid "Ship To:"
+#~ msgstr "Expédier à:"
+
+#~ msgid "Short"
+#~ msgstr "Court"
+
+#~ msgid "Signature"
+#~ msgstr "Signature"
+
+#~ msgid "Sort by"
+#~ msgstr "Trier par"
+
+#~ msgid "Start Date:"
+#~ msgstr "Date de début:"
+
+#~ msgid "State/Province"
+#~ msgstr "Région/État"
+
+#~ msgid "Stylesheet"
+#~ msgstr "Feuille de style"
+
+#~ msgid "Subcontract GIFI:"
+#~ msgstr "Code d'identification comptable ou fiscale - Sous-traitance"
+
+#~ msgid "Subtotal:"
+#~ msgstr "Sous total:"
+
+#~ msgid "System Defaults"
+#~ msgstr "Préférences système"
+
+#~ msgid "TOTAL"
+#~ msgstr "TOTAL"
+
+#~ msgid "Tax Account"
+#~ msgstr "Compte de taxe"
+
+#~ msgid "Tax Number/SSN"
+#~ msgstr "Numéro de taxe"
+
+#~ msgid "Tax Number/SSN:"
+#~ msgstr "Numéro de taxe/Assurance sociale"
+
+#~ msgid "Tax Number: [_1]"
+#~ msgstr "Numéro de taxe: [_1]"
+
+#~ msgid "Tax included"
+#~ msgstr "Taxes incluses"
+
+#~ msgid "Taxable"
+#~ msgstr "Imposable"
+
+#~ msgid "Taxnumber:"
+#~ msgstr "Numéro de taxe:"
+
+#~ msgid "Taxnumber: [_1]"
+#~ msgstr "Numéro de taxe: [_1]"
+
+#~ msgid "Tel:"
+#~ msgstr "Tél:"
+
+#~ msgid "Tel: [_1]"
+#~ msgstr "Tél: [_1]"
+
+#~ msgid "Templates"
+#~ msgstr "Squelettes"
+
+#~ msgid "Time Card"
+#~ msgstr "Carte de temps"
+
+#~ msgid "To [_1]"
+#~ msgstr "À [_1]"
+
+#~ msgid "To:"
+#~ msgstr "À:"
+
+#~ msgid "Transactions"
+#~ msgstr "Mouvements"
+
+#~ msgid "Unit Price"
+#~ msgstr "Prix unitaire"
+
+#~ msgid "Upgrade"
+#~ msgstr "Mise à jour"
+
+#~ msgid "Upgrade Info"
+#~ msgstr "Information de mise à jour"
+
+#~ msgid "Url"
+#~ msgstr "Url"
+
+#~ msgid "Valid From"
+#~ msgstr "Valable depuis"
+
+#~ msgid "Valid To"
+#~ msgstr "Valable au"
+
+#~ msgid "Vendor Name"
+#~ msgstr "Nom du fournisseur"
+
+#~ msgid "Version [_1]"
+#~ msgstr "Version [_1]"
+
+#~ msgid "Warning!"
+#~ msgstr "Attention!"
+
+#~ msgid "Warning:  Your password will expire in [_1]"
+#~ msgstr "Attention:  Votre mot de passe expirera dans [_1]"
+
+#~ msgid "Yearend"
+#~ msgstr "Écriture de fin d'exercice"
+
+#~ msgid "Yearend complete"
+#~ msgstr "Écriture de fin d'exercice complétée"
+
+#~ msgid "ZIP/Post Code"
+#~ msgstr "Code Postal"
+
+#~ msgid "Zip/Post Code"
+#~ msgstr "Code Postal"
+
+#~ msgid "Zip/Post Code:"
+#~ msgstr "Code Postal:"
+
+#~ msgid "Zip/Postal Code"
+#~ msgstr "Code Postal"
+
+#~ msgid "debits"
+#~ msgstr "débits"
+
+#~ msgid "fr"
+#~ msgstr "fr"
+
+#~ msgid "nl"
+#~ msgstr "nl"
+
+#~ msgid "permalink"
+#~ msgstr "lien permanent"
+
+#~ msgid "subtotal"
+#~ msgstr "sous total"
+
+#~ msgid "zh_CN"
+#~ msgstr "zh_CN"


### PR DESCRIPTION
Use minimal unescaping and add translation for tooltips and migration instructions. Fixes #3080