### PR TITLE
Remove useless dblog file tests from xt/40-dbsetup.t

### DIFF
--- a/xt/40-dbsetup.t
+++ b/xt/40-dbsetup.t
@@ -25,7 +25,7 @@ for my $evar (qw(LSMB_NEW_DB LSMB_TEST_DB)){
 }
 
 if ($run_tests){
-        plan tests => 20;
+        plan tests => 19;
         $ENV{PGDATABASE} = $ENV{LSMB_NEW_DB};
 }
 

--- a/xt/40-dbsetup.t
+++ b/xt/40-dbsetup.t
@@ -16,9 +16,7 @@ HINT:  Set LSMB_NEW_DB environment variable and try running again.');
 
 my $temp = $ENV{TEMP} || '/tmp/';
 my $run_tests = 1;
-for my $log (qw(dblog dblog_stderr dblog_stdout)){
-    unlink "$LedgerSMB::Sysconfig::tempdir/$log";
-}
+
 for my $evar (qw(LSMB_NEW_DB LSMB_TEST_DB)){
   if (!defined $ENV{$evar}){
       $run_tests = 0;
@@ -142,15 +140,6 @@ SKIP: {
       $dbh->commit;
 };
 
-open  my $log, '<', "$LedgerSMB::Sysconfig::tempdir/dblog";
-
-my $passed_no_errs = 1;
-while (my $line = <$log>){
-    last if $line =~ /Fixes/i; # Fixes roll back!
-    $passed_no_errs = 0 if $line =~ /Rollback/i;
-}
-
-is($passed_no_errs, 1, 'No rollbacks in db scripts');
 
 SKIP: {
      skip 'No COA specified', 1 if !defined $ENV{LSMB_LOAD_COA};


### PR DESCRIPTION
xt/40-dbsetup.t attempts to check and clean up various dblog files
from a temporary directory, but these files are never created, hence
the checks and cleanup are useless and are removed by this patch.

This patch is in preparation to enable InputOutput::RequireCheckedOpen
Perl::Critic policy on the tests.