### PR TITLE
* Using constant identifiers as hash keys requires parens

### DIFF
--- a/lib/LedgerSMB/Report/Listings/TemplateTrans.pm
+++ b/lib/LedgerSMB/Report/Listings/TemplateTrans.pm
@@ -112,9 +112,11 @@ sub name {
 
 =cut
 
-my %jtype = ( JRNL_GJ => 'gl',
-              JRNL_AR => 'ar',
-              JRNL_AP => 'ap' );
+my %jtype = (
+    JRNL_GJ() => 'gl',
+    JRNL_AR() => 'ar',
+    JRNL_AP() => 'ap'
+    );
 
 sub run_report {
     my ($self) = @_;

--- a/lib/LedgerSMB/Scripts/file.pm
+++ b/lib/LedgerSMB/Scripts/file.pm
@@ -39,13 +39,13 @@ use LedgerSMB::Magic qw(  FC_TRANSACTION FC_ORDER FC_PART FC_ENTITY FC_ECA
 use HTTP::Status qw( HTTP_OK HTTP_SEE_OTHER );
 
 our $fileclassmap = {
-   FC_TRANSACTION   => 'LedgerSMB::File::Transaction',
-   FC_ORDER         => 'LedgerSMB::File::Order',
-   FC_PART          => 'LedgerSMB::File::Part',
-   FC_ENTITY        => 'LedgerSMB::File::Entity',
-   FC_ECA           => 'LedgerSMB::File::ECA',
-   FC_INTERNAL      => 'LedgerSMB::File::Internal',
-   FC_INCOMING      => 'LedgerSMB::File::Incoming',
+   FC_TRANSACTION()   => 'LedgerSMB::File::Transaction',
+   FC_ORDER()         => 'LedgerSMB::File::Order',
+   FC_PART()          => 'LedgerSMB::File::Part',
+   FC_ENTITY()        => 'LedgerSMB::File::Entity',
+   FC_ECA()           => 'LedgerSMB::File::ECA',
+   FC_INTERNAL()      => 'LedgerSMB::File::Internal',
+   FC_INCOMING()      => 'LedgerSMB::File::Incoming',
 };
 
 sub get {

--- a/lib/LedgerSMB/Scripts/vouchers.pm
+++ b/lib/LedgerSMB/Scripts/vouchers.pm
@@ -14,18 +14,22 @@ LedgerSMB::Scripts::vouchers - web entry points for voucher/batch workflows
 
 package LedgerSMB::Scripts::vouchers;
 
+use strict;
+use warnings;
+
 use LedgerSMB::Batch;
-use LedgerSMB::Template;
-use HTTP::Status qw( HTTP_OK);
+use LedgerSMB::Magic qw(BC_AR BC_SALES_INVOICE BC_VENDOR_INVOICE);
 use LedgerSMB::Report::Unapproved::Batch_Overview;
 use LedgerSMB::Report::Unapproved::Batch_Detail;
 use LedgerSMB::Scripts::payment;
 use LedgerSMB::Scripts::reports;
-
-use strict;
-use warnings;
+use LedgerSMB::Template;
 
 use LedgerSMB::old_code qw(dispatch);
+
+
+use HTTP::Status qw( HTTP_OK);
+
 
 our $VERSION = '0.1';
 our $custom_batch_types = {};

--- a/lib/LedgerSMB/Scripts/vouchers.pm
+++ b/lib/LedgerSMB/Scripts/vouchers.pm
@@ -395,44 +395,47 @@ sub reverse_overpayment {
 }
 
 my %print_dispatch = (
-   BC_AR => { script => 'ar.pl',
-          entrypoint => sub {
-               my ($voucher, $request) = @_;
-               $lsmb_legacy::form->{ARAP} = 'AR';
-               $lsmb_legacy::form->{arap} = 'ar';
-               $lsmb_legacy::form->{vc} = 'customer';
-               $lsmb_legacy::form->{id} = $voucher->{transaction_id}
-                    if ref $voucher;
-               $lsmb_legacy::form->{formname} = 'ar_transaction';
+   BC_AR() => {
+       script => 'ar.pl',
+       entrypoint => sub {
+           my ($voucher, $request) = @_;
+           $lsmb_legacy::form->{ARAP} = 'AR';
+           $lsmb_legacy::form->{arap} = 'ar';
+           $lsmb_legacy::form->{vc} = 'customer';
+           $lsmb_legacy::form->{id} = $voucher->{transaction_id}
+                if ref $voucher;
+           $lsmb_legacy::form->{formname} = 'ar_transaction';
 
-               lsmb_legacy::create_links();
-               $lsmb_legacy::form->{media} = $request->{media};
-               lsmb_legacy::print();
-          }
-        },
-   BC_SALES_INVOICE => { script => 'is.pl',
-          entrypoint => sub {
-               my ($voucher, $request) = @_;
-               $lsmb_legacy::form->{formname} = 'invoice';
-               $lsmb_legacy::form->{id} = $voucher->{transaction_id}
+           lsmb_legacy::create_links();
+           $lsmb_legacy::form->{media} = $request->{media};
+           lsmb_legacy::print();
+       }
+    },
+    BC_SALES_INVOICE() => {
+        script => 'is.pl',
+        entrypoint => sub {
+            my ($voucher, $request) = @_;
+            $lsmb_legacy::form->{formname} = 'invoice';
+            $lsmb_legacy::form->{id} = $voucher->{transaction_id}
                                if ref $voucher;
 
-               lsmb_legacy::create_links();
-               $lsmb_legacy::form->{media} = $request->{media};
-               lsmb_legacy::print();
-          }
-        },
-   BC_VENDOR_INVOICE => { script => 'is.pl',
-          entrypoint => sub {
-               my ($voucher, $request) = @_;
-               $lsmb_legacy::form->{formname} = 'product_receipt';
-               $lsmb_legacy::form->{id} = $voucher->{transaction_id}
-                               if ref $voucher;
+            lsmb_legacy::create_links();
+            $lsmb_legacy::form->{media} = $request->{media};
+            lsmb_legacy::print();
+        }
+    },
+   BC_VENDOR_INVOICE() => {
+       script => 'is.pl',
+       entrypoint => sub {
+           my ($voucher, $request) = @_;
+           $lsmb_legacy::form->{formname} = 'product_receipt';
+           $lsmb_legacy::form->{id} = $voucher->{transaction_id}
+                if ref $voucher;
 
-               lsmb_legacy::create_links();
-               lsmb_legacy::print();
-          }
-        },
+           lsmb_legacy::create_links();
+           lsmb_legacy::print();
+       }
+    },
     );
 
 =item print_batch


### PR DESCRIPTION
... because they are essentially function definitions.