### PR TITLE
* Follow-up to cba4b20, adding tests for role prefix addition upon copy

### DIFF
--- a/lib/LedgerSMB/Database.pm
+++ b/lib/LedgerSMB/Database.pm
@@ -344,8 +344,8 @@ sub copy {
          username  => $self->username,
          password  => $self->password,
      ))->connect->do(
-        qq|SELECT setting__set('role_prefix',
-                               coalesce((setting_get('role_prefix')).value,?))|,
+        q|SELECT setting__set('role_prefix',
+                              coalesce((setting_get('role_prefix')).value,?))|,
         undef, 'lsmb_' . $self->dbname . '__');
 
     return $rc;

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -326,14 +326,7 @@ sub copy_db {
 
     my $rc = $database->copy($request->{new_name})
            || die 'An error occurred. Please check your database logs.' ;
-    my $dbh = LedgerSMB::Database->new(
-           +{%$database, (dbname => $request->{new_name})}
-    )->connect({ PrintError => 0, AutoCommit => 0 });
-    $dbh->prepare(q{SELECT setting__set('role_prefix',
-                               coalesce((setting_get('role_prefix')).value, ?))}
-    )->execute("lsmb_$database->{dbname}__");
-    $dbh->commit;
-    $dbh->disconnect;
+
     return complete($request);
 }
 

--- a/xt/40-dbsetup.t
+++ b/xt/40-dbsetup.t
@@ -27,8 +27,8 @@ for my $evar (qw(LSMB_NEW_DB LSMB_TEST_DB)){
 }
 
 if ($run_tests){
-	plan tests => 12;
-	$ENV{PGDATABASE} = $ENV{LSMB_NEW_DB};
+        plan tests => 20;
+        $ENV{PGDATABASE} = $ENV{LSMB_NEW_DB};
 }
 
 my $db = LedgerSMB::Database->new({
@@ -52,6 +52,59 @@ if (!$ENV{LSMB_INSTALL_DB}){
     open (DBLOCK, '>', "$temp/LSMB_TEST_DB");
     print DBLOCK $ENV{LSMB_NEW_DB};
     close (DBLOCK);
+}
+
+# Validate that we can copy the database
+my $copy = $db->copy($ENV{LSMB_NEW_DB} . '_copy');
+ok($copy, 'Copy database');
+my $copy_dbh = (LedgerSMB::Database->new(
+                    dbname       => $ENV{LSMB_NEW_DB} . '_copy',
+                    username     => $ENV{PGUSER},
+                    password     => $ENV{PGPASSWORD},
+                ))->connect;
+ok($copy_dbh, 'Connect to copy database');
+my $copy_sth =
+    $copy_dbh->prepare(q|select value from defaults
+                          where setting_key='role_prefix'|);
+ok($copy_sth, 'Prepare validation statement');
+$copy_sth->execute();
+my ($role_prefix) =
+    @{$copy_sth->fetchrow_arrayref()};
+is($role_prefix, "lsmb_$ENV{LSMB_NEW_DB}__",
+   'Correct role prefix on copy-database');
+$copy_sth->finish;
+$copy_dbh->disconnect;
+
+# Validate that a database which already has a role prefix
+# maintains that role prefix
+my $copy_copy = (LedgerSMB::Database->new(
+                     dbname       => $ENV{LSMB_NEW_DB} . '_copy',
+                     username     => $ENV{PGUSER},
+                     password     => $ENV{PGPASSWORD},
+                 ))->copy($ENV{LSMB_NEW_DB} . '_copy_copy');
+ok($copy_copy, 'Copy copy-database');
+$copy_dbh = (LedgerSMB::Database->new(
+                 dbname       => $ENV{LSMB_NEW_DB} . '_copy_copy',
+                 username     => $ENV{PGUSER},
+                 password     => $ENV{PGPASSWORD},
+             ))->connect;
+ok($copy_dbh, 'Connect to copy copy-database');
+$copy_sth =
+    $copy_dbh->prepare(q|select value from defaults
+                          where setting_key='role_prefix'|);
+ok($copy_sth, 'Prepare validation statement');
+$copy_sth->execute();
+($role_prefix) =
+    @{$copy_sth->fetchrow_arrayref()};
+is($role_prefix, "lsmb_$ENV{LSMB_NEW_DB}__",
+   'Correct role prefix on copy of copy-database');
+$copy_sth->finish;
+$copy_dbh->disconnect;
+
+{
+    my $dbh = $db->connect;
+    $dbh->do(qq|DROP DATABASE "$ENV{LSMB_NEW_DB}_copy"|);
+    $dbh->do(qq|DROP DATABASE "$ENV{LSMB_NEW_DB}_copy_copy"|);
 }
 
 #Changed the COA and GIFI loading to use this, and move admin user to 


### PR DESCRIPTION
Note that this commit moves the role prefix creation into
  the LedgerSMB::Database class based on the philosophy that
  modules are testable and that the web-wrappers should be
  as thin as possible in order to allow testing from our
  test scripts.

This commit adds test scripts to verify the role prefix
  is added to the correct database (used to be added to
  the original database before cba4b20).

