### PR TITLE
Follow-up to PR #3307: Render the output before trying to output it

### DIFF
--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -1169,13 +1169,15 @@ sub process_and_run_upgrade_script {
         no_auto_output => 1,
         format_options => {extension => 'sql'},
         format => 'TXT' );
+
+    $dbtemplate->render($request);
+
     my $tempfile = File::Temp->new();
     print $tempfile $dbtemplate->{output}
        or die q{Failed to create upgrade instructions to be sent to 'psql'};
     close $tempfile
        or warn 'Failed to close temporary file';
 
-    $dbtemplate->render($request);
     $database->run_file(
         file => $tempfile,
         log => $temp . '_stdout',


### PR DESCRIPTION
Migration sql commands must be rendered before outputting them in a file.

