### PR TITLE
* Fix #2820: Contact Info not escaped properly (and bic/iban)

### DIFF
--- a/UI/Contact/divs/bank_act.html
+++ b/UI/Contact/divs/bank_act.html
@@ -4,8 +4,8 @@
 href_base = script _ '?&entity_id=' _ entity_id _ '&target_div=bank_act_div' _
             '&form_id=' _ form_id _ '&credit_id=' _ credit_id _ '&id=';
 FOREACH ba IN bank_account;
-    ba.iban_href_suffix = '&bic=' _ ba.bic _ '&iban=' _ ba.iban _
-         '&action=edit' _ '&id=' _ ba.id;
+    ba.iban_href_suffix = '&bic=' _ tt_url(ba.bic) _ '&iban='
+         _ tt_url(ba.iban) _ '&action=edit' _ '&id=' _ ba.id;
     ba.delete_href_suffix=ba.id _ '&action=delete_bank_account';
     ba.delete = '[' _ text('Delete') _ ']';
 END;


### PR DESCRIPTION
Note that the primary keys of the related tables (entity_to_contact,
  eca_to_contact and entity_bank_account) have primary keys which include
  character data (which by consequence must be URL-escaped when used
  in URL-composition).

