### PR TITLE
* Fix #2585: Add missing content for outstanding report columns

### DIFF
--- a/sql/modules/Report.sql
+++ b/sql/modules/Report.sql
@@ -402,6 +402,9 @@ CREATE TYPE aa_transactions_line AS (
     entity_name text,
     transdate date,
     invnumber text,
+    ordnumber text,
+    ponumber text,
+    curr char(3),
     amount numeric,
     netamount numeric,
     tax numeric,
@@ -426,17 +429,18 @@ CREATE OR REPLACE FUNCTION report__aa_outstanding_details
 RETURNS SETOF aa_transactions_line LANGUAGE SQL AS $$
 
 SELECT a.id, a.invoice, eeca.id, eca.meta_number, eeca.name, a.transdate,
-       a.invnumber, a.amount, a.netamount, a.amount - a.netamount as tax,
+       a.invnumber, a.ordnumber, a.ponumber, a.curr, a.amount, a.netamount,
+       a.amount - a.netamount as tax,
        a.amount - p.due as paid, p.due, p.last_payment, a.duedate, a.notes,
        a.till, ee.name, me.name, a.shippingpoint, a.shipvia,
        '{}'::text[] as business_units -- TODO
-  FROM (select id, transdate, invnumber, amount, netamount, duedate, notes,
+  FROM (select id, transdate, invnumber, curr, amount, netamount, duedate, notes,
                till, person_id, entity_credit_account, invoice, shippingpoint,
                shipvia, ordnumber, ponumber, description, on_hold, force_closed
           FROM ar
          WHERE in_entity_class = 2 and approved
          UNION
-        SELECT id, transdate, invnumber, amount, netamount, duedate, notes,
+        SELECT id, transdate, invnumber, curr, amount, netamount, duedate, notes,
                null, person_id, entity_credit_account, invoice, shippingpoint,
                shipvia, ordnumber, ponumber, description, on_hold, force_closed
           FROM ap
@@ -493,6 +497,7 @@ RETURNS SETOF aa_transactions_line LANGUAGE SQL AS $$
 
 SELECT null::int as id, null::bool as invoice, entity_id, meta_number,
        entity_name, null::date as transdate, count(*)::text as invnumber,
+       null::text as ordnumber, null::text as ponumber, curr,
        sum(amount) as amount, sum(netamount) as netamount, sum(tax) as tax,
        sum(paid) as paid, sum(due) as due, max(last_payment) as last_payment,
        null::date as duedate, null::text as notes, null::text as till,
@@ -501,7 +506,7 @@ SELECT null::int as id, null::bool as invoice, entity_id, meta_number,
        null::text[] as business_units
   FROM report__aa_outstanding_details($1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
     $11, $12)
- GROUP BY meta_number, entity_name, entity_id;
+ GROUP BY meta_number, entity_name, entity_id, curr;
 
 $$;
 
@@ -531,20 +536,21 @@ CREATE OR REPLACE FUNCTION report__aa_transactions
 RETURNS SETOF aa_transactions_line LANGUAGE SQL AS $$
 
 SELECT a.id, a.invoice, eeca.id, eca.meta_number, eeca.name,
-       a.transdate, a.invnumber, a.amount, a.netamount,
+       a.transdate, a.invnumber, a.ordnumber, a.ponumber, a.curr,
+       a.amount, a.netamount,
        a.amount - a.netamount as tax, a.amount - p.due, p.due, p.last_payment,
        a.duedate, a.notes,
        a.till, eee.name as employee, mee.name as manager, a.shippingpoint,
        a.shipvia, '{}'::text[]
 
-  FROM (select id, transdate, invnumber, amount, netamount, duedate, notes,
+  FROM (select id, transdate, invnumber, curr, amount, netamount, duedate, notes,
                till, person_id, entity_credit_account, invoice, shippingpoint,
                shipvia, ordnumber, ponumber, description, on_hold, force_closed
           FROM ar
          WHERE in_entity_class = 2
                and (in_approved is null or (in_approved = approved))
          UNION
-        SELECT id, transdate, invnumber, amount, netamount, duedate, notes,
+        SELECT id, transdate, invnumber, curr, amount, netamount, duedate, notes,
                null, person_id, entity_credit_account, invoice, shippingpoint,
                shipvia, ordnumber, ponumber, description, on_hold, force_closed
           FROM ap


### PR DESCRIPTION
This change adds the content for the columns Currency, Order Number and
PO Number which are already present and selectable in the UI. Before this
change, the columns would be shown without data.

This is a placeholder pull request template.

