### PR TITLE
Enable Log4Perl DebugPanel

### DIFF
--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -549,7 +549,7 @@ for (sort $cfg->Parameters('log4perl_config_modules_loglevel')){
 }
 # Log4perl configuration
 our $log4perl_config = qq(
-    log4perl.rootlogger = $LedgerSMB::Sysconfig::log_level, Basic, Debug
+    log4perl.rootlogger = $LedgerSMB::Sysconfig::log_level, Basic, Debug, DebugPanel
     )
     .
     $modules_loglevel_overrides
@@ -585,7 +585,7 @@ our $log4perl_config = qq(
     log4perl.appender.DebugPanel.mode         = append
     log4perl.appender.DebugPanel.layout       = PatternLayout
     log4perl.appender.DebugPanel.layout.ConversionPattern = %i %r >> %p >> %m >> %c >> at %F line %L%n
-    log4perl.appender.DebugPanel.Threshold = TRACE
+    #log4perl.appender.DebugPanel.Threshold = TRACE
 
     );
 #some examples of loglevel setting for modules

--- a/tools/starman-development.psgi
+++ b/tools/starman-development.psgi
@@ -82,7 +82,7 @@ builder {
             enable "Debug::$_"
                 if check_config_option("$_","Plack::Middleware::Debug::$_");
         }
-        enable 'Debug::Log4perl', method => $LedgerSMB::Sysconfig::Log4perl_method
+        enable 'Debug::Log4perl'
             if check_config_option('Log4perl','Plack::Middleware::Debug::Log4perl');
         enable 'Debug::DBIProfile', profile => $LedgerSMB::Sysconfig::DBIProfile_profile
             if check_config_option('DBIProfile','Plack::Middleware::Debug::DBIProfile');


### PR DESCRIPTION
With the new Log4perl middleware, we can use this to display in a hideable Debug Pane.