### PR TITLE
* Fix #3289: sql/changes/ infrastructure incorrectly handling db transactions

### DIFF
--- a/lib/LedgerSMB/Database/Change.pm
+++ b/lib/LedgerSMB/Database/Change.pm
@@ -34,7 +34,11 @@ $properties is optional and a hashref with any of the following keys set:
 
 =item no_transactions
 
-Do not wrap this in a transaction
+Do not group statements into a single transaction.
+
+Note: as DBI/DBD::Pg never runs statements outside of transactions;
+  code running in C<no_transactions> mode will run each statement
+  in its own transaction.
 
 =item reload_subsequent
 
@@ -65,9 +69,7 @@ sub path {
 
 =head2 content($raw)
 
-SQL content, wrapped in a transaction (unless no_transactions was set)
-
-If $raw is set to a true value, we do not wrap in a transaction.
+SQL content read from the change file.
 
 =cut
 
@@ -81,20 +83,7 @@ sub content {
         $self->{_content} = join '', <$fh>;
         close $fh or die 'Cannot close file ' .  $self->path();
     }
-    my $content = $self->{_content};
-    return $self->_wrap_transaction($content, $raw);
-}
-
-sub _wrap_transaction {
-    my ($self, $content, $raw) = @_;
-    $content = _wrap($content, 'BEGIN;', 'COMMIT;')
-       unless $self->{properties}->{no_transactions} or $raw;
-    return $content;
-}
-
-sub _wrap {
-    my ($content, $before, $after) = @_;
-    return "$before\n$content\n$after";
+    return $self->{_content};
 }
 
 =head2 sha
@@ -116,30 +105,6 @@ sub sha {
     return $self->{_sha};
 }
 
-=head2 content_wrapped($before, $after)
-
-Wrap a file with more statements in the same transaction.
-
-So you get something like:
-
-BEGIN;
-$before
-$self->content
-$after
-COMMIT;
-
-Useful for db updates so you can update version numbers or the like.
-
-=cut
-
-sub content_wrapped {
-    my ($self, $before, $after) = @_;
-    $before //= '';
-    $after //= '';
-    return $self->_wrap_transaction(
-        _wrap($self->content(1), $before, $after)
-    );
-}
 
 =head2 is_applied($dbh)
 
