### PR TITLE
Supporting older working versions of PGObject

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -28,7 +28,7 @@ requires 'Moose::Role';
 requires 'Moose::Util::TypeConstraints';
 requires 'MooseX::NonMoose';
 requires 'Number::Format';
-requires 'PGObject', '2.000002';
+requires 'PGObject', '1.403.2';
 # PGObject::Simple 3.0.1 breaks our file uploads
 requires 'PGObject::Simple', '>=3.0.2';
 requires 'PGObject::Simple::Role', '1.13.2';


### PR DESCRIPTION
This will avoid having to use local::lib for one extra dependency on Debian.