### PR TITLE
Preserve stacktrace in error messages

### DIFF
--- a/lib/LedgerSMB/PSGI/Util.pm
+++ b/lib/LedgerSMB/PSGI/Util.pm
@@ -39,9 +39,10 @@ sub internal_server_error {
     my ($msg, $title, $company, $dbversion) = @_;
 
     $title //= 'Error!';
+    $msg =~ s/\n/<br>/g;
     my @body_lines = ( '<html><body>',
                        q{<h2 class="error">Error!</h2>},
-                       "<p><b><pre>$msg</pre></b></p>" );
+                       "<p><b>$msg</b></p>" );
     push @body_lines, "<p>dbversion: $dbversion, company: $company</p>"
         if $company || $dbversion;
 

--- a/lib/LedgerSMB/PSGI/Util.pm
+++ b/lib/LedgerSMB/PSGI/Util.pm
@@ -41,7 +41,7 @@ sub internal_server_error {
     $title //= 'Error!';
     my @body_lines = ( '<html><body>',
                        q{<h2 class="error">Error!</h2>},
-                       "<p><b>$msg</b></p>" );
+                       "<p><b><pre>$msg</pre></b></p>" );
     push @body_lines, "<p>dbversion: $dbversion, company: $company</p>"
         if $company || $dbversion;
 


### PR DESCRIPTION
Our error handling routine packs error messages in one paragraph, thus rendering stacktraces and formatted messages hard to read. This sets the message itself as a preformatted text.