### PR TITLE
* Fix depreciation method lists non-existing stored procedure

### DIFF
--- a/sql/Pg-database.sql
+++ b/sql/Pg-database.sql
@@ -3756,16 +3756,20 @@ insert the relevant lines into asset_report_line. $$;
 comment on column asset_dep_method.method IS
 $$ These are keyed to specific stored procedures.  Currently only "straight_line" is supported$$;
 
-INSERT INTO asset_dep_method(method, unit_class, sproc, unit_label, short_name)
-values ('Annual Straight Line Daily', 1, 'asset_dep_straight_line_yr_d', 'in years', 'SLYD');
-
-
-INSERT INTO asset_dep_method(method, unit_class, sproc, unit_label, short_name)
-values ('Whole Month Straight Line', 1, 'asset_dep_straight_line_whl_m',
-'in months', 'SLMM');
-
-INSERT INTO asset_dep_method(method, unit_class, sproc, unit_label, short_name)
-values ('Annual Straight Line Monthly', 1, 'asset_dep_straight_line_yr_m', 'in years', 'SLYM');
+INSERT INTO asset_dep_method
+  (method, unit_class,
+   sproc,
+   unit_label, short_name)
+values
+  ('Annual Straight Line Daily', 1,
+   'asset_dep_straight_line_yr_d',
+   'in years', 'SLYD'),
+  ('Whole Month Straight Line', 1,
+   'asset_dep_straight_line_month',
+   'in months', 'SLMM'),
+  ('Annual Straight Line Monthly', 1,
+   'asset_dep_straight_line_yr_m',
+   'in years', 'SLYM');
 
 CREATE TABLE asset_class (
         id serial not null unique,

--- a/sql/changes/1.5/fixed-assets-depreciation-sproc.sql
+++ b/sql/changes/1.5/fixed-assets-depreciation-sproc.sql
@@ -1,0 +1,5 @@
+
+update asset_dep_method
+   set sproc = 'asset_dep_straight_line_month'
+ where sproc = 'asset_dep_straight_line_whl_m';
+

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -46,6 +46,7 @@
 1.5/issue-2278-modify-acc_trans-index.sql
 1.5/template_menu3.sql
 1.5/template_menu4.sql
+1.5/fixed-assets-depreciation-sproc.sql
 #tag: migration-target
 # Note: the schema as created up to here, is the one as required by
 #   the migration scripts in sql/upgrade/. Don't insert any change


### PR DESCRIPTION
Note that this commit changes Pg-database, but doesn't change the
schema it loads; it only changes the data being loaded -- in a way
which won't let the upgrade script fail.

The above makes the exception to the rule not to change Pg-database.

