### PR TITLE
* Fix #3266: invoice entry item and description numbers should match …

### DIFF
--- a/sql/modules/Parts.sql
+++ b/sql/modules/Parts.sql
@@ -10,7 +10,7 @@ RETURNS SETOF parts AS
 $$
 SELECT *
   FROM parts
- WHERE ($1 IS NULL OR (partnumber ilike $1 || '%'))
+ WHERE ($1 IS NULL OR (partnumber ilike '%' || $1 || '%'))
        AND ($2 IS NULL
             OR description ilike '%' || $2 || '%'
             OR plainto_tsquery(get_default_lang()::regconfig, $2)

--- a/sql/modules/Parts.sql
+++ b/sql/modules/Parts.sql
@@ -10,10 +10,12 @@ RETURNS SETOF parts AS
 $$
 SELECT *
   FROM parts
- WHERE ($1 IS NULL OR (partnumber like $1 || '%'))
-       AND ($2 IS NULL OR plainto_tsquery(get_default_lang()::regconfig, $2)
-                          =
-                          plainto_tsquery(get_default_lang()::regconfig, '')
+ WHERE ($1 IS NULL OR (partnumber ilike $1 || '%'))
+       AND ($2 IS NULL
+            OR description ilike '%' || $2 || '%'
+            OR plainto_tsquery(get_default_lang()::regconfig, $2)
+               =
+               plainto_tsquery(get_default_lang()::regconfig, '')
             OR (description
                 @@
                 plainto_tsquery(get_default_lang()::regconfig, $2)))

--- a/xt/42-parts.pg
+++ b/xt/42-parts.pg
@@ -1,0 +1,71 @@
+
+BEGIN;
+    -- Load the TAP functions.
+    CREATE EXTENSION pgtap;
+
+    -- Plan the tests.
+
+    SELECT plan(14);
+
+    -- Add data
+
+    \i sql/modules/test/Base.sql
+
+    -- Validate required tables
+
+    SELECT has_table('parts');
+
+    -- Validate required functions
+
+    SELECT has_function('parts__search_lite');
+    SELECT has_function('parts__get_by_id');
+    SELECT has_function('parts__get_by_partnumber');
+    SELECT has_function('pricegroup__list');
+
+    -- Basic setup
+
+    INSERT INTO account_heading(id, accno ) VALUES (-255, '-billion');
+    INSERT INTO account (id, accno, category, heading )
+                 VALUES (-255, '-billion', 'L', -255);
+
+    INSERT INTO parts (id, partnumber, description)
+               values (-255, 'FlatWasher_3mm', '3mm Flat Washer SS');
+
+
+
+
+    SELECT results_eq(
+       'SELECT count(*) FROM parts',
+       ARRAY[1::bigint],
+       'Verify that there is one part in the parts table');
+
+   -- Matching non-lexemes
+   SELECT results_eq(
+              'SELECT count(*)
+                 FROM parts__search_lite(null, ''' || x || ''')',
+               ARRAY[1::bigint],
+               'Parts description search "' || x || '"')
+     FROM (select unnest(ARRAY['flat', 'washer', '3', '3mm',
+                               'mm', 'ss']::text[]) as x) g;
+   -- Non-matching non-lexemes
+   SELECT results_eq(
+              'SELECT count(*)
+                 FROM parts__search_lite(null, ''' || x || ''')',
+               ARRAY[0::bigint],
+               'Parts description search "' || x || '"')
+     FROM (select unnest(ARRAY['qq']::text[]) as x) g;
+
+   -- Matching, reverse order lexemes
+   SELECT results_eq(
+              'SELECT count(*)
+                 FROM parts__search_lite(null, ''' || x || ''')',
+               ARRAY[1::bigint],
+               'Parts description search "' || x || '"')
+     FROM (select unnest(ARRAY['washer flat']::text[]) as x) g;
+
+
+    -- Finish the tests and clean up.
+    SELECT * FROM finish();
+
+ROLLBACK;
+


### PR DESCRIPTION
…case insensitive

Note that next to matching case insensitive, we now support matching
substrings as well as doing full text search (i.e. match words, even if
in the wrong order).

This is a placeholder pull request template.

