### PR TITLE
* Fix #3271: Invoice shows fewer decimal places than configured

### DIFF
--- a/bin/io.pl
+++ b/bin/io.pl
@@ -290,10 +290,8 @@ qq|<option value="$ref->{partsgroup}--$ref->{id}">$ref->{partsgroup}\n|;
         }
         my $moneyplaces = LedgerSMB::Setting->get('decimal_places');
         $dec = length $dec;
-        $dec ||= $moneyplaces;
-        $form->{"precision_$i"} ||= $dec;
-        $dec =  $form->{"precision_$i"};
         $decimalplaces = ( $dec > $moneyplaces ) ? $dec : $moneyplaces;
+        $form->{"precision_$i"} = $decimalplaces;
 
         # undo formatting
         for (qw(qty oldqty ship discount sellprice)) {

--- a/bin/ir.pl
+++ b/bin/ir.pl
@@ -287,8 +287,8 @@ sub prepare_invoice {
             my $moneyplaces = LedgerSMB::Setting->get('decimal_places');
             my ($dec) = ($form->{"sellprice_$i"} =~/\.(\d*)/);
             $dec = length $dec;
-            $form->{"precision_$i"} ||= $dec;
             $decimalplaces = ( $dec > $moneyplaces ) ? $dec : $moneyplaces;
+            $form->{"precision_$i"} = $decimalplaces;
 
             $form->{"sellprice_$i"} =
               $form->format_amount( \%myconfig, $form->{"sellprice_$i"},

--- a/bin/is.pl
+++ b/bin/is.pl
@@ -281,8 +281,8 @@ sub prepare_invoice {
             my $moneyplaces = LedgerSMB::Setting->get('decimal_places');
             my ($dec) = ($form->{"sellprice_$i"} =~/\.(\d*)/);
             $dec = length $dec;
-            $form->{"precision_$i"} = $dec;
             $decimalplaces = ( $dec > $moneyplaces ) ? $dec : $moneyplaces;
+            $form->{"precision_$i"} = $decimalplaces;
 
             $form->{"sellprice_$i"} =
               $form->format_amount( \%myconfig, $form->{"sellprice_$i"},


### PR DESCRIPTION
Note that the error can only be seen when the value of
$form->{precision} somehow gets out of sync with the
allowed range. One such way is saving an invoice without
updating. The precision will be out of date when reloading
the invoice.
