### PR TITLE
Remove Plack::Middleware::TemplateToolkit and associated debug panel

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -104,8 +104,6 @@ feature 'debug', "Debug pane" =>
         recommends 'Plack::Middleware::Debug::TraceENV';                # Optional
         recommends 'Plack::Middleware::Debug::W3CValidate';             # Optional
         recommends 'Plack::Middleware::InteractiveDebugger';            # Optional
-#        recommends 'Plack::Middleware::TemplateToolkit';                # Optional
-#        recommends 'Plack::Middleware::Debug::TemplateToolkit';         # Optional
 };
 
 # Even with cpanm --notest, 'test' target of --installdeps

--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -254,11 +254,6 @@ def 'Timer',
     default => 0,
     doc => q{};
 
-#def 'TemplateToolkit',
-#    section => 'debug',
-#    default => 1,
-#    doc => q{};
-
 def 'TraceENV',
     section => 'debug',
     default => 1,

--- a/tools/starman-development.psgi
+++ b/tools/starman-development.psgi
@@ -72,7 +72,7 @@ builder {
                 enable "Debug::$_";
             }
         }
-        for (qw(LazyLoadModules W3CValidate)) { # TemplateToolkit?
+        for (qw(LazyLoadModules W3CValidate)) {
             enable "Debug::$_"
                 if check_config_option("$_","Plack::Middleware::Debug::$_");
         }
@@ -88,10 +88,6 @@ builder {
             if check_config_option('NYTProf','Plack::Middleware::Debug::Profiler::NYTProf');
     }
 #   qw/Dancer::Settings Dancer::Logger Dancer::Version/
-
-#    enable 'TemplateToolkit',
-#        INCLUDE_PATH => 'UI',     # required
-#        pass_through => 1;        # delegate missing templates to $app
 
     LedgerSMB::PSGI::setup_url_space(
             development => ($ENV{PLACK_ENV} eq 'development'),


### PR DESCRIPTION
Remove the already commented out Middleware from suggested debugging tools. We do not rely on TT.* environment values with our implementation of TemplateToolkit, so the debugging panel is worthless for us.

