### PR TITLE
Show file name when reporting lock file error for xt/89-dropdb.t

### DIFF
--- a/xt/89-dropdb.t
+++ b/xt/89-dropdb.t
@@ -20,8 +20,9 @@ if ($run_tests){
 	$ENV{PGDATABASE} = $ENV{LSMB_NEW_DB};
 }
 
-ok(open (DBLOCK, '<', "$temp/LSMB_TEST_DB"), 'Opened db lock file')
-  || BAIL_OUT("could not open lock file: \$!=$!, \$@=$@");
+my $lock_file = "$temp/LSMB_TEST_DB";
+ok(open (DBLOCK, '<', $lock_file), 'Opened db lock file')
+  || BAIL_OUT("could not open lock file $lock_file: \$!=$!, \$@=$@");
 my $db = <DBLOCK>;
 chomp($db);
 cmp_ok($db, 'eq', $ENV{LSMB_NEW_DB}, 'Got expected db name out') &&


### PR DESCRIPTION
Test xt/89-dropdb.t will fail if a lock file is missing, or has
incorrect permissions. It's useful to present information to help
debug this, rather than requiring the admin to search the source.

This patch display the name of the lock file when reporting an
error opening it.
