### PR TITLE
Use Perl Pattern Recognizer (PPR) to extract strings for localization

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -115,6 +115,7 @@ on 'develop' => sub {
     requires 'Perl::Critic::Moose';
     requires 'Pherkin::Extension::Weasel', '0.02';
     requires 'Plack::Middleware::Pod'; # YLA - Generate browseable documentation
+    requires 'PPR';
     requires 'Selenium::Remote::Driver';
     requires 'TAP::Parser::SourceHandler::pgTAP';
     requires 'Test::BDD::Cucumber', '0.52';

--- a/cpanfile
+++ b/cpanfile
@@ -104,12 +104,15 @@ feature 'debug', "Debug pane" =>
 on 'develop' => sub {
     requires 'App::Prove', '3.36';
     requires 'File::Util';
+    requires 'Getopt::Long';
     requires 'HTML::Lint';
     requires 'HTML::Lint::Parser', '2.26';
     requires 'HTML::Lint::Pluggable';
     requires 'HTML::Lint::Pluggable::HTML5';
     requires 'HTML::Lint::Pluggable::WhiteList';
     recommends 'Linux::Inotify2';
+    requires 'List::Util';
+    requires 'Locale::Maketext::Simple';
     requires 'Module::CPANfile'; # for 01.2-deps.t
     requires 'Perl::Critic';
     requires 'Perl::Critic::Moose';

--- a/cpanfile
+++ b/cpanfile
@@ -104,14 +104,12 @@ feature 'debug', "Debug pane" =>
 on 'develop' => sub {
     requires 'App::Prove', '3.36';
     requires 'File::Util';
-    requires 'Getopt::Long';
     requires 'HTML::Lint';
     requires 'HTML::Lint::Parser', '2.26';
     requires 'HTML::Lint::Pluggable';
     requires 'HTML::Lint::Pluggable::HTML5';
     requires 'HTML::Lint::Pluggable::WhiteList';
     recommends 'Linux::Inotify2';
-    requires 'List::Util';
     requires 'Locale::Maketext::Simple';
     requires 'Module::CPANfile'; # for 01.2-deps.t
     requires 'Perl::Critic';

--- a/t/07.1-extract-perl.t
+++ b/t/07.1-extract-perl.t
@@ -47,7 +47,13 @@ my @tests = (
       results => [ 'Continue', 'Ok' ] },
     { statement => "my f\$ = test(<<END;\nA heredoc string\nwith many lines\nEND\n);",
       results => [ "A heredoc string\nwith many lines" ] },
-    { statement => "my e\$ = test(<<'END';\nA heredoc string\nwith many lines\n"
+    { statement => "my f\$ = test(<<'END';\nA heredoc string\nwith single quotes\nEND\n);",
+      results => [ "A heredoc string\nwith single quotes" ] },
+    { statement => "my f\$ = test(<<\"END\";\nA heredoc string\nwith double quotes\nEND\n);",
+      results => [ "A heredoc string\nwith double quotes" ] },
+    { statement => "my f\$ = test(<<`END`;\nA heredoc string\nwith back ticks\nEND\n);",
+      results => [ "A heredoc string\nwith back ticks" ] },
+    { statement => "my e\$ = test(<<'END'; #Comment\nA heredoc string\nwith many lines\n"
                                   . "and a literal which shouldn't be interpolated \$a\nEND\n);",
       results => [ "A heredoc string\nwith many lines\n"
                                   . "and a literal which shouldn't be interpolated \$a" ] },

--- a/t/07.1-extract-perl.t
+++ b/t/07.1-extract-perl.t
@@ -3,9 +3,9 @@
 use strict;
 use warnings;
 
-use LedgerSMB::Sysconfig;
+use File::Spec;
 
-my $tempdir  = $LedgerSMB::Sysconfig::tempdir;
+my $tempdir  = File::Spec->tmpdir();
 my $testfile = "$tempdir/extract-tests.pl";
 my $pofile   = "$tempdir/extract-tests.po";
 

--- a/t/07.1-extract-perl.t
+++ b/t/07.1-extract-perl.t
@@ -1,0 +1,108 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use LedgerSMB::Sysconfig;
+
+my $tempdir  = $LedgerSMB::Sysconfig::tempdir;
+my $testfile = "$tempdir/extract-tests.pl";
+my $pofile   = "$tempdir/extract-tests.po";
+
+use Locale::Maketext::Simple(
+    Path => $tempdir
+);
+use Test::More;
+use List::Util qw(sum);
+
+my @tests = (
+    { statement => "# text('Comment test')",
+      results => [ 'Comment test' ] },
+    { statement => 'my a$ = text("$form->{title}");',
+      results => [],
+      fail => "?" },
+    { statement => 'my b$ = Text("Can\'t void a voided invoice!");',
+      results => [ "Can't void a voided invoice!" ] },
+    { statement => 'my b$ = marktext("Disposal Report [_1] on date [_2]");',
+      results => [ 'Disposal Report [_1] on date [_2]' ],
+      arguments => [ '[_1]', '[_2]' ]},
+    { statement => 'my c$ = MarkText("There shouldn\'t be reconciliations on non-bank accounts.<br>");',
+      results => [ "There shouldn't be reconciliations on non-bank accounts.<br>" ] },
+    { statement => "my \@d = ( text('Exchange rate hasn\\'t been defined!'),",
+      results => [ "Exchange rate hasn't been defined!" ] },
+    { statement => 'text(\'GIFI accounts not in "gifi" table\'),',
+      results => [ 'GIFI accounts not in "gifi" table'] },
+    { statement => 'text("Testing \\"quote string\\" here"),',
+      results => [ 'Testing \"quote string\" here' ] },
+    { statement => 'text(q(A quoting style with \' and " embedded)),',
+      results => [ q(A quoting style with ' and " embedded) ] },
+    { statement => 'text(qq(Another quoting style with \' and " embedded))',
+      results => [ qq(Another quoting style with ' and " embedded)] },
+    { statement => 'text(q(A quoting style with a literal which shouldn\'t be interpolated $a)),',
+      results => [ q(A quoting style with a literal which shouldn't be interpolated $a)] },
+    { statement => 'text(qq(Another quoting style with a forbidden interpolation $b->{c}))',
+      results => [],
+      fail => "?" },
+    { statement => "my \$d = text('Continue') .\n\t\ttext('Ok') .\ntext('Continue');",
+      results => [ 'Continue', 'Ok' ] },
+    { statement => "my f\$ = test(<<END;\nA heredoc string\nwith many lines\nEND\n);",
+      results => [ "A heredoc string\nwith many lines" ] },
+    { statement => "my e\$ = test(<<'END';\nA heredoc string\nwith many lines\n"
+                                  . "and a literal which shouldn't be interpolated \$a\nEND\n);",
+      results => [ "A heredoc string\nwith many lines\n"
+                                  . "and a literal which shouldn't be interpolated \$a" ] },
+#TODO: Enable heredocs with doublequotes once PPR is ok with them
+#    { statement => "my g\$ = test(<<\"END\";\nA heredoc string\nwith many lines\n"
+#                                  . "and a forbidden interpolation \$b->{c}\nEND\n);",
+#      results => [],
+#      fail => "?" },
+);
+
+plan tests => sum map { (scalar @{$_->{results}}) + (defined $_->{fail} ? 1 : 0)} @tests;
+
+for my $test (@tests) {
+
+    # Set the source file
+    open(SOURCE, '>', $testfile)
+         or die "Could not open file '$testfile' $!";
+    print SOURCE $test->{statement} . "\n";
+    close SOURCE;
+
+    # Produce a PO file
+    system("echo \"$testfile\" | utils/devel/extract-perl > $pofile");
+    my $exit = $?;
+
+    # Read it back
+    Locale::Maketext::Simple->import(
+        {
+            '*'     => [ Gettext => "$pofile", ],
+            _auto   => 1,
+            _decode => 1,
+        }
+    );
+
+    my @results = defined $test->{results}
+                ? @{$test->{results}}
+                : [];
+
+    for my $result (@results) {
+
+        my $text = loc($result,@{$test->{arguments}});
+
+        ok($text eq $result,$test->{statement})
+            if !defined $test->{fail};
+
+        if ( $test->{comments} ) {
+            TODO: {
+                local $TODO = "Comments not implemented yet";
+            }
+        }
+    }
+    if ( $test->{fail} ) {
+        ok($exit != 0,$test->{statement})
+    }
+}
+
+unlink $testfile;
+
+done_testing;

--- a/utils/devel/extract-perl
+++ b/utils/devel/extract-perl
@@ -19,12 +19,6 @@ use utf8;
 
 use PPR;
 use Carp qw( croak );
-use Getopt::Long;
-
-#TODO: What relevant options to add?
-my $pack;
-  GetOptions ("pack"  => \$pack)     # pack references
-  or die("Error in command line arguments\n");
 
 my %dict;
 
@@ -63,7 +57,7 @@ while (<>) {
              }gmx;
     next if !@text;
 
-    # Deduplicate, standardize and pack line references
+    # Deduplicate and standardize
     my %text;
     for (@text) {
         my $string = $_;
@@ -102,14 +96,9 @@ while (<>) {
 
         push @{$text{$string}}, $line;
     }
-    if ( $pack ) {
-        add_entry($_, $file, join(',',@{$text{$_}}))
-            for (keys %text);
-    } else {
-        for my $k (keys %text) {
-            add_entry($k, $file, $_)
-                for (@{$text{$k}});
-        }
+    for my $k (keys %text) {
+        add_entry($k, $file, $_)
+            for (@{$text{$k}});
     }
 };
 

--- a/utils/devel/extract-perl
+++ b/utils/devel/extract-perl
@@ -1,132 +1,123 @@
 #!/usr/bin/perl
 
-=pod
+=description
 
-This script contains a relatively simple state machine to scan various
-Perl files for translatable strings.
+This script scans various Perl files for translatable strings.
 
-The scanner consists of 2 main state processes (block comment (POD) and
-text() call parsing).
-
-Single line comments are intentionally *not* stripped, because single line
-comments sometimes intentionally contain translatable strings.
+The scanner uses the Perl Pattern Recognizer to find text() or marktext()
+translation routines, either in code or comments, because they sometimes
+intentionally contain translatable strings.
 
 This script exists because xgettext and xgettext.pl don't allow us to
 extract a sub-set of strings from our SQL files.
 
 =cut
 
-
 use strict;
 use warnings;
 
+use PPR;
+use utf8;
+use Carp qw( croak );
+use Getopt::Long;
 
-use constant {
-    NUL => 1,
-    POD => 10,
-    TXT => 20,
-    TXT_FIN => 21,
-};
-
+#TODO: What relevant options to add?
+my $pack;
+  GetOptions ("pack"  => \$pack)     # pack references
+  or die("Error in command line arguments\n");
 
 my %dict;
 
 sub add_entry {
     my ($string, $file, $line) = @_;
 
-    return if $string =~ m/^[\s\t\n]*$/g; # return on empty/space-only strings
-
+    if ( !$line ) {
+        croak "No line for $file:$string";
+    }
     $dict{$string} = []
         if ! exists $dict{$string};
 
     push @{$dict{$string}}, "#: $file:$line\n";
 }
 
+sub slurp{ local (*ARGV, $/); @ARGV = shift; readline; }
 
 while (<>) {
     chomp;
-    open SOURCE, "<:encoding(UTF-8)", $_
-        or die "Can't open '$_'; error: $!";
 
-    my $state = NUL;
-    my $line_no = 1;
     my $file = $_;
-    while (<SOURCE>) {
+    my $source = slurp($file);
 
-        ++$line_no;
+    # Empty line count array
+    my @lines;        # To record line numbers
+    my $line = 1;
 
-      PARSER: {
-          $_ = substr($_,pos($_)) if pos($_);
-          # print "S:$state:$_";
+    my @text = grep {defined}
+        $source =~
+            m{
+               ((?&PerlEndOfLine) (??{ ++$line }))*?     # Count the lines
+               (?: (?:[Mm]ark)?[Tt]ext\b                 # Introducer
+                   (?&PerlOWS) [\(\s] (?&PerlOWS))       # '(' or ' '
+               ((?&PerlString)) (?{ push @lines,$line }) # string and line
+               $PPR::GRAMMAR                             # Preload our grammar
+             }gmx;
+    next if !@text;
 
-          $state==NUL &&
-              m/^=[a-zA-Z]\S*\s*/g
-              && do { $state = POD; next; };
+    # Deduplicate, standardize and pack line references
+    my %text;
+    for (@text) {
+        my $string = $_;
 
-          $state==POD &&
-              m/^=cut/g
-              && do { $state = NUL; next; };
+        # @lines must follow @text
+        my $line = shift @lines;
 
-          $state==NUL &&
-              # the reports use a workaround with a function called Text()
-              # or MarkText()
-              m/(?<![\w\d_])([Mm]ark)?[tT]ext[\s\t\n]*\(/g
-              && do { $state = TXT; redo; };
+        my $type = $string =~ m/^('|q\b|<<\s*')/  ?  "Q"
+                 : $string =~ m/^("|qq\b|<<\s*")/ ? "DQ"
+                                                  :  "-";
+        # Prevent unwanted interpolations
+        if ( $type ne "Q" && $string =~ m( .* ((?&PerlVariable)) .* $PPR::GRAMMAR)x ) {
+            croak "$file:$line: Direct variable interpolation not supported; use bracketed ([_1]) syntax to replace $1";
+            next;
+        }
 
-          $state==TXT &&
-              m/^[\s\t\n]*'(([^'\\]|''|\\.)*)'/g
-              && do { $state = TXT_FIN;
-                      my $string = $1;
-                      $string =~ s/\\'/'/g;
-                      $string =~ s/\\/\\\\/g;
-                      $string =~ s/"/\\"/g;
-                      $string =~ s/\$/\\\$/g;
-                      add_entry($string, $file, $line_no);
-                      redo;
-          };
+        # Remove beginning and end delimitors
+        # The following doesn't work yet
+        #$string = $2
+        #    if $string =~ m( .* ((?&PerlString)) .* $PPR::GRAMMAR);
+        #warn "string = '$string', 1 = <$1>, 2 = <$2>, 3 = <$3>, 4 = <$4>";
+        #TODO: Replace by the above once PPR has added support
+        if    ( $string =~ /^(["'])(.*)\1$/s )       { $string = $2 ;} # "string"
+        elsif ( $string =~ /^q{1,2}\((.*)\)$/s)      { $string = $1 ;} # q() or qq()
+        elsif ( $string =~ /^<<(['"\b])([a-z0-9_])\1;
+                             \s*(?:\#[^\n]*)
+                             (.*)\n\2$/mxi)          { $string = $3 ;} # heredoc
+        else {
+            croak "$file:$line: Unsupported string delimiters in <$string>";
+            next;
+        }
+        # Prepare for GetText, using doublequotes
+        $string =~ s/\\'/'/g if $type eq "Q";  # No need to escape single quotes
 
-          $state==TXT &&
-              m/^[\s\t\n]*"(([^"\\]|\\.)*)"/g
-              && do { $state = TXT_FIN;
-                      my $string = $1;
-                      if ($string =~ m/(?<!\\)\$/g) {
-                          warn "$file:$line_no: Direct variable interpolation not supported; use bracketed ([_1]) syntax!";
-                          $state = NUL;
-                      }
-                      else {
-                          add_entry($1, $file, $line_no);
-                      }
-                      redo; };
+        next if $string =~ m/^[\s\t\n]*$/g; # skip empty/space-only strings
 
-          $state==TXT &&
-              ! m/^[\s\t]*$/g
-              && do { warn "$file:$line_no: text() called with non string first argument; resetting scan (consider using maketext() directly!\n";
-                      $state = NUL;
-          };
-
-          $state==TXT_FIN &&
-              m/^[\s\t\n]*,/g
-              && do { $state = NUL; redo; };
-
-          $state==TXT_FIN &&
-              m/^[\s\t\n]*\)/g
-              && do { $state = NUL; redo; };
-
-          $state==TXT_FIN &&
-              ! m/^[\s\t\n]*$/g
-              && do { warn "$file:$line_no: junk '$_' after first text() argument; resetting scan!\n";
-                      $state = NUL;
-          };
-        };
-    };
-    close SOURCE;
+        push @{$text{$string}}, $line;
+    }
+    if ( $pack ) {
+        add_entry($_, $file, join(',',@{$text{$_}}))
+            for (keys %text);
+    } else {
+        for my $k (keys %text) {
+            add_entry($k, $file, $_)
+                for (@{$text{$k}});
+        }
+    }
 };
 
-
-foreach my $string (keys %dict) {
-    foreach my $location (@{$dict{$string}}) {
+foreach my $string (sort keys %dict) {
+    foreach my $location (sort @{$dict{$string}}) {
         print $location;
     }
+    $string =~ s/\n/\"\n\"/g;
     print "msgid \"$string\"\n";
     print "msgstr \"\"\n\n";
 }

--- a/utils/devel/extract-perl
+++ b/utils/devel/extract-perl
@@ -15,9 +15,9 @@ extract a sub-set of strings from our SQL files.
 
 use strict;
 use warnings;
+use utf8;
 
 use PPR;
-use utf8;
 use Carp qw( croak );
 use Getopt::Long;
 

--- a/utils/devel/extract-perl
+++ b/utils/devel/extract-perl
@@ -71,26 +71,26 @@ while (<>) {
         # @lines must follow @text
         my $line = shift @lines;
 
-        my $type = $string =~ m/^('|q\b|<<\s*')/  ?  "Q"
-                 : $string =~ m/^("|qq\b|<<\s*")/ ? "DQ"
-                                                  :  "-";
+        my $type = $string =~ m/^(?&PerlQuotelikeQ)  $PPR::GRAMMAR/x ?  "Q"
+                 : $string =~ m/^(?&PerlQuotelikeQQ) $PPR::GRAMMAR/x ? "DQ"
+                                                                     :  "-";
         # Prevent unwanted interpolations
-        if ( $type ne "Q" && $string =~ m( .* ((?&PerlVariable)) .* $PPR::GRAMMAR)x ) {
+        if ( $type ne "Q" && $string =~ m/ ((?&PerlVariable)) $PPR::GRAMMAR/x ) {
             croak "$file:$line: Direct variable interpolation not supported; use bracketed ([_1]) syntax to replace $1";
             next;
         }
 
-        # Remove beginning and end delimitors
+        # Remove beginning and end delimiters
         # The following doesn't work yet
         #$string = $2
-        #    if $string =~ m( .* ((?&PerlString)) .* $PPR::GRAMMAR);
-        #warn "string = '$string', 1 = <$1>, 2 = <$2>, 3 = <$3>, 4 = <$4>";
-        #TODO: Replace by the above once PPR has added support
+        #    if $string =~ m( .* ((?&PerlStringUnquoted)) .* $PPR::GRAMMAR);
+        #TODO: Replace the 3 next lines by the above once PPR has added support
         if    ( $string =~ /^(["'])(.*)\1$/s )       { $string = $2 ;} # "string"
         elsif ( $string =~ /^q{1,2}\((.*)\)$/s)      { $string = $1 ;} # q() or qq()
-        elsif ( $string =~ /^<<(['"\b])([a-z0-9_])\1;
-                             \s*(?:\#[^\n]*)
-                             (.*)\n\2$/mxi)          { $string = $3 ;} # heredoc
+        elsif ( $string =~ m/^(?<PerlHeredoc>)
+                             \s*(?:\#[^\n]*)\n
+                             (.*)\n(?<_heredoc_terminator>)
+                             $PPR::GRAMMAR $/mxi)    { $string = $3 ;} # heredoc
         else {
             croak "$file:$line: Unsupported string delimiters in <$string>";
             next;

--- a/utils/devel/extract-perl
+++ b/utils/devel/extract-perl
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 
-=description
+=pod
 
 This script scans various Perl files for translatable strings.
 


### PR DESCRIPTION
With the advent of multilines in tooltips and migration instructions, there was a need to support all forms of Perl strings. This proved difficult with the current state machine and developing the regexes to properly support `q`, `qq` and `heredocs` were redundant in regard of PPR ability to handle those.

