### PR TITLE
Remove redundant use Cwd from Sysconfig.pm

### DIFF
--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -5,7 +5,6 @@
 package LedgerSMB::Sysconfig;
 use strict;
 use warnings;
-use Cwd;
 
 use Config;
 use Config::IniFiles;


### PR DESCRIPTION
Sysconfig.pm no longer needs to `use Cwd` - the code that needed this was removed some time ago.

