### PR TITLE
Enable more Perl::Critic policies for lsmb tests

### DIFF
--- a/t/04-template-handling.t
+++ b/t/04-template-handling.t
@@ -317,9 +317,9 @@ SKIP: {
     $template->render({media => 'test'});
     $template->output(media => 'test');
 
-    ok (open (LPR_TEST, '<', "$temp/04-lpr-test"), 'LedgerSMB::Template::_output_lpr output file opened successfully');
+    ok (open (my $LPR_TEST, '<', "$temp/04-lpr-test"), 'LedgerSMB::Template::_output_lpr output file opened successfully');
 
-    my $line1 = <LPR_TEST>;
+    my $line1 = <$LPR_TEST>;
 
     like($line1, qr/^%PDF/, 'output file is pdf');
 }

--- a/t/04-template-handling.t
+++ b/t/04-template-handling.t
@@ -21,12 +21,10 @@ use Log::Log4perl;
 Log::Log4perl::init(\$LedgerSMB::Sysconfig::log4perl_config);
 
 
-my @r;
 my $temp = $LedgerSMB::Sysconfig::tempdir;
 my $form;
 my $myconfig;
 my $template;
-my $FH;
 my $locale;
 
 $locale = LedgerSMB::Locale->get_handle('fr');
@@ -316,8 +314,8 @@ SKIP: {
         'template' => '04-template', 'locale' => $locale, no_auto_output => 1);
     $template->render({media => 'test'});
     $template->output(media => 'test');
-
-    ok (open (my $LPR_TEST, '<', "$temp/04-lpr-test"), 'LedgerSMB::Template::_output_lpr output file opened successfully');
+    my $LPR_TEST;
+    ok(open ($LPR_TEST, '<', "$temp/04-lpr-test"), 'LedgerSMB::Template::_output_lpr output file opened successfully');
 
     my $line1 = <$LPR_TEST>;
 

