### PR TITLE
Remove dependency on LedgerSMB::AM from configuration.pm

### DIFF
--- a/lib/LedgerSMB/Scripts/configuration.pm
+++ b/lib/LedgerSMB/Scripts/configuration.pm
@@ -10,7 +10,6 @@ LedgerSMB::Scripts::configuration->can('action')->($request);
 package LedgerSMB::Scripts::configuration;
 use LedgerSMB::Setting;
 use LedgerSMB::Setting::Sequence;
-use LedgerSMB::AM; # To be removed, only for template directories right now
 use LedgerSMB::App_State;
 use strict;
 use warnings;


### PR DESCRIPTION
Removed an unecessary vestige of the past from
`lib/LedgerSMB/Scripts/configuration.pm` - no longer needs
`LedgerSMB::AM` which it once used for template directory.
