### PR TITLE
Disable migration when AR or AP missing

### DIFF
--- a/UI/js-src/lsmb/setup/upgrade_info.js
+++ b/UI/js-src/lsmb/setup/upgrade_info.js
@@ -1,0 +1,21 @@
+define([
+    "dijit/form/Form",
+    "dojo/_base/declare",
+    "dijit/registry",
+    ],
+       function(Form, declare, registry) {
+           return declare("lsmb/setup/upgrade_info",
+                          [Form],
+              {
+                  startup: function() {
+                      var self = this;
+                      this.inherited(arguments);
+                      var button = registry.byId("button-upgrade-action");
+                      button.attr("disabled", !self.isValid()); // set initial state
+                        button.connect(self, "onValidStateChange", function(state){
+                            button.attr("disabled", !state);
+                        });
+                  },
+              });
+       }
+    );

--- a/UI/setup/upgrade_info.html
+++ b/UI/setup/upgrade_info.html
@@ -9,7 +9,7 @@ include_stylesheet=["setup/stylesheet.css"] ?>
 <form data-dojo-type="lsmb/SimpleForm"
       action="setup.pl" method="POST"
       name="upgrade_info">
-            <?lsmb upgrade_allowed = 1 ?>
+<?lsmb upgrade_allowed = 1 ?>
 <?lsmb INCLUDE input element_data = {
     name = 'database'
     type = 'hidden'
@@ -22,11 +22,10 @@ include_stylesheet=["setup/stylesheet.css"] ?>
 </p>
 <p>
   In addition to these new defaults LedgerSMB adds stricter
-  checks on data validity in the database. Because of these
-  stricter checks it's no longer valid to leave companies
-  without a country or customers without accounts receivable
-  reference. The defaults you choose below will be used to add
-  values where these are currently missing but required.
+  checks on data validity in the database. Because of these stricter checks
+  it's no longer valid to leave companies without a country or customers
+  without accounts receivable reference. The defaults you choose below will
+  be used to add values where these are currently missing but required.
 </p>
 <div class="input_row">
 <?lsmb INCLUDE select element_data = {
@@ -36,28 +35,27 @@ include_stylesheet=["setup/stylesheet.css"] ?>
                             name  = 'default_country'
                            label  = text('Default Country') #'
                             class = 'country'
+                         required = 1
 } ?>
 </div>
 <div class="input_row">
 <p>
-  LedgerSMB supports multiple <em>Accounts receivable (AR)
-  </em> accounts per company.
-  <?lsmb IF ar_accounts.size > 1 ?>
-    <span>One of those must be the system default.
-   Please select your default below.</span>
-  <?lsmb ELSE; ?>
+  LedgerSMB supports multiple <em>Accounts receivable (AR) </em> accounts
+per company.
+<?lsmb IF ar_accounts.size > 1 ?>
+    <span>One of those must be the system default. Please select
+your default below.</span>
+<?lsmb ELSE; ?>
     <span>Your AR account has been selected to be the
     system default. Please review.</span>
-  <?lsmb END ?>
-  <?lsmb AR_DISABLED = "";
-    IF ar_accounts.size <= 1 && !ar_accounts.0.id; ?>
+<?lsmb END ?>
+<?lsmb AR_DISABLED = "";
+IF ar_accounts.size <= 1 && !ar_accounts.0.id && lsmb_info.ar > 0; ?>
     <span style='font-weight:bold'>
           No <em>AR</em> account available, your database is
           in an inconsistent state and needs to be fixed first.
     </span>
-  <?lsmb AR_DISABLED = "disabled";
-         upgrade_allowed = 0;
-  END ?>
+  <?lsmb AR_DISABLED = "disabled"; END ?>
 </p>
 <?lsmb INCLUDE select element_data = {
                             name  = 'default_ar'
@@ -66,29 +64,28 @@ include_stylesheet=["setup/stylesheet.css"] ?>
                             options = ar_accounts
                             value_attr = 'accno'
                             text_attr = 'desc'
+                            required = 1
                             disabled = AR_DISABLED
 } ?>
 </div>
 <div class="input_row">
 <p>
-LedgerSMB supports multiple <em>Accounts payable (AP)
-</em> accounts per company.
-<?lsmb IF ap_accounts.size > 1 ?>
-<span>One of those must be the system default.
-Please select your default below.</span>
-<?lsmb ELSE; ?>
-<span>Your AP account has been selected to be the
-system default. Please review.</span>
-<?lsmb END ?>
-<?lsmb AP_DISABLED = "";
-IF ap_accounts.size <= 1 && !ap_accounts.0.id; ?>
-<span style='font-weight:bold'>
-      No <em>AP</em> account available, your database is
-      in an inconsistent state and needs to be fixed first.
-</span>
-<?lsmb AP_DISABLED = "disabled";
-     upgrade_allowed = 0;
-END ?>
+  LedgerSMB supports multiple <em>Accounts payable (AP) </em> accounts
+per company.
+  <?lsmb IF ap_accounts.size > 1 ?>
+    <span>One of those must be the system default.
+   Please select your default below.</span>
+  <?lsmb ELSE; ?>
+    <span>Your AP account has been selected to be the
+    system default. Please review.</span>
+  <?lsmb END ?>
+  <?lsmb AP_DISABLED = "";
+    IF ap_accounts.size <= 1 && !ap_accounts.0.id && lsmb_info.ap > 0; ?>
+    <span style='font-weight:bold'>
+          No <em>AP</em> account available, your database is
+          in an inconsistent state and needs to be fixed first.
+    </span>
+  <?lsmb AP_DISABLED = "disabled"; END ?>
 </p>
 <?lsmb INCLUDE select element_data = {
                             name  = 'default_ap'
@@ -97,24 +94,24 @@ END ?>
                             options = ap_accounts
                             value_attr = 'accno'
                             text_attr = 'desc'
-                                                disabled = AP_DISABLED
+                             required = 1
+                            disabled = AP_DISABLED
 } ?>
 </div>
-<div class="input_row">
-<p>
-  Note that the process invoked by hitting the button below might
-  take long to complete as it will run the upgrade process and will
-  copy all data from the original tables into the newer tables.
-</p>
-<?lsmb IF upgrade_allowed;
-    INCLUDE button element_data = {
-    text = text('Upgrade')
-    name = 'action'
-   value = upgrade_action
+    <div class="input_row">
+        <p>
+          Note that the process invoked by hitting the button below might
+          take long to complete as it will run the upgrade process and will
+          copy all data from the original tables into the newer tables.
+        </p>
+<?lsmb INCLUDE button element_data = {
+      id = 'button-upgrade-action'
+        text = text('Upgrade')
+        name = 'action'
+       value = upgrade_action
         type = 'submit'
        class = 'submit'
     };
-END;
 INCLUDE button element_data = {
     text = text('Cancel')
     name = 'action'

--- a/UI/setup/upgrade_info.html
+++ b/UI/setup/upgrade_info.html
@@ -9,6 +9,7 @@ include_stylesheet=["setup/stylesheet.css"] ?>
 <form data-dojo-type="lsmb/SimpleForm"
       action="setup.pl" method="POST"
       name="upgrade_info">
+            <?lsmb upgrade_allowed = 1 ?>
 <?lsmb INCLUDE input element_data = {
     name = 'database'
     type = 'hidden'
@@ -20,11 +21,12 @@ include_stylesheet=["setup/stylesheet.css"] ?>
   you will need to set as part of the upgrade process.
 </p>
 <p>
-  In addition to these new defaults LedgerSMB 1.3 adds stricter
-  checks on data validity in the database. Because of these stricter checks
-  it's no longer valid to leave companies without a country or customers
-  without accounts receivable reference. The defaults you choose below will
-  be used to add values where these are currently missing but required.
+  In addition to these new defaults LedgerSMB adds stricter
+  checks on data validity in the database. Because of these
+  stricter checks it's no longer valid to leave companies
+  without a country or customers without accounts receivable
+  reference. The defaults you choose below will be used to add
+  values where these are currently missing but required.
 </p>
 <div class="input_row">
 <?lsmb INCLUDE select element_data = {
@@ -38,10 +40,24 @@ include_stylesheet=["setup/stylesheet.css"] ?>
 </div>
 <div class="input_row">
 <p>
-  LedgerSMB supports multiple <em>Accounts receivable (AR)</em> accounts
-per company. One of those must be the system default. Please select
-your default below in case of multiple. If the list below is empty,
-your database is in an inconsistent state and needs to be fixed first.
+  LedgerSMB supports multiple <em>Accounts receivable (AR)
+  </em> accounts per company.
+  <?lsmb IF ar_accounts.size > 1 ?>
+    <span>One of those must be the system default.
+   Please select your default below.</span>
+  <?lsmb ELSE; ?>
+    <span>Your AR account has been selected to be the
+    system default. Please review.</span>
+  <?lsmb END ?>
+  <?lsmb AR_DISABLED = "";
+    IF ar_accounts.size <= 1 && !ar_accounts.0.id; ?>
+    <span style='font-weight:bold'>
+          No <em>AR</em> account available, your database is
+          in an inconsistent state and needs to be fixed first.
+    </span>
+  <?lsmb AR_DISABLED = "disabled";
+         upgrade_allowed = 0;
+  END ?>
 </p>
 <?lsmb INCLUDE select element_data = {
                             name  = 'default_ar'
@@ -50,14 +66,29 @@ your database is in an inconsistent state and needs to be fixed first.
                             options = ar_accounts
                             value_attr = 'accno'
                             text_attr = 'desc'
+                            disabled = AR_DISABLED
 } ?>
 </div>
 <div class="input_row">
 <p>
-  LedgerSMB supports multiple <em>Accounts payable (AP)</em> accounts
-per company. One of those must be the system default. Please select
-your default below in case of multiple. If the list below is empty,
-your database is in an inconsistent state and needs to be fixed first.
+LedgerSMB supports multiple <em>Accounts payable (AP)
+</em> accounts per company.
+<?lsmb IF ap_accounts.size > 1 ?>
+<span>One of those must be the system default.
+Please select your default below.</span>
+<?lsmb ELSE; ?>
+<span>Your AP account has been selected to be the
+system default. Please review.</span>
+<?lsmb END ?>
+<?lsmb AP_DISABLED = "";
+IF ap_accounts.size <= 1 && !ap_accounts.0.id; ?>
+<span style='font-weight:bold'>
+      No <em>AP</em> account available, your database is
+      in an inconsistent state and needs to be fixed first.
+</span>
+<?lsmb AP_DISABLED = "disabled";
+     upgrade_allowed = 0;
+END ?>
 </p>
 <?lsmb INCLUDE select element_data = {
                             name  = 'default_ap'
@@ -66,18 +97,28 @@ your database is in an inconsistent state and needs to be fixed first.
                             options = ap_accounts
                             value_attr = 'accno'
                             text_attr = 'desc'
+                                                disabled = AP_DISABLED
 } ?>
 </div>
 <div class="input_row">
 <p>
   Note that the process invoked by hitting the button below might
   take long to complete as it will run the upgrade process and will
-  copy all data from the 1.2 tables into the 1.3 tables.
+  copy all data from the original tables into the newer tables.
 </p>
-<?lsmb INCLUDE button element_data = {
+<?lsmb IF upgrade_allowed;
+    INCLUDE button element_data = {
     text = text('Upgrade')
     name = 'action'
    value = upgrade_action
+        type = 'submit'
+       class = 'submit'
+    };
+END;
+INCLUDE button element_data = {
+    text = text('Cancel')
+    name = 'action'
+   value = cancel
     type = 'submit'
    class = 'submit'
 } ?>


### PR DESCRIPTION
- Adjust dialogs for any LSMB and SL versions
- Reformat (add &w=1 to remove space changes)
- Allow cancel migration if default AR or AP cannot be find.

