### PR TITLE
Trap and report errors when running 06-blacklist test

### DIFF
--- a/t/06-blacklist.t
+++ b/t/06-blacklist.t
@@ -1,18 +1,19 @@
 #!/usr/bin/perl
 
-use Test::More tests => 3;
+use Test::More tests => 4;
 use Digest::SHA 'sha512_base64'; #already a dependency
 use FindBin;
 
 my $sqldir = "$FindBin::Bin/../sql/modules";
 
-open my $blist, '<', "$sqldir/BLACKLIST";
+ok(open(my $blist, '<', "$sqldir/BLACKLIST"), "open BLACKLIST");
 my $contents = join "", map { $a = $_; chomp $a; $a } <$blist>;
 close $blist;
 
 ok($contents, "Got contents from original blacklist");
 
 diag `perl $FindBin::Bin/../tools/makeblacklist.pl`;
+$? and BAIL_OUT("received non-zero exit from makeblacklist.pl");
 
 open $blist, '<', "$sqldir/BLACKLIST";
 my $contents2 = join "", map {  $a = $_; chomp $a; $a } <$blist>;

--- a/tools/makeblacklist.pl
+++ b/tools/makeblacklist.pl
@@ -9,8 +9,11 @@ no lib '.'; # can run from anywhere
 
 my %func = (); # set of functions as keys
 
+my $order_file = "$FindBin::Bin/../sql/modules/LOADORDER";
 my $order;
-open ($order, '<', "$FindBin::Bin/../sql/modules/LOADORDER");
+open ($order, '<', $order_file)
+    or die "failed to open $order_file $!";
+
 for my $mod (<$order>) {
     chomp($mod);
     $mod =~ s/(\s+|#.*)//g;
@@ -22,7 +25,9 @@ close ($order); ### return failure to execute the script?
 
 sub process_mod {
     my ($mod) = @_;
-    open my $mod_h, '<', "$FindBin::Bin/../sql/modules/$mod";
+    my $mod_file = "$FindBin::Bin/../sql/modules/$mod";
+    open my $mod_h, '<', $mod_file
+        or die "failed to open $mod_file $!";
     my %func =  map { /FUNCTION (\w+)\(/i; ($1 => 1) }
                 grep { /CREATE (OR REPLACE )?FUNCTION \w+\(/i }  <$mod_h>;
     close $mod_h;
@@ -31,7 +36,9 @@ sub process_mod {
 
 sub write_blacklist {
     my @funcs = @_;
-    open my $bl, '>', "$FindBin::Bin/../sql/modules/BLACKLIST";
+    my $bl_file = "$FindBin::Bin/../sql/modules/BLACKLIST";
+    open my $bl, '>', $bl_file
+        or die "Failed to open $bl_file $!";
     say $bl $_ for @funcs;
-    close $bl;
+    close $bl or die "failed to close $bl_file after writing $!";
 }


### PR DESCRIPTION
* Added checks on file open/write operations.
* Check exit code when running external makeblacklist.pl script
* Report meaningful errors

This test inspired by trying to run local tests for 1.5 branch and
getting a screen full of unhelpful errors owing to a permissions
issue.

This patch cannot be applied to master. I'll prepare a separate PR
for master.