### PR TITLE
Fix duplicated 'From' and 'To' labels on form date range input

### DIFF
--- a/UI/lib/report_base.html
+++ b/UI/lib/report_base.html
@@ -115,7 +115,6 @@ END # BLOCK -?>
         IF !name.defined();     name     = 'from_date'; END;
         IF !required.defined(); required = 'false';           END;
     ?>
-      <th align="right"><?lsmb label ?></th>
       <td>
         <?lsmb INCLUDE _date_block label=label name=name required=required SUFFIX=SUFFIX ?>
       </td>
@@ -127,7 +126,6 @@ END # BLOCK -?>
         IF !name.defined();     name     = 'to_date'; END;
         IF !required.defined(); required = 'false';         END;
     ?>
-      <th align="right"><?lsmb label ?></th>
       <td>
         <?lsmb INCLUDE _date_block label=label name=name required=required SUFFIX=SUFFIX ?>
       </td>
@@ -196,6 +194,7 @@ END # BLOCK -?>
 
 <?lsmb- BLOCK date_row ?>
         <tr>
+          <th align="right"><?lsmb text('Date Range') ?></th>
           <?lsmb INCLUDE date_from_date required=required SUFFIX=SUFFIX ?>
           <?lsmb INCLUDE date_to_date   required=required SUFFIX=SUFFIX ?>
         </tr>


### PR DESCRIPTION
For example AR->Search was displaying:

`From From [date dropdown]  To To [date dropdown]`

This because in addition to a `<label>` element, a separate
`<th>` element was being created, also with the label text
for each input element.