--- a/t/07.1-extract-perl.t
+++ b/t/07.1-extract-perl.t
@@ -69,10 +69,10 @@ my @tests = (
 for my $test (@tests) {
 
     # Set the source file
-    open(SOURCE, '>', $testfile)
+    open(my $SOURCE, '>', $testfile)
          or die "Could not open file '$testfile' $!";
-    print SOURCE $test->{statement} . "\n";
-    close SOURCE;
+    print $SOURCE $test->{statement} . "\n";
+    close $SOURCE;
 
     # Produce a PO file
     my ($stderr,$exit) = capture_stderr {

--- a/t/11-ledgersmb.t
+++ b/t/11-ledgersmb.t
@@ -33,7 +33,6 @@ sub lsmb_error_func {
 
 
 $lsmb = LedgerSMB->new();
-my %myconfig;
 my $utfstr;
 my @r;
 

--- a/xt/01-html-checks.t
+++ b/xt/01-html-checks.t
@@ -39,7 +39,7 @@ sub content_test {
 
     my ($fh, @tab_lines, @trailing_space_lines, $text);
     $text = '';
-    open $fh, "<$filename";
+    open $fh, '<', $filename;
     $is_snippet = 1
         if ($filename !~ m#(log(in|out))|main|setup/#
             || $filename =~ m#setup/ui-db-credentials#);

--- a/xt/01-js-checks.t
+++ b/xt/01-js-checks.t
@@ -20,7 +20,7 @@ sub content_test {
     my ($filename) = @_;
 
     my ($fh, @tab_lines, @trailing_space_lines);
-    open $fh, "<$filename";
+    open $fh, '<', $filename;
     while (<$fh>) {
         push @tab_lines, ($.) if /\t/;
         push @trailing_space_lines, ($.) if / $/;

--- a/xt/01-sql-checks.t
+++ b/xt/01-sql-checks.t
@@ -20,7 +20,7 @@ sub content_test {
     my ($filename) = @_;
 
     my ($fh, @tab_lines, @trailing_space_lines);
-    open $fh, "<$filename";
+    open $fh, '<', $filename;
     while (<$fh>) {
         push @tab_lines, ($.) if /\t/;
         push @trailing_space_lines, ($.) if / $/;

--- a/xt/40-dbsetup.t
+++ b/xt/40-dbsetup.t
@@ -45,9 +45,9 @@ ok($db->apply_changes, 'applied changes');
 
 ok($db->load_modules('LOADORDER'), 'Modules loaded');
 if (!$ENV{LSMB_INSTALL_DB}){
-    open (DBLOCK, '>', "$temp/LSMB_TEST_DB");
-    print DBLOCK $ENV{LSMB_NEW_DB};
-    close (DBLOCK);
+    open (my $DBLOCK, '>', "$temp/LSMB_TEST_DB");
+    print $DBLOCK $ENV{LSMB_NEW_DB};
+    close ($DBLOCK);
 }
 
 # Validate that we can copy the database

--- a/xt/40-dbsetup.t
+++ b/xt/40-dbsetup.t
@@ -142,7 +142,7 @@ SKIP: {
       $dbh->commit;
 };
 
-open  my $log, "< $LedgerSMB::Sysconfig::tempdir/dblog";
+open  my $log, '<', "$LedgerSMB::Sysconfig::tempdir/dblog";
 
 my $passed_no_errs = 1;
 while (my $line = <$log>){

--- a/xt/89-dropdb.t
+++ b/xt/89-dropdb.t
@@ -21,13 +21,13 @@ if ($run_tests){
 }
 
 my $lock_file = "$temp/LSMB_TEST_DB";
-ok(open (DBLOCK, '<', $lock_file), 'Opened db lock file')
+ok(open (my $DBLOCK, '<', $lock_file), 'Opened db lock file')
   || BAIL_OUT("could not open lock file $lock_file: \$!=$!, \$@=$@");
-my $db = <DBLOCK>;
+my $db = <$DBLOCK>;
 chomp($db);
 cmp_ok($db, 'eq', $ENV{LSMB_NEW_DB}, 'Got expected db name out') &&
 ok(!system ("dropdb $ENV{LSMB_NEW_DB}"), 'dropped db');
-ok(close (DBLOCK), 'Closed db lock file');
+ok(close ($DBLOCK), 'Closed db lock file');
 ok(unlink ("$temp/LSMB_TEST_DB"), 'Removed test db lockfile');
 
 

--- a/xt/lib/PageObject/App/Menu.pm
+++ b/xt/lib/PageObject/App/Menu.pm
@@ -101,7 +101,6 @@ sub click_menu {
         my $tgt_class = $menu_path_pageobject_map{join(' > ', @$paths)};
         if (!defined $tgt_class || $tgt_class eq '') {
             die join(' > ', @$paths) . ' not implemented';
-            return undef;
         }
         # make sure the widget is registered before resolving the Weasel widget
         ok(use_module($tgt_class),

--- a/xt/perlcriticrc
+++ b/xt/perlcriticrc
@@ -34,7 +34,7 @@ pager = less
 [ControlStructures::ProhibitMutatingListFunctions]
     set_themes = lsmb lsmb_new lsmb_tests
 [ControlStructures::ProhibitUnreachableCode]
-    set_themes = lsmb lsmb_new
+    set_themes = lsmb lsmb_new lsmb_tests
 [InputOutput::ProhibitBarewordFileHandles]
     set_themes = lsmb lsmb_new
 [InputOutput::ProhibitInteractiveTest]

--- a/xt/perlcriticrc
+++ b/xt/perlcriticrc
@@ -36,7 +36,7 @@ pager = less
 [ControlStructures::ProhibitUnreachableCode]
     set_themes = lsmb lsmb_new lsmb_tests
 [InputOutput::ProhibitBarewordFileHandles]
-    set_themes = lsmb lsmb_new
+    set_themes = lsmb lsmb_new lsmb_tests
 [InputOutput::ProhibitInteractiveTest]
     set_themes = lsmb lsmb_new
 [InputOutput::ProhibitOneArgSelect]

--- a/xt/perlcriticrc
+++ b/xt/perlcriticrc
@@ -42,7 +42,7 @@ pager = less
 [InputOutput::ProhibitOneArgSelect]
     set_themes = lsmb lsmb_new lsmb_tests
 [InputOutput::ProhibitTwoArgOpen]
-    set_themes = lsmb lsmb_new
+    set_themes = lsmb lsmb_new lsmb_tests
 [InputOutput::RequireCheckedOpen]
     set_themes = lsmb lsmb_new
 [Miscellanea::ProhibitFormats]

--- a/xt/perlcriticrc
+++ b/xt/perlcriticrc
@@ -38,40 +38,40 @@ pager = less
 [InputOutput::ProhibitBarewordFileHandles]
     set_themes = lsmb lsmb_new lsmb_tests
 [InputOutput::ProhibitInteractiveTest]
-    set_themes = lsmb lsmb_new
+    set_themes = lsmb lsmb_new lsmb_tests
 [InputOutput::ProhibitOneArgSelect]
-    set_themes = lsmb lsmb_new
+    set_themes = lsmb lsmb_new lsmb_tests
 [InputOutput::ProhibitTwoArgOpen]
     set_themes = lsmb lsmb_new
 [InputOutput::RequireCheckedOpen]
     set_themes = lsmb lsmb_new
 [Miscellanea::ProhibitFormats]
-    set_themes = lsmb lsmb_new
+    set_themes = lsmb lsmb_new lsmb_tests
 [Modules::ProhibitEvilModules]
-    set_themes = lsmb lsmb_new
+    set_themes = lsmb lsmb_new lsmb_tests
     modules_file = xt/prohibited_modules
 [Modules::RequireEndWithOne]
     set_themes = lsmb lsmb_new  lsmb_old
 [Objects::ProhibitIndirectSyntax]
     set_themes = lsmb lsmb_new
 [Subroutines::ProhibitReturnSort]
-    set_themes = lsmb lsmb_new
+    set_themes = lsmb lsmb_new lsmb_tests
 [Subroutines::ProhibitSubroutinePrototypes]
-    set_themes = lsmb lsmb_new
+    set_themes = lsmb lsmb_new lsmb_tests
 [TestingAndDebugging::ProhibitProlongedStrictureOverride]
-    set_themes = lsmb lsmb_new
+    set_themes = lsmb lsmb_new lsmb_tests
 [TestingAndDebugging::RequireUseStrict]
     set_themes = lsmb lsmb_new
 [TestingAndDebugging::RequireUseWarnings]
     set_themes = lsmb lsmb_new
 [ValuesAndExpressions::ProhibitLeadingZeros]
-    set_themes = lsmb lsmb_new
+    set_themes = lsmb lsmb_new lsmb_tests
 [Variables::ProhibitPerl4PackageNames]
-    set_themes = lsmb lsmb_new
+    set_themes = lsmb lsmb_new lsmb_tests
 [Variables::ProhibitUnusedVariables]
     set_themes = lsmb lsmb_new
 [Variables::ProtectPrivateVars]
-    set_themes = lsmb lsmb_new
+    set_themes = lsmb lsmb_new lsmb_tests
 [Variables::RequireLexicalLoopIterators]
 
 
@@ -84,9 +84,9 @@ pager = less
 
 
 [Modules::ProhibitAutomaticExportation]
-    set_themes = lsmb lsmb_new lsmb_old
+    set_themes = lsmb lsmb_new lsmb_old lsmb_tests
 [Modules::ProhibitConditionalUseStatements]
-    set_themes = lsmb lsmb_new lsmb_old
+    set_themes = lsmb lsmb_new lsmb_old lsmb_tests
 [Modules::ProhibitEvilModules]
     set_themes = lsmb lsmb_new lsmb_old
 [Modules::ProhibitExcessMainComplexity]
@@ -102,9 +102,9 @@ pager = less
 [Modules::RequireExplicitPackage]
     set_themes = lsmb lsmb_new lsmb_old
 [Modules::RequireFilenameMatchesPackage]
-    set_themes = lsmb lsmb_new lsmb_old_wip
+    set_themes = lsmb lsmb_new lsmb_old_wip lsmb_tests
 [Modules::RequireNoMatchVarsWithUseEnglish]
-    set_themes = lsmb lsmb_new lsmb_old
+    set_themes = lsmb lsmb_new lsmb_old lsmb_tests
 
 
 [Moose::RequireMakeImmutable]
@@ -129,12 +129,12 @@ pager = less
 [InputOutput::RequireEncodingWithUTF8Layer]
     set_themes = lsmb lsmb_new lsmb_old_wip
 [Subroutines::ProhibitExplicitReturnUndef]
-    set_themes = lsmb lsmb_wip lsmb_old_wip
+    set_themes = lsmb lsmb_wip lsmb_old_wip lsmb_tests
 
 [BuiltinFunctions::ProhibitBooleanGrep]
     set_themes = lsmb lsmb_wip lsmb_old_wip
 [BuiltinFunctions::ProhibitUniversalIsa]
-    set_themes = lsmb lsmb_wip lsmb_old_wip
+    set_themes = lsmb lsmb_wip lsmb_old_wip lsmb_tests
 [InputOutput::RequireCheckedClose]
     set_themes = lsmb lsmb_wip lsmb_old_wip
 [InputOutput::RequireCheckedSyscalls]
@@ -148,7 +148,7 @@ pager = less
 [Subroutines::RequireFinalReturn]
     set_themes = lsmb lsmb_wip lsmb_old_wip
 [ValuesAndExpressions::ProhibitCommaSeparatedStatements]
-    set_themes = lsmb lsmb_new lsmb_old_wip
+    set_themes = lsmb lsmb_new lsmb_old_wip lsmb_tests
 [ValuesAndExpressions::ProhibitMismatchedOperators]
     set_themes = lsmb lsmb_new lsmb_old_wip
 [ValuesAndExpressions::ProhibitMixedBooleanOperators]

--- a/xt/perlcriticrc
+++ b/xt/perlcriticrc
@@ -69,7 +69,7 @@ pager = less
 [Variables::ProhibitPerl4PackageNames]
     set_themes = lsmb lsmb_new lsmb_tests
 [Variables::ProhibitUnusedVariables]
-    set_themes = lsmb lsmb_new
+    set_themes = lsmb lsmb_new lsmb_tests
 [Variables::ProtectPrivateVars]
     set_themes = lsmb lsmb_new lsmb_tests
 [Variables::RequireLexicalLoopIterators]


### PR DESCRIPTION
This enables the following Perl::Critic policies for files in `/t` and `/xt`:

  * ControlStructures::ProhibitUnreachableCode
  * InputOutput::ProhibitBarewordFileHandles
  * InputOutput::ProhibitInteractiveTest
  * InputOutput::ProhibitOneArgSelect
  * InputOutput::ProhibitTwoArgOpen
  * Miscellanea::ProhibitFormats
  * Modules::ProhibitEvilModules
  * Subroutines::ProhibitSubroutinePrototypes
  * TestingAndDebugging::ProhibitProlongedStrictureOverride
  * ValuesAndExpressions::ProhibitLeadingZeros
  * Variables::ProhibitPerl4PackageNames
  * Variables::ProhibitUnusedVariables
  * Variables::ProtectPrivateVars
  * Modules::ProhibitAutomaticExportation
  * Modules::ProhibitConditionalUseStatements
  * Modules::RequireFilenameMatchesPackage
  * Modules::RequireNoMatchVarsWithUseEnglish
  * Subroutines::ProhibitExplicitReturnUndef
  * BuiltinFunctions::ProhibitUniversalIsa
  * ValuesAndExpressions::ProhibitCommaSeparatedStatements

Some trivial refactoring has been required:
  * remove unused variables
  * use three-argument form of open
  * replace bare filehandles with scoped variables
  * remove unreachable code