### PR TITLE
Keep displayed information if user must be imported

### DIFF
--- a/UI/setup/new_user.html
+++ b/UI/setup/new_user.html
@@ -13,15 +13,13 @@ include_stylesheet=["setup/stylesheet.css"] ?>
    value = database
 } ?>
 <div class="form">
-<?lsmb- IF notice -?>
-<div class="notice"><?lsmb notice ?></div>
-<?lsmb- END # IF notice -?>
 <div class="input_row">
 <?lsmb INCLUDE input element_data = {
                             name  = 'username'
                             type  = 'text'
                            label  = text('Username')
                             class = 'username'
+                            value = username
                          required = 'true'
 } ?>
 </div>
@@ -49,7 +47,7 @@ text('Password') ?></label>
          label_pos = 1 ;
          ?>
     </div>
-    <div>
+    <div style="float:left">
       <?lsmb
          PROCESS input element_data = {
          label   = text("Import existing user")
@@ -60,6 +58,9 @@ text('Password') ?></label>
          }
          label_pos = 1 ; ?>
     </div>
+    <?lsmb- IF notice -?>
+    <div class="notice" style="float:left"><?lsmb notice ?></div>
+    <?lsmb- END # IF notice -?>
   </div>
   <div data-dojo-type="dijit/Tooltip"
        data-dojo-props="connectId:'pls-import-1',position:['below']">
@@ -89,6 +90,7 @@ text('Password') ?></label>
         text_attr = 'salutation'
        value_attr = 'id'
     default_blank = 1
+   default_values = [salutation_id]
              name = 'salutation_id'
             label = 'Salutation'
 } ?>
@@ -99,6 +101,7 @@ text('Password') ?></label>
    class = 'name'
     type = 'text'
     size = '15'
+   value = first_name
    label = text('First Name') #'
 required = 'true'
 } ?>
@@ -109,6 +112,7 @@ required = 'true'
    class = 'name'
     type = 'text'
     size = '15'
+   value = last_name
    label = text('Last name') #'
 required = 'true'
 } ?>
@@ -120,6 +124,7 @@ required = 'true'
     type = 'text'
     size = '15'
    label = text('Employee Number') #'
+   value = employeenumber
 required = 'true'
 } ?>
 </div>
@@ -130,6 +135,7 @@ required = 'true'
     type = 'text'
     size = '10'
    label = text('Date of Birth') #'
+   value = dob
 required = 'true'
 } ?>
 </div>
@@ -140,6 +146,7 @@ required = 'true'
     type = 'text'
     size = '15'
    label = text('Tax ID/SSN') #'
+   value = ssn
 required = 'true'
 } ?>
 </div>
@@ -149,6 +156,7 @@ INCLUDE select element_data = {
           options = countries
         text_attr = 'name'
        value_attr = 'id'
+    default_blank = 1
    default_values = [country_id]
              name = 'country_id'
             label = 'Country'
@@ -161,6 +169,8 @@ INCLUDE select element_data = {
         text_attr = 'label'
        value_attr = 'id'
              name = 'perms'
+    default_blank = 1
+   default_values = [perms]
             label = 'Assign Permissions'
 } ?>
 </div>

--- a/UI/setup/stylesheet.css
+++ b/UI/setup/stylesheet.css
@@ -114,3 +114,9 @@ tr.listrow:nth-child(odd) {background: #EEE}
 td.dijitStretch {
     min-width: 125px;
 }
+
+.notice {
+    background-color: red;
+    color: white;
+    margin-left: 1px;
+}

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -1106,6 +1106,16 @@ sub save_user {
            my $template = LedgerSMB::Template->new_UI(
                $request,
                template => 'setup/new_user',
+               hiddens  => {
+                                employeenumber => $request->{employeenumber},
+                                 salutation_id => $request->{salutation_id},
+                                         perms => $request->{perms},
+                                           ssn => $request->{ssn},
+                                    first_name => $request->{first_name},
+                                     last_name => $request->{last_name},
+                                           dob => $request->{dob},
+                                      username => $request->{username},
+                           },
            );
            $duplicate = $template->render_to_psgi($request);
        } else {

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -1106,16 +1106,6 @@ sub save_user {
            my $template = LedgerSMB::Template->new_UI(
                $request,
                template => 'setup/new_user',
-               hiddens  => {
-                                employeenumber => $request->{employeenumber},
-                                 salutation_id => $request->{salutation_id},
-                                         perms => $request->{perms},
-                                           ssn => $request->{ssn},
-                                    first_name => $request->{first_name},
-                                     last_name => $request->{last_name},
-                                           dob => $request->{dob},
-                                      username => $request->{username},
-                           },
            );
            $duplicate = $template->render_to_psgi($request);
        } else {


### PR DESCRIPTION
This is an interim PR to stop voiding user entered information after we discovered that the desired user must be imported.
A complete solution would be also to check if username already exists immediately after user entry, even though if this requires a server trip, and guide the user on import instead of creation.

