### PR TITLE
Make sure that changes to the defaults table are committed

### DIFF
--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -1248,6 +1248,7 @@ sub process_and_run_upgrade_script {
     if ! $success;
 
     $dbh->do(q{delete from defaults where setting_key like 'migration_%'});
+    $dbh->commit;
 
     # the schema was left incomplete when we created it, in order to provide
     # a frozen (fixed) migration target. Now, however, we need to apply the


### PR DESCRIPTION
Fix a long outstanding problem. Commit all changes to `defaults` before loading the modules changes to avoid a deadlock if one change alter that table.