### PR TITLE
Fix LedgerSMB::Template::LaTeX broken on Perl <= 5.14

### DIFF
--- a/lib/LedgerSMB/Template/LaTeX.pm
+++ b/lib/LedgerSMB/Template/LaTeX.pm
@@ -27,6 +27,7 @@ use Template::Plugin::Latex;
 use Log::Log4perl;
 use TeX::Encode::charmap;
 use TeX::Encode;
+use charnames ':full';
 
 BEGIN {
     delete $TeX::Encode::charmap::ACCENTED_CHARS{


### PR DESCRIPTION
Added `use charnames ':full'`

Behaviour changed in Perl 5.16. Without this, running on
Perl 5.14 and earlier would give an error message:

```
Constant(\N{LATIN CAPITAL LETTER A WITH RING ABOVE}) unknown: (possibly a missing "use charnames ...") at lib/LedgerSMB/Template/LaTeX.pm line 33, within string
Constant(\N{LATIN SMALL LETTER A WITH RING ABOVE}) unknown: (possibly a missing "use charnames ...") at lib/LedgerSMB/Template/LaTeX.pm line 35, within string
BEGIN not safe after errors--compilation aborted at lib/LedgerSMB/Template/LaTeX.pm line 49
```

See https://perldoc.perl.org/5.16.2/charnames.html for description of the change.