### PR TITLE
Enable ProhibitIndirectSyntax policy on lsmb tests

### DIFF
--- a/t/02-number-handling.t
+++ b/t/02-number-handling.t
@@ -30,11 +30,11 @@ $skipdbtests = 0 if $LedgerSMB::App_State::DBH;
 my $no_format_message = qr/LedgerSMB::PGNumber No Format Set/;
 my $nan_message       = qr/LedgerSMB::PGNumber Invalid Number/;
 my @r;
-my $form = new Form;
+my $form = Form->new;
 my %myconfig;
 ok(defined $form);
 isa_ok($form, 'Form');
-my $lsmb = new LedgerSMB;
+my $lsmb = LedgerSMB->new;
 ok(defined $lsmb);
 isa_ok($lsmb, 'LedgerSMB');
 

--- a/t/03-date-handling.t
+++ b/t/03-date-handling.t
@@ -21,13 +21,13 @@ $ENV{REQUEST_METHOD} = 'GET';
      # Suppress warnings from LedgerSMB::_process_cookies
 
 
-my $form = new Form;
+my $form = Form->new;
 my $locale_en = LedgerSMB::Locale->get_handle('en_CA');
 my $locale_es = LedgerSMB::Locale->get_handle('es');
 my %myconfig;
 ok(defined $form);
 isa_ok($form, 'Form');
-my $lsmb = new LedgerSMB;
+my $lsmb = LedgerSMB->new;
 ok(defined $lsmb);
 isa_ok($lsmb, 'LedgerSMB');
 

