### PR TITLE
* Eliminate warning during testing

### DIFF
--- a/xt/lib/Pherkin/Extension/LedgerSMB.pm
+++ b/xt/lib/Pherkin/Extension/LedgerSMB.pm
@@ -196,7 +196,7 @@ sub create_template {
 
     $dbh->do("INSERT INTO defaults
                      VALUES ('role_prefix', 'lsmb_${template}__')");
-    $dbh->commit;
+    $dbh->commit if ! $dbh->{AutoCommit};
     $dbh->disconnect;
 
     $self->template_created(1);

--- a/xt/lib/Pherkin/Extension/ledgersmb_steps/common_steps.pl
+++ b/xt/lib/Pherkin/Extension/ledgersmb_steps/common_steps.pl
@@ -231,7 +231,8 @@ Given qr/inventory has been built up for '(.*)' from these transactions:$/, sub 
 
         IR->post_invoice({}, $form);
     }
-    S->{ext_lsmb}->admin_dbh->commit;
+    S->{ext_lsmb}->admin_dbh->commit
+        if ! S->{ext_lsmb}->admin_dbh->{AutoCommit};
 };
 
 


### PR DESCRIPTION
During testing a warning 'commit ineffective with AutoCommit enabled' is
being shown. This commit eliminates that.

