### PR TITLE
* Implement a request ID for use by both the access and the debug log

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -8,6 +8,7 @@ requires 'CGI::Parse::PSGI';
 requires 'Config::IniFiles';
 requires 'DBD::Pg', '3.3.0';
 requires 'DBI', '1.635';
+requires 'Data::UUID';
 requires 'DateTime';
 requires 'DateTime::Format::Strptime';
 requires 'File::MimeInfo';

--- a/cpanfile
+++ b/cpanfile
@@ -21,6 +21,7 @@ recommends 'Cpanel::JSON::XS';
 requires 'List::MoreUtils';
 requires 'Locale::Maketext::Lexicon', '0.62';
 requires 'Log::Log4perl';
+requires 'Log::Log4perl::Layout::PatternLayout';
 requires 'LWP::Simple';
 requires 'MIME::Lite';
 requires 'Module::Runtime';

--- a/lib/LedgerSMB/Middleware/DynamicLoadWorkflow.pm
+++ b/lib/LedgerSMB/Middleware/DynamicLoadWorkflow.pm
@@ -46,6 +46,7 @@ sub call {
     my $script_name = $env->{SCRIPT_NAME};
     $script_name =~ m/([^\/\\\?]*)\.pl$/;
     my $module = "LedgerSMB::Scripts::$1";
+    my $script_name = $1;
     my $script = "$1.pl";
 
     return LedgerSMB::PSGI::Util::internal_server_error(
@@ -91,6 +92,7 @@ sub call {
 
     $env->{'lsmb.module'} = $module;
     $env->{'lsmb.script'} = $script;
+    $env->{'lsmb.script_name'} = $script_name;
     $env->{'lsmb.action'} = $action;
     $env->{'lsmb.action_name'} = $action_name;
     return $self->app->($env);

--- a/lib/LedgerSMB/Middleware/Log4perl.pm
+++ b/lib/LedgerSMB/Middleware/Log4perl.pm
@@ -3,7 +3,7 @@ package LedgerSMB::Middleware::Log4perl;
 
 =head1 NAME
 
-LedgerSMB::Middleware::DisableBackButton - Disables back button
+LedgerSMB::Middleware::Log4perl - Sets up Log4perl logging environment
 
 =head1 SYNOPSIS
 
@@ -14,12 +14,15 @@ LedgerSMB::Middleware::DisableBackButton - Disables back button
 
 =head1 DESCRIPTION
 
-LedgerSMB::Middleware::DisableBackButton sets extremely strict cache
-control policies, effectively rendering the back button useless as a
-means of leaking information (no way to "back button back into the
-ledger" after logging out).
+LedgerSMB::Middleware::Log4perl sets up the 'psgix.logger' PSGI environment
+variable with a Log4perl category of 'lsmb.<script_name>.<entrypoint>' where
+<script_name> excludes the script's extension and <entrypoint> is the
+sub routine name of the entrypoint being invoked. E.g. the category
+for the authentication entrypoint is 'lsmb.login.authenticate'.
 
-The policy kicks in when so configured in the company database.
+This middleware depends on the PSGI environment variables 'lsmb.script_name'
+and 'lsmb.action_name' to exist. These variables are set up by the
+middleware C<DynamicLoadWorkflow>.
 
 =cut
 
@@ -43,7 +46,7 @@ sub call {
     my ($env) = @_;
 
     my $logger = Log::Log4perl->get_logger('LedgerSMB.'
-                                           . $env->{'lsmb.script'}
+                                           . $env->{'lsmb.script_name'}
                                            . '.' . $env->{'lsmb.action_name'});
     $env->{'psgix.logger'} = sub {
         my $args = shift;

--- a/lib/LedgerSMB/Middleware/Log4perl.pm
+++ b/lib/LedgerSMB/Middleware/Log4perl.pm
@@ -1,0 +1,76 @@
+
+package LedgerSMB::Middleware::Log4perl;
+
+=head1 NAME
+
+LedgerSMB::Middleware::DisableBackButton - Disables back button
+
+=head1 SYNOPSIS
+
+ builder {
+   enable "+LedgerSMB::Middleware::DisableBackButton";
+   $app;
+ }
+
+=head1 DESCRIPTION
+
+LedgerSMB::Middleware::DisableBackButton sets extremely strict cache
+control policies, effectively rendering the back button useless as a
+means of leaking information (no way to "back button back into the
+ledger" after logging out).
+
+The policy kicks in when so configured in the company database.
+
+=cut
+
+use strict;
+use warnings;
+use parent qw ( Plack::Middleware );
+
+use Log::Log4perl;
+
+
+=head1 METHODS
+
+=head2 $self->call($env)
+
+Implements C<Plack::Middleware->call()>.
+
+=cut
+
+sub call {
+    my $self = shift;
+    my ($env) = @_;
+
+    my $logger = Log::Log4perl->get_logger('LedgerSMB.'
+                                           . $env->{'lsmb.script'}
+                                           . '.' . $env->{'lsmb.action_name'});
+    $env->{'psgix.logger'} = sub {
+        my $args = shift;
+        my $level = $args->{level};
+        local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1;
+        $args->{message} =~ s/\n/\\n/g;
+        $logger->$level($args->{message});
+    };
+    local $SIG{__WARN__} = sub {
+        my $msg = shift;
+
+        $msg =~ s/\n/\\n/g;
+        $logger->warn($_);
+    };
+
+    return $self->app->($env);
+}
+
+=head1 COPYRIGHT
+
+Copyright (C) 2017 The LedgerSMB Core Team
+
+This file is licensed under the Gnu General Public License version 2, or at your
+option any later version.  A copy of the license should have been included with
+your software.
+
+=cut
+
+
+1;

--- a/lib/LedgerSMB/Middleware/RequestID.pm
+++ b/lib/LedgerSMB/Middleware/RequestID.pm
@@ -3,7 +3,7 @@ package LedgerSMB::Middleware::RequestID;
 
 =head1 NAME
 
-LedgerSMB::Middleware::DisableBackButton - Disables back button
+LedgerSMB::Middleware::RequestID - Generate a unique ID per request
 
 =head1 SYNOPSIS
 
@@ -14,12 +14,14 @@ LedgerSMB::Middleware::DisableBackButton - Disables back button
 
 =head1 DESCRIPTION
 
-LedgerSMB::Middleware::DisableBackButton sets extremely strict cache
-control policies, effectively rendering the back button useless as a
-means of leaking information (no way to "back button back into the
-ledger" after logging out).
+LedgerSMB::Middleware::RequestID sets the variable HTTP_REQUEST_ID
+in the PSGI environment to a (practically unique) value to identify
+a specific request. This request ID can be used to identify log output
+lines belonging to the trace of a single request.
 
-The policy kicks in when so configured in the company database.
+Note that the variable is strictly not an HTTP variable, but the name
+has been chosen to allow the C<AccessLog> module to use the C<%{Request-Id}i>
+syntax for inclusion in log messages.
 
 =cut
 

--- a/lib/LedgerSMB/Middleware/RequestID.pm
+++ b/lib/LedgerSMB/Middleware/RequestID.pm
@@ -1,0 +1,64 @@
+
+package LedgerSMB::Middleware::RequestID;
+
+=head1 NAME
+
+LedgerSMB::Middleware::DisableBackButton - Disables back button
+
+=head1 SYNOPSIS
+
+ builder {
+   enable "+LedgerSMB::Middleware::DisableBackButton";
+   $app;
+ }
+
+=head1 DESCRIPTION
+
+LedgerSMB::Middleware::DisableBackButton sets extremely strict cache
+control policies, effectively rendering the back button useless as a
+means of leaking information (no way to "back button back into the
+ledger" after logging out).
+
+The policy kicks in when so configured in the company database.
+
+=cut
+
+use strict;
+use warnings;
+use parent qw ( Plack::Middleware );
+
+use Data::UUID;
+
+our $request_id;
+my $ug = Data::UUID->new;
+
+=head1 METHODS
+
+=head2 $self->call($env)
+
+Implements C<Plack::Middleware->call()>.
+
+=cut
+
+sub call {
+    my $self = shift;
+    my ($env) = @_;
+
+    local $request_id = substr($ug->create_hex, 2);
+    $env->{HTTP_REQUEST_ID} = $request_id;
+
+    return $self->app->($env);
+}
+
+=head1 COPYRIGHT
+
+Copyright (C) 2017 The LedgerSMB Core Team
+
+This file is licensed under the Gnu General Public License version 2, or at your
+option any later version.  A copy of the license should have been included with
+your software.
+
+=cut
+
+
+1;

--- a/lib/LedgerSMB/PSGI.pm
+++ b/lib/LedgerSMB/PSGI.pm
@@ -198,14 +198,14 @@ sub setup_url_space {
         # not using @LedgerSMB::Sysconfig::scripts: it has not only entry-points
         mount "/$_.pl" => builder {
             enable '+LedgerSMB::Middleware::RequestID';
-            enable 'AccessLog', format => "Req:%{Request-Id}i %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-agent}i\"";
+            enable 'AccessLog', format => 'Req:%{Request-Id}i %h %l %u %t "%r" %>s %b "%{Referer}i" "%{User-agent}i"';
             $old_app
         }
         for ('aa', 'am', 'ap', 'ar', 'gl', 'ic', 'ir', 'is', 'oe', 'pe');
 
         mount "/$_" => builder {
             enable '+LedgerSMB::Middleware::RequestID';
-            enable 'AccessLog', format => "Req:%{Request-Id}i %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-agent}i\"";
+            enable 'AccessLog', format => 'Req:%{Request-Id}i %h %l %u %t "%r" %>s %b "%{Referer}i" "%{User-agent}i"';
             enable '+LedgerSMB::Middleware::DynamicLoadWorkflow';
             enable '+LedgerSMB::Middleware::Log4perl';
             enable '+LedgerSMB::Middleware::AuthenticateSession';

--- a/lib/LedgerSMB/PSGI.pm
+++ b/lib/LedgerSMB/PSGI.pm
@@ -132,6 +132,9 @@ sub psgi_app {
         # The database setup middleware will roll back before disconnecting
         my $error = $_;
         if ($error !~ /^Died at/) {
+            $env->{'psgix.logger'}->({
+                level => 'error',
+                message => $_ });
             ($status, $headers, $body) =
                 @{LedgerSMB::PSGI::Util::internal_server_error(
                       $_, 'Error!',
@@ -194,14 +197,17 @@ sub setup_url_space {
 
         # not using @LedgerSMB::Sysconfig::scripts: it has not only entry-points
         mount "/$_.pl" => builder {
-            enable 'AccessLog';
+            enable '+LedgerSMB::Middleware::RequestID';
+            enable 'AccessLog', format => "Req:%{Request-Id}i %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-agent}i\"";
             $old_app
         }
         for ('aa', 'am', 'ap', 'ar', 'gl', 'ic', 'ir', 'is', 'oe', 'pe');
 
         mount "/$_" => builder {
-            enable 'AccessLog';
+            enable '+LedgerSMB::Middleware::RequestID';
+            enable 'AccessLog', format => "Req:%{Request-Id}i %h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-agent}i\"";
             enable '+LedgerSMB::Middleware::DynamicLoadWorkflow';
+            enable '+LedgerSMB::Middleware::Log4perl';
             enable '+LedgerSMB::Middleware::AuthenticateSession';
             enable '+LedgerSMB::Middleware::DisableBackButton';
             enable '+LedgerSMB::Middleware::ClearDownloadCookie';

--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -556,7 +556,8 @@ our $log4perl_config = qq(
     .
     q(
     log4perl.appender.Screen = Log::Log4perl::Appender::Screen
-    log4perl.appender.Screen.layout = SimpleLayout
+    log4perl.appender.Screen.layout = PatternLayout
+    log4perl.appender.Screen.layout.ConversionPattern = Req:%Z %p - %m%n
     # Filter for debug level
     log4perl.filter.MatchDebug = Log::Log4perl::Filter::LevelMatch
     log4perl.filter.MatchDebug.LevelToMatch = INFO
@@ -570,21 +571,22 @@ our $log4perl_config = qq(
     # layout for DEBUG,TRACE messages
     log4perl.appender.Debug = Log::Log4perl::Appender::Screen
     log4perl.appender.Debug.layout = PatternLayout
-    log4perl.appender.Debug.layout.ConversionPattern = %d - %p - %l -- %m%n
+    log4perl.appender.Debug.layout.ConversionPattern = Req:%Z %d - %p - %l -- %m%n
     log4perl.appender.Debug.Filter = MatchDebug
 
     # layout for non-DEBUG messages
     log4perl.appender.Basic = Log::Log4perl::Appender::Screen
     log4perl.appender.Basic.layout = PatternLayout
-    log4perl.appender.Basic.layout.ConversionPattern = %d - %p - %M -- %m%n
+    log4perl.appender.Basic.layout.ConversionPattern = Req:%Z %d - %p - %M -- %m%n
     log4perl.appender.Basic.Filter = MatchRest
 
     log4perl.appender.DebugPanel              = Log::Log4perl::Appender::TestBuffer
     log4perl.appender.DebugPanel.name         = psgi_debug_panel
     log4perl.appender.DebugPanel.mode         = append
     log4perl.appender.DebugPanel.layout       = PatternLayout
-    log4perl.appender.DebugPanel.layout.ConversionPattern = %r >> %p >> %m >> %c >> at %F line %L%n
+    log4perl.appender.DebugPanel.layout.ConversionPattern = %i %r >> %p >> %m >> %c >> at %F line %L%n
     log4perl.appender.DebugPanel.Threshold = TRACE
+
     );
 #some examples of loglevel setting for modules
 #FATAL, ERROR, WARN, INFO, DEBUG, TRACE

--- a/old/bin/old-handler.pl
+++ b/old/bin/old-handler.pl
@@ -52,23 +52,18 @@ $| = 1;
 
 binmode (STDIN, ':utf8');
 binmode (STDOUT, ':utf8');
+use LedgerSMB;
 use LedgerSMB::User;
 use LedgerSMB::Form;
 use LedgerSMB::Locale;
 use LedgerSMB::App_State;
-
-$form = Form->new;
-use LedgerSMB;
+use LedgerSMB::Middleware::RequestID;
 use LedgerSMB::Sysconfig;
 
+use Data::UUID;
 use Log::Log4perl;
-#make logger available to other old programs
-our $logger=Log::Log4perl->get_logger('old-handler-chain');
 
-print 'Set-Cookie: '
-    . $form->{"request.download-cookie"} . '=downloaded' . "\n"
-    if $form->{"request.download-cookie"};
-
+$form = Form->new;
 # name of this script
 my $script;
 $uri = $ENV{REQUEST_URI};
@@ -76,12 +71,29 @@ $uri =~ s/\?.*//;
 $ENV{SCRIPT_NAME} = $uri;
 $ENV{SCRIPT_NAME} =~ m/([^\/\\]*.pl)\?*.*$/;
 $script = $1;
+$script =~ m/(.*)\.pl/;
+my $script_module = $1;
+
+$form->{action} = $form->{nextsub} if (!$form->{action} and $form->{nextsub});
+
+
+#make logger available to other old programs
+our $logger=Log::Log4perl->get_logger("lsmb.$script_module.$form->{action}");
+local $SIG{__WARN__} = sub {
+    my $msg = shift;
+
+    $msg =~ s/\n/\\n/g;
+    $logger->warn($msg);
+};
+
+print 'Set-Cookie: '
+    . $form->{"request.download-cookie"} . '=downloaded' . "\n"
+    if $form->{"request.download-cookie"};
 
 
 $locale = LedgerSMB::Locale->get_handle( ${LedgerSMB::Sysconfig::language} )
   or $form->error( __FILE__ . ':' . __LINE__ . ": Locale not loaded: $!\n" );
 
-$form->{action} = $form->{nextsub} if (!$form->{action} and $form->{nextsub});
 
 # we use $script for the language module
 $form->{script} = $script;
@@ -186,7 +198,9 @@ Content-Type: text/html; charset=utf-8
 </html>
 |;
 
-    die;
+    local $Log::Log4perl::caller_depth = $Log::Log4perl::caller_depth + 1;
+    $msg =~ s/\n/\\n/g;
+    $logger->error($msg);
 }
 
 

--- a/t/01-load.t
+++ b/t/01-load.t
@@ -95,6 +95,8 @@ my @modules =
           'LedgerSMB::Middleware::ClearDownloadCookie',
           'LedgerSMB::Middleware::DisableBackButton',
           'LedgerSMB::Middleware::DynamicLoadWorkflow',
+          'LedgerSMB::Middleware::Log4perl',
+          'LedgerSMB::Middleware::RequestID',
           'LedgerSMB::old_code', 'LedgerSMB::Part',
           'LedgerSMB::Payroll::Deduction_Type',
           'LedgerSMB::Payroll::Income_Type',

--- a/t/01-load.t
+++ b/t/01-load.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Test::More tests => 207;
+use Test::More tests => 209;
 use File::Find;
 
 my @on_disk;

--- a/tools/starman.psgi
+++ b/tools/starman.psgi
@@ -21,6 +21,8 @@ use LedgerSMB::PSGI;
 use LedgerSMB::PSGI::Preloads;
 use LedgerSMB::Sysconfig;
 use Log::Log4perl;
+use Log::Log4perl::Layout::PatternLayout;
+use LedgerSMB::Middleware::RequestID;
 
 require Plack::Middleware::Pod
     if ( $ENV{PLACK_ENV} && $ENV{PLACK_ENV} eq 'development' );
@@ -37,7 +39,11 @@ if ( $LedgerSMB::Sysconfig::dojo_built) {
     print "Starting Worker on PID $$ Using Dojo Source\n";
 }
 
+Log::Log4perl::Layout::PatternLayout::add_global_cspec(
+    'Z',
+    sub { return $LedgerSMB::Middleware::RequestID::request_id.''; });
 Log::Log4perl::init(\$LedgerSMB::Sysconfig::log4perl_config);
+
 
 LedgerSMB::PSGI::setup_url_space(
         development => ($ENV{PLACK_ENV} eq 'development'),


### PR DESCRIPTION
Also catch warnings into the debug logs (or suppress them, if warnings
  aren't requested to be logged for the specific entrypoint).

Introduces the concept of logging configuration per entrypoint, by
  specifying the hierarchy: 'lsmb.<script_name>.<action-entrypoint>'
  where <script_name> is the name of the script without the '.pl' extension
  and <action-entrypoint> is the name of the subroutine held in the
  'action' request parameter.