### PR TITLE
* Fix #3243: Action Not Defined when printing AR/AP aging statement

### DIFF
--- a/UI/js-src/lsmb/iframe.js
+++ b/UI/js-src/lsmb/iframe.js
@@ -26,12 +26,13 @@ define([
     'dojo/dom-construct',
     'dojo/cookie',
     'dojo/_base/window',
+    'dojo/NodeList-manipulate',
     'dojo/NodeList-dom'/*=====,
                        '../request',
                        '../_base/declare' =====*/
 ], function(module, require, watch, util, handlers,
             lang, ioQuery, query, has, dom, domConstruct, cookie, win
-            /*=====, NodeList, request, declare =====*/){
+            /*=====, NodeList, NodeList, request, declare =====*/){
     var mid = module.id.replace(/[\/\.\-]/g, '_'),
         onload = mid + '_onload',
         downloadCookie = 'request-download.'+(new Date()).getTime();
@@ -197,10 +198,11 @@ define([
                                 createInput(x, val[i]);
                             }
                         }else{
-                            if(!formNode[x]){
+                            var n = query("input[name='"+x+"']");
+                            if(n.indexOf() == -1){
                                 createInput(x, val);
                             }else{
-                                formNode[x].value = val;
+                                n.val(val);
                             }
                         }
                     }


### PR DESCRIPTION
Note: the form formNode['action'] was dereferencing the node's 'action' attribute
  instead of the form-node with name attribute of value 'action'.
  This commit starts to explicitly search for such a node.