### PR TITLE
Require newer to circumvent _DBH initialization problems

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -31,7 +31,7 @@ requires 'Number::Format';
 requires 'PGObject', '1.403.2';
 # PGObject::Simple 3.0.1 breaks our file uploads
 requires 'PGObject::Simple', '>=3.0.2';
-requires 'PGObject::Simple::Role', '1.13.2';
+requires 'PGObject::Simple::Role', '>1.13.2';
 requires 'PGObject::Type::BigFloat', '1.0.0';
 requires 'PGObject::Type::DateTime', '1.0.4';
 requires 'PGObject::Type::ByteString', '1.1.1';


### PR DESCRIPTION
PGObject::Simple::Role sometimes uses _DBH before initialization, which fails in our template tests.
Force upgrade.

