### PR TITLE
Perl critic on tests

### DIFF
--- a/t/01-load.t
+++ b/t/01-load.t
@@ -68,7 +68,7 @@ my @modules =
           'LedgerSMB::Form', 'LedgerSMB::IS',
           'LedgerSMB::Num2text', 'LedgerSMB::OE', 'LedgerSMB::Auth::DB',
           'LedgerSMB::DBObject::Asset_Class', 'LedgerSMB::DBObject::Draft',
-          'LedgerSMB::DBObject::EOY', 
+          'LedgerSMB::DBObject::EOY',
           'LedgerSMB::DBObject::Pricelist', 'LedgerSMB::DBObject::TaxForm',
           'LedgerSMB::DBObject::TransTemplate', 'LedgerSMB::DBObject::Menu',
           'LedgerSMB::DBObject::User', 'LedgerSMB::DBObject::Account',

--- a/t/02-number-handling.t
+++ b/t/02-number-handling.t
@@ -40,242 +40,245 @@ isa_ok($lsmb, 'LedgerSMB');
 
 @r = trap{$form->format_amount({'apples' => '1000.00'}, 'foo', 2)};
 is($trap->exit, undef,
-	'form: No numberformat set, invalid amount (NaN check)');
+    'form: No numberformat set, invalid amount (NaN check)');
 cmp_ok($trap->die, , '=~', $no_format_message,
-	'lsmb: No numberformat set, invalid amount message (NaN check)');
+    'lsmb: No numberformat set, invalid amount message (NaN check)');
 my $expected;
-foreach my $value ('0.01', '0.05', '0.015', '0.025', '1.1', '1.5', '1.9',
-		'10.01', '4', '5', '5.1', '5.4', '5.5', '5.6', '6', '0',
-		'0.000', '10.155', '55', '0.001', '14.5', '15.5', '4.5') {
-	foreach my $places ('3', '2', '1', '0') {
-		Math::BigFloat->round_mode('+inf');
-		$expected = Math::BigFloat->new($value)->ffround(-$places);
-		$expected->precision(undef);
-		is($form->round_amount($value, $places), $expected,
-			"form: $value to $places decimal places - $expected");
+foreach my $value (
+    '0.01', '0.05', '0.015', '0.025', '1.1', '1.5', '1.9',
+    '10.01', '4', '5', '5.1', '5.4', '5.5', '5.6', '6', '0',
+    '0.000', '10.155', '55', '0.001', '14.5', '15.5', '4.5'
+) {
+    foreach my $places ('3', '2', '1', '0') {
+        Math::BigFloat->round_mode('+inf');
+        $expected = Math::BigFloat->new($value)->ffround(-$places);
+        $expected->precision(undef);
+        is($form->round_amount($value, $places), $expected,
+           "form: $value to $places decimal places - $expected");
 
-		Math::BigFloat->round_mode('-inf');
-		$expected = Math::BigFloat->new(-$value)->ffround(-$places);
-		$expected->precision(undef);
-		is($form->round_amount(-$value, $places), $expected,
-			"form: -$value to $places decimal places - $expected");
-	}
-	foreach my $places ('-1', '-2') {
-		Math::BigFloat->round_mode('+inf');
-		$expected = Math::BigFloat->new($value)->ffround(-($places-1));
-		is($form->round_amount($value, $places), $expected,
-			"form: $value to $places decimal places - $expected");
+        Math::BigFloat->round_mode('-inf');
+        $expected = Math::BigFloat->new(-$value)->ffround(-$places);
+        $expected->precision(undef);
+        is($form->round_amount(-$value, $places), $expected,
+           "form: -$value to $places decimal places - $expected");
+    }
+    foreach my $places ('-1', '-2') {
+        Math::BigFloat->round_mode('+inf');
+        $expected = Math::BigFloat->new($value)->ffround(-($places-1));
+        is($form->round_amount($value, $places), $expected,
+           "form: $value to $places decimal places - $expected");
 
-		Math::BigFloat->round_mode('-inf');
-		$expected = Math::BigFloat->new(-$value)->ffround(-($places-1));
-		is($form->round_amount(-$value, $places), $expected,
-			"form: -$value to $places decimal places - $expected");
-	}
+        Math::BigFloat->round_mode('-inf');
+        $expected = Math::BigFloat->new(-$value)->ffround(-($places-1));
+        is($form->round_amount(-$value, $places), $expected,
+           "form: -$value to $places decimal places - $expected");
+    }
 }
 
 # TODO Number formatting still needs work for l10n
 my @formats = (#['1,000.00', ',', '.'], ["1'000.00", "'", '.'],
-		['1.000,00', '.', ','], ['1000,00', '', ','],);
-		#['1000.00', '', '.'], ['1 000.00', ' ', '.']);
+    ['1.000,00', '.', ','], ['1000,00', '', ','],);
+    #['1000.00', '', '.'], ['1 000.00', ' ', '.']);
 my %myfooconfig = (numberformat => '1000.00');
