### PR TITLE
Remove SQL notices on DROP IF EXISTS

### DIFF
--- a/sql/changes/1.4/drop-je-functions.sql
+++ b/sql/changes/1.4/drop-je-functions.sql
@@ -1,2 +1,4 @@
+SET LOCAL client_min_messages=warning;
 DROP FUNCTION IF EXISTS je_get_default_lines();
 DROP FUNCTION IF EXISTS je_set_default_lines(integer);
+RESET client_min_messages;

--- a/sql/changes/1.5/issue-2278-modify-acc_trans-index.sql
+++ b/sql/changes/1.5/issue-2278-modify-acc_trans-index.sql
@@ -1,5 +1,6 @@
-
+SET LOCAL client_min_messages=warning;
 DROP INDEX IF EXISTS ac_transdate_year_idx;
+RESET client_min_messages;
 
 CREATE INDEX acc_trans_transdate_year_idx
     ON acc_trans (transdate, date_part('YEAR', transdate))

--- a/sql/changes/1.5/trial_balance_cleanup.sql
+++ b/sql/changes/1.5/trial_balance_cleanup.sql
@@ -1,8 +1,10 @@
 BEGIN;
 
+SET LOCAL client_min_messages=warning;
 DROP TABLE IF EXISTS trial_balance__account_to_report;
 DROP TABLE IF EXISTS trial_balance__heading_to_report;
 DROP FUNCTION IF EXISTS trial_balance__list();
 DROP TABLE IF EXISTS trial_balance;
+RESET client_min_messages;
 
 COMMIT;

--- a/sql/changes/1.6/no-inv-entity-cleanup.sql
+++ b/sql/changes/1.6/no-inv-entity-cleanup.sql
@@ -1,3 +1,4 @@
+SET LOCAL client_min_messages=warning;
 
 -- Views
 
@@ -25,3 +26,4 @@ DROP TYPE IF EXISTS inventory_adjustment_line CASCADE;
 DROP AGGREGATE IF EXISTS product(numeric);
 DROP FUNCTION IF EXISTS product(numeric, numeric);
 
+RESET client_min_messages;


### PR DESCRIPTION
Lower the noise level, those notices don't serve any usefull purpose.

