### PR TITLE
Makeblacklist test file ops

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -288,7 +288,7 @@ endif
 
 # make blacklist
 blacklist:
-	perl tools/makeblacklist.pl -- --regenerate
+	perl tools/makeblacklist.pl --regenerate
 
 # make pod
 #make submodules

--- a/t/06-blacklist.t
+++ b/t/06-blacklist.t
@@ -2,13 +2,18 @@
 
 use LedgerSMB::Sysconfig;
 
-use Test::More tests => 3;
+use Test::More tests => 4;
 use Digest::SHA 'sha512_base64'; #already a dependency
 use FindBin;
 
 my $sqldir = "$FindBin::Bin/../sql/modules";
+my $blacklist_file = "$sqldir/BLACKLIST";
 
-open my $blist, '<', "$sqldir/BLACKLIST";
+ok(
+    open(my $blist, '<', $blacklist_file),
+    "open BLACKLIST",
+) or BAIL_OUT "Failed to open $blacklist_file $!";
+
 local $/ = undef;
 my $contents = <$blist>;
 $contents =~ s/\n//g;
@@ -17,6 +22,8 @@ close $blist;
 ok($contents, "Got contents from original blacklist");
 
 my $contents2 = `perl $FindBin::Bin/../tools/makeblacklist.pl`;
+$? and BAIL_OUT 'makeblacklist.pl gave non-zero exit code';
+
 $contents2 =~ s/\n//g;
 ok($contents2, "Got contents from new blacklist");
 

--- a/tools/makeblacklist.pl
+++ b/tools/makeblacklist.pl
@@ -12,7 +12,9 @@ use LedgerSMB::Sysconfig;
 
 my $out;
 if ( defined $ARGV[1] && $ARGV[1] eq '--regenerate') {
-    open $out, ">", "$FindBin::Bin/../sql/modules/BLACKLIST";
+    my $out_file = "$FindBin::Bin/../sql/modules/BLACKLIST";
+    open $out, ">", $out_file
+        or die "failed to open $out_file for writing $!";
 }
 else {
     $out = \*STDOUT;
@@ -21,28 +23,39 @@ else {
 my %func = (); # set of functions as keys
 
 my $order;
-open ($order, '<', "$FindBin::Bin/../sql/modules/LOADORDER")
-    or die "Cannot open LOADORDER";
+my $order_file = "$FindBin::Bin/../sql/modules/LOADORDER";
+open ($order, '<', $order_file)
+    or die "Cannot open $order_file $!";
+
 for my $mod (<$order>) {
     chomp($mod);
     $mod =~ s/(\s+|#.*)//g;
     next unless $mod; # skipping comment-only, whitespace-only, and blank lines
     %func = (%func, process_mod($mod));
 }
+
 write_blacklist(sort keys %func);
-close ($order); ### return failure to execute the script?
-close ($out);
+close ($order);
+close ($out) or die "failed to close output file after writing $!";
+
 
 sub process_mod {
     my ($mod) = @_;
-    open my $mod_h, '<', "$FindBin::Bin/../sql/modules/$mod";
+
+    my $mod_file = "$FindBin::Bin/../sql/modules/$mod";
+    open my $mod_h, '<', $mod_file
+        or die "cannot open $mod_file $!";
+
     my %func =  map { /FUNCTION (\w+)\(/i; ($1 => 1) }
                 grep { /CREATE (OR REPLACE )?FUNCTION \w+\(/i }  <$mod_h>;
     close $mod_h;
     return %func;
 }
 
+
 sub write_blacklist {
     my @funcs = @_;
-    say $out $_ for @funcs;
+    foreach my $function(@funcs) {
+        say $out $function or die "failed write to output file $!";
+    }
 }

--- a/tools/makeblacklist.pl
+++ b/tools/makeblacklist.pl
@@ -10,7 +10,7 @@ no lib '.'; # can run from anywhere
 use LedgerSMB::Sysconfig;
 
 my $out;
-if ( defined $ARGV[1] && $ARGV[1] eq '--regenerate') {
+if ( defined $ARGV[0] && $ARGV[0] eq '--regenerate') {
     my $out_file = "$FindBin::Bin/../sql/modules/BLACKLIST";
     open $out, ">", $out_file
         or die "failed to open $out_file for writing $!";

--- a/tools/makeblacklist.pl
+++ b/tools/makeblacklist.pl
@@ -4,7 +4,6 @@ use FindBin;
 use strict;
 use warnings;
 use lib "$FindBin::Bin/../lib";
-use File::Temp;
 use 5.010; # say makes things easier
 no lib '.'; # can run from anywhere
 


### PR DESCRIPTION
This PR makes it easier to debug test failures when setting up a new lsmb test environment, where permissions issues would previously lead to opaque test failures.

This PR:
* Checks the success of each file operation, rather than silently failing
* Checks the exit code of `makeblacklist.pl` when called from within a test
* Normalises the `--regenerate` argument to `makeblacklist.pl`
* Removes unnecessary dependency on File::Temp from `makeblacklist.pl`

As the `--regenerate` argument to `makeblacklist.pl` is not present in lsmb 1.5 or earlier, the change to the position of this argument is not expected to break existing production systems.
