### PR TITLE
Don't remove the lock file if the database wasn't dropped

### DIFF
--- a/xt/89-dropdb.t
+++ b/xt/89-dropdb.t
@@ -26,10 +26,9 @@ ok(open (my $DBLOCK, '<', $lock_file), 'Opened db lock file')
 my $db = <$DBLOCK>;
 chomp($db);
 cmp_ok($db, 'eq', $ENV{LSMB_NEW_DB}, 'Got expected db name out') &&
-ok(!system ("dropdb $ENV{LSMB_NEW_DB}"), 'dropped db');
-ok(close ($DBLOCK), 'Closed db lock file');
+ok(!system ("dropdb $ENV{LSMB_NEW_DB}"), 'dropped db') &&
+ok(close ($DBLOCK), 'Closed db lock file') &&
 ok(unlink ("$temp/LSMB_TEST_DB"), 'Removed test db lockfile');
-
 
 my $dbh = DBI->connect("dbi:Pg:dbname=template1",
                                        undef, undef, { AutoCommit => 0 });


### PR DESCRIPTION
Make sure that the database was dropped before dropping the lockfile, otherwise `xt/89-dropdb.t` won't be able to drop the database anymore and it will have to be deleted manually.