### PR TITLE
Make 1.5 tests run on docker compose

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -3,6 +3,13 @@ Changelog for 1.5 Series
 Released 2016-12-24
 
 Changelog for 1.5.14
+* Be explicit about which Perl::Critic policies to apply in tests (Nick P)
+* Check for file errors when blacklist test (Nick P)
+
+Nick P is Nick Prater
+
+
+Changelog for 1.5.14
 * Post (instead of save) transaction on depreciation approval (Erik H)
 * Fix role prefix set on copied databases from setup.pl (Erik H, #3219)
 * Fix argument names due to move to PGObject::Util::DBAdmin (Erik H)

--- a/t/.pherkin.yaml
+++ b/t/.pherkin.yaml
@@ -13,7 +13,7 @@ default:
            post-step: 0
          sessions:
            selenium:
-             base_url: http://localhost:5000
+             base_url: ${LSMB_BASE_URL}
              page_class: PageObject::Root
              driver:
                 drv_name: Weasel::Driver::Selenium2
@@ -21,5 +21,6 @@ default:
                 window_size:  1024x1280
                 caps:
                   port: 4422
+                  remote_server_addr: ${REMOTE_SERVER_ADDR}
       Pherkin::Extension::PageObject:
          dummy: 1

--- a/t/lib/Pherkin/Extension/LedgerSMB.pm
+++ b/t/lib/Pherkin/Extension/LedgerSMB.pm
@@ -28,7 +28,7 @@ extends 'Test::BDD::Cucumber::Extension';
 has db_name => (is => 'rw', default => $ENV{PGDATABASE});
 has username => (is => 'rw', default => $ENV{PGUSER});
 has password => (is => 'rw', default => $ENV{PGPASSWORD});
-has host => (is => 'rw', default => 'localhost');
+has host => (is => 'rw', default => $ENV{PGHOST} // 'localhost');
 has template_db_name => (is => 'rw', default => 'standard-template');
 has admin_user_name => (is => 'rw', default => 'test-user-admin');
 has admin_user_password => (is => 'rw', default => 'password');

--- a/t/perlcriticrc
+++ b/t/perlcriticrc
@@ -1,4 +1,46 @@
-[Modules::ProhibitEvilModules]
-modules = Carp::Always Data::Dumper
-    [CodeLayout::ProhibitHardTabs]
+# LedgerSMB 1.5 perlcriticrc file
+
+# Use these themes:
+# lsmb_new -- themes enforced on 'new' code
+# lsmb_old -- themes enforced on 'old' code
+
+# Run only the policies listed in this configuration
+only = 1
+
+# Fail if listed policy modules are not available
+profile-strictness = fatal
+
+[CodeLayout::ProhibitHardTabs]
     allow_leading_tabs = 0
+    set_themes = lsmb_new lsmb_old
+[CodeLayout::ProhibitTrailingWhitespace]
+    set_themes = lsmb_new lsmb_old
+[Modules::ProhibitAutomaticExportation]
+    set_themes = lsmb_new
+[Modules::ProhibitConditionalUseStatements]
+    set_themes = lsmb_new
+[Modules::ProhibitEvilModules]
+    modules = Carp::Always Data::Dumper
+    set_themes = lsmb_new
+[Modules::ProhibitExcessMainComplexity]
+    set_themes = lsmb_new
+[Modules::ProhibitMultiplePackages]
+    set_themes = lsmb_new
+[Modules::RequireBarewordIncludes]
+    set_themes = lsmb_new
+[Modules::RequireEndWithOne]
+    set_themes = lsmb_new
+[Modules::RequireExplicitPackage]
+    set_themes = lsmb_new
+[Modules::RequireFilenameMatchesPackage]
+    set_themes = lsmb_new
+[Modules::RequireNoMatchVarsWithUseEnglish]
+    set_themes = lsmb_new
+[TestingAndDebugging::ProhibitProlongedStrictureOverride]
+    set_themes = lsmb_new
+[TestingAndDebugging::RequireTestLabels]
+    set_themes = lsmb_new
+[TestingAndDebugging::RequireUseStrict]
+    set_themes = lsmb_new
+[TestingAndDebugging::RequireUseWarnings]
+    set_themes = lsmb_new

--- a/xt/01.1-critic.t
+++ b/xt/01.1-critic.t
@@ -19,7 +19,7 @@ sub test_files {
 
         ok(scalar(@findings) == 0, "Critique for $file");
         for my $finding (@findings) {
-            diag($finding->description);
+            diag($finding);
         }
     }
 

--- a/xt/01.1-critic.t
+++ b/xt/01.1-critic.t
@@ -12,6 +12,8 @@ my @on_disk;
 sub test_files {
     my ($critic, $files) = @_;
 
+    Perl::Critic::Violation::set_format( 'S%s %p %f: %l\n');
+
     for my $file (@$files) {
         my @findings = $critic->critique($file);
 

--- a/xt/01.1-critic.t
+++ b/xt/01.1-critic.t
@@ -48,60 +48,19 @@ my @on_disk_oldcode =
 
 plan tests => scalar(@on_disk) + scalar(@on_disk_oldcode);
 
-&test_files(Perl::Critic->new(
-                -profile => 't/perlcriticrc',
-                -severity => 5,
-                -theme => '',
-                -exclude => [ 'BuiltinFunctions',
-                              'ClassHierarchies',
-                              'ControlStructures',
-                              'Documentation',
-                              'ErrorHandling',
-                              'InputOutput',
-                              'Miscelenea',
-                              'Modules::RequireVersionVar',
-                              'NamingConventions::Capitalization',
-                              'Objects',
-                              'RegularExpressions',
-                              'Subroutines',
-                              'TestingAndDebugging::ProhibitNoStrict',
-                              'TestingAndDebugging::ProhibitNoWarnings',
-                              'ValuesAndExpressions',
-                              'Variables'
-                ],
-                -include => [ 'ProhibitTrailingWhitespace',
-                              'ProhibitHardTabs',
-                              'Modules',
-                              'TestingAndDebugging',
-                              'ProhibitPuncutationVars',
-                ]),
-            \@on_disk);
+&test_files(
+    Perl::Critic->new(
+        -profile => 't/perlcriticrc',
+        -theme => 'lsmb_new',
+    ),
+    \@on_disk
+);
 
-&test_files(Perl::Critic->new(
-                -profile => 't/perlcriticrc',
-                -severity => 5,
-                -theme => '',
-                -exclude => [ 'BuiltinFunctions',
-                              'ClassHierarchies',
-                              'ControlStructures',
-                              'Documentation',
-                              'ErrorHandling',
-                              'InputOutput',
-                              'Miscelenea',
-                              'Modules',
-                              'NamingConventions::Capitalization',
-                              'Objects',
-                              'RegularExpressions',
-                              'Subroutines',
-                              'TestingAndDebugging',
-                              'ValuesAndExpressions',
-                              'Variables'
-                ],
-                -include => [ 'ProhibitTrailingWhitespace',
-                              'ProhibitHardTabs',
-                              'ProhibitPuncutationVars',
-                ]),
-            \@on_disk_oldcode);
-
-
+&test_files(
+    Perl::Critic->new(
+        -profile => 't/perlcriticrc',
+        -theme => 'lsmb_old',
+    ),
+    \@on_disk_oldcode
+);
 

--- a/xt/65-phantom.t
+++ b/xt/65-phantom.t
@@ -9,16 +9,19 @@ use Test::More;
     plan tests => 2;
     require Selenium::Remote::Driver;
 
+    my $base_url = $ENV{LSMB_BASE_URL} // 'http://localhost:5000';
+
     my $driver = new Selenium::Remote::Driver(
-                          'port' => 4422,
+        port => 4422,
+        remote_server_addr => $ENV{REMOTE_SERVER_ADDR} // 'localhost'
                           )
     || die "Unable to connect to PhantomJS";
     $driver->set_implicit_wait_timeout(30000); # 30s
-    $driver->get('http://localhost:5000/login.pl');
+    $driver->get("$base_url/login.pl");
 
     ok($driver->find_element_by_name('password'), 'got a password');
 
-    $driver->get('http://localhost:5000/setup.pl');
+    $driver->get("$base_url/setup.pl");
 
     ok($driver->find_element_by_name('s_password'), 'got a user');
 #}


### PR DESCRIPTION
Makes tests respect LSMB_BASE_URL, REMOTE_SERVER_ADDR and PGHOST environment variables.

The tests for 1.5 are written assuming all services are running
on localhost. Using lsmb's docker-compose containers for testing,
starman, database, and selenium are running in different containers.

This patch makes the tests respect environment variables to work with
the docker-compose test environment.