### PR TITLE
Add an empty salutation.

### DIFF
--- a/sql/changes/1.6/add_empty_salutation.sql
+++ b/sql/changes/1.6/add_empty_salutation.sql
@@ -1,0 +1,4 @@
+INSERT INTO salutation (id,salutation) VALUES (7,'');
+
+SELECT SETVAL('salutation_id_seq',8);
+

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -65,3 +65,4 @@
 1.6/drop-entity-duplicate_constraint.sql
 1.6/fix-entity-primary-key.sql
 1.6/add-eca-business-foreign-key.sql
+1.6/add_empty_salutation.sql


### PR DESCRIPTION
Many businesses would like to be on friendly casual terms with customers.
Some will want to avoid gendered titles when uncertain of sex.
The same avoidance may apply to Dr. versus Mr/Mrs/Ms.
There are many more titles that may apply, e.g.  "The Honorable".
A multiplicity of sexual identities looms in some areas.
Some religions eschew titles as an interference to better interaction.

An empty salutation seems to help a lot.

The current design is too constrained for the ambitions of, or for, lsmb.