### PR TITLE
Fix migration test and old test

### DIFF
--- a/lib/LedgerSMB/Upgrade_Tests.pm
+++ b/lib/LedgerSMB/Upgrade_Tests.pm
@@ -320,7 +320,7 @@ push @tests, __PACKAGE__->new(
                    'Please make all vendor numbers unique'),
          name => 'unique_vendornumber',
  display_cols => ['vendornumber', 'name', 'address1', 'city', 'state', 'zip'],
-      columns => ['customernumber'],
+      columns => ['vendornumber'],
         table => 'customer',
       appname => 'ledgersmb',
   min_version => '1.2',

--- a/xt/50-upgrade-tests.t
+++ b/xt/50-upgrade-tests.t
@@ -3,30 +3,33 @@
 use Test::More;
 use LedgerSMB::Upgrade_Tests;
 
-my @tests = LedgerSMB::Upgrade_Tests->get_tests();
+my @tests = sort { $a->{appname}     cmp $b->{appname}     or
+                   $a->{name}        cmp $b->{name}        or
+                   $a->{min_version} cmp $b->{min_version} or
+                   $a->{max_version} cmp $b->{max_version}
+                 } LedgerSMB::Upgrade_Tests->get_tests();
 
 plan tests => scalar @tests;
 
 sub _validate_displayed_key {
     my ($test,@keys) = @_;
     for my $key (@keys) {
-        ok grep( $key, $test->{display_cols}),
-            "'$key' not displayed in test '$test->{name}'";
+        ok grep (/^$key$/, @{$test->{display_cols}}),
+            "$key displayed in test $test->{name}:$test->{appname}";
     }
 };
 
 for my $test (@tests){
-    subtest $test->{name} => sub {
+    subtest "$test->{name}:$test->{appname} $test->{min_version}-$test->{max_version}" => sub {
         _validate_displayed_key($test,keys %{$test->{selectable_values}})
             if $test->{selectable_values};
 
-        _validate_displayed_key($test,$test->{columns})
-            if $test->{columns};
+        _validate_displayed_key($test,@{$test->{columns}})
+            if @{$test->{columns}};
 
         for my $btn (keys %{$test->{tooltips}}) {
-            warn np $test if !grep( /^$btn$/, @{$test->{buttons}});
             ok grep( /^$btn$/, @{$test->{buttons}}),
-                "No button '$btn' in test '$test->{name}'";
+                "Button '$btn' in test '$test->{name}'";
         }
     }
 }


### PR DESCRIPTION
Fixing the test showed an inappropriate use of key in LedgerSMB 1.2 unique_vendor migration test