### PR TITLE
* Uploading fails due 'Not an ARRAY ref' error

### DIFF
--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -372,7 +372,7 @@ sub upload {
     my ($self, $name) = @_;
 
     if (! defined $name) {
-        return map { $_->basename } @{$self->{_uploads}};
+        return map { $_->basename } $self->{_uploads}->values;
     }
 
     my $tmpfname = $self->{_uploads}->get_one($name)->path;


### PR DESCRIPTION
The problem is caused by the fact that the _upload field contains a
Hash::MultiValue instance.  Instead of using it as an array ref, we want
to use the values from it.