### PR TITLE
* Bail when running as 'root' in PSGI.pm (instead of Sysconfig.pm)

### DIFF
--- a/lib/LedgerSMB/PSGI.pm
+++ b/lib/LedgerSMB/PSGI.pm
@@ -36,6 +36,22 @@ use Plack::Middleware::ReverseProxy;
 use Plack::Builder::Conditionals;
 use Plack::Util;
 
+
+use English qw(-no_match_vars);
+if ($EUID == 0) {
+    die join("\n",
+        'Running a Web Service as root is a security problem',
+        'If you are starting LedgerSMB as a system service',
+        'please make sure that you drop privlidges as per README.md',
+        'and the example files in conf/',
+        'This makes it difficult to run on a privlidged port (<1024)',
+        'In theory you can pass the --user argument to starman,',
+        'However starman drops privlidges too late, starting us as root.'
+        );
+}
+
+
+
 local $@ = undef; # localizes just for initial load.
 eval { require LedgerSMB::Template::LaTeX; };
 

--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -598,21 +598,6 @@ if(!(-d LedgerSMB::Sysconfig::tempdir())){
 }
 
 sub check_permissions {
-    use English qw(-no_match_vars);
-
-    if($EUID == 0){
-        die_pretty(
-            'Running a Web Service as root is a security problem',
-            'If you are starting LedgerSMB as a system service',
-            'please make sure that you drop privlidges as per README.md',
-            'and the example files in conf/',
-            'This makes it difficult to run on a privlidged port (<1024)',
-            'In theory you can pass the --user argument to starman,',
-            'However starman drops privlidges too late, starting us as root.'
-        )
-    }
-
-
     my $tempdir = LedgerSMB::Sysconfig::tempdir();
     # commit 6978b88 added this line to resolve issues if HOME isn't set
     $ENV{HOME} = $tempdir;    ## no critic   # sniff


### PR DESCRIPTION
Note that other applications may use LedgerSMB::Sysconfig outside of
  the context of the webserver, which makes bailing undesirable.
  (In fact, the cli database upgrader patch-release-upgrade.pl does\!)

Moving to PSGI.pm ensures that the bail-out code applies to all code
hooked to a webserver/application server, not just starman.psgi.