### PR TITLE
Fix invalid password duration

### DIFF
--- a/lib/LedgerSMB/Scripts/configuration.pm
+++ b/lib/LedgerSMB/Scripts/configuration.pm
@@ -60,7 +60,11 @@ sub _default_settings {
                 label => $locale->text('Disable Back Button'),
                 type => 'YES_NO', },
               { name => 'password_duration',
-                label => $locale->text('Password Duration') },
+                label => (
+                    $locale->text('Password Duration') .
+                    ' (' . $locale->text('days') . ')'
+                )
+              },
               { name => 'session_timeout',
         label => $locale->text('Session Timeout'), },
               { name => 'never_logout',

--- a/lib/LedgerSMB/Scripts/configuration.pm
+++ b/lib/LedgerSMB/Scripts/configuration.pm
@@ -60,10 +60,7 @@ sub _default_settings {
                 label => $locale->text('Disable Back Button'),
                 type => 'YES_NO', },
               { name => 'password_duration',
-                label => (
-                    $locale->text('Password Duration') .
-                    ' (' . $locale->text('days') . ')'
-                )
+                label => $locale->text('Password Duration (days)')
               },
               { name => 'session_timeout',
         label => $locale->text('Session Timeout'), },

--- a/sql/changes/1.6/constrain_default_password_duration.sql
+++ b/sql/changes/1.6/constrain_default_password_duration.sql
@@ -4,7 +4,7 @@
 -- Bad values are replaced with NULL, which sets
 -- 'infinity' as the password expiry for future
 -- password changes.
--- 
+--
 -- There is no benefit in retaining the old, bad
 -- values as they do nothing other than prevent
 -- passwords being changed.

--- a/sql/changes/1.6/constrain_default_password_duration.sql
+++ b/sql/changes/1.6/constrain_default_password_duration.sql
@@ -1,11 +1,13 @@
-/* Clear an invalid password_duration settings,
- * which effectively sets 'infinity' as the password
- * expiry.
+/* Clear an invalid password_duration setting,
+ * which prevents user passwords from being changed.
+ *
+ * Bad values are replaced with NULL, which sets
+ * 'infinity' as the password expiry for future
+ * password changes.
  * 
- * if current password_duration value is invalid, it
- * will do nothing other than prevent passwords
- * being changed on the system. There is therefore
- * no benefit in retaining the old value.
+ * There is no benefit in retaining the old, bad
+ * values as they do nothing other than prevent
+ * passwords being changed.
  */
 UPDATE defaults
 SET value = NULL

--- a/sql/changes/1.6/constrain_default_password_duration.sql
+++ b/sql/changes/1.6/constrain_default_password_duration.sql
@@ -1,0 +1,34 @@
+/* Clear an invalid password_duration settings,
+ * which effectively sets 'infinity' as the password
+ * expiry.
+ * 
+ * if current password_duration value is invalid, it
+ * will do nothing other than prevent passwords
+ * being changed on the system. There is therefore
+ * no benefit in retaining the old value.
+ */
+UPDATE defaults
+SET value = NULL
+WHERE setting_key = 'password_duration' AND (
+  value ~ '^([0-9]+[.]?[0-9]*|[.][0-9]+)$' OR
+  value::numeric <= 0 OR
+  value::numeric >= 3654
+)
+
+
+/* Add a constraint that enforces a valid
+ * password duration and constrains its value
+ * to a sane range.
+ */
+ALTER TABLE defaults
+ADD CONSTRAINT defaults_password_duration_check
+CHECK(
+  setting_key != 'password_duration' OR
+  value IS NULL OR
+  value = '' OR
+  (
+    value ~ '^([0-9]+[.]?[0-9]*|[.][0-9]+)$' AND
+    value::numeric > 0 AND
+    value::numeric < 3654  /* abitrary maximum 10 years */
+  )
+);

--- a/sql/changes/1.6/constrain_default_password_duration.sql
+++ b/sql/changes/1.6/constrain_default_password_duration.sql
@@ -1,27 +1,26 @@
-/* Clear an invalid password_duration setting,
- * which prevents user passwords from being changed.
- *
- * Bad values are replaced with NULL, which sets
- * 'infinity' as the password expiry for future
- * password changes.
- * 
- * There is no benefit in retaining the old, bad
- * values as they do nothing other than prevent
- * passwords being changed.
- */
+-- Clear an invalid password_duration setting,
+-- which prevents user passwords from being changed.
+--
+-- Bad values are replaced with NULL, which sets
+-- 'infinity' as the password expiry for future
+-- password changes.
+-- 
+-- There is no benefit in retaining the old, bad
+-- values as they do nothing other than prevent
+-- passwords being changed.
+
 UPDATE defaults
 SET value = NULL
 WHERE setting_key = 'password_duration' AND (
   value ~ '^([0-9]+[.]?[0-9]*|[.][0-9]+)$' OR
   value::numeric <= 0 OR
   value::numeric >= 3654
-)
+);
 
 
-/* Add a constraint that enforces a valid
- * password duration and constrains its value
- * to a sane range.
- */
+-- Add a constraint that enforces a valid
+-- password duration and constrains its value
+-- to a sane range.
 ALTER TABLE defaults
 ADD CONSTRAINT defaults_password_duration_check
 CHECK(
@@ -31,6 +30,6 @@ CHECK(
   (
     value ~ '^([0-9]+[.]?[0-9]*|[.][0-9]+)$' AND
     value::numeric > 0 AND
-    value::numeric < 3654  /* abitrary maximum 10 years */
+    value::numeric < 3654  -- abitrary maximum 10 years
   )
 );

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -67,3 +67,4 @@
 1.6/add-eca-business-foreign-key.sql
 1.6/add_empty_salutation.sql
 1.6/missing-countries.sql
+1.6/constrain_default_password_duration.sql


### PR DESCRIPTION
This is part of a fix for issue #3231, which prevents user password changes. It enforces database integrity for the default password_duration.

The value of default password_duration is expected to be a positive
number, NULL or ''. Anything else will cause a fatal error when
trying to change a password.

The database uses a key/value table to store defaults, with the
value stored as a text field. This patch adds a check constraint
when the key is 'password_duration'.

During an upgrade, bad password_durations are dropped, effectively
replacing the bad value with the default 'infinite' password
validity. As the bad values don't work, no valid data is lost
by this process.

I propose as a second step to add validation to the UI, so that a bad value
can never be submitted to the database.