### PR TITLE
Improved temp file handling

### DIFF
--- a/lib/LedgerSMB/Database.pm
+++ b/lib/LedgerSMB/Database.pm
@@ -33,6 +33,7 @@ use warnings;
 
 use DateTime;
 use DBI;
+use File::Spec;
 use Log::Log4perl;
 use Moose;
 use namespace::autoclean;
@@ -82,7 +83,7 @@ This creates a log file for the specific upgrade attempt.
 sub loader_log_filename {
     my $dt = DateTime->now();
     $dt =~ s/://g; # strip out disallowed Windows characters
-    return LedgerSMB::Sysconfig::tempdir() . "/dblog_${dt}_$$";
+    return File::Spec->tmpdir . "/dblog_${dt}_$$";
 }
 
 

--- a/lib/LedgerSMB/Database.pm
+++ b/lib/LedgerSMB/Database.pm
@@ -49,8 +49,6 @@ our $VERSION = '1.2';
 
 my $logger = Log::Log4perl->get_logger('LedgerSMB::Database');
 
-my $temp = $LedgerSMB::Sysconfig::tempdir;
-
 
 =head1 PROPERTIES
 
@@ -84,7 +82,7 @@ This creates a log file for the specific upgrade attempt.
 sub loader_log_filename {
     my $dt = DateTime->now();
     $dt =~ s/://g; # strip out disallowed Windows characters
-    return $temp . "/dblog_${dt}_$$";
+    return LedgerSMB::Sysconfig::tempdir() . "/dblog_${dt}_$$";
 }
 
 

--- a/lib/LedgerSMB/Scripts/vouchers.pm
+++ b/lib/LedgerSMB/Scripts/vouchers.pm
@@ -27,7 +27,7 @@ use LedgerSMB::Template;
 
 use LedgerSMB::old_code qw(dispatch);
 
-
+use File::Temp;
 use HTTP::Status qw( HTTP_OK);
 
 
