### PR TITLE
* Fix #3154: failure selecting business details from business list

### DIFF
--- a/lib/LedgerSMB/Report/Listings/Business_Type.pm
+++ b/lib/LedgerSMB/Report/Listings/Business_Type.pm
@@ -89,7 +89,7 @@ sub run_report {
     $self->manual_totals(1); #don't display totals
     my @rows = $self->call_dbmethod(funcname => 'business_type__list');
     for my $ref(@rows){
-        $ref->{id} = $ref->{id};
+        $ref->{row_id} = $ref->{id};
         $ref->{discount} *= RATIO_TO_PERCENT;
     }
     return $self->rows(\@rows);

--- a/old/lib/LedgerSMB/AM.pm
+++ b/old/lib/LedgerSMB/AM.pm
@@ -315,8 +315,8 @@ sub get_business {
           FROM business
          WHERE id = ?|;
 
-    $sth = $dbh->prepare($query);
-    $sth->execute( $form->{id} );
+    $sth = $dbh->prepare($query) || $form->dberror($query);
+    $sth->execute( $form->{id} ) || $from->dberror($query);
     ( $form->{description}, $form->{discount} ) = $sth->fetchrow_array();
 
 }


### PR DESCRIPTION
Adding missing query failure checks to help diagnosing errors;
the real fix is setting the 'row_id' value (instead of 'id')
because the report uses 'row_id' to determine the details
lookup.