### PR TITLE
Travis build enables all LedgerSMB feature options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ matrix:
             - nginx postgresql-9.5-pgtap
             - texlive-latex-recommended
             - texlive-xetex
-     env:
+      env:
         # - TEST_SAUCE=1
         - DOJO_BUILT=0
     - perl: '5.22'
@@ -58,7 +58,7 @@ matrix:
              - nginx postgresql-9.4-pgtap
              - texlive-latex-recommended
              - texlive-xetex
-     env:
+      env:
         - COVERAGE=1
     - perl: '5.20'
       addons:
@@ -68,7 +68,7 @@ matrix:
             - nginx postgresql-9.4-pgtap
             - texlive-latex-recommended
             - texlive-xetex
-    env:
+      env:
         - COA_TESTING=1
     - perl: '5.18'
       addons:
@@ -78,7 +78,7 @@ matrix:
             - nginx postgresql-9.3-pgtap
             - texlive-latex-recommended
             - texlive-xetex
-    env:
+      env:
         - DB_TESTING=1
     - perl: '5.16'
       addons:
@@ -88,7 +88,7 @@ matrix:
             - nginx postgresql-9.2-pgtap
             - texlive-latex-recommended
             - texlive-xetex
-     env:
+      env:
         - DB_TESTING=1
     - perl: '5.14'
       addons:
@@ -98,7 +98,7 @@ matrix:
             - nginx postgresql-9.2-pgtap
             - texlive-latex-recommended
             - texlive-xetex
-     env:
+      env:
         - DB_TESTING=1
 
 before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,8 @@ matrix:
         apt:
           packages:
             - nginx postgresql-9.6-pgtap
+            - texlive-latex-recommended
+            - texlive-xetex
       env:
         - POD_TESTING=1
     - perl: '5.24'
@@ -43,7 +45,9 @@ matrix:
         apt:
           packages:
             - nginx postgresql-9.5-pgtap
-      env:
+            - texlive-latex-recommended
+            - texlive-xetex
+     env:
         # - TEST_SAUCE=1
         - DOJO_BUILT=0
     - perl: '5.22'
@@ -51,8 +55,10 @@ matrix:
         postgresql: "9.4"
         apt:
           packages:
-            - nginx postgresql-9.4-pgtap
-      env:
+             - nginx postgresql-9.4-pgtap
+             - texlive-latex-recommended
+             - texlive-xetex
+     env:
         - COVERAGE=1
     - perl: '5.20'
       addons:
@@ -60,7 +66,9 @@ matrix:
         apt:
           packages:
             - nginx postgresql-9.4-pgtap
-      env:
+            - texlive-latex-recommended
+            - texlive-xetex
+    env:
         - COA_TESTING=1
     - perl: '5.18'
       addons:
@@ -68,7 +76,9 @@ matrix:
         apt:
           packages:
             - nginx postgresql-9.3-pgtap
-      env:
+            - texlive-latex-recommended
+            - texlive-xetex
+    env:
         - DB_TESTING=1
     - perl: '5.16'
       addons:
@@ -76,7 +86,9 @@ matrix:
         apt:
           packages:
             - nginx postgresql-9.2-pgtap
-      env:
+            - texlive-latex-recommended
+            - texlive-xetex
+     env:
         - DB_TESTING=1
     - perl: '5.14'
       addons:
@@ -84,7 +96,9 @@ matrix:
         apt:
           packages:
             - nginx postgresql-9.2-pgtap
-      env:
+            - texlive-latex-recommended
+            - texlive-xetex
+     env:
         - DB_TESTING=1
 
 before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -127,7 +127,7 @@ before_install:
   - npm install uglify-js@">=2.0 <3.0"
 
 install:
-  - cpanm --quiet --notest --with-develop --with-feature=edi --with-feature=xls --installdeps .
+  - cpanm --quiet --notest --installdeps --with-develop --with-feature=edi --with-feature=latex-pdf-images --with-feature=latex-pdf-ps --with-feature=openoffice  --with-feature=starman --with-feature=xls .
   - cpan-install --coverage
 
 before_script:


### PR DESCRIPTION
This ensures module loading is tested across all versions of Perl, for all
features of LedgerSMB.

Not having all features enabled means that bugs slip through, because
chunks of our code are not tested, e.g.fix #3384 where
`LedgerSMB::Template::LaTeX` was broken on Perl <= 5.14.