### PR TITLE
Enable more Perl::Critic polices on lsmb tests

### DIFF
--- a/t/04-template-handling.t
+++ b/t/04-template-handling.t
@@ -301,7 +301,7 @@ my $payment_template =  LedgerSMB::Template->new(
 
 $payment_template->render({ request => { script => '' },
                             payment => $payment });
-my @output =  split "\n", $payment_template->{output};
+my @output =  split /\n/, $payment_template->{output};
 is(grep(/name="payment_101"/, @output), 0, 'Invoice locked');
 is(grep(/Locked by/, @output), 1, 'Invoice locked label shown');
 

--- a/xt/41-coaload/TestsFor/COATest.pm
+++ b/xt/41-coaload/TestsFor/COATest.pm
@@ -77,7 +77,7 @@ sub test_constructor {
     my $db = $coatest->test_db;
 
     my $returnstring = `psql '$db' -c "SELECT 1 FROM pg_database WHERE datname='$db'"`;
-    my $testval = grep { /^ +1$/ } split("\n", $returnstring);
+    my $testval = grep { /^ +1$/ } split /\n/, $returnstring;
     ok($testval, "DB created for $sqlfile testing");
 
     $! = undef; # reset if system failed
@@ -86,7 +86,7 @@ sub test_constructor {
 
     $returnstring = `psql '$db' -c "SELECT COUNT(*), 'TESTRESULT' from account"`;
     if ( $returnstring ) {
-        $testval = grep { /TESTRESULT/ } split("\n", $returnstring);
+        $testval = grep { /TESTRESULT/ } split /\n/, $returnstring;
         $testval =~ s/\D//g;
     }
     ok($testval, "Got rows back for account, for $sqlfile");

--- a/xt/perlcriticrc
+++ b/xt/perlcriticrc
@@ -26,7 +26,7 @@ pager = less
 [ValuesAndExpressions::ProhibitInterpolationOfLiterals]
     set_themes = lsmb lsmb_new
 [BuiltinFunctions::ProhibitStringySplit]
-    set_themes = lsmb lsmb_new
+    set_themes = lsmb lsmb_new lsmb_tests
 [BuiltinFunctions::ProhibitUniversalCan]
     set_themes = lsmb lsmb_new
 [ClassHierarchies::ProhibitExplicitISA]

--- a/xt/perlcriticrc
+++ b/xt/perlcriticrc
@@ -28,11 +28,11 @@ pager = less
 [BuiltinFunctions::ProhibitStringySplit]
     set_themes = lsmb lsmb_new lsmb_tests
 [BuiltinFunctions::ProhibitUniversalCan]
-    set_themes = lsmb lsmb_new
+    set_themes = lsmb lsmb_new lsmb_tests
 [ClassHierarchies::ProhibitExplicitISA]
-    set_themes = lsmb lsmb_new lsmb_old_wip
+    set_themes = lsmb lsmb_new lsmb_old_wip lsmb_tests
 [ControlStructures::ProhibitMutatingListFunctions]
-    set_themes = lsmb lsmb_new
+    set_themes = lsmb lsmb_new lsmb_tests
 [ControlStructures::ProhibitUnreachableCode]
     set_themes = lsmb lsmb_new
 [InputOutput::ProhibitBarewordFileHandles]


### PR DESCRIPTION
  Added:
  * BuiltinFunctions::ProhibitUniversalCan
  * ClassHierarchies::ProhibitExplicitISA
  * ControlStructures::ProhibitMutatingListFunctions
  * Perl::Critic ProhibitStringySplit
