### PR TITLE
Add pod testing dependencies to cpanfile

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -132,6 +132,8 @@ on 'develop' => sub {
     requires 'Test::Dependencies', '0.20';
     requires 'Test::Exception';
     requires 'Test::Harness', '3.36';
+    requires 'Test::Pod', '1.00';
+    requires 'Test::Pod::Coverage';
     requires 'Test::Trap';
     requires 'Weasel', '0.11';
     requires 'Weasel::Driver::Selenium2', '0.05';

--- a/xt/08-pod-coverage.t
+++ b/xt/08-pod-coverage.t
@@ -69,6 +69,10 @@ my @exception_modules =
      # Exclude because tested conditionally on XML::Twig way below
      'LedgerSMB::Template::ODS',
 
+     # Exclude because tested conditionally on Excel::Writer::XLSX
+     # and Spreadsheet::WriteExcel
+     'LedgerSMB::Template::XLSX',
+
      # Exclude because tested conditionally on CGI::Emulate::PSGI way below
      'LedgerSMB::PSGI',
 
@@ -103,6 +107,17 @@ SKIP: {
     skip 'Template::Latex not installed', 1;
 
     my $f = 'LedgerSMB::Template::LaTeX';
+    pod_coverage_ok($f, { also_private => $also_private{$f} });
+}
+
+SKIP: {
+    eval { require Excel::Writer::XLSX };
+    skip 'Excel::Writer::XLSX not installed', 1 if $@;
+
+    eval { require Spreadsheet::WriteExcel };
+    skip 'Spreadsheet::WriteExcel not installed', 1 if $@;
+
+    my $f = 'LedgerSMB::Template::XLSX';
     pod_coverage_ok($f, { also_private => $also_private{$f} });
 }
 


### PR DESCRIPTION
Dependencies for xt/07-pod.t and xt/08-pod-coverage.t were not listed in cpanfile.

Test xt/08-pod-coverage.t updated so that module LedgerSMB::Template::XLSX is only checked if the xls feature dependencies are installed.