-my $test_args = {format => 0,
-                 places => 2,
-             neg_format => 'def',
+my $test_args = {
+    format => 0,
+    places => 2,
+    neg_format => 'def',
 };
 foreach my $format (0 .. $#formats) {
-	%myconfig = (numberformat => $formats[$format][0]);
-        $LedgerSMB::App_State::User = \%myconfig;
-        $test_args->{format} = $formats[$format][0];
-	my $thou = $formats[$format][1];
-	my $dec = $formats[$format][2];
-	foreach my $rawValue (#'10t000d00', '9t999d99', '333d33',
-			'7t777t777d77', '-12d34', '0d00') {
-		$expected = $rawValue;
-		$expected =~ s/t/$thou/gx;
-		$expected =~ s/d/$dec/gx;
-		my $value = $rawValue;
-		$value =~ s/t//gx;
-		$value =~ s/d/\./gx;
-		$value = LedgerSMB::PGNumber->from_db($value);
-                is(LedgerSMB::PGNumber->from_input($value, $test_args
-                    )->to_output($test_args),
-                    $expected,
-                    "Pgnumber: $value formatted as $test_args->{format} : $expected");
-		is($form->format_amount(\%myconfig, $value, 2, '0'), $expected,
-			"form: $value formatted as $formats[$format][0] : $expected");
-	}
+    %myconfig = (numberformat => $formats[$format][0]);
+    $LedgerSMB::App_State::User = \%myconfig;
+    $test_args->{format} = $formats[$format][0];
+    my $thou = $formats[$format][1];
+    my $dec = $formats[$format][2];
+    foreach my $rawValue (#'10t000d00', '9t999d99', '333d33',
+                           '7t777t777d77', '-12d34', '0d00') {
+        $expected = $rawValue;
+        $expected =~ s/t/$thou/gx;
+        $expected =~ s/d/$dec/gx;
+        my $value = $rawValue;
+        $value =~ s/t//gx;
+        $value =~ s/d/\./gx;
+        $value = LedgerSMB::PGNumber->from_db($value);
+        is(LedgerSMB::PGNumber->from_input($value, $test_args
+            )->to_output($test_args),
+            $expected,
+            "Pgnumber: $value formatted as $test_args->{format} : $expected");
+        is($form->format_amount(\%myconfig, $value, 2, '0'), $expected,
+            "form: $value formatted as $formats[$format][0] : $expected");
+    }
 }
 
 foreach my $format (0 .. $#formats) {
-	%myconfig = (numberformat => $formats[$format][0]);
-        $LedgerSMB::App_State::User = \%myconfig;
-	my $thou = $formats[$format][1];
-	my $dec = $formats[$format][2];
-	foreach my $rawValue ('10t000d00', '9t999d99', '333d33',
-			'7t777t777d77', '-12d34', '0d00') {
-		$expected = $rawValue;
-		$expected =~ s/t/$thou/gx;
-		$expected =~ s/d/$dec/gx;
-		my $value = $rawValue;
-		$value =~ s/t//gx;
-		$value =~ s/d/\./gx;
-                my $val2 = $value;
-		##$value = Math::BigFloat->new($value);
-		$value = $form->parse_amount(\%myfooconfig,$value);
-		is($form->format_amount(\%myconfig, $value, 2, '0'), $expected,
-			"form: $value formatted as $formats[$format][0] - $expected");
-	}
+    %myconfig = (numberformat => $formats[$format][0]);
+    $LedgerSMB::App_State::User = \%myconfig;
+    my $thou = $formats[$format][1];
+    my $dec = $formats[$format][2];
+    foreach my $rawValue ('10t000d00', '9t999d99', '333d33',
+                          '7t777t777d77', '-12d34', '0d00') {
+        $expected = $rawValue;
+        $expected =~ s/t/$thou/gx;
+        $expected =~ s/d/$dec/gx;
+        my $value = $rawValue;
+        $value =~ s/t//gx;
+        $value =~ s/d/\./gx;
+        my $val2 = $value;
+        ##$value = Math::BigFloat->new($value);
+        $value = $form->parse_amount(\%myfooconfig,$value);
+        is($form->format_amount(\%myconfig, $value, 2, '0'), $expected,
+            "form: $value formatted as $formats[$format][0] - $expected");
+    }
 }
 
 foreach my $format (0 .. $#formats) {
-	%myconfig = (numberformat => $formats[$format][0]);
-        $LedgerSMB::App_State::User = \%myconfig;
-	my $thou = $formats[$format][1];
-	my $dec = $formats[$format][2];
-	my $rawValue = '6d00';
-	$expected = $rawValue;
-	$expected =~ s/d/$dec/gx;
-	my $value = $form->parse_amount(\%myfooconfig, '6');
-	is($form->format_amount(\%myconfig, $value, 2, '0'), $expected,
-		"form: $value formatted as $formats[$format][0] - $expected");
+    %myconfig = (numberformat => $formats[$format][0]);
+    $LedgerSMB::App_State::User = \%myconfig;
+    my $thou = $formats[$format][1];
+    my $dec = $formats[$format][2];
+    my $rawValue = '6d00';
+    $expected = $rawValue;
+    $expected =~ s/d/$dec/gx;
+    my $value = $form->parse_amount(\%myfooconfig, '6');
+    is($form->format_amount(\%myconfig, $value, 2, '0'), $expected,
+        "form: $value formatted as $formats[$format][0] - $expected");
 }
 
 $expected = $form->parse_amount({'numberformat' => '1000.00'}, '0.00');
 is($form->format_amount({'numberformat' => '1000.00'} , $expected, 2, ''), '0.00',
-	"form: 0.00 with dash ''");
+    "form: 0.00 with dash ''");
 is($form->format_amount({'numberformat' => '1000.00'} , $expected, 2), '0.00',
-	"form: 0.00 with undef dash");
+    "form: 0.00 with undef dash");
 $ENV{GATEWAY_INTERFACE} = 'yes';
 $form->{pre} = 'Blah';
 $form->{header} = 'Blah';
 is($form->format_amount({'numberformat' => '1000.00'} , '-1.00', 2, 'paren'), '(1.00)',
-	"form: -1.00 with dash '-'");
+    "form: -1.00 with dash '-'");
 is($form->format_amount({'numberformat' => '1000.00'} , '1.00', 2, 'paren'), '1.00',
-	"form: 1.00 with dash '-'");
+    "form: 1.00 with dash '-'");
 is($form->format_amount({'numberformat' => '1000.00'} , '-1.00', 2, 'DRCR'),
-	'1.00 DR', "form: -1.00 with dash DRCR");
+    '1.00 DR', "form: -1.00 with dash DRCR");
 is($form->format_amount({'numberformat' => '1000.00'} , '1.00', 2, 'DRCR'),
-	'1.00 CR', "form: 1.00 with dash DRCR");
+    '1.00 CR', "form: 1.00 with dash DRCR");
 is($form->format_amount({'numberformat' => '1000.00'} , '-1.00', 2), '-1.00',
-	"form: -1.00 with dash undefined");
+    "form: -1.00 with dash undefined");
 is($form->format_amount({'numberformat' => '1000.00'} , '1.00', 2), '1.00',
-	"form: 1.00 with dash undefined");
+    "form: 1.00 with dash undefined");
 # Triggers the $amount .= "\.$dec" if ($dec ne ""); check to false
 is($form->format_amount({'numberformat' => '1000.00'} , '1.00'), '1',
-	"form: 1.00 with no precision or dash (1000.00)");
+    "form: 1.00 with no precision or dash (1000.00)");
 is($form->format_amount({'numberformat' => '1,000.00'} , '1.00'), '1',
-	"form: 1.00 with no precision or dash (1,000.00)");
+    "form: 1.00 with no precision or dash (1,000.00)");
 is($form->format_amount({'numberformat' => '1 000.00'} , '1.00'), '1',
-	"form: 1.00 with no precision or dash (1 000.00)");
+    "form: 1.00 with no precision or dash (1 000.00)");
 is($form->format_amount({'numberformat' => '1\'000.00'} , '1.00'), '1',
-	"form: 1.00 with no precision or dash (1'000.00)");
+    "form: 1.00 with no precision or dash (1'000.00)");
 is($form->format_amount({'numberformat' => '1.000,00'} , '1,00'), '1',
-	"form: 1,00 with no precision or dash (1.000,00)");
+    "form: 1,00 with no precision or dash (1.000,00)");
 is($form->format_amount({'numberformat' => '1000,00'} , '1,00'), '1',
-	"form: 1,00 with no precision or dash (1000,00)");
+    "form: 1,00 with no precision or dash (1000,00)");
 is($form->format_amount({'numberformat' => '1000.00'} , '1.50'), '1.5',
-	"form: 1.50 with no precision or dash");
+    "form: 1.50 with no precision or dash");
 is($form->format_amount({'numberformat' => '1000.00'} , '0.0', undef, '0'), '0',
-	"form: 0.0 with no precision, dash '0'");
+    "form: 0.0 with no precision, dash '0'");
 
 foreach my $format (0 .. $#formats) {
-	%myconfig = (numberformat => $formats[$format][0]);
-        $LedgerSMB::App_State::User = \%myconfig;
-	my $thou = $formats[$format][1];
-	my $dec = $formats[$format][2];
-	foreach my $rawValue ('10t000d00', '9t999d99', '333d33',
-			'7t777t777d77', '-12d34') {
-		$expected = $rawValue;
-		$expected =~ s/t/$thou/gx;
-		$expected =~ s/d/$dec/gx;
-		my $value = $rawValue;
-		$value =~ s/t//gx;
-		$value =~ s/d/\./gx;
-		#my $ovalue = $value;
-		$value = $form->parse_amount(\%myfooconfig,$value);
-		is($form->format_amount(\%myconfig,
-			$form->format_amount(\%myconfig, $value, 2, 'def'),
-			2, 'def'), $expected,
-			"form: Double formatting of $value as $formats[$format][0] - $expected");
-	}
+    %myconfig = (numberformat => $formats[$format][0]);
+    $LedgerSMB::App_State::User = \%myconfig;
+    my $thou = $formats[$format][1];
+    my $dec = $formats[$format][2];
+    foreach my $rawValue ('10t000d00', '9t999d99', '333d33',
+                          '7t777t777d77', '-12d34') {
+        $expected = $rawValue;
+        $expected =~ s/t/$thou/gx;
+        $expected =~ s/d/$dec/gx;
+        my $value = $rawValue;
+        $value =~ s/t//gx;
+        $value =~ s/d/\./gx;
+        #my $ovalue = $value;
+        $value = $form->parse_amount(\%myfooconfig,$value);
+        is($form->format_amount(\%myconfig,
+            $form->format_amount(\%myconfig, $value, 2, 'def'),
+            2, 'def'), $expected,
+            "form: Double formatting of $value as $formats[$format][0] - $expected");
+    }
 }
 
 foreach my $format (0 .. $#formats) {
-	%myconfig = ('numberformat' => $formats[$format][0]);
-        $LedgerSMB::App_State::User = \%myconfig;
-	my $thou = $formats[$format][1];
-	my $dec = $formats[$format][2];
-	foreach my $rawValue ('10t000d00', '9t999d99', '333d33',
-			'7t777t777d77', '-12d34', '(76t543d21)') {
-		$expected = $rawValue;
-		$expected =~ s/t/$thou/gx;
-		$expected =~ s/d/$dec/gx;
-		my $value = $rawValue;
-		$value =~ s/t//gx;
-		$value =~ s/d/\./gx;
-		if ($value =~ m/^\(/gx) {
-			$value = Math::BigFloat->new('-'.substr($value, 1, -1));
-		} else {
-			$value = Math::BigFloat->new($value);
-		}
-		cmp_ok($form->parse_amount(\%myconfig, $expected), '==',  $value,
-			"form: $expected parsed as $formats[$format][0] - $value");
-	}
-	$expected = '12 CR';
-	my $value = Math::BigFloat->new('12');
-	cmp_ok($form->parse_amount(\%myconfig, $expected), '==',  $value,
-		"form: $expected parsed as $formats[$format][0] - $value");
-	$expected = '21 DR';
-	$value = Math::BigFloat->new('-21');
-	cmp_ok($form->parse_amount(\%myconfig, $expected), '==',  $value,
-		"form: $expected parsed as $formats[$format][0] - $value");
+    %myconfig = ('numberformat' => $formats[$format][0]);
+    $LedgerSMB::App_State::User = \%myconfig;
+    my $thou = $formats[$format][1];
+    my $dec = $formats[$format][2];
+    foreach my $rawValue ('10t000d00', '9t999d99', '333d33',
+                          '7t777t777d77', '-12d34', '(76t543d21)') {
+        $expected = $rawValue;
+        $expected =~ s/t/$thou/gx;
+        $expected =~ s/d/$dec/gx;
+        my $value = $rawValue;
+        $value =~ s/t//gx;
+        $value =~ s/d/\./gx;
+        if ($value =~ m/^\(/gx) {
+            $value = Math::BigFloat->new('-'.substr($value, 1, -1));
+        } else {
+            $value = Math::BigFloat->new($value);
+        }
+        cmp_ok($form->parse_amount(\%myconfig, $expected), '==',  $value,
+               "form: $expected parsed as $formats[$format][0] - $value");
+    }
+    $expected = '12 CR';
+    my $value = Math::BigFloat->new('12');
+    cmp_ok($form->parse_amount(\%myconfig, $expected), '==',  $value,
+        "form: $expected parsed as $formats[$format][0] - $value");
+    $expected = '21 DR';
+    $value = Math::BigFloat->new('-21');
+    cmp_ok($form->parse_amount(\%myconfig, $expected), '==',  $value,
+        "form: $expected parsed as $formats[$format][0] - $value");
 
-	cmp_ok($form->parse_amount(\%myconfig, ''), '==', 0,
-		"form: Empty string returns 0");
-	@r = trap{$form->parse_amount(\%myconfig, 'foo')};
+    cmp_ok($form->parse_amount(\%myconfig, ''), '==', 0,
+         "form: Empty string returns 0");
+    @r = trap{$form->parse_amount(\%myconfig, 'foo')};
 }
 
 foreach my $format (0 .. $#formats) {
-	%myconfig = ('numberformat' => $formats[$format][0]);
-        $LedgerSMB::App_State::User = \%myconfig;
-	my $thou = $formats[$format][1];
-	my $dec = $formats[$format][2];
-	foreach my $rawValue ('10t000d00', '9t999d99', '333d33',
-			'7t777t777d77', '-12d34', '(76t543d21)') {
-		$expected = $rawValue;
-		$expected =~ s/t/$thou/gx;
-		$expected =~ s/d/$dec/gx;
-		my $value = $rawValue;
-		$value =~ s/t//gx;
-		$value =~ s/d/\./gx;
-		if ($value =~ m/^\(/gx) {
-			$value = Math::BigFloat->new('-'.substr($value, 1, -1));
-		} else {
-			$value = Math::BigFloat->new($value);
-		}
-		cmp_ok($form->parse_amount(\%myconfig,
-			$form->parse_amount(\%myconfig, $expected)),
-			'==',  $value,
-			"form: $expected parsed as $formats[$format][0] - $value");
-	}
-	$expected = '12 CR';
-	my $value = Math::BigFloat->new('12');
-	cmp_ok($form->parse_amount(\%myconfig,
-		$form->parse_amount(\%myconfig, $expected)),
-		'==',  $value,
-		"form: $expected parsed as $formats[$format][0] - $value");
-	$expected = '21 DR';
-	$value = Math::BigFloat->new('-21');
-	cmp_ok($form->parse_amount(\%myconfig,
-		$form->parse_amount(\%myconfig, $expected)),
-		'==',  $value,
-		"form: $expected parsed as $formats[$format][0] - $value");
+    %myconfig = ('numberformat' => $formats[$format][0]);
+    $LedgerSMB::App_State::User = \%myconfig;
+    my $thou = $formats[$format][1];
+    my $dec = $formats[$format][2];
+    foreach my $rawValue ('10t000d00', '9t999d99', '333d33',
+                          '7t777t777d77', '-12d34', '(76t543d21)') {
+        $expected = $rawValue;
+        $expected =~ s/t/$thou/gx;
+        $expected =~ s/d/$dec/gx;
+        my $value = $rawValue;
+        $value =~ s/t//gx;
+        $value =~ s/d/\./gx;
+        if ($value =~ m/^\(/gx) {
+            $value = Math::BigFloat->new('-'.substr($value, 1, -1));
+        } else {
+            $value = Math::BigFloat->new($value);
+        }
+        cmp_ok($form->parse_amount(\%myconfig,
+            $form->parse_amount(\%myconfig, $expected)),
+            '==',  $value,
+            "form: $expected parsed as $formats[$format][0] - $value");
+    }
+    $expected = '12 CR';
+    my $value = Math::BigFloat->new('12');
+    cmp_ok($form->parse_amount(\%myconfig,
+        $form->parse_amount(\%myconfig, $expected)),
+        '==',  $value,
+        "form: $expected parsed as $formats[$format][0] - $value");
+    $expected = '21 DR';
+    $value = Math::BigFloat->new('-21');
+    cmp_ok($form->parse_amount(\%myconfig,
+        $form->parse_amount(\%myconfig, $expected)),
+        '==',  $value,
+        "form: $expected parsed as $formats[$format][0] - $value");
 
-	cmp_ok($form->parse_amount(\%myconfig, ''), '==', 0,
-		"form: Empty string returns 0");
-	cmp_ok($form->parse_amount(\%myconfig), '==', 0,
-		"form: undef string returns 0");
-	@r = trap{$form->parse_amount(\%myconfig, 'foo')};
-	is($trap->exit, undef,
-		'form: Invalid string gives NaN exit');
+    cmp_ok($form->parse_amount(\%myconfig, ''), '==', 0,
+        "form: Empty string returns 0");
+    cmp_ok($form->parse_amount(\%myconfig), '==', 0,
+        "form: undef string returns 0");
+    @r = trap{$form->parse_amount(\%myconfig, 'foo')};
+    is($trap->exit, undef,
+        'form: Invalid string gives NaN exit');
 }

--- a/t/17-setting.t
+++ b/t/17-setting.t
@@ -6,7 +6,7 @@ use strict;
 use warnings;
 
 {
-  no strict 'refs'; # avoiding addming more dependencies 
+  no strict 'refs'; # avoiding addming more dependencies
                     # so doing mocking by hand
 
   no warnings 'redefine';
@@ -21,4 +21,4 @@ use warnings;
   is(LedgerSMB::Setting->dbh(), 'db', 'got mocked db return');
   is(LedgerSMB::Setting->get('database'), '123', 'got mocked value back');
 
-} 
+}

--- a/xt/01.1-critic.t
+++ b/xt/01.1-critic.t
@@ -28,22 +28,26 @@ sub test_files {
 }
 
 sub collect {
-    return if $File::Find::name !~ m/\.(pm|pl)$/;
+    return if $File::Find::name !~ m/\.(pm|pl|t)$/;
 
     my $module = $File::Find::name;
     push @on_disk, $module
 }
-find(\&collect, 'lib/', 'old/');
+find(\&collect, 'lib/', 'old/', 't/', 'xt/');
 
 my @on_disk_oldcode =
     grep { m#^old/#  }
     @on_disk;
 
-@on_disk =
-    grep { ! m#^old/# }
+my @on_disk_tests =
+    grep { m#^(t|xt)/# }
     @on_disk;
 
-plan tests => scalar(@on_disk) + scalar(@on_disk_oldcode);
+@on_disk =
+    grep { ! m#^(old|t|xt)/# }
+    @on_disk;
+
+plan tests => scalar(@on_disk) + scalar(@on_disk_oldcode) + scalar(@on_disk_tests);
 
 test_files(
     Perl::Critic->new(
@@ -65,5 +69,13 @@ test_files(
     \@on_disk_oldcode
 );
 
-
+test_files(
+    Perl::Critic->new(
+        -only => 1,
+        -profile => 'xt/perlcriticrc',
+        -severity => 1,
+        -theme => 'lsmb_tests',
+    ),
+    \@on_disk_tests
+);
 

--- a/xt/09-versioning.t
+++ b/xt/09-versioning.t
@@ -36,44 +36,44 @@ my @dparts;
 my @lparts;
 my $age;
 SKIP: {
-	skip 'LedgerSMB is trunk', 1 if $lsmb->{version} =~ /trunk$/i;
-        $lsmb->{version} =~ s/(\d+\.\d+\.\d+)\D.*/$1/;
-        $lsmb->{dbversion} =~ s/(\d+\.\d+\.\d+)\D.*/$1/;
-	@dparts = split /\./, $lsmb->{dbversion};
-	@lparts = split /\./, $lsmb->{version};
-	$age = 0;
-	foreach my $dpart (@dparts) {
-		my $lpart = shift @lparts;
-		if (!defined $lpart) {
-			$age = 1;
-			last;
-		} elsif ($lpart > $dpart) {
-			last;
-		} elsif ($dpart > $lpart) {
-			$age = 1;
-			last;
-		}
-	}
-	ok($age == 0, 'lsmb: version >= dbversion');
+    skip 'LedgerSMB is trunk', 1 if $lsmb->{version} =~ /trunk$/i;
+    $lsmb->{version} =~ s/(\d+\.\d+\.\d+)\D.*/$1/;
+    $lsmb->{dbversion} =~ s/(\d+\.\d+\.\d+)\D.*/$1/;
+    @dparts = split /\./, $lsmb->{dbversion};
+    @lparts = split /\./, $lsmb->{version};
+    $age = 0;
+    foreach my $dpart (@dparts) {
+        my $lpart = shift @lparts;
+        if (!defined $lpart) {
+            $age = 1;
+            last;
+        } elsif ($lpart > $dpart) {
+            last;
+        } elsif ($dpart > $lpart) {
+            $age = 1;
+            last;
+        }
+    }
+    ok($age == 0, 'lsmb: version >= dbversion');
 }
 SKIP: {
-	skip 'Form is trunk', 1 if $form->{version} =~ /trunk$/i;
-        $form->{version} =~ s/(\d+\.\d+\.\d+)\D.*/$1/;
-        $form->{dbversion} =~ s/(\d+\.\d+\.\d+)\D.*/$1/;
-	@dparts = split /\./, $form->{dbversion};
-	@lparts = split /\./, $form->{version};
-	$age = 0;
-	foreach my $dpart (@dparts) {
-		my $lpart = shift @lparts;
-		if (!defined $lpart) {
-			$age = 1;
-			last;
-		} elsif ($lpart > $dpart) {
-			last;
-		} elsif ($dpart > $lpart) {
-			$age = 1;
-			last;
-		}
-	}
-	ok($age == 0, 'form: version >= dbversion');
+    skip 'Form is trunk', 1 if $form->{version} =~ /trunk$/i;
+    $form->{version} =~ s/(\d+\.\d+\.\d+)\D.*/$1/;
+    $form->{dbversion} =~ s/(\d+\.\d+\.\d+)\D.*/$1/;
+    @dparts = split /\./, $form->{dbversion};
+    @lparts = split /\./, $form->{version};
+    $age = 0;
+    foreach my $dpart (@dparts) {
+        my $lpart = shift @lparts;
+        if (!defined $lpart) {
+            $age = 1;
+            last;
+        } elsif ($lpart > $dpart) {
+            last;
+        } elsif ($dpart > $lpart) {
+            $age = 1;
+            last;
+        }
+    }
+    ok($age == 0, 'form: version >= dbversion');
 }

--- a/xt/40-dbsetup.t
+++ b/xt/40-dbsetup.t
@@ -38,7 +38,7 @@ my $db = LedgerSMB::Database->new({
 });
 
 # Manual tests
-ok($db->create, 'Database Created') 
+ok($db->create, 'Database Created')
   || BAIL_OUT('Database could not be created! ');
 ok($db->load_base_schema, 'Basic schema loaded');
 ok($db->apply_changes, 'applied changes');
@@ -103,12 +103,12 @@ $copy_dbh->disconnect;
     $dbh->do(qq|DROP DATABASE "$ENV{LSMB_NEW_DB}_copy_copy"|);
 }
 
-#Changed the COA and GIFI loading to use this, and move admin user to 
+#Changed the COA and GIFI loading to use this, and move admin user to
 #Database.pm --CT
 
 SKIP: {
      skip 'No admin info', 5
-           if (!defined $ENV{LSMB_ADMIN_USERNAME} 
+           if (!defined $ENV{LSMB_ADMIN_USERNAME}
                 or !defined $ENV{LSMB_ADMIN_PASSWORD}
                 or !defined $ENV{LSMB_COUNTRY_CODE}
                 or !defined $ENV{LSMB_ADMIN_FNAME}
@@ -117,7 +117,7 @@ SKIP: {
      my $lsmb = new LedgerSMB;
      ok(defined $lsmb, '$lsmb defined');
      isa_ok($lsmb, 'LedgerSMB');
-     $lsmb->{dbh} = DBI->connect("dbi:Pg:dbname=$ENV{PGDATABASE}", 
+     $lsmb->{dbh} = DBI->connect("dbi:Pg:dbname=$ENV{PGDATABASE}",
                                        undef, undef, { AutoCommit => 0 });
      my $dbh = $lsmb->{dbh};
      ok($dbh, 'Connected to new database');
@@ -136,7 +136,7 @@ SKIP: {
       ok($user->save_user, 'User saved');
       $sth = $dbh->prepare("SELECT admin__add_user_to_role(?, ?)");
       my $rolename = "lsmb_" . $ENV{PGDATABASE} . "__users_manage";
-      ok($sth->execute($ENV{LSMB_ADMIN_USERNAME}, $rolename), 
+      ok($sth->execute($ENV{LSMB_ADMIN_USERNAME}, $rolename),
             'Admin user assigned rights');
       $sth->finish;
       $dbh->commit;
@@ -154,8 +154,8 @@ is($passed_no_errs, 1, 'No rollbacks in db scripts');
 
 SKIP: {
      skip 'No COA specified', 1 if !defined $ENV{LSMB_LOAD_COA};
-     is($db->exec_script({script => 'sql/coa/' 
-                                     . lc($ENV{LSMB_COUNTRY_CODE}) 
+     is($db->exec_script({script => 'sql/coa/'
+                                     . lc($ENV{LSMB_COUNTRY_CODE})
                                      ."/chart/$ENV{LSMB_LOAD_COA}.sql"
                          }), 0,
         'Ran Chart of Accounts Script');
@@ -163,8 +163,8 @@ SKIP: {
 
 SKIP: {
      skip 'No GIFI specified', 1 if !defined $ENV{LSMB_LOAD_GIFI};
-     is($db->exec_script({script => 'sql/coa/' 
-                                   . lc($ENV{LSMB_COUNTRY_CODE}) 
+     is($db->exec_script({script => 'sql/coa/'
+                                   . lc($ENV{LSMB_COUNTRY_CODE})
                                     ."/gifi/$ENV{LSMB_LOAD_GIFI}.sql"
                          }), 0,
         'Ran GIFI Script');

--- a/xt/64-x12.t
+++ b/xt/64-x12.t
@@ -3,7 +3,7 @@
 # X12 tests for LedgerSMB 1.4
 #
 # This provides a few very basic tests for parsing X12 docs
-# These include parsing the current test files, and creating 997 docs in 
+# These include parsing the current test files, and creating 997 docs in
 # response.
 #
 use Test::More;
@@ -24,7 +24,7 @@ plan tests => 5;
 my $e850t1 = LedgerSMB::X12::EDI850->new(message => 't/data/sample_po.edi');
 #print Dumper($e850t1->order) . "\n";
 is($e850t1->order->{transdate}, '2009-05-08', 'Valid EDI 1, order date 2009-05-08');
-is($e850t1->order->{ordnumber}, '99AKDF9DAL393', 'valid EDI 1, ordnumber 99AKDF9DAL393'); 
+is($e850t1->order->{ordnumber}, '99AKDF9DAL393', 'valid EDI 1, ordnumber 99AKDF9DAL393');
 is($e850t1->order->{qty_1}, 100, 'Valid EDI 1, First line item quantity of 100');
 is($e850t1->order->{sellprice_1}, '100.00', 'Sell price of 100.00 for first line item');
 is($e850t1->order->{description_1}, 'GENERAL PURPOSE', 'Correct EDI description for line item 1');

--- a/xt/66-cucumber/11-ar/step_definitions/common_steps.pl
+++ b/xt/66-cucumber/11-ar/step_definitions/common_steps.pl
@@ -66,8 +66,8 @@ Given qr/a customer named "(.*)"/, sub {
 
 
 Given qr/a service "(.*)"/, sub {
-    
-    
+
+
 };
 
 

--- a/xt/89-dropdb.t
+++ b/xt/89-dropdb.t
@@ -16,8 +16,8 @@ if ($ENV{LSMB_INSTALL_DB}){
 }
 
 if ($run_tests){
-	plan tests => $run_tests;
-	$ENV{PGDATABASE} = $ENV{LSMB_NEW_DB};
+    plan tests => $run_tests;
+    $ENV{PGDATABASE} = $ENV{LSMB_NEW_DB};
 }
 
 my $lock_file = "$temp/LSMB_TEST_DB";

--- a/xt/89-dropdb.t
+++ b/xt/89-dropdb.t
@@ -1,7 +1,7 @@
 use Test::More;
 use strict;
 use DBI;
-    
+
 my $temp = $ENV{TEMP} || '/tmp/';
 my $run_tests = 6;
 for my $evar (qw(LSMB_NEW_DB LSMB_TEST_DB)){
@@ -35,8 +35,8 @@ my $dbh = DBI->connect("dbi:Pg:dbname=template1",
                                        undef, undef, { AutoCommit => 0 });
 
 my $sth_getroles = $dbh->prepare(
-                           "select quote_ident(rolname) as role 
-                              FROM pg_roles 
+                           "select quote_ident(rolname) as role
+                              FROM pg_roles
                              WHERE rolname LIKE ?");
 
 $sth_getroles->execute("lsmb_$ENV{LSMB_NEW_DB}__%");
@@ -49,4 +49,3 @@ while (my $ref = $sth_getroles->fetchrow_hashref('NAME_lc')){
 $dbh->commit;
 
 is($rc, 0, 'Roles dropped');
-

--- a/xt/lib/PageObject/App/Invoices/Line.pm
+++ b/xt/lib/PageObject/App/Invoices/Line.pm
@@ -34,7 +34,7 @@ my %field_map = (
 
 sub field_value {
     my ($self, $label, $new_value) = @_;
-    
+
 }
 
 

--- a/xt/perlcriticrc
+++ b/xt/perlcriticrc
@@ -4,7 +4,8 @@
 
 #  lsmb         -- includes all themes we want to use 
 #  lsmb_new     -- themes enforced on 'new' code
-#  lsmb_old     --  themes enforced on 'old' code; subset of lsmb_new
+#  lsmb_old     -- themes enforced on 'old' code; subset of lsmb_new
+#  lsmb_tests   -- themes enforced on tests
 #  lsmb_wip     -- themes we are trying to use on 'new' code 
 #  lsmb_old_wip -- themes we are trying to use on 'old' code, subset of lsmb_wip
 
@@ -75,10 +76,10 @@ pager = less
 
 
 [CodeLayout::ProhibitTrailingWhitespace]
-    set_themes = lsmb lsmb_new lsmb_old
+    set_themes = lsmb lsmb_new lsmb_old lsmb_tests
     
 [CodeLayout::ProhibitHardTabs]
-    set_themes = lsmb lsmb_new lsmb_old
+    set_themes = lsmb lsmb_new lsmb_old lsmb_tests
     allow_leading_tabs = 0
 
 


### PR DESCRIPTION
Start to apply Perl::Critic policies to LedgerSMB tests in `t/` and `xt/` to ensure consistency with rest of code.

