### PR TITLE
Remove spurious warning about main::SOURCE

### DIFF
--- a/utils/devel/extract-perl
+++ b/utils/devel/extract-perl
@@ -44,6 +44,7 @@ sub add_entry {
 }
 
 sub slurp{
+    no warnings 'once';
     local (*ARGV, $/);
     @ARGV = shift;
     open SOURCE, "<:encoding(UTF-8)", $_

--- a/utils/devel/extract-perl
+++ b/utils/devel/extract-perl
@@ -44,12 +44,11 @@ sub add_entry {
 }
 
 sub slurp{
-    no warnings 'once';
     local (*ARGV, $/);
     @ARGV = shift;
-    open SOURCE, "<:encoding(UTF-8)", $_
+    open my $fh, "<:encoding(UTF-8)", $_
         or die "Can't open '$_'; error: $!";
-    readline(SOURCE);
+    readline($fh);
 }
 
 while (<>) {


### PR DESCRIPTION
Used only once warnings were failing the tests.

