### PR TITLE
* Fix database name used to add role prefix after copying database

### DIFF
--- a/lib/LedgerSMB/Database.pm
+++ b/lib/LedgerSMB/Database.pm
@@ -8,7 +8,7 @@ LedgerSMB::Database - Provides the APIs for database creation and management.
 This module wraps both DBI and the PostgreSQL commandline tools.
 
   my $db = LedgerSMB::Database->new({
-       company_name => 'mycompany',
+       dbname => 'mycompany',
        username => 'foo',
        password => 'foospassword'
   });
@@ -225,7 +225,7 @@ sub get_info {
         my $sth = $dbh->prepare(
             'select count(*) = 1 from pg_database where datname = ?'
             );
-        $sth->execute($self->{company_name});
+        $sth->execute($self->{dbname});
         my ($exists) = $sth->fetchrow_array();
         if ($exists){
             $retval->{status} = 'exists';

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -331,7 +331,7 @@ sub copy_db {
     )->connect({ PrintError => 0, AutoCommit => 0 });
     $dbh->prepare(q{SELECT setting__set('role_prefix',
                                coalesce((setting_get('role_prefix')).value, ?))}
-    )->execute("lsmb_$database->{company_name}__");
+    )->execute("lsmb_$database->{dbname}__");
     $dbh->commit;
     $dbh->disconnect;
     return complete($request);

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -327,7 +327,7 @@ sub copy_db {
     my $rc = $database->copy($request->{new_name})
            || die 'An error occurred. Please check your database logs.' ;
     my $dbh = LedgerSMB::Database->new(
-           +{%$database, (company_name => $request->{new_name})}
+           +{%$database, (dbname => $request->{new_name})}
     )->connect({ PrintError => 0, AutoCommit => 0 });
     $dbh->prepare(q{SELECT setting__set('role_prefix',
                                coalesce((setting_get('role_prefix')).value, ?))}


### PR DESCRIPTION
Note that due to using the wrong name key (company_name), the
  role prefix was added to the database being copied instead
  of the new one.

Found by @sbts.

