### PR TITLE
* Fix mapping of constant numeric values

### DIFF
--- a/lib/LedgerSMB/Report/Listings/TemplateTrans.pm
+++ b/lib/LedgerSMB/Report/Listings/TemplateTrans.pm
@@ -112,16 +112,19 @@ sub name {
 
 =cut
 
-my %jtype = ( JRNL_GJ => 'gl',
-              JRNL_AR => 'ar',
-              JRNL_AP => 'ap' );
+my @journal_type = (
+    undef,
+    'gl',
+    'ar',
+    'ap',
+    );
 
 sub run_report {
     my ($self) = @_;
     $self->manual_totals(1); #don't display totals
     my @rows = $self->call_dbmethod(funcname => 'journal__search');
     for my $ref(@rows){
-       $ref->{journal_type} = $jtype{$ref->{entry_type}};
+       $ref->{journal_type} = $journal_type[$ref->{entry_type}];
        $ref->{row_id} = $ref->{id};
     }
     return $self->rows(\@rows);

--- a/lib/LedgerSMB/Scripts/file.pm
+++ b/lib/LedgerSMB/Scripts/file.pm
@@ -33,20 +33,23 @@ use LedgerSMB::File::Entity;
 use LedgerSMB::File::ECA;
 use LedgerSMB::File::Internal;
 use LedgerSMB::File::Incoming;
+
 use DBD::Pg qw(:pg_types);
-use LedgerSMB::Magic qw(  FC_TRANSACTION FC_ORDER FC_PART FC_ENTITY FC_ECA 
-            FC_INTERNAL FC_INCOMING);
 use HTTP::Status qw( HTTP_OK HTTP_SEE_OTHER );
 
-our $fileclassmap = {
-   FC_TRANSACTION   => 'LedgerSMB::File::Transaction',
-   FC_ORDER         => 'LedgerSMB::File::Order',
-   FC_PART          => 'LedgerSMB::File::Part',
-   FC_ENTITY        => 'LedgerSMB::File::Entity',
-   FC_ECA           => 'LedgerSMB::File::ECA',
-   FC_INTERNAL      => 'LedgerSMB::File::Internal',
-   FC_INCOMING      => 'LedgerSMB::File::Incoming',
-};
+
+# file classes are "addressed" (submitted) from the web client by number,
+# 1-based; as Perl arrays are 0-based, leave the first entry empty
+my @fileclassmap = (
+   undef,
+   'LedgerSMB::File::Transaction',
+   'LedgerSMB::File::Order',
+   'LedgerSMB::File::Part',
+   'LedgerSMB::File::Entity',
+   'LedgerSMB::File::ECA',
+   'LedgerSMB::File::Internal',
+   'LedgerSMB::File::Incoming',
+);
 
 sub get {
     my ($request) = @_;
@@ -100,7 +103,7 @@ Attaches a file to an object
 
 sub attach_file {
     my ($request) = @_;
-    my $file = $fileclassmap->{$request->{file_class}}->new(%$request);
+    my $file = $fileclassmap[$request->{file_class}]->new(%$request);
     my @fnames =  $request->upload;
     $file->file_name($fnames[0]) if $fnames[0];
     if ($request->{url}){


### PR DESCRIPTION
Note: the reason this needs fixing is because the numeric
 constants (e.g. FC_TRANSACTION) aren't being recognized
 as such; instead, they are interpreted as inline bare
 litteral strings. By consequence, { FC_TRANSACTION => 1 }
 is being parsed into { 'FC_TRANSACTION' => 1 } instead of
 the intended { '1' => 1 }.

This commit fixes the above by mapping numbers to the
target values by using array-positions.

This is a placeholder pull request template.

