### PR TITLE
Fail tests if missing Perl::Critic policies

### DIFF
--- a/xt/01.1-critic.t
+++ b/xt/01.1-critic.t
@@ -51,9 +51,7 @@ plan tests => scalar(@on_disk) + scalar(@on_disk_oldcode) + scalar(@on_disk_test
 
 test_files(
     Perl::Critic->new(
-        -only => 1,
         -profile => 'xt/perlcriticrc',
-        -severity => 1,
         -theme => 'lsmb_new',
     ),
     \@on_disk
@@ -61,9 +59,7 @@ test_files(
 
 test_files(
     Perl::Critic->new(
-        -only => 1,
         -profile => 'xt/perlcriticrc',
-        -severity => 1,
         -theme => 'lsmb_old',
     ),
     \@on_disk_oldcode
@@ -71,9 +67,7 @@ test_files(
 
 test_files(
     Perl::Critic->new(
-        -only => 1,
         -profile => 'xt/perlcriticrc',
-        -severity => 1,
         -theme => 'lsmb_tests',
     ),
     \@on_disk_tests

--- a/xt/perlcriticrc
+++ b/xt/perlcriticrc
@@ -13,12 +13,22 @@
 #  lsmb_consider -- themes we are confused about using
 
 theme = lsmb_wip
+
+# Run just the policies listed in this configuration
 only = 1
+
+# Fail if listed policy modules are not available
+profile-strictness = fatal
+
+# 1 is the most strict setting, which is the
+# default when only == 1
 severity = 1
+
 verbose =%s %p %f   %l\n
 #verbose =%f %p   %l  (%s)\n
 color =  0
 pager = less
+
 
 [ValuesAndExpressions::ProhibitMagicNumbers]
     allowed_values = -1 0 1 2 100


### PR DESCRIPTION
This PR changes the configuration so that a missing policy triggers a fatal error, ensuring we don't skip wanted test without realising. The previous default behaviour was to silently skip missing policies.

There is no need to duplicate configuration in both `xt/01.1-critic.t` and `xt/perlcriticrc` so such duplications have been removed - better to separate code and configuration.