### PR TITLE
* Fix #2820: Contact Info not escaped properly (and bic/iban)

### DIFF
--- a/UI/Contact/divs/bank_act.html
+++ b/UI/Contact/divs/bank_act.html
@@ -8,8 +8,8 @@
 href_base = request.script _ '?&entity_id=' _ entity_id _ '&target_div=bank_act_div' _
             '&form_id=' _ form_id _ '&credit_id=' _ credit_id _ '&id=';
 FOREACH ba IN bank_account;
-    ba.iban_href_suffix = '&bic=' _ ba.bic _ '&iban=' _ ba.iban _
-         '&action=edit' _ '&id=' _ ba.id;
+    ba.iban_href_suffix = '&bic=' _ tt_url(ba.bic) _ '&iban='
+         _ tt_url(ba.iban) _ '&action=edit' _ '&id=' _ ba.id;
     ba.delete_href_suffix=ba.id _ '&action=delete_bank_account';
     ba.delete = '[' _ text('Delete') _ ']';
 END;

--- a/UI/Contact/divs/contact_info.html
+++ b/UI/Contact/divs/contact_info.html
@@ -10,8 +10,10 @@ FOREACH ROW IN contacts;
     ROW.edit = '[' _ text('Edit') _ ']';
     ROW.delete = '[' _ text('Delete') _ ']';
     base_suffix =
-               "$request.script?entity_id=$entity_id&contact=$ROW.contact" _
-               "&class_id=$ROW.class_id&description=$ROW.description" _
+               "$request.script?entity_id=$entity_id&" _
+               "contact=" _ tt_url(ROW.contact) _
+               "&class_id=$ROW.class_id&" _
+               "description=" _ tt_url(ROW.description) _
                "&credit_id=$credit_act.id&for_credit=$ROW.credit_id&target_div=contact_info_div";
     ROW.edit_href_suffix = base_suffix _ '&action=edit';
     ROW.delete_href_suffix = base_suffix _ '&action=delete_contact';


### PR DESCRIPTION
Note that the primary keys of the related tables (entity_to_contact,
  eca_to_contact and entity_bank_account) have primary keys which include
  character data (which by consequence must be URL-escaped when used
  in URL-composition).

This is a placeholder pull request template.

