### PR TITLE
Reverse tests for missing AP/AR

### DIFF
--- a/UI/setup/upgrade_info.html
+++ b/UI/setup/upgrade_info.html
@@ -63,7 +63,13 @@ your database is in an inconsistent state and needs to be fixed first.
                             text_attr = 'desc'
 } ?>
 </div>
-<?lsmb END ?>
+<?lsmb ELSE;
+INCLUDE input element_data = {
+    name = 'default_ar'
+    type = 'hidden'
+   value = default_ar
+};
+END ?>
 <?lsmb IF ap_accounts.size > 1; ?>
 <div class="input_row">
 <p>
@@ -81,7 +87,13 @@ your database is in an inconsistent state and needs to be fixed first.
                             text_attr = 'desc'
 } ?>
 </div>
-<?lsmb END ?>
+<?lsmb ELSE;
+INCLUDE input element_data = {
+    name = 'default_ap'
+    type = 'hidden'
+   value = default_ap
+};
+END ?>
 <div class="input_row">
 <p>
   Note that the process invoked by hitting the button below might

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -622,27 +622,36 @@ sub upgrade_info {
 
     if (applicable_for_upgrade('default_ar', $upgrade_type)) {
         @{$request->{ar_accounts}} = _get_linked_accounts($request, 'AR');
-        if (scalar(@{$request->{ar_accounts}}) > 1) {
+        my $n = scalar(@{$request->{ar_accounts}});
+        if ($n > 1) {
             unshift @{$request->{ar_accounts}}, {};
             $retval++;
         }
-        else {
+        elsif ($n == 1) {
             # If there's only 1 (or none at all), don't ask the question
             $request->{default_ar} =
-                (pop @{$request->{ar_accounts}}) // 'null';
+                (pop @{$request->{ar_accounts}})->{accno};
+        }
+        else {
+            $request->{default_ar} = 'null';
         }
     }
 
     if (applicable_for_upgrade('default_ap', $upgrade_type)) {
         @{$request->{ap_accounts}} = _get_linked_accounts($request, 'AP');
-        if (scalar(@{$request->{ap_accounts}}) > 1) {
+        my $n = scalar(@{$request->{ap_accounts}});
+        if ($n > 1) {
             unshift @{$request->{ap_accounts}}, {};
             $retval++;
         }
-        else {
+        elsif ($n == 1) {
             # If there's only 1 (or none at all), don't ask the question
             $request->{default_ap} =
-                (pop @{$request->{ap_accounts}}) // 'null';
+                (pop @{$request->{ap_accounts}})->{accno};
+        }
+        else {
+            # If there's only 1 (or none at all), don't ask the question
+            $request->{default_ap} = 'null';
         }
     }
 

--- a/lib/LedgerSMB/Upgrade_Tests.pm
+++ b/lib/LedgerSMB/Upgrade_Tests.pm
@@ -242,7 +242,7 @@ push @tests, __PACKAGE__->new(
              where (select count(*)
                       from chart
                      where 'AR' = ANY(string_to_array(link,':'))) > 0
-            having count(*) > 0},
+            having count(*) = 0},
  display_name => marktext('AR account available when customers defined'),
  instructions => marktext(
                    q(When customers are defined, an AR account must be defined,
@@ -263,7 +263,7 @@ push @tests, __PACKAGE__->new(
              where (select count(*)
                       from chart
                      where 'AP' = ANY(string_to_array(link,':'))) > 0
-            having count(*) > 0},
+            having count(*) = 0},
  display_name => marktext('AP account available when vendors defined'),
  instructions => marktext(
                    q(When vendors are defined, an AP account must be defined,
@@ -458,7 +458,7 @@ push @tests, __PACKAGE__->new(
              where (select count(*)
                       from chart
                      where 'AR' = ANY(string_to_array(link,':'))) > 0
-            having count(*) > 0},
+            having count(*) = 0},
  display_name => marktext('AR account available when customers defined'),
  instructions => marktext(
                    q(When customers are defined, an AR account must be defined,
@@ -479,7 +479,7 @@ push @tests, __PACKAGE__->new(
              where (select count(*)
                       from chart
                      where 'AP' = ANY(string_to_array(link,':'))) > 0
-            having count(*) > 0},
+            having count(*) = 0},
  display_name => marktext('AP account available when vendors defined'),
  instructions => marktext(
                    q(When vendors are defined, an AP account must be defined,


### PR DESCRIPTION
Following #3329, fix the tests about missing AP or AR.