### PR TITLE
Apply RequiredCheckedOpen policy to lsmb tests

### DIFF
--- a/xt/01-html-checks.t
+++ b/xt/01-html-checks.t
@@ -39,7 +39,8 @@ sub content_test {
 
     my ($fh, @tab_lines, @trailing_space_lines, $text);
     $text = '';
-    open $fh, '<', $filename;
+    open $fh, '<', $filename
+        or BAIL_OUT("failed to open $filename for reading $!");
     $is_snippet = 1
         if ($filename !~ m#(log(in|out))|main|setup/#
             || $filename =~ m#setup/ui-db-credentials#);

--- a/xt/01-js-checks.t
+++ b/xt/01-js-checks.t
@@ -20,7 +20,8 @@ sub content_test {
     my ($filename) = @_;
 
     my ($fh, @tab_lines, @trailing_space_lines);
-    open $fh, '<', $filename;
+    open $fh, '<', $filename
+        or BAIL_OUT("failed to open $filename $!");
     while (<$fh>) {
         push @tab_lines, ($.) if /\t/;
         push @trailing_space_lines, ($.) if / $/;

--- a/xt/01-sql-checks.t
+++ b/xt/01-sql-checks.t
@@ -20,7 +20,8 @@ sub content_test {
     my ($filename) = @_;
 
     my ($fh, @tab_lines, @trailing_space_lines);
-    open $fh, '<', $filename;
+    open $fh, '<', $filename
+        or BAIL_OUT("couldn't open $filename for reading $!");
     while (<$fh>) {
         push @tab_lines, ($.) if /\t/;
         push @trailing_space_lines, ($.) if / $/;

--- a/xt/40-dbsetup.t
+++ b/xt/40-dbsetup.t
@@ -25,7 +25,7 @@ for my $evar (qw(LSMB_NEW_DB LSMB_TEST_DB)){
 }
 
 if ($run_tests){
-        plan tests => 20;
+        plan tests => 19;
         $ENV{PGDATABASE} = $ENV{LSMB_NEW_DB};
 }
 

--- a/xt/40-dbsetup.t
+++ b/xt/40-dbsetup.t
@@ -45,9 +45,13 @@ ok($db->apply_changes, 'applied changes');
 
 ok($db->load_modules('LOADORDER'), 'Modules loaded');
 if (!$ENV{LSMB_INSTALL_DB}){
-    open (my $DBLOCK, '>', "$temp/LSMB_TEST_DB");
-    print $DBLOCK $ENV{LSMB_NEW_DB};
-    close ($DBLOCK);
+    my $dblock_file = "$temp/LSMB_TEST_DB";
+    open (my $DBLOCK, '>', $dblock_file)
+        or BAIL_OUT("failed to open $dblock_file for writing : $!");
+    print $DBLOCK $ENV{LSMB_NEW_DB}
+        or BAIL_OUT("failed writing to $dblock_file : $!");
+    close ($DBLOCK)
+        or BAIL_OUT("failed to close $dblock_file after writing $!");
 }
 
 # Validate that we can copy the database

--- a/xt/40-dbsetup.t
+++ b/xt/40-dbsetup.t
@@ -16,9 +16,7 @@ HINT:  Set LSMB_NEW_DB environment variable and try running again.');
 
 my $temp = $ENV{TEMP} || '/tmp/';
 my $run_tests = 1;
-for my $log (qw(dblog dblog_stderr dblog_stdout)){
-    unlink "$LedgerSMB::Sysconfig::tempdir/$log";
-}
+
 for my $evar (qw(LSMB_NEW_DB LSMB_TEST_DB)){
   if (!defined $ENV{$evar}){
       $run_tests = 0;
@@ -146,15 +144,6 @@ SKIP: {
       $dbh->commit;
 };
 
-open  my $log, '<', "$LedgerSMB::Sysconfig::tempdir/dblog";
-
-my $passed_no_errs = 1;
-while (my $line = <$log>){
-    last if $line =~ /Fixes/i; # Fixes roll back!
-    $passed_no_errs = 0 if $line =~ /Rollback/i;
-}
-
-is($passed_no_errs, 1, 'No rollbacks in db scripts');
 
 SKIP: {
      skip 'No COA specified', 1 if !defined $ENV{LSMB_LOAD_COA};

--- a/xt/perlcriticrc
+++ b/xt/perlcriticrc
@@ -54,7 +54,7 @@ pager = less
 [InputOutput::ProhibitTwoArgOpen]
     set_themes = lsmb lsmb_new lsmb_tests
 [InputOutput::RequireCheckedOpen]
-    set_themes = lsmb lsmb_new
+    set_themes = lsmb lsmb_new lsmb_tests
 [Miscellanea::ProhibitFormats]
     set_themes = lsmb lsmb_new lsmb_tests
 [Modules::ProhibitEvilModules]


### PR DESCRIPTION
Applies minor refactoring to ensure file open operations are checked - and errors raised on failure - in lsmb tests.
