### PR TITLE
Properly compute cleared balance ending

### DIFF
--- a/old/lib/LedgerSMB/DBObject/Reconciliation.pm
+++ b/old/lib/LedgerSMB/DBObject/Reconciliation.pm
@@ -386,7 +386,10 @@ sub get {
     $self->{account_info} = $ref;
     ($ref) = $self->call_dbmethod(funcname=>'reconciliation__get_cleared_balance',
                                 args => { chart_id => $ref->{id},
-                                          report_date => $self->{end_date}->clone->add_interval('month',-1) });
+                                          report_date => $self->{end_date}->clone
+                                                            ->truncate(to => 'month')
+                                                            ->add_interval('second',-1)
+                                        });
 
     my $our_balance = $ref->{reconciliation__get_cleared_balance};
     $self->{beginning_balance} = $our_balance;

--- a/old/lib/LedgerSMB/DBObject/Reconciliation.pm
+++ b/old/lib/LedgerSMB/DBObject/Reconciliation.pm
@@ -384,12 +384,20 @@ sub get {
         $neg = -1;
     }
     $self->{account_info} = $ref;
+
+    my ($previous) = $self->call_dbmethod(funcname=>'reconciliation__previous_report_date',
+                                args => { in_chart_id => $self->{chart_id},
+                                          in_end_date => $self->{end_date}
+                                        });
     ($ref) = $self->call_dbmethod(funcname=>'reconciliation__get_cleared_balance',
                                 args => { chart_id => $ref->{id},
-                                          report_date => $self->{end_date}
+                                          report_date => $previous->{end_date}
                                         });
 
     my $our_balance = $ref->{reconciliation__get_cleared_balance};
+    warn "$previous->{their_total} should always equal $our_balance"
+        if $previous->{their_total} != $our_balance;
+
     $self->{beginning_balance} = $our_balance;
     $self->{cleared_total} = LedgerSMB::PGNumber->from_db(0);
     $self->{outstanding_total} = LedgerSMB::PGNumber->from_db(0);

--- a/old/lib/LedgerSMB/DBObject/Reconciliation.pm
+++ b/old/lib/LedgerSMB/DBObject/Reconciliation.pm
@@ -386,9 +386,7 @@ sub get {
     $self->{account_info} = $ref;
     ($ref) = $self->call_dbmethod(funcname=>'reconciliation__get_cleared_balance',
                                 args => { chart_id => $ref->{id},
-                                          report_date => $self->{end_date}->clone
-                                                            ->truncate(to => 'month')
-                                                            ->add_interval('second',-1)
+                                          report_date => $self->{end_date}
                                         });
 
     my $our_balance = $ref->{reconciliation__get_cleared_balance};

--- a/sql/modules/Reconciliation.sql
+++ b/sql/modules/Reconciliation.sql
@@ -574,6 +574,26 @@ in_date_to and in_date_from give a range of reports.  All other inputs are
 exact matches.
 $$;
 
+CREATE OR REPLACE FUNCTION reconciliation__previous_report_date
+(in_chart_id int, in_end_date DATE)
+returns setof cr_report AS
+$$
+                SELECT r.* FROM cr_report r
+                  JOIN account c ON r.chart_id = c.id
+                 WHERE in_end_date > end_date
+                   AND in_chart_id = chart_id
+                   AND submitted
+                   AND NOT r.deleted
+                 ORDER BY end_date DESC
+                 LIMIT 1
+$$ language sql;
+
+COMMENT ON FUNCTION reconciliation__previous_report_date
+(in_chart_id int, in_end_date DATE) IS
+$$ Returns the submitted reconciliation report before in_end_date
+for the in_chart_id account
+$$;
+
 DROP TYPE IF EXISTS recon_accounts CASCADE;
 
 create type recon_accounts as (

--- a/xt/42-reconciliation.pg
+++ b/xt/42-reconciliation.pg
@@ -5,7 +5,7 @@ BEGIN;
 
     -- Plan the tests.
 
-    SELECT plan(58);
+    SELECT plan(62);
 
     -- Add data
 
@@ -38,6 +38,7 @@ BEGIN;
     SELECT has_function('reconciliation__get_current_balance',array['integer', 'date']);
     SELECT has_function('reconciliation__new_report_id',array['integer', 'numeric', 'date', 'boolean']);
     SELECT has_function('reconciliation__pending_transactions',array['integer', 'numeric']);
+    SELECT has_function('reconciliation__previous_report_date',ARRAY['integer','date']);
     SELECT has_function('reconciliation__reject_set',array['integer']);
     SELECT has_function('reconciliation__report_approve',array['integer']);
     SELECT has_function('reconciliation__report_details',array['integer']);
@@ -68,7 +69,11 @@ BEGIN;
     SELECT results_eq('test', Array[4], 'Transactions that should be in cr_report');
     DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__new_report_id(test_get_account_id('-11111'), 100, now()::date, false);
+    PREPARE test AS SELECT reconciliation__previous_report_date(test_get_account_id('-11111'), now()::date);
+    SELECT results_eq('test', ARRAY[]::cr_report[], 'No previous report');
+    DEALLOCATE test;
+
+    PREPARE test AS SELECT reconciliation__new_report_id(test_get_account_id('-11111'), 100, '1001-01-01', false);
     SELECT results_eq('test', $$ SELECT id+1 FROM test_parameters $$, 'Create Recon Report');
     DEALLOCATE test;
 
@@ -76,7 +81,11 @@ BEGIN;
     SELECT results_eq('test',ARRAY[true],'Delete Recon Report');
     DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__new_report_id(test_get_account_id('-11111'), 100, now()::date, false);
+    PREPARE test AS SELECT reconciliation__previous_report_date(test_get_account_id('-11111'), now()::date);
+    SELECT results_eq('test', ARRAY[]::cr_report[], 'Deleted previous report doesn''t show up');
+    DEALLOCATE test;
+
+    PREPARE test AS SELECT reconciliation__new_report_id(test_get_account_id('-11111'), 100, '1001-01-01', false);
     SELECT results_eq('test', $$ SELECT id+2 FROM test_parameters $$, 'Create Recon Report');
     DEALLOCATE test;
 
@@ -107,12 +116,16 @@ BEGIN;
     SELECT results_eq('test',ARRAY[true],'Report Submitted');
     DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__submit_set(currval('cr_report_id_seq')::int, (select as_array(id::int) from cr_report_line where report_id = currval('cr_report_id_seq')::int));
-    SELECT results_eq('test',ARRAY[true],'Report Submitted');
+    PREPARE test AS SELECT reconciliation__previous_report_date(test_get_account_id('-11111'), '1001-01-01');
+    SELECT results_eq('test', ARRAY[]::cr_report[], 'No previous report before 1001-01-01');
     DEALLOCATE test;
 
     PREPARE test AS SELECT reconciliation__report_approve(currval('cr_report_id_seq')::int) > 0;
     SELECT results_eq('test',ARRAY[true],'1 Report Approved');
+    DEALLOCATE test;
+
+    PREPARE test AS SELECT end_date FROM reconciliation__previous_report_date(test_get_account_id('-11111'), '1001-01-02');
+    SELECT results_eq('test', ARRAY['1001-01-01']::date[], 'One previous report at 1001-01-01');
     DEALLOCATE test;
 
     PREPARE test as SELECT count(*)::int


### PR DESCRIPTION
Substracting a month doesn't give end of last month, specially when we are computing february balances, where 2 or 3 days of transactions won't be accounted for.

