### PR TITLE
HTML::Lint 2.28-2.30 cannot parse url parameters

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -114,7 +114,7 @@ feature 'debug', "Debug pane" =>
 on 'develop' => sub {
     requires 'App::Prove', '3.36';
     requires 'File::Util';
-    requires 'HTML::Lint';
+    requires 'HTML::Lint', '<=2.26'; # YLA 2018-01-08 - 2.28 cannot parse url?param1=2&param2=1
     requires 'HTML::Lint::Parser', '2.26';
     requires 'HTML::Lint::Pluggable';
     requires 'HTML::Lint::Pluggable::HTML5';


### PR DESCRIPTION
This make xt/01-html-checks.t fail with entries like ` <a href="admin.pl?action=new_user&first_name=<?lsmb tt_url(first_name)?>>`
Holding HTML::Lint at 2.26 until a fixing release is produced.
  