--- a/t/04-template-handling.t
+++ b/t/04-template-handling.t
@@ -82,7 +82,7 @@ is_deeply(LedgerSMB::Template::preprocess({'fruit' => '&veggies',
 # Template->new
 $myconfig = {'templates' => 't/data'};
 $template = undef;
-$template = new LedgerSMB::Template('user' => $myconfig, 'language' => 'de',
+$template = LedgerSMB::Template->new('user' => $myconfig, 'language' => 'de',
         'path' => 't/data', 'format' => 'HTML');
 ok(defined $template,
         'Template, new: Object creation with valid language and path');
@@ -92,7 +92,7 @@ is($template->{include_path}, 't/data',
         'Template, new: Object creation with valid path overrides language');
 
 $template = undef;
-$template = new LedgerSMB::Template('user' => $myconfig, 'format' => 'HTML',
+$template = LedgerSMB::Template->new('user' => $myconfig, 'format' => 'HTML',
         path => 't/data', 'template' => '04-template', 'locale' => $locale);
 ok(defined $template,
         'Template, new: Object creation with locale');
@@ -100,7 +100,7 @@ isa_ok($template, 'LedgerSMB::Template',
         'Template, new: Object creation with locale');
 
 $template = undef;
-$template = new LedgerSMB::Template('user' => $myconfig, 'format' => 'HTML',
+$template = LedgerSMB::Template->new('user' => $myconfig, 'format' => 'HTML',
         path => 't/data', 'template' => '04-template-2', 'no_auto_output' => 1);
 ok(defined $template,
         'Template, new: Object creation with non-existent template');
@@ -114,7 +114,7 @@ throws_ok{$template->render({'login' => 'foo'})} qr/not found/,
 SKIP: {
     skip "LATEX_TESTING not set", 7 unless $ENV{LATEX_TESTING};
     $template = undef;
-    $template = new LedgerSMB::Template('user' => $myconfig, 'format' => 'PDF',
+    $template = LedgerSMB::Template->new('user' => $myconfig, 'format' => 'PDF',
         path => 't/data', 'template' => '04-template', 'no_auto_output' => 1);
     ok(defined $template,
         'Template, new (PDF): Object creation with format and template');
@@ -133,7 +133,7 @@ SKIP: {
         'Template, render (PDF): testfile removed');
 
     $template = undef;
-    $template = new LedgerSMB::Template('user' => $myconfig, 'format' => 'PS',
+    $template = LedgerSMB::Template->new('user' => $myconfig, 'format' => 'PS',
         path => 't/data', 'template' => '04-template', 'no_auto_output' => 1);
     ok(defined $template,
         'Template, new (PS): Object creation with format and template');
@@ -151,7 +151,7 @@ SKIP: {
         'Template, render (PS): testfile removed');
 
     $template = undef;
-    $template = new LedgerSMB::Template('user' => $myconfig, 'format' => 'XLS',
+    $template = LedgerSMB::Template->new('user' => $myconfig, 'format' => 'XLS',
         path => 't/data', 'template' => '04-template', 'no_auto_output' => 1);
     ok(defined $template,
         'Template, new (XLS): Object creation with format and template');
@@ -169,7 +169,7 @@ SKIP: {
         'Template, render (XLS): testfile removed');
 
     $template = undef;
-    $template = new LedgerSMB::Template('user' => $myconfig, 'format' => 'XLSX',
+    $template = LedgerSMB::Template->new('user' => $myconfig, 'format' => 'XLSX',
         path => 't/data', 'template' => '04-template', 'no_auto_output' => 1);
     ok(defined $template,
         'Template, new (XLSX): Object creation with format and template');
@@ -189,7 +189,7 @@ SKIP: {
 }
 
 $template = undef;
-$template = new LedgerSMB::Template('user' => $myconfig, 'format' => 'TXT',
+$template = LedgerSMB::Template->new('user' => $myconfig, 'format' => 'TXT',
         path => 't/data', 'template' => '04-template', 'no_auto_output' => 1);
 ok(defined $template,
         'Template, new (TXT): Object creation with format and template');
@@ -202,7 +202,7 @@ is($template->{output}, "I am a template.\nLook at me foo&bar.",
         'Template, render (TXT): Simple TXT template, correct output');
 
 $template = undef;
-$template = new LedgerSMB::Template('user' => $myconfig, 'format' => 'HTML',
+$template = LedgerSMB::Template->new('user' => $myconfig, 'format' => 'HTML',
         path => 't/data', 'template' => '04-template', 'no_auto_output' => 1);
 ok(defined $template,
         'Template, new (HTML): Object creation with format and template');
@@ -220,7 +220,7 @@ is($template->{output}, "I am a template.\nLook at me foo&amp;bar.",
 
 use Math::BigFloat;
 $template = undef;
-$template = new LedgerSMB::Template('user' => {numberformat => '1.000,00'},
+$template = LedgerSMB::Template->new('user' => {numberformat => '1.000,00'},
         'format' => 'HTML', 'template' => '04-template', 'no_auto_output' => 1);
 ok(defined $template,
         'Template, private (preprocess): Object creation with format and template');
@@ -255,7 +255,7 @@ $locale = LedgerSMB::Locale->get_handle( LedgerSMB::Sysconfig::language() )
   or $lsmb->error( __FILE__ . ':' . __LINE__ . ": Locale not loaded: $!\n" );
 
 
-$template = new LedgerSMB::Template('user' => {numberformat => '1.000,00'},
+$template = LedgerSMB::Template->new('user' => {numberformat => '1.000,00'},
         'format' => 'HTML', path => 't/data', locale => $locale, 'template' => '04-complex_template', 'no_auto_output' => 1);
 
 $template->render({});
@@ -312,7 +312,7 @@ SKIP: {
     use LedgerSMB::Sysconfig;
     %LedgerSMB::Sysconfig::printer = ('test' => 'cat > t/var/04-lpr-test');
 
-    $template = new LedgerSMB::Template('user' => $myconfig, 'format' => 'PDF',
+    $template = LedgerSMB::Template->new('user' => $myconfig, 'format' => 'PDF',
         'template' => '04-template', 'locale' => $locale, no_auto_output => 1);
     $template->render({media => 'test'});
     $template->output(media => 'test');

--- a/t/10-form.t
+++ b/t/10-form.t
@@ -75,7 +75,7 @@ sub redirect {
         print "redirected\n";
 }
 
-my $form = new Form;
+my $form = Form->new;
 my %myconfig;
 my $utfstr;
 my @r;
@@ -152,14 +152,14 @@ cmp_ok($form->numtextrows("hello world\n12345678901234567890\n", 20, 3), '==', 2
         'numtextrows: 2 rows (3 max)');
 
 ## $form->hide_form checks
-$form = new Form;
+$form = Form->new;
 
 $form->{header} = 1;
 @r = trap{$form->hide_form('path')};
 ok($form->{header}, 'hide_form: header flag not cleared');
 
 ## $form->info checks
-$form = new Form;
+$form = Form->new;
 $ENV{GATEWAY_INTERFACE} = 'yes';
 $form->{header} = 'Blah';
 
@@ -171,7 +171,7 @@ delete $form->{header};
 $ENV{LSMB_NOHEAD} = 0;
 
 ## $form->isblank checks
-$form = new Form;
+$form = Form->new;
 $ENV{GATEWAY_INTERFACE} = 'yes';
 $form->{header} = 'yes';
 $form->{blank} = '    ';
@@ -180,7 +180,7 @@ is($trap->exit, undef,
         'isblank: Blank, termination');
 
 ## $form->header checks
-$form = new Form;
+$form = Form->new;
 $form->{header} = 'yes';
 ok(!$form->header, 'header: preset');
 
@@ -199,7 +199,7 @@ $ENV{LSMB_NOHEAD} = 0;
 ## $form->sort_column checks
 ## Note that sort_column merely sorts the value of $form->{sort} to being the
 ##  first element of the list, adding it if needed
-$form = new Form;
+$form = Form->new;
 @ary = ('projectnumber', 'description', 'name', 'startdate');
 $form->{sort} = 'name';
 is_deeply([$form->sort_columns(@ary)],
@@ -217,7 +217,7 @@ is_deeply([$form->sort_columns(@ary)], \@ary,
 ## $form->sort_order checks
 ## Note that $ordinal is intended to be a hashref mapping column names to
 ##  position
-$form = new Form;
+$form = Form->new;
 $aryref = ['projectnumber', 'description', 'name', 'startdate'];
 delete $form->{direction};
 delete $form->{sort};
@@ -265,16 +265,16 @@ is($form->sort_order($aryref, {name => 0, projectnumber => 3, startdate => 1}),
         'sort_order: direction => \'DESC\', sort => \'name\', ordinal b');
 
 ## $form->print_button checks
-$form = new Form;
+$form = Form->new;
 @r = trap{$form->print_button({'pear' => {'key' => 'P', 'value' => 'Pears'}}, 'pear')};
 is($trap->stdout, "<button data-dojo-type=\"dijit/form/Button\" class=\"submit\" type=\"submit\" name=\"action\" value=\"pear\" accesskey=\"P\" title=\"Pears [Alt-P]\">Pears</button>\n", 'print_button');
 
 ## $form->like checks
-$form = new Form;
+$form = Form->new;
 is($form->like('hello world'), '%hello world%', 'like');
 
 ## $form->redirect checks
-$form = new Form;
+$form = Form->new;
 ok(!defined $form->{callback}, 'redirect: No callback set');
 @r = trap{$form->redirect};
 is($trap->stdout, "Location: login.pl\nContent-type: text/html\n\n", 'redirect: No message or callback redirect');

--- a/xt/09-versioning.t
+++ b/xt/09-versioning.t
@@ -17,13 +17,13 @@ $ENV{REQUEST_METHOD} = 'GET';
 
 
 
-my $lsmb = new LedgerSMB;
+my $lsmb = LedgerSMB->new;
 ok(defined $lsmb, 'lsmb: defined');
 isa_ok($lsmb, 'LedgerSMB', 'lsmb: correct type');
 ok(defined $lsmb->{version}, 'lsmb: version set');
 ok(defined $lsmb->{dbversion}, 'lsmb: dbversion set');
 
-my $form = new Form;
+my $form = Form->new;
 ok(defined $form, 'form: defined');
 isa_ok($form, 'Form', 'form: correct type');
 ok(defined $form->{version}, 'form: version set');

--- a/xt/40-dbsetup.t
+++ b/xt/40-dbsetup.t
@@ -114,7 +114,7 @@ SKIP: {
                 or !defined $ENV{LSMB_ADMIN_FNAME}
                 or !defined $ENV{LSMB_ADMIN_LNAME});
      # Move to LedgerSMB::DBObject::Admin calls.
-     my $lsmb = new LedgerSMB;
+     my $lsmb = LedgerSMB->new;
      ok(defined $lsmb, '$lsmb defined');
      isa_ok($lsmb, 'LedgerSMB');
      $lsmb->{dbh} = DBI->connect("dbi:Pg:dbname=$ENV{PGDATABASE}",

--- a/xt/65-browser.t
+++ b/xt/65-browser.t
@@ -38,7 +38,7 @@ my %caps = (
           remote_server_addr => $remote_server_addr
 );
 
-my $driver = new Selenium::Remote::Driver(%caps)
+my $driver = Selenium::Remote::Driver->new(%caps)
           || die "Unable to connect to remote browser";
 
 $driver->set_implicit_wait_timeout(30000); # 30s

--- a/xt/65-sauce.t
+++ b/xt/65-sauce.t
@@ -12,7 +12,7 @@ if (@missing) {
     my $passwd = $ENV{SAUCE_ACCESS_KEY};
     my $host = "$user:$passwd\@localhost";
 
-    my $driver = new Selenium::Remote::Driver(
+    my $driver = Selenium::Remote::Driver->new(
                           'remote_server_addr' => $host,
                           'port' => 4445,
                           'browser_name' => "chrome",

--- a/xt/perlcriticrc
+++ b/xt/perlcriticrc
@@ -53,7 +53,7 @@ pager = less
 [Modules::RequireEndWithOne]
     set_themes = lsmb lsmb_new  lsmb_old
 [Objects::ProhibitIndirectSyntax]
-    set_themes = lsmb lsmb_new
+    set_themes = lsmb lsmb_new lsmb_tests
 [Subroutines::ProhibitReturnSort]
     set_themes = lsmb lsmb_new lsmb_tests
 [Subroutines::ProhibitSubroutinePrototypes]


### PR DESCRIPTION
Trivial refactoring changes to apply Perl::Critic Objects::ProhibitIndirectSyntax policy to files in /t and /xt

