### PR TITLE
Apply Moose::RequireMakeImmutable policy to lsmb tests

### DIFF
--- a/xt/41-coaload/COATest.pm
+++ b/xt/41-coaload/COATest.pm
@@ -32,4 +32,5 @@ sub _build_test_db {
           . "_$self->{name}";
 }
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/xt/lib/PageObject/Root.pm
+++ b/xt/lib/PageObject/Root.pm
@@ -48,4 +48,5 @@ sub wait_for_body {
     return $self->body;
 }
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/xt/lib/Pherkin/Extension/LedgerSMB.pm
+++ b/xt/lib/Pherkin/Extension/LedgerSMB.pm
@@ -306,4 +306,5 @@ INSERT INTO acc_trans(trans_id, transdate, chart_id, amount)
     }
 }
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/xt/lib/Pherkin/Extension/PageObject.pm
+++ b/xt/lib/Pherkin/Extension/PageObject.pm
@@ -86,4 +86,5 @@ has 'page' => (is => 'rw');
 =cut
 
 
+__PACKAGE__->meta->make_immutable;
 1;

--- a/xt/perlcriticrc
+++ b/xt/perlcriticrc
@@ -118,7 +118,7 @@ pager = less
 
 
 [Moose::RequireMakeImmutable]
-    set_themes = lsmb lsmb_new lsmb_old
+    set_themes = lsmb lsmb_new lsmb_old lsmb_tests
 [Moose::RequireCleanNamespace]
     set_themes = lsmb lsmb_new lsmb_old
 


### PR DESCRIPTION
Apply Moose::RequireMakeImmutable policy to lsmb tests.