### PR TITLE
Extend and simplify pod-coverage tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,6 @@ notifications:
   webhooks: https://ledgersmb.org/webhook/travis_ci_notifications
 
 
-# POD_TESTING=1 can be set as an environment variable to enable pod tests,
-# but these only work with perl versions >= 5.20. Earlier versions of perl
-# handle constants in a way which causes Test::Pod::Coverage to consider
-# them as naked subroutines.
-
-
 matrix:
   include:
     - perl: '5.26'
@@ -37,7 +31,6 @@ matrix:
             - texlive-latex-recommended
             - texlive-xetex
       env:
-        - POD_TESTING=1
     - perl: '5.24'
       addons:
         postgresql: '9.5'

--- a/xt/08-pod-coverage.t
+++ b/xt/08-pod-coverage.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 #
-# t/98-pod-coverage.t
+# xt/08-pod-coverage.t
 #
 # Checks POD coverage.
 #
@@ -12,7 +12,17 @@ use Test::More; # plan automatically generated below
 use File::Find;
 use File::Util;
 
-plan skip_all => "POD_TESTING missing" if ! $ENV{POD_TESTING};
+# Only test with perl versions >= 5.20. Earlier versions of perl
+# handle constants in a way which causes Test::Pod::Coverage to
+# consider them naked subroutines.
+eval{require 5.20.0} or plan skip_all => 'perl version < 5.20.0';
+
+
+eval "use Test::Pod::Coverage";
+if ($@){
+    plan skip_all => "Test::Pod::Coverage required for testing POD coverage";
+}
+
 
 my @on_disk;
 
@@ -38,27 +48,15 @@ sub collect {
     my $module = $File::Find::name;
     push @on_disk, $module
 }
-find(\&collect, 'lib/LedgerSMB.pm', 'lib/LedgerSMB/');
 
 # only check new code; we're scaling down on old code anyway
+find(\&collect, 'lib');
+
 @on_disk =
-    grep { ! m#^old/bin/# }
-    grep { ! m#^lib/LedgerSMB/..\.pm# }
-    grep { ! m#^lib/LedgerSMB/Form\.pm# }
-    grep { ! m#^lib/LedgerSMB/Auth/# }
-    grep { ! m#^lib/LedgerSMB/Num2text\.pm# } # LedgerSMB::Num2text is old code
     grep { ! m#^lib/LedgerSMB/Sysconfig.pm# } # LedgerSMB::Sysconfig false fail
     @on_disk;
 
-
-use Test::More;
-eval "use Test::Pod::Coverage";
-if ($@){
-    plan skip_all => "Test::Pod::Coverage required for testing POD coverage";
-} else {
-    plan tests => scalar(@on_disk);
-}
-
+plan tests => scalar(@on_disk);
 
 # Copied from 01-load.t
 my @exception_modules =


### PR DESCRIPTION
* Remove check on POD_TESTING environment variable - no longer needed now we check for Perl version and better to have tests enabled by default

* Correct test file name in comments

* Simplify file selection code now that 'old' code has been separated

* Extend test coverage

* Require perl >= 5.20 as this test throws spurious errors with earlier versions
