### PR TITLE
Expand coverage of pod syntax testing

### DIFF
--- a/t/15-loadorder.t
+++ b/t/15-loadorder.t
@@ -26,6 +26,9 @@ data is in t/data/loadorder
 =item scripts all have correct paths
 
 =item scripts all have correct properties
+
+=back
+
 =cut
 
 my $loadorder = LedgerSMB::Database::Loadorder->new('t/data/loadorder/LOADORDER');

--- a/xt/07-pod.t
+++ b/xt/07-pod.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-# t/97-pod.t
+# xt/07-pod.t
 #
 # Checks POD syntax.
 #
@@ -9,9 +9,8 @@ use strict;
 use warnings;
 
 use Test::More;
-plan skip_all => "POD_TESTING missing" if ! $ENV{POD_TESTING};
 
 eval "use Test::Pod 1.00";
 plan skip_all => "Test::Pod 1.00 required for testing POD" if $@;
 
-all_pod_files_ok(all_pod_files('lib'));
+all_pod_files_ok(all_pod_files('old', 'lib', 't', 'xt'));

--- a/xt/43-dbchange.t
+++ b/xt/43-dbchange.t
@@ -80,10 +80,6 @@ $chg_db->do(q{SELECT count(*) FROM test2;});
 like $chg_db->errstr, qr/relation "test2" does not exist/,
     'Correctly failed to create the table';
 
-=back
-
-=cut
-
 $chg_db->disconnect;
 
 $dbh->do(qq{DROP DATABASE  "$ENV{LSMB_NEW_DB}_41_dbchange"});


### PR DESCRIPTION
* Fix pod syntax errors

* Include files in `old`, `t`, `xt`
    
* Correct test file name in comments
    
* Remove check on `POD_TESTING` environment variable. Unlike the
pod-coverage test, there is no need to disable this test as it
runs fine with all the perl versions we support.
