### PR TITLE
* Fix an error in ODS output generation

### DIFF
--- a/lib/LedgerSMB/Template/ODS.pm
+++ b/lib/LedgerSMB/Template/ODS.pm
@@ -834,9 +834,14 @@ sub preprocess {
         return escapeHTML($rawvars);
     } elsif ($type eq 'SCALAR' or $type eq 'Math::BigInt::GMP') {
         return escapeHTML($$rawvars);
+    } elsif ($type eq 'CODE') {
+        return $rawvars;
+    } elsif ($type eq 'IO::File') {
+        return undef;
     } else { # Hashes and objects
         for ( keys %{$rawvars} ) {
-            $vars->{preprocess($_)} = preprocess( $rawvars->{$_} );
+            $vars->{preprocess($_)} = preprocess( $rawvars->{$_} )
+                if $_ !~ /^_/;
         }
     }
 


### PR DESCRIPTION
On the #ledgersmb channel, an ISE/500 error was reported in the code generating
ODS (OpenOffice) output. The code on 'master' has been refactored and isn't
affected. Committing the fix directly into 1.5.

