### PR TITLE
* Fix #2972: Forms sometimes seem to hang

### DIFF
--- a/UI/js-src/lsmb/Form.js
+++ b/UI/js-src/lsmb/Form.js
@@ -11,6 +11,7 @@ define([
     ],
        function(Form, declare, event, on, hash, domattr, domform,
                 query, registry) {
+           var c = 0;
            return declare("lsmb/Form",
                           [Form],
               {
@@ -46,9 +47,10 @@ define([
                               alert('Form contains no action. Please file a bug');
                               return false;
                           }
+                          c++;
                           var qobj = domform.toQuery(this.domNode);
                           qobj = "action=" + this.clickedAction + "&" + qobj;
-                          url = url + "?" + qobj;
+                          url = url + "?" + qobj + '#' + c.toString(16);
                           hash(url); // add GET forms to the back button history
                       } else {
                           options["method"] = method;


### PR DESCRIPTION
The cause of the seeming hang is that the new pages are loaded when the
'hash' section of the URL changes. However, because any intermediate POST
requests don't change the hash, it can happen that two subsequent GET
form posts end up requesting the same URL. As a result, the second GET
won't be executed (as the 'hash' part of the window.location doesn't change).

This is a placeholder pull request template.

