### PR TITLE
Allow custom base url for Is_LSMB_running.sh test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -152,6 +152,7 @@ script:
      PGUSER=postgres PGPASSWORD=test
      LSMB_TEST_DB=1 LSMB_NEW_DB=lsmbinstalltest
      LSMB_BASE_URL="http://127.0.0.1:5000"
+     PSGI_BASE_URL="http://127.0.0.1:5001"
      HARNESS_RULESFILE="t/testrules.yml"
     prove -j9 -r
           --pgtap-option dbname=lsmbinstalltest

--- a/t/README.md
+++ b/t/README.md
@@ -13,7 +13,10 @@ To run the '66' tests, the following works with the right PostgreSQL,
 PhantomJS and Starman configurations:
 
 ```sh
- $ PGUSER=postgres PGPASSWORD=password LSMB_BASE_URL=http://localhost:5000 prove
+ $ PGUSER=postgres PGPASSWORD=password \
+     LSMB_BASE_URL=http://localhost:5762 \
+     PSGI_BASE_URL=http://localhost:5752 \
+     prove -r t/ xt/
 ```
 
 Note that the '66' tests may be run at a much smaller granularity
@@ -60,6 +63,9 @@ PGUSER              username for logging in in PostgreSQL
 PGPASSWORD          password for above username
 LSMB_NEW_DB         database to test against (will be created in test 40)
 PGDATABASE          database to test against, if LSMB_NEW_DB not provided
+LSMB_INSTALL_DB     if set, database will NOT be removed after tests are run
+LSMB_BASE_URL       address used for requests to lsmb (may be a proxy)
+PSGI_BASE_URL       address used to test if plack/starman server is running
 ````
 
 ### Admin user creation

--- a/t/README.md
+++ b/t/README.md
@@ -15,7 +15,7 @@ PhantomJS and Starman configurations:
 ```sh
  $ PGUSER=postgres PGPASSWORD=password \
      LSMB_BASE_URL=http://localhost:5762 \
-     PSGI_BASE_URL=http://localhost:5752 \
+     PSGI_BASE_URL=http://localhost:5762 \
      prove -r t/ xt/
 ```
 

--- a/xt/66-cucumber/README.md
+++ b/xt/66-cucumber/README.md
@@ -24,7 +24,9 @@ they can be run separately as well, using the 'pherkin' test runner
 which comes with Test:BDD::Cucumber:
 
 ```sh
- $ PGUSER=postgres PGPASSWORD=password LSMB_BASE_URL="http://localhost:5000" \
+ $ PGUSER=postgres PGPASSWORD=password \
+     LSMB_BASE_URL="http://localhost:5000" \
+     PSGI_BASE_URL="http://localhost:5000" \
      pherkin t/66-cucumber/*/
 ```
 


### PR DESCRIPTION
Previously Is_LSMB_running.sh used a hard-coded url for ledgersmb,
meaning the Is_LSMB_running.sh test failed when a different port or url
was used, such as in the Docker ledgersmb-dev-lsmb container environment.

This change keeps the default localhost:5001 location, but allows a
different base url to be specified via the LSMB_BASE_URL environment
variable, as used in the standard lsmb Docker containers.

This is a placeholder pull request template.