@@ -454,8 +454,11 @@ sub print_batch {
     my $report = LedgerSMB::Report::Unapproved::Batch_Detail->new(%$request);
     $request->{format} = 'pdf';
     $request->{media} = 'zip';
-    my $dirname = "$LedgerSMB::Sysconfig::tempdir/docs-$request->{batch_id}-" . time;
-    mkdir $dirname;
+
+    # Make sure we have a temporary directory which gets cleaned up
+    # after exiting this routine
+    my $dir = File::Temp->newdir( CLEANUP => 1);
+    my $dirname = $dir->dirname;
 
     # zipdir gets consumed by io.pl and arapprn.pl
     $request->{zipdir} = $dirname;
@@ -491,7 +494,6 @@ sub print_batch {
         binmode $zip, ':bytes';
         unlink $file_path;
 
-        # TODO: clean up the temp dir!!
         return [
             HTTP_OK,
             [
@@ -504,7 +506,6 @@ sub print_batch {
         ];
     }
     else {
-        # TODO: clean up the temp dir!!
         return $report->render_to_psgi($request);
     }
 }

--- a/lib/LedgerSMB/Scripts/vouchers.pm
+++ b/lib/LedgerSMB/Scripts/vouchers.pm
@@ -23,6 +23,7 @@ use LedgerSMB::Report::Unapproved::Batch_Overview;
 use LedgerSMB::Report::Unapproved::Batch_Detail;
 use LedgerSMB::Scripts::payment;
 use LedgerSMB::Scripts::reports;
+use LedgerSMB::Sysconfig;
 use LedgerSMB::Template;
 
 use LedgerSMB::old_code qw(dispatch);

--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -514,7 +514,7 @@ sub get_template_args {
         $arghash->{COMPILE_EXT} = '.lttc';
         $arghash->{COMPILE_DIR} =
            File::Spec->rel2abs( $LedgerSMB::Sysconfig::templates_cache,
-                                $LedgerSMB::Sysconfig::tempdir );
+                                File::Spec->tmpdir );
     }
     $self->{binmode} = $binmode;
     return $arghash;

--- a/lib/LedgerSMB/Template/ODS.pm
+++ b/lib/LedgerSMB/Template/ODS.pm
@@ -747,11 +747,12 @@ sub _format_cleanup_handler {
 
 sub _ods_process {
     my ($output, $template) = @_;
+    my $workdir = File::Temp->newdir;
     my $fn;
     my $fh; # if we need to use a temp file, we need to keep the object
             # in scope, because when it goes out of scope, the file is removed
     if (ref $output) {
-        $fh = File::Temp->new( DIR => LedgerSMB::Sysconfig::tempdir());
+        $fh = File::Temp->new( DIR => $workdir );
         $fn = $fh->filename;
     }
     else {
@@ -759,7 +760,7 @@ sub _ods_process {
     }
     $ods = ooDocument(file => $fn,
                       create => 'spreadsheet',
-                      work_dir => LedgerSMB::Sysconfig::tempdir());
+                      work_dir => $workdir );
 
     my $parser = XML::Twig->new(
         start_tag_handlers => {

--- a/lib/LedgerSMB/X12.pm
+++ b/lib/LedgerSMB/X12.pm
@@ -32,8 +32,8 @@ use Moose;
 use namespace::autoclean;
 use X12::Parser;
 use LedgerSMB::Magic qw( EDI_PATHNAME_MAX );
-use LedgerSMB::Sysconfig;
 use DateTime;
+use File::Temp;
 
 my $counter = 1000; #for 997 generation  ## no critic (ProhibitMagicNumbers) sniff
 my $dt = DateTime->now;
@@ -159,11 +159,9 @@ sub parse {
     my $file;
     my $parser = $self->parser;
     if (!$self->is_message_file){
-        $file = $LedgerSMB::Sysconfig::tempdir . '/' . $$ . '-' . $self->message;
-        open my $fh, '>', $file
-            or die "Failed to open temporary output file $file : $!";
-        print $fh $self->message or die "Cannot print to file $file";;
-        close $fh or die "Cannot close file $file";;
+        $file = File::Temp->new();
+        print $file $self->message or die "Cannot print to file $file";;
+        close $file or die "Cannot close file $file";;
     }
     else {
         $file = $self->message;

--- a/t/06-blacklist.t
+++ b/t/06-blacklist.t
@@ -9,13 +9,16 @@ use FindBin;
 my $sqldir = "$FindBin::Bin/../sql/modules";
 
 open my $blist, '<', "$sqldir/BLACKLIST";
-my $contents = join "", map { $a = $_; chomp $a; $a } <$blist>;
+local $/ = undef;
+my $contents = <$blist>;
+$contents =~ s/\n//g;
 close $blist;
 
 ok($contents, "Got contents from original blacklist");
 
 my $contents2 = `perl $FindBin::Bin/../tools/makeblacklist.pl`;
-ok($contents, "Got contents from new blacklist");
+$contents2 =~ s/\n//g;
+ok($contents2, "Got contents from new blacklist");
 
 is(sha512_base64($contents2),
    sha512_base64($contents),

--- a/t/06-blacklist.t
+++ b/t/06-blacklist.t
@@ -7,7 +7,6 @@ use Digest::SHA 'sha512_base64'; #already a dependency
 use FindBin;
 
 my $sqldir = "$FindBin::Bin/../sql/modules";
-my $tempdir = $LedgerSMB::Sysconfig::tempdir;
 
 open my $blist, '<', "$sqldir/BLACKLIST";
 my $contents = join "", map { $a = $_; chomp $a; $a } <$blist>;
@@ -15,14 +14,13 @@ close $blist;
 
 ok($contents, "Got contents from original blacklist");
 
-diag `perl $FindBin::Bin/../tools/makeblacklist.pl`;
-
-open $blist, '<', "$tempdir/BLACKLIST";
-my $contents2 = join "", map {  $a = $_; chomp $a; $a } <$blist>;
-close $blist;
+my $contents2 = `perl $FindBin::Bin/../tools/makeblacklist.pl`;
 ok($contents, "Got contents from new blacklist");
 
-is(sha512_base64($contents2), sha512_base64($contents), 'Contents did not change')
-or diag " The contents of your blacklisted file changed.  
-Please re-run make blacklist so that anyone running this software from 
+is(sha512_base64($contents2),
+   sha512_base64($contents),
+   'Contents did not change'
+)
+or diag " The contents of your blacklisted file changed.
+Please re-run make blacklist so that anyone running this software from
 version control software is protected against sudden errors.";

--- a/tools/makeblacklist.pl
+++ b/tools/makeblacklist.pl
@@ -28,8 +28,8 @@ for my $mod (<$order>) {
     $mod =~ s/(\s+|#.*)//g;
     next unless $mod; # skipping comment-only, whitespace-only, and blank lines
     %func = (%func, process_mod($mod));
-    write_blacklist(sort keys %func); 
 }
+write_blacklist(sort keys %func);
 close ($order); ### return failure to execute the script?
 close ($out);
 

--- a/tools/makeblacklist.pl
+++ b/tools/makeblacklist.pl
@@ -4,15 +4,19 @@ use FindBin;
 use strict;
 use warnings;
 use lib "$FindBin::Bin/../lib";
+use File::Temp;
 use 5.010; # say makes things easier
 no lib '.'; # can run from anywhere
 
 use LedgerSMB::Sysconfig;
 
-my $tempdir = $LedgerSMB::Sysconfig::tempdir;
-my $outputfile = ( defined $ARGV[1] && $ARGV[1] eq '--regenerate')
-               ? "$FindBin::Bin/../sql/modules/BLACKLIST"
-               : "$tempdir/BLACKLIST";
+my $out;
+if ( defined $ARGV[1] && $ARGV[1] eq '--regenerate') {
+    open $out, ">", "$FindBin::Bin/../sql/modules/BLACKLIST";
+}
+else {
+    $out = \*STDOUT;
+}
 
 my %func = (); # set of functions as keys
 
@@ -27,6 +31,7 @@ for my $mod (<$order>) {
     write_blacklist(sort keys %func); 
 }
 close ($order); ### return failure to execute the script?
+close ($out);
 
 sub process_mod {
     my ($mod) = @_;
@@ -39,8 +44,5 @@ sub process_mod {
 
 sub write_blacklist {
     my @funcs = @_;
-    open my $bl, '>', $outputfile
-        or die "Cannot write BLACKLIST";
-    say $bl $_ for @funcs;
-    close $bl;
+    say $out $_ for @funcs;
 }


### PR DESCRIPTION
File::Temp uses File::Spec->tmpdir() to retrieve a writeable temporary directory. If you want to influence the returned value on Unix, the way forward is setting `$ENV{TMPDIR}`.

My point: the standard modules can be used, as long as we influence `$ENV{TMPDIR}` in some startup script.