@@ -161,7 +126,8 @@ sub is_applied {
 
 =head2 run($dbh)
 
-Runs against the current dbh without tracking.
+Runs against the current dbh without tracking, in a single
+transaction.
 
 =cut
 
@@ -172,53 +138,177 @@ sub run {
 
 =head2 apply($dbh)
 
-Applies the current file to the db in the current dbh.
+Applies the current file to the db in the current dbh. May issue
+one or more C<$dbh->commit()>s; if there's a pending transaction on
+a handle, C<$dbh->clone()> can be used to create a separate copy.
 
 =cut
 
 sub apply {
     my ($self, $dbh) = @_;
-    my $need_commit = _need_commit($dbh);
-    my $before = '';
-    my $after;
-    my $sha = $dbh->quote($self->sha);
-    my $path = $dbh->quote($self->path);
+    return if $self->is_applied($dbh);
+
+    my @after_params =  ( $self->sha );
     my $no_transactions = $self->{properties}->{no_transactions};
-    if ($self->is_applied($dbh)){
-        $after = "
-              UPDATE db_patches
-                     SET last_updated = now()
-               WHERE sha = $sha;
-        ";
-    } else {
-        $after = "
+
+    my @statements = _combine_statement_blocks($self->_split_statements);
+    my $last_stmt_rc;
+
+    $dbh->do(q{set client_min_messages = 'warning';});
+    $dbh->commit if ! $dbh->{AutoCommit};
+
+    # If we're in auto-commit mode, but we want 1 lengthy transaction,
+    # open one.
+    $dbh->begin_work if not $no_transactions and $dbh->{AutoCommit};
+    for my $stmt (@statements) {
+        $last_stmt_rc = $dbh->do($stmt);
+
+        # in case the caller wanted 'transactionless' execution of the
+        # statements, either commit or roll back after each statement(group)
+        # **when the $dbh isn't itself already set to do so!**
+
+        # Note that we don't need to commit in any case when the caller
+        # requested with-transactions processing: all statements are
+        # returned in a single block, which means 'single transaction' in
+        # all modes.
+        if (not $dbh->{AutoCommit} and $no_transactions) {
+            if (!$last_stmt_rc) {
+                $dbh->rollback;
+            }
+            else {
+                $dbh->commit;
+            }
+        }
+    }
+
+    # For transactionless processing, due to the commit and rollback
+    # above, this starts in a clean transaction.
+    # For with-transaction processing, this transaction runs in the
+    # same transaction because above no commit was executed and higher up
+    # a transaction started with 'begin_work()'
+
+    $last_stmt_rc = $dbh->do(q{
            INSERT INTO db_patches (sha, path, last_updated)
-           VALUES ($sha, $path, now());
-        ";
+           VALUES (?, ?, now());
+        }, undef, $self->sha, $self->path);
+
+    # When there is no auto commit, simulated it by committing after each
+    # query
+    # When there *is* auto commit, but a single transaction was requested,
+    # we called 'begin_work()' above; close that by calling 'commit()' or
+    # 'rollback()' here.
+    if ((not $dbh->{AutoCommit})
+        or (not $no_transactions and $dbh->{AutoCommit})) {
+        if (!$last_stmt_rc) {
+            $dbh->rollback;
+        }
+        else {
+            $dbh->commit;
+        }
     }
-    if ($no_transactions){
-        $dbh->do($after);
-        $after = '';
-        $dbh->commit if $need_commit;
-    }
-    my $success = eval {
-         $dbh->prepare($self->content_wrapped($before, $after))->execute();
-    };
-    die "$DBI::state: $DBI::errstr while applying $path"
-        unless $success or $no_transactions;
-    $dbh->commit if $need_commit;
-    $dbh->prepare("
+
+    $dbh->do(q{
             INSERT INTO db_patch_log(when_applied, path, sha, sqlstate, error)
-            VALUES(now(), $path, $sha, ?, ?)
-    ")->execute($dbh->state, $dbh->errstr);
-    $dbh->commit if $need_commit;
+            VALUES(now(), ?, ?, ?, ?)
+    }, undef, $self->sha, $self->path, $dbh->state, $dbh->errstr);
+    $dbh->commit if (! $dbh->{AutoCommit});
+
     return;
 }
 
-sub _need_commit{
-    my ($dbh) = @_;
-    return 1; # todo, detect existing transactions and autocommit status
+# $self->_split_statements()
+#
+# Returns an array of strings, where each string is one (or multiple)
+# statement(s) to be run in a single transaction.
+
+sub _split_statements {
+    my ($self) = @_;
+
+    # Early escape when the caller wants all statements to run in a
+    # single transaction. No need to split and regroup statements...
+    # Just run the entire block.
+    return ($self->content)
+        if ! $self->{properties}->{no_transactions};
+
+    my $content = $self->content;
+    $content =~ s/\s*--.*//g;
+    my @statements = ();
+
+    while ($content =~ m/
+((?&Statement))
+(?(DEFINE)
+   (?<BareIdentifier>[a-zA-Z_][a-zA-Z0-9_]*)
+   (?<QuotedIdentifier>"[^\"]+")
+   (?<SingularIdentifier>(?&BareIdentifier)|(?&QuotedIdentifier))
+   (?<Identifier>(?&SingularIdentifier)(\.(?&SingularIdentifier))*)
+   (?<QuotedString>'[^\\']* (?: \\. [^\\']* )*')
+   (?<DollarQString>\$(?<_dollar_block>(?&BareIdentifier)?)\$
+                      [^\$]* (?: \$(?!\g{_dollar_block}\$) [^\$]*+)*
+                      \$\g{_dollar_block}\$)
+   (?<String> (?&QuotedString) | (?&DollarQString) )
+   (?<Number>[+-]?[0-9]++(\.[0-9]*)? )
+   (?<Operator> [=<>#^%?@!&~|*+-]+|::)
+   (?<Array> \[ (?&WhiteSp)
+                (?: (?&ComplexTokenSequence)
+                    (?&WhiteSp) )?
+             \] )
+   (?<WhiteSp>[\s\t\n]*)
+   (?<TokenSep>,)
+   (?<Token>
+           (?&String)
+           | (?&Identifier)
+           | (?&Number)
+           | (?&Operator)
+           | (?&TokenSep))
+   (?<TokenGroup> \(
+                  (?&WhiteSp)
+                  (?: (?&ComplexTokenSequence)
+                      (?&WhiteSp) )?
+                  \) )
+   (?<ComplexToken>(?&Token)
+                 | (?&TokenGroup)
+                 | (?&Array))
+   (?<ComplexTokenSequence>
+                   (?&ComplexToken)
+                   (?: (?&WhiteSp) (?&ComplexToken) )* )
+   (?<Statement> (?&BareIdentifier) (?&WhiteSp)
+                 (?: (?&ComplexTokenSequence) (?&WhiteSp) )? ; )
+)
+    /gxms) {
+        push @statements, $1;
+    }
+    return @statements;
 }
+
+
+sub _combine_statement_blocks {
+    my @statements = @_;
+
+    my @blocks = ();
+    my $cum_stmt = '';
+    my $in_transaction = 0;
+    for my $stmt (@statements) {
+        if ($stmt =~ m/^\s*BEGIN\s*;\s*$/i) {
+          $in_transaction = 1;
+          next;
+       }
+        elsif ($stmt =~ m/^\s*COMMIT\s*;\s*$/i) {
+          push @blocks, $cum_stmt;
+          $cum_stmt = '';
+          $in_transaction = 0;
+          next;
+       }
+
+       if ($in_transaction) {
+          $cum_stmt .= $stmt;
+       }
+       else {
+          push @blocks, $stmt;
+       }
+   }
+   return @blocks;
+}
+
 =head1 Package Functions
 
 =head2 init($dbh)

--- a/sql/changes/1.5/template_menu.sql
+++ b/sql/changes/1.5/template_menu.sql
@@ -1,11 +1,11 @@
-INSERT INTO menu_node(id, parent, position, label)
+INSERT INTO menu_node (id, parent, position, label)
 values (29, 156, 18, 'Payment'), -- printPayment.html
        (30, 172, 18, 'Check Base'), -- check_base.tex
        (31, 172, 19, 'Multiple Checks'), -- check_multiple.tex
        (32, 172, 20, 'Envelope'), -- envelope
        (33, 172, 21, 'Shipping Label'); -- shipping_label.tex
 
-INSERT INTO menu_attribute(id, node_id, attribute, value)
+INSERT INTO menu_attribute (id, node_id, attribute, value)
 VALUES (256, 29, 'action', 'display'),
        (257, 29, 'format', 'html'),
        (258, 29, 'module', 'template.pl'),

--- a/sql/changes/1.5/template_menu.sql
+++ b/sql/changes/1.5/template_menu.sql
@@ -1,11 +1,11 @@
-INSERT INTO menu_node (id, parent, position, label)
+INSERT INTO menu_node(id, parent, position, label)
 values (29, 156, 18, 'Payment'), -- printPayment.html
        (30, 172, 18, 'Check Base'), -- check_base.tex
        (31, 172, 19, 'Multiple Checks'), -- check_multiple.tex
        (32, 172, 20, 'Envelope'), -- envelope
        (33, 172, 21, 'Shipping Label'); -- shipping_label.tex
 
-INSERT INTO menu_attribute (id, node_id, attribute, value)
+INSERT INTO menu_attribute(id, node_id, attribute, value)
 VALUES (256, 29, 'action', 'display'),
        (257, 29, 'format', 'html'),
        (258, 29, 'module', 'template.pl'),

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -30,10 +30,10 @@
 1.4/business_unit_class_id_seq-fix.sql
 #1.5 changes
 !1.5/invoice-tbl-cogs-constraint.sql
-1.5/trial_balance_cleanup.sql
+!1.5/trial_balance_cleanup.sql
 1.5/templates-last-modified.sql
 1.5/parts_fkeys.sql
-1.5/open_forms_callers.sql
+!1.5/open_forms_callers.sql
 1.5/robot_entity.sql
 1.5/cleanup_invoice_id.sql
 1.5/invoice_id_fkey.sql

--- a/sql/modules/Roles.sql
+++ b/sql/modules/Roles.sql
@@ -1066,7 +1066,7 @@ SELECT lsmb__create_role('template_edit');
 SELECT lsmb__grant_perms('template_edit', 'template', 'ALL');
 SELECT lsmb__grant_perms('template_edit', 'template_id_seq', 'ALL');
 SELECT lsmb__grant_menu('template_edit', id, 'allow')
-  FROM unnest(array[30,31,32,33,90, 99, 159,160,161,162,163,164,165,
+  FROM unnest(array[90, 99, 159,160,161,162,163,164,165,
                     166,167,168,169,170,171,173,174,175,176,177,178,179,180,
                     181,182,183,184,185,186,187,241,242]) id;
 

--- a/sql/modules/Roles.sql
+++ b/sql/modules/Roles.sql
@@ -1066,7 +1066,7 @@ SELECT lsmb__create_role('template_edit');
 SELECT lsmb__grant_perms('template_edit', 'template', 'ALL');
 SELECT lsmb__grant_perms('template_edit', 'template_id_seq', 'ALL');
 SELECT lsmb__grant_menu('template_edit', id, 'allow')
-  FROM unnest(array[29,30,31,32,33,90, 99, 159,160,161,162,163,164,165,
+  FROM unnest(array[30,31,32,33,90, 99, 159,160,161,162,163,164,165,
                     166,167,168,169,170,171,173,174,175,176,177,178,179,180,
                     181,182,183,184,185,186,187,241,242]) id;
 

--- a/t/16-dbchange.t
+++ b/t/16-dbchange.t
@@ -5,9 +5,20 @@ LedgerSMB::Database::Change
 =cut
 
 use LedgerSMB::Database::Change;
-use Test::More tests => 20;
+use Test::More;
+use File::Find;
 
 my $testpath = 't/data/loadorder/';
+
+#
+#
+######################################
+#
+#
+# See also xt/43-dbchange.t
+#
+######################################
+
 
 =head1 TEST PLAN
 
@@ -51,22 +62,73 @@ is($test2->{properties}->{$_}, 1, "$_ property for test2 is 1")
 
 is($test1->sha, $test2->sha, 'SHA is equal for both test1 and test2');
 
-isnt($test1->sha, LedgerSMB::Database::Change->new($testpath . 'test3.sql')->sha, 'SHA changes when content chenges');
+isnt($test1->sha,
+     LedgerSMB::Database::Change->new($testpath . 'test3.sql')->sha,
+     'SHA changes when content changes');
 
-=head2 Wrapping Tests
+=head2 Internals Tests
 
 =over
 
-=item test1 should have begin/commit when asking for content
+=item _combine_transaction_blocks()
 
-=item test2 should not have begin/commit when asking for content
+=cut
+
+is_deeply([ LedgerSMB::Database::Change::_combine_statement_blocks(
+            'begin;', 'a;', 'b;', 'commit;') ],
+          [ 'a;b;' ],
+          'Combine into single transaction');
+
+is_deeply([ LedgerSMB::Database::Change::_combine_statement_blocks(
+              'a;','begin;','b;', 'c;' ,'commit;','d;') ],
+          [ 'a;', 'b;c;', 'd;' ],
+          'Combine into multiple transactions');
+
+=item _split_statements()
+
+Verify that our statement parser can parse each of our changes files
+without skipping content -- by glueing the parsed bits together and
+comparing a cleaned-up result.
+
+=cut
+
+$test1->{_content} = "aa;\n b; c; \nbegin; d; e; commit;";
+$test1->{properties}->{no_transactions} = 1;
+
+is_deeply([ $test1->_split_statements() ],
+          ['aa;', 'b;', 'c;', 'begin;', 'd;', 'e;', 'commit;'],
+          'Split statements');
+
+my @changes;
+sub collect {
+    return if $File::Find::name !~ m/\.sql$/;
+
+    push @changes, $File::Find::name;
+}
+find(\&collect, 'sql/changes/');
+
+for my $change (@changes) {
+    open $fh, "<:encoding(UTF-8)", $change
+        or die "Can't open: $change ($!, $@)";
+    my $content;
+    {
+        local $/;
+        $content = <$fh>;
+    }
+    close $fh;
+
+    $test1->{_content} = $content;
+    $test1->{properties}->{no_transactions} = 1;
+    my $joined_content = join('', $test1->_split_statements);
+    $joined_content =~ s/[\s\n\t]+//g;
+    $content =~ s/--.*//g;
+    $content =~ s/[\s\n\t]+//g;
+    is($joined_content,$content,"Complete recognition of $change");
+}
+
 
 =back
 
 =cut
 
-like($test1->content, qr/BEGIN;/, 'Test1 content has BEGIN');
-like($test1->content, qr/COMMIT;/, 'Test1 content has COMMIT');
-
-unlike($test2->content, qr/BEGIN;/, 'Test2 content has no BEGIN');
-unlike($test2->content, qr/COMMIT;/, 'Test2 content has no COMMIT');
+done_testing;

--- a/xt/43-dbchange.t
+++ b/xt/43-dbchange.t
@@ -1,0 +1,91 @@
+=head1 UNIT TESTS FOR
+
+LedgerSMB::Database::Change
+
+=cut
+
+use LedgerSMB::Database::Change;
+use Test::Exception;
+use Test::More;
+use DBI;
+
+#
+#
+######################################
+#
+#
+# See also t/16-dbchange.t
+#
+######################################
+
+
+my $dbh = DBI->connect("dbi:Pg:dbname=$ENV{LSMB_NEW_DB}", undef, undef,
+                       { AutoCommit => 1, PrintError => 0 });
+
+$dbh->do(qq{CREATE DATABASE $ENV{LSMB_NEW_DB}_41_dbchange});
+my $chg_db = DBI->connect(qq{dbi:Pg:dbname=$ENV{LSMB_NEW_DB}_41_dbchange},
+                          undef, undef, { AutoCommit => 0, PrintError => 0 });
+
+my $change = LedgerSMB::Database::Change->new();
+LedgerSMB::Database::Change::init($chg_db);
+$chg_db->commit;
+
+=head1 TEST PLAN
+
+=head2 Changes in non-'AutoCommit' mode (transactional mode)
+
+=head3 WITHOUT transactions
+
+=cut
+
+$change->{properties}->{no_transactions} = 1;
+$change->{_path} = 'test1';
+$change->{_sha} = 'nosha';
+
+# Test a transaction: second statement will fail
+# DDL statements in PSQL are transactional, so the first statement
+#  will have no effect
+$change->{_content} = qq{
+  CREATE TABLE test1 (
+     id serial
+  );
+  UPDATE test1 SET id = 'a';
+};
+$change->apply($chg_db);
+$chg_db->commit or $chg_db->rollback;
+$chg_db->do(q{SELECT count(*) FROM test1;});
+is $chg_db->rows, -1, 'Successfully created the table';
+
+
+=head2 Changes in 'AutoCommit' mode
+
+=head3 WITH transactions
+
+=cut
+
+$chg_db = $chg_db->clone( { AutoCommit => 1 } );
+$change->{properties}->{no_transactions} = 1;
+
+# Test a transaction: second statement will fail
+# DDL statements in PSQL are transactional, so the first statement
+#  will have no effect
+$change->{_content} = qq{
+  CREATE TABLE test2 (
+     id serial
+  );
+  UPDATE test2 SET id = 'a';
+};
+$change->apply($chg_db);
+$chg_db->do(q{SELECT count(*) FROM test2;});
+like $chg_db->errstr, qr/relation "test2" does not exist/,
+    'Correctly failed to create the table';
+
+=back
+
+=cut
+
+$chg_db->disconnect;
+
+$dbh->do(qq{DROP DATABASE  "$ENV{LSMB_NEW_DB}_41_dbchange"});
+
+done_testing;


### PR DESCRIPTION
Close #3240: Eliminates errors from 'change loading' phase of database creation.

Before this change, 'no transaction' changes were loaded in a single transaction due to
how DBD::Pg works. Other changes (schema changes) were being wrapped with a
BEGIN; ... COMMIT; block -- leading to a 'double transaction' being applied
(causing the errors being output).

Since 'no transaction' changes need to be executed statement-by-statement,
individual statements need to be extracted from the change file which explains
the need for an 'SQL parser' (better: recogniser).
