### PR TITLE
Be explicit about which Perl::Critic policies are applied

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -3,6 +3,13 @@ Changelog for 1.5 Series
 Released 2016-12-24
 
 Changelog for 1.5.14
+* Be explicit about which Perl::Critic policies to apply in tests (Nick P)
+* Check for file errors when blacklist test (Nick P)
+
+Nick P is Nick Prater
+
+
+Changelog for 1.5.14
 * Post (instead of save) transaction on depreciation approval (Erik H)
 * Fix role prefix set on copied databases from setup.pl (Erik H, #3219)
 * Fix argument names due to move to PGObject::Util::DBAdmin (Erik H)

--- a/t/perlcriticrc
+++ b/t/perlcriticrc
@@ -1,4 +1,46 @@
-[Modules::ProhibitEvilModules]
-modules = Carp::Always Data::Dumper
-    [CodeLayout::ProhibitHardTabs]
+# LedgerSMB 1.5 perlcriticrc file
+
+# Use these themes:
+# lsmb_new -- themes enforced on 'new' code
+# lsmb_old -- themes enforced on 'old' code
+
+# Run only the policies listed in this configuration
+only = 1
+
+# Fail if listed policy modules are not available
+profile-strictness = fatal
+
+[CodeLayout::ProhibitHardTabs]
     allow_leading_tabs = 0
+    set_themes = lsmb_new lsmb_old
+[CodeLayout::ProhibitTrailingWhitespace]
+    set_themes = lsmb_new lsmb_old
+[Modules::ProhibitAutomaticExportation]
+    set_themes = lsmb_new
+[Modules::ProhibitConditionalUseStatements]
+    set_themes = lsmb_new
+[Modules::ProhibitEvilModules]
+    modules = Carp::Always Data::Dumper
+    set_themes = lsmb_new
+[Modules::ProhibitExcessMainComplexity]
+    set_themes = lsmb_new
+[Modules::ProhibitMultiplePackages]
+    set_themes = lsmb_new
+[Modules::RequireBarewordIncludes]
+    set_themes = lsmb_new
+[Modules::RequireEndWithOne]
+    set_themes = lsmb_new
+[Modules::RequireExplicitPackage]
+    set_themes = lsmb_new
+[Modules::RequireFilenameMatchesPackage]
+    set_themes = lsmb_new
+[Modules::RequireNoMatchVarsWithUseEnglish]
+    set_themes = lsmb_new
+[TestingAndDebugging::ProhibitProlongedStrictureOverride]
+    set_themes = lsmb_new
+[TestingAndDebugging::RequireTestLabels]
+    set_themes = lsmb_new
+[TestingAndDebugging::RequireUseStrict]
+    set_themes = lsmb_new
+[TestingAndDebugging::RequireUseWarnings]
+    set_themes = lsmb_new

--- a/xt/01.1-critic.t
+++ b/xt/01.1-critic.t
@@ -19,7 +19,7 @@ sub test_files {
 
         ok(scalar(@findings) == 0, "Critique for $file");
         for my $finding (@findings) {
-            diag($finding->description);
+            diag($finding);
         }
     }
 

--- a/xt/01.1-critic.t
+++ b/xt/01.1-critic.t
@@ -12,6 +12,8 @@ my @on_disk;
 sub test_files {
     my ($critic, $files) = @_;
 
+    Perl::Critic::Violation::set_format( 'S%s %p %f: %l\n');
+
     for my $file (@$files) {
         my @findings = $critic->critique($file);
 

--- a/xt/01.1-critic.t
+++ b/xt/01.1-critic.t
@@ -48,60 +48,19 @@ my @on_disk_oldcode =
 
 plan tests => scalar(@on_disk) + scalar(@on_disk_oldcode);
 
-&test_files(Perl::Critic->new(
-                -profile => 't/perlcriticrc',
-                -severity => 5,
-                -theme => '',
-                -exclude => [ 'BuiltinFunctions',
-                              'ClassHierarchies',
-                              'ControlStructures',
-                              'Documentation',
-                              'ErrorHandling',
-                              'InputOutput',
-                              'Miscelenea',
-                              'Modules::RequireVersionVar',
-                              'NamingConventions::Capitalization',
-                              'Objects',
-                              'RegularExpressions',
-                              'Subroutines',
-                              'TestingAndDebugging::ProhibitNoStrict',
-                              'TestingAndDebugging::ProhibitNoWarnings',
-                              'ValuesAndExpressions',
-                              'Variables'
-                ],
-                -include => [ 'ProhibitTrailingWhitespace',
-                              'ProhibitHardTabs',
-                              'Modules',
-                              'TestingAndDebugging',
-                              'ProhibitPuncutationVars',
-                ]),
-            \@on_disk);
+&test_files(
+    Perl::Critic->new(
+        -profile => 't/perlcriticrc',
+        -theme => 'lsmb_new',
+    ),
+    \@on_disk
+);
 
-&test_files(Perl::Critic->new(
-                -profile => 't/perlcriticrc',
-                -severity => 5,
-                -theme => '',
-                -exclude => [ 'BuiltinFunctions',
-                              'ClassHierarchies',
-                              'ControlStructures',
-                              'Documentation',
-                              'ErrorHandling',
-                              'InputOutput',
-                              'Miscelenea',
-                              'Modules',
-                              'NamingConventions::Capitalization',
-                              'Objects',
-                              'RegularExpressions',
-                              'Subroutines',
-                              'TestingAndDebugging',
-                              'ValuesAndExpressions',
-                              'Variables'
-                ],
-                -include => [ 'ProhibitTrailingWhitespace',
-                              'ProhibitHardTabs',
-                              'ProhibitPuncutationVars',
-                ]),
-            \@on_disk_oldcode);
-
-
+&test_files(
+    Perl::Critic->new(
+        -profile => 't/perlcriticrc',
+        -theme => 'lsmb_old',
+    ),
+    \@on_disk_oldcode
+);
 


### PR DESCRIPTION
This patch explicitly lists the Perl::Critic policies we wish to apply,
raises an error if they are not available on the system and separates this
configuration from code.

Though it may appear we have dropped the ProhibitPunctuationVars policy,
in fact it was not being applied as the exclusion of 'Variables' took
precedence to exclude it. This illustrates the advantage of explcitly
listing policies to apply.

Previously we specified a combination of severity, theme, inclusion
and exclusion which meant different policies would be applied according
to what perl modules were installed on the system - unpredictable.

This brings 1.5 more in-line with master, which also explicitly lists
Perl::Critic policies in a separate configuration file

Also backports change from master to display more meaningful messages
when policy violations are found during test.
