### PR TITLE
Compile schema validation files for stricter tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,15 +43,15 @@ RHEL_perlmodules += perl-namespace-autoclean perl-MooseX-NonMoose
 RHEL_perlmodules += perl-XML-Simple
 RHEL_perlmodules += perl-YAML perl-FCGI-ProcManager
 RHEL_feature_PDF := perl-TeX-Encode texlive
-RHEL_feature_PDF_utf8 := 
-RHEL_feature_OpenOffice := 
-RHEL_feature_XLS := 
+RHEL_feature_PDF_utf8 :=
+RHEL_feature_OpenOffice :=
+RHEL_feature_XLS :=
 
-FBSD_essential := 
-FBSD_perlmodules := 
-FBSD_feature_PDF := 
-FBSD_feature_OpenOffice := 
-FBSD_feature_XLS := 
+FBSD_essential :=
+FBSD_perlmodules :=
+FBSD_feature_PDF :=
+FBSD_feature_OpenOffice :=
+FBSD_feature_XLS :=
 
 APT_GET = sudo apt-get install
 YUM = sudo yum install
@@ -200,6 +200,7 @@ Help on using this Makefile
     - submodules   : Initialises and updates our git submodules
     - test         : Runs tests
     - devtest      : Runs all tests including development/author tests
+    - tapgen       : Compile Schema validation files
     - dist         : builds the release distribution archive
     - dependencies : Installs all dependencies including cpan ones. (except features)
                      Preferring system perl modules over cpan ones
@@ -468,6 +469,14 @@ devtest:
 	prove -Ilib t/*.t
 	prove -Ilib xt/*.t
 
+tapgen:
+	prove -Ilib xt/40-dbsetup.t
+	pg_tapgen --directory xt/pgtap --dbname lsmbinstalltest
+	find xt/pgtap -type f -name '*.sql' \
+        -execdir sh -c 'awk -f ../../tools/compile_pgtap.awk {} > {}.pg_include' \; \
+        -execdir rm {} \;
+	prove -Ilib xt/89-dropdb.t
+
 ########
 # todo list
 ########
@@ -477,13 +486,13 @@ devtest:
 # - postgres_access
 # - postgres_verify
 # - postgres (depends on postgres_*)
-# 
+#
 # - starman (adds system user and systemd script)
-# 
+#
 # - letsencrypt
-# 
+#
 # - nginx
-# 
+#
 # - apache
 # - httpd (defaults to nginx)
 # Oh, and the first to add would be

--- a/tools/compile_pgtap.awk
+++ b/tools/compile_pgtap.awk
@@ -1,0 +1,30 @@
+# Prologue
+BEGIN{
+    file = ARGV[1];
+    gsub("\.sql","",file);
+    gsub("\./?","_",file);
+    printf("CREATE OR REPLACE FUNCTION lsmb_pgtap.%s()\n",file);
+    printf("RETURNS SETOF TEXT AS $$\nBEGIN\n");
+}
+
+# Skip plan/finish
+/^SELECT plan\([0-9]+\);/     { next }
+/^SELECT \* FROM finish\(\);/ { next }
+/^(BEGIN|ROLLBACK);/          { next }
+
+# Skip config settings
+/client_encoding|client_min_messages|CREATE EXTENSION/ { next }
+
+# Comment bugged statement
+/col_default_is.+\(''.+''/    { printf("--%s",$0)}
+
+# Convert for runtests
+{
+    sub("^SELECT","RETURN NEXT",$0);
+    print
+}
+
+# Epilogue
+END{
+    printf("END;\n$$ LANGUAGE plpgsql;");
+}

--- a/xt/42-reconciliation.pg
+++ b/xt/42-reconciliation.pg
@@ -1,253 +1,306 @@
 BEGIN;
 
+    -- Standard prologue according to pgTap documentation
+
+    \set ECHO 'none'
+    \set QUIET 1
+    \pset format unaligned
+    \pset tuples_only true
+    \pset pager
+    \set ON_ERROR_ROLLBACK 1
+    \set ON_ERROR_STOP true
+
     -- Load the TAP functions.
+
     CREATE EXTENSION pgtap;
-
-    -- Plan the tests.
-
-    SELECT plan(62);
 
     -- Add data
 
     \i sql/modules/test/Base.sql
     \i sql/modules/test/data/Reconciliation.sql
 
+    CREATE SCHEMA lsmb_pgtap;
+
     -- Validate required tables
 
-    SELECT has_table('cr_report');
-    SELECT has_table('cr_report_line');
-    SELECT has_table('cr_coa_to_account');
+    \ir pgtap/table_public.acc_trans.sql.pg_include
+    \ir pgtap/table_public.account.sql.pg_include
+    \ir pgtap/table_public.ap.sql.pg_include
+    \ir pgtap/table_public.ar.sql.pg_include
+    \ir pgtap/table_public.cr_coa_to_account.sql.pg_include
+    \ir pgtap/table_public.cr_report.sql.pg_include
+    \ir pgtap/table_public.cr_report_line.sql.pg_include
+    \ir pgtap/table_public.entity.sql.pg_include
+    \ir pgtap/table_public.transactions.sql.pg_include
+
+    CREATE OR REPLACE FUNCTION lsmb_pgtap.startup_reconciliation_test()
+    RETURNS SETOF TEXT AS $$
+    BEGIN
+        RETURN NEXT results_eq('SELECT setval(''cr_report_id_seq'',1)::int',ARRAY[1],'Initialize Sequence');
+    END;
+    $$ LANGUAGE plpgsql;
 
     -- Validate required view
 
-    SELECT has_view('recon_payee');
+    CREATE OR REPLACE FUNCTION lsmb_pgtap.reconciliation_test1_views()
+    RETURNS SETOF TEXT AS $$
+    BEGIN
+        RETURN NEXT has_view('public','recon_payee','View recon_payee exists');
+    END;
+    $$ LANGUAGE plpgsql;
 
     -- Validate required triggers
 
-    SELECT has_trigger('cr_report','block_change_when_approved');
+    CREATE OR REPLACE FUNCTION lsmb_pgtap.reconciliation_test1_triggers()
+    RETURNS SETOF TEXT AS $$
+    BEGIN
+        RETURN NEXT has_trigger('cr_report','block_change_when_approved');
+    END;
+    $$ LANGUAGE plpgsql;
 
     -- Validate required functions
 
-    SELECT has_function('cr_report_block_changing_approved',ARRAY['']);
-    SELECT has_function('reconciliation__account_list',ARRAY['']);
-    SELECT has_function('reconciliation__add_entry',array['integer', 'text', 'text', 'timestamp without time zone', 'numeric']);
-    SELECT has_function('reconciliation__check',array['date', 'integer']);
-    SELECT has_function('reconciliation__delete_my_report',array['integer']);
-    SELECT has_function('reconciliation__delete_unapproved',array['integer']);
-    SELECT has_function('reconciliation__get_cleared_balance',array['integer', 'date']);
-    SELECT has_function('reconciliation__get_current_balance',array['integer', 'date']);
-    SELECT has_function('reconciliation__new_report_id',array['integer', 'numeric', 'date', 'boolean']);
-    SELECT has_function('reconciliation__pending_transactions',array['integer', 'numeric']);
-    SELECT has_function('reconciliation__previous_report_date',ARRAY['integer','date']);
-    SELECT has_function('reconciliation__reject_set',array['integer']);
-    SELECT has_function('reconciliation__report_approve',array['integer']);
-    SELECT has_function('reconciliation__report_details',array['integer']);
-    SELECT has_function('reconciliation__report_details_payee',array['integer']);
-    SELECT has_function('reconciliation__report_details_payee_with_days',array['integer', 'date']);
-    SELECT has_function('reconciliation__report_summary',array['integer']);
-    SELECT has_function('reconciliation__save_set',array['integer', 'integer[]']);
-    SELECT has_function('reconciliation__search',array['date', 'date', 'numeric', 'numeric', 'integer', 'boolean', 'boolean']);
-    SELECT has_function('reconciliation__submit_set',array['integer', 'integer[]']);
+    CREATE OR REPLACE FUNCTION lsmb_pgtap.reconciliation_test1_functions()
+    RETURNS SETOF TEXT AS $$
+    BEGIN
+        RETURN NEXT has_function('cr_report_block_changing_approved',ARRAY['']);
+        RETURN NEXT has_function('reconciliation__account_list',ARRAY['']);
+        RETURN NEXT has_function('reconciliation__add_entry',array['integer', 'text', 'text', 'timestamp without time zone', 'numeric']);
+        RETURN NEXT has_function('reconciliation__check',array['date', 'integer']);
+        RETURN NEXT has_function('reconciliation__delete_my_report',array['integer']);
+        RETURN NEXT has_function('reconciliation__delete_unapproved',array['integer']);
+        RETURN NEXT has_function('reconciliation__get_cleared_balance',array['integer', 'date']);
+        RETURN NEXT has_function('reconciliation__get_current_balance',array['integer', 'date']);
+        RETURN NEXT has_function('reconciliation__new_report_id',array['integer', 'numeric', 'date', 'boolean']);
+        RETURN NEXT has_function('reconciliation__pending_transactions',array['integer', 'numeric']);
+        RETURN NEXT has_function('reconciliation__previous_report_date',ARRAY['integer','date']);
+        RETURN NEXT has_function('reconciliation__reject_set',array['integer']);
+        RETURN NEXT has_function('reconciliation__report_approve',array['integer']);
+        RETURN NEXT has_function('reconciliation__report_details',array['integer']);
+        RETURN NEXT has_function('reconciliation__report_details_payee',array['integer']);
+        RETURN NEXT has_function('reconciliation__report_details_payee_with_days',array['integer', 'date']);
+        RETURN NEXT has_function('reconciliation__report_summary',array['integer']);
+        RETURN NEXT has_function('reconciliation__save_set',array['integer', 'integer[]']);
+        RETURN NEXT has_function('reconciliation__search',array['date', 'date', 'numeric', 'numeric', 'integer', 'boolean', 'boolean']);
+        RETURN NEXT has_function('reconciliation__submit_set',array['integer', 'integer[]']);
+    END;
+    $$ LANGUAGE plpgsql;
 
-    -- Run tests
+    -- Prepare tests
 
---    PREPARE test AS SELECT count(*)
---                      FROM defaults
---                      WHERE setting_key = 'check_prefix';
---    SELECT results_eq('test',ARRAY[1],'check_prefix set');
+    CREATE OR REPLACE FUNCTION lsmb_pgtap.reconciliation_test2_report2()
+    RETURNS SETOF TEXT AS $$
+    BEGIN
+        RETURN NEXT results_eq('SELECT currval(''cr_report_id_seq'')::int',ARRAY[1],'Initialize Test for empty report');
 
---    UPDATE defaults
---    SET value = 'Recon gl test '
---    WHERE setting_key = 'check_prefix';
+        PREPARE test AS SELECT COUNT(*)::INT FROM acc_trans
+                        WHERE cleared
+                        AND entry_id NOT IN (SELECT ledger_id FROM cr_report_line);
+        RETURN NEXT results_eq('test', Array[4], 'Transactions that should be in cr_report');
+        DEALLOCATE test;
 
-    CREATE TEMPORARY TABLE test_parameters (id int);
-    INSERT INTO test_parameters(id) VALUES(nextval('cr_report_id_seq'));
+        PREPARE test AS SELECT reconciliation__previous_report_date(test_get_account_id('-11111'), now()::date);
+        RETURN NEXT results_eq('test', ARRAY[]::cr_report[], 'No previous report');
+        DEALLOCATE test;
 
-    PREPARE test AS SELECT COUNT(*)::INT FROM acc_trans
-                    WHERE cleared
-                    AND entry_id NOT IN (SELECT ledger_id FROM cr_report_line);
-    SELECT results_eq('test', Array[4], 'Transactions that should be in cr_report');
-    DEALLOCATE test;
+        PREPARE test AS SELECT reconciliation__new_report_id(test_get_account_id('-11111'), 100, '1000-01-01', false);
+        RETURN NEXT results_eq('test', ARRAY[currval('cr_report_id_seq')::int+1], 'Create Recon Report');
+        DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__previous_report_date(test_get_account_id('-11111'), now()::date);
-    SELECT results_eq('test', ARRAY[]::cr_report[], 'No previous report');
-    DEALLOCATE test;
+        PREPARE test AS SELECT reconciliation__delete_my_report(currval('cr_report_id_seq')::int);
+        RETURN NEXT results_eq('test',ARRAY[true],'Delete Recon Report');
+        DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__new_report_id(test_get_account_id('-11111'), 100, '1001-01-01', false);
-    SELECT results_eq('test', $$ SELECT id+1 FROM test_parameters $$, 'Create Recon Report');
-    DEALLOCATE test;
+        PREPARE test AS SELECT reconciliation__previous_report_date(test_get_account_id('-11111'), now()::date);
+        RETURN NEXT results_eq('test', ARRAY[]::cr_report[], 'Deleted previous report doesn''t show up');
+        DEALLOCATE test;
+    END;
+    $$ LANGUAGE plpgsql;
 
-    PREPARE test AS SELECT reconciliation__delete_my_report(currval('cr_report_id_seq')::int);
-    SELECT results_eq('test',ARRAY[true],'Delete Recon Report');
-    DEALLOCATE test;
+    CREATE OR REPLACE FUNCTION lsmb_pgtap.reconciliation_test2_report3()
+    RETURNS SETOF TEXT AS $$
+    BEGIN
+        RETURN NEXT results_eq('SELECT currval(''cr_report_id_seq'')::int',ARRAY[2],'Initialize Test for unsubmitable report');
 
-    PREPARE test AS SELECT reconciliation__previous_report_date(test_get_account_id('-11111'), now()::date);
-    SELECT results_eq('test', ARRAY[]::cr_report[], 'Deleted previous report doesn''t show up');
-    DEALLOCATE test;
+        PREPARE test AS SELECT reconciliation__new_report_id(test_get_account_id('-11111'), 100, '1001-01-01', false);
+        RETURN NEXT results_eq('test', ARRAY[currval('cr_report_id_seq')::int+1], 'Create Recon Report');
+        DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__new_report_id(test_get_account_id('-11111'), 100, '1001-01-01', false);
-    SELECT results_eq('test', $$ SELECT id+2 FROM test_parameters $$, 'Create Recon Report');
-    DEALLOCATE test;
+        --TODO: Shouldn't reconciliation__pending_transactions returns the
+        --      number of transactions ran instead of the report number?
+        PREPARE test AS SELECT reconciliation__pending_transactions(currval('cr_report_id_seq')::int, 110);
+        RETURN NEXT results_eq('test', ARRAY[currval('cr_report_id_seq')::int], 'Pending Transactions Ran');
+        DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__pending_transactions(currval('cr_report_id_seq')::int, 110) > 0;
-    SELECT results_eq('test',ARRAY[true],'Pending Transactions Ran');
-    DEALLOCATE test;
+        PREPARE test AS SELECT count(*)::int
+                          FROM cr_report_line
+                          WHERE report_id = currval('cr_report_id_seq')::int;
+        RETURN NEXT results_eq('test',Array[10],'Correct number of transactions');
+        DEALLOCATE test;
 
-    PREPARE test AS SELECT count(*)::int
-                      FROM cr_report_line
-                      WHERE report_id = currval('cr_report_id_seq')::int;
-    SELECT results_eq('test',Array[10],'Correct number of transactions 1');
-    DEALLOCATE test;
+        PREPARE test AS SELECT count(*)::int
+                          FROM cr_report_line
+                          WHERE scn LIKE '% gl %'
+                          AND report_id = currval('cr_report_id_seq')::int;
+        RETURN NEXT results_eq('test', ARRAY[3], 'Correct number of GL groups');
+        DEALLOCATE test;
 
-    PREPARE test AS SELECT count(*)::int
-                      FROM cr_report_line
-                      WHERE scn LIKE '% gl %'
-                      AND report_id = currval('cr_report_id_seq')::int;
-    SELECT results_eq('test', ARRAY[3], 'Correct number of GL groups');
-    DEALLOCATE test;
+        PREPARE test AS SELECT count(*)::int
+                          FROM cr_report_line
+                          WHERE report_id = currval('cr_report_id_seq')::int;
+        RETURN NEXT results_eq('test',ARRAY[10],'Correct number of report lines');
+        DEALLOCATE test;
 
-    PREPARE test AS SELECT count(*)::int
-                      FROM cr_report_line
-                      WHERE report_id = currval('cr_report_id_seq')::int;
-    SELECT results_eq('test',ARRAY[10],'Correct number of report lines');
-    DEALLOCATE test;
+        PREPARE test AS SELECT reconciliation__submit_set(currval('cr_report_id_seq')::int,
+                        (SELECT as_array(id::int)
+                           FROM cr_report_line
+                          WHERE report_id = currval('cr_report_id_seq')::int));
+        RETURN NEXT results_eq('test',ARRAY[true],'Report Submitted');
+        DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__submit_set(currval('cr_report_id_seq')::int, (select as_array(id::int) from cr_report_line where report_id = currval('cr_report_id_seq')::int));
-    SELECT results_eq('test',ARRAY[true],'Report Submitted');
-    DEALLOCATE test;
+        PREPARE test AS SELECT reconciliation__previous_report_date(test_get_account_id('-11111'), '1001-01-01');
+        RETURN NEXT results_eq('test', ARRAY[]::cr_report[], 'No previous report before 1001-01-01');
+        DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__previous_report_date(test_get_account_id('-11111'), '1001-01-01');
-    SELECT results_eq('test', ARRAY[]::cr_report[], 'No previous report before 1001-01-01');
-    DEALLOCATE test;
+        PREPARE test AS SELECT reconciliation__report_approve(currval('cr_report_id_seq')::int);
+        RETURN NEXT results_eq('test',ARRAY[1],'Report Approved');
+        DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__report_approve(currval('cr_report_id_seq')::int) > 0;
-    SELECT results_eq('test',ARRAY[true],'1 Report Approved');
-    DEALLOCATE test;
+        PREPARE test AS SELECT end_date FROM reconciliation__previous_report_date(test_get_account_id('-11111'), '1001-01-02');
+        RETURN NEXT results_eq('test', ARRAY['1001-01-01']::date[], 'One previous report at 1001-01-01');
+        DEALLOCATE test;
 
-    PREPARE test AS SELECT end_date FROM reconciliation__previous_report_date(test_get_account_id('-11111'), '1001-01-02');
-    SELECT results_eq('test', ARRAY['1001-01-01']::date[], 'One previous report at 1001-01-01');
-    DEALLOCATE test;
+        PREPARE test as SELECT count(*)::int
+                          FROM acc_trans
+                          JOIN account a ON (acc_trans.chart_id = a.id)
+                          WHERE a.accno = '-11111'
+                          AND NOT cleared;
+        RETURN NEXT results_eq('test',ARRAY[2],'1 Transactions closed');
+        DEALLOCATE test;
+    END;
+    $$ LANGUAGE plpgsql;
 
-    PREPARE test as SELECT count(*)::int
-                      FROM acc_trans
-                      JOIN account a ON (acc_trans.chart_id = a.id)
-                      WHERE a.accno = '-11111'
-                      AND NOT cleared;
-    SELECT results_eq('test',ARRAY[2],'1 Transactions closed');
-    DEALLOCATE test;
+    CREATE OR REPLACE FUNCTION lsmb_pgtap.reconciliation_test2_report4()
+    RETURNS SETOF TEXT AS $$
+    BEGIN
+        RETURN NEXT results_eq('SELECT currval(''cr_report_id_seq'')::int',ARRAY[3],'Initialize Test Balanced submit and approve');
 
-    PREPARE test AS SELECT reconciliation__new_report_id(test_get_account_id('-11112'), 100, now()::date, false) > 0;
-    SELECT results_eq('test',ARRAY[true],'1 Create Recon Report');
-    DEALLOCATE test;
+        PREPARE test AS SELECT reconciliation__new_report_id(test_get_account_id('-11112'), 100, now()::date, false);
+        RETURN NEXT results_eq('test', ARRAY[currval('cr_report_id_seq')::int+1], 'Create Recon Report');
+        DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__pending_transactions(currval('cr_report_id_seq')::int, 110) > 0;
-    SELECT results_eq('test',ARRAY[true],'1 Pending Transactions Ran');
-    DEALLOCATE test;
+        PREPARE test AS SELECT reconciliation__pending_transactions(currval('cr_report_id_seq')::int, 110);
+        RETURN NEXT results_eq('test', ARRAY[currval('cr_report_id_seq')::int], 'Pending Transactions Ran');
+        DEALLOCATE test;
 
-    PREPARE test AS SELECT count(*)::int
-                      FROM cr_report_line
-                      WHERE report_id = currval('cr_report_id_seq')::int;
-    SELECT results_eq('test',ARRAY[10],'Correct number of transactions 2');
-    DEALLOCATE test;
+        PREPARE test AS SELECT count(*)::int
+                          FROM cr_report_line
+                          WHERE report_id = currval('cr_report_id_seq')::int;
+        RETURN NEXT results_eq('test',ARRAY[10],'Correct number of transactions 2');
+        DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__pending_transactions(currval('cr_report_id_seq')::int, 110);
-    SELECT results_eq('test',$$ SELECT id+3 FROM test_parameters $$,'1 Pending Transactions Ran');
-    DEALLOCATE test;
+        PREPARE test AS SELECT reconciliation__pending_transactions(currval('cr_report_id_seq')::int, 110);
+        RETURN NEXT results_eq('test', ARRAY[currval('cr_report_id_seq')::int], 'Pending Transactions Ran');
+        DEALLOCATE test;
 
-    PREPARE test AS SELECT count(*)::int
-                      FROM cr_report_line
-                      WHERE report_id = currval('cr_report_id_seq')::int;
-    SELECT results_eq('test',ARRAY[10],'Correct number of transactions 3');
-    DEALLOCATE test;
+        PREPARE test AS SELECT count(*)::int
+                          FROM cr_report_line
+                          WHERE report_id = currval('cr_report_id_seq')::int;
+        RETURN NEXT results_eq('test',ARRAY[10],'Correct number of transactions 3');
+        DEALLOCATE test;
 
-    PREPARE test AS SELECT count(*)::int
-                      FROM cr_report_line
-                      WHERE scn like '% gl %'
-                      AND report_id = currval('cr_report_id_seq')::int;
-    SELECT results_eq('test',ARRAY[3],'1 Correct number of GL groups');
-    DEALLOCATE test;
+        PREPARE test AS SELECT count(*)::int
+                          FROM cr_report_line
+                          WHERE scn like '% gl %'
+                          AND report_id = currval('cr_report_id_seq')::int;
+        RETURN NEXT results_eq('test',ARRAY[3],'Correct number of GL groups');
+        DEALLOCATE test;
 
-    PREPARE test AS SELECT count(*)::int
-                      FROM cr_report_line
-                      WHERE report_id = currval('cr_report_id_seq')::int;
-    SELECT results_eq('test',ARRAY[10],'1 Correct number of report lines');
-    DEALLOCATE test;
+        PREPARE test AS SELECT count(*)::int
+                          FROM cr_report_line
+                          WHERE report_id = currval('cr_report_id_seq')::int;
+        RETURN NEXT results_eq('test',ARRAY[10],'Correct number of report lines');
+        DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__submit_set(currval('cr_report_id_seq')::int, '{}');
-    SELECT results_eq('test',ARRAY[true],'1 Report Submitted');
-    DEALLOCATE test;
+        PREPARE test AS SELECT reconciliation__submit_set(currval('cr_report_id_seq')::int, '{}');
+        RETURN NEXT results_eq('test',ARRAY[true],'1 Report Submitted');
+        DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__get_cleared_balance(test_get_account_id('-11112')) = -10;
-    SELECT results_eq('test',ARRAY[true],'1 Cleared balance pre-approval is 10');
-    DEALLOCATE test;
+        PREPARE test AS SELECT reconciliation__get_cleared_balance(test_get_account_id('-11112'));
+        RETURN NEXT results_eq('test',ARRAY[-10.],'Cleared balance pre-approval is -10');
+        DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__report_approve(currval('cr_report_id_seq')::int) > 0;
-    SELECT results_eq('test',ARRAY[true],'1 Report Approved');
-    DEALLOCATE test;
+        PREPARE test AS SELECT reconciliation__report_approve(currval('cr_report_id_seq')::int) = 1;
+        RETURN NEXT results_eq('test',ARRAY[true],'Report Approved');
+        DEALLOCATE test;
 
-    PREPARE test AS SELECT count(*)::int
-                      FROM acc_trans
-                      JOIN account ON (acc_trans.chart_id = account.id)
-                      WHERE accno = '-11112'
-                      AND NOT cleared;
-    SELECT results_eq('test',ARRAY[14],'1 Transactions open');
-    DEALLOCATE test;
+        PREPARE test AS SELECT count(*)::int
+                          FROM acc_trans
+                          JOIN account ON (acc_trans.chart_id = account.id)
+                          WHERE accno = '-11112'
+                          AND NOT cleared;
+        RETURN NEXT results_eq('test',ARRAY[14],'Transactions open');
+        DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__get_cleared_balance(test_get_account_id('-11112')) = -10;
-    SELECT results_eq('test',ARRAY[true],'1 Cleared balance post-approval is 10');
-    DEALLOCATE test;
+        PREPARE test AS SELECT reconciliation__get_cleared_balance(test_get_account_id('-11112'));
+        RETURN NEXT results_eq('test',ARRAY[-10.],'Cleared balance post-approval is -10');
+        DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__new_report_id(test_get_account_id('-11112'), 100, now()::date, false);
-    SELECT results_eq('test',$$ SELECT id+4 FROM test_parameters $$,'1 Create Recon Report');
-    DEALLOCATE test;
+        RETURN NEXT results_eq('SELECT currval(''cr_report_id_seq'')::int',ARRAY[4],'Initialize Delete report');
 
-    PREPARE test AS SELECT reconciliation__pending_transactions(currval('cr_report_id_seq')::int, 110);
-    SELECT results_eq('test',$$ SELECT id+4 FROM test_parameters $$,'1 Pending Transactions Ran');
-    DEALLOCATE test;
+        PREPARE test AS SELECT reconciliation__new_report_id(test_get_account_id('-11112'), 100, now()::date, false);
+        RETURN NEXT results_eq('test', ARRAY[currval('cr_report_id_seq')::int+1],'Create Recon Report');
+        DEALLOCATE test;
 
-    PREPARE test AS SELECT count(*)::int
-                      FROM cr_report_line
-                      WHERE report_id = currval('cr_report_id_seq')::int;
-    SELECT results_eq('test',ARRAY[10],'Correct number of transactions 4');
-    DEALLOCATE test;
+        PREPARE test AS SELECT reconciliation__pending_transactions(currval('cr_report_id_seq')::int, 110);
+        RETURN NEXT results_eq('test', ARRAY[currval('cr_report_id_seq')::int],'Pending Transactions Ran');
+        DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__submit_set(currval('cr_report_id_seq')::int, (select as_array(id::int)
-                      FROM cr_report_line
-                      WHERE report_id = currval('cr_report_id_seq')::int));
-    SELECT results_eq('test',ARRAY[true],'Report Submitted');
-    DEALLOCATE test;
+        PREPARE test AS SELECT count(*)::int
+                          FROM cr_report_line
+                          WHERE report_id = currval('cr_report_id_seq')::int;
+        RETURN NEXT results_eq('test',ARRAY[10],'Correct number of transactions');
+        DEALLOCATE test;
 
-    PREPARE test AS SELECT their_total::int
-                      FROM reconciliation__report_summary(currval('cr_report_id_seq')::int);
-    SELECT results_eq('test',ARRAY[110],'Their Balance Updated');
-    DEALLOCATE test;
+        PREPARE test AS SELECT reconciliation__submit_set(currval('cr_report_id_seq')::int, (select as_array(id::int)
+                          FROM cr_report_line
+                          WHERE report_id = currval('cr_report_id_seq')::int));
+        RETURN NEXT results_eq('test',ARRAY[true],'Report Submitted');
+        DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__get_cleared_balance(test_get_account_id('-11112'))= -10;
-    SELECT results_eq('test',ARRAY[true],'Cleared balance pre-approval is 10');
-    DEALLOCATE test;
+        PREPARE test AS SELECT their_total::int
+                          FROM reconciliation__report_summary(currval('cr_report_id_seq')::int);
+        RETURN NEXT results_eq('test',ARRAY[110],'Their Balance Updated');
+        DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__report_approve(currval('cr_report_id_seq')::int) > 0;
-    SELECT results_eq('test',ARRAY[true],'Report Approved');
-    DEALLOCATE test;
+        PREPARE test AS SELECT reconciliation__get_cleared_balance(test_get_account_id('-11112'));
+        RETURN NEXT results_eq('test',ARRAY[-10.],'Cleared balance pre-approval is 0');
+        DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__delete_my_report(currval('cr_report_id_seq')::int) IS NULL;
-    -- Should we thrown an exception?
-    SELECT results_eq('test',ARRAY[true],'Cannot Delete Approved Recon Report');
-    DEALLOCATE test;
+        PREPARE test AS SELECT reconciliation__report_approve(currval('cr_report_id_seq')::int) = 1;
+        RETURN NEXT results_eq('test',ARRAY[true],'Report Approved');
+        DEALLOCATE test;
 
-    PREPARE test AS SELECT count(*)::int
-                      FROM acc_trans
-                      JOIN account a ON (acc_trans.chart_id = a.id)
-                      WHERE accno = '-11112'
-                      AND NOT cleared;
-    SELECT results_eq('test',ARRAY[2],'Transactions closed');
-    DEALLOCATE test;
+        PREPARE test AS SELECT reconciliation__delete_my_report(currval('cr_report_id_seq')::int) IS NULL;
+        -- Should we thrown an exception?
+        RETURN NEXT results_eq('test',ARRAY[true],'Cannot Delete Approved Recon Report');
+        DEALLOCATE test;
 
-    PREPARE test AS SELECT reconciliation__get_cleared_balance(test_get_account_id('-11112'));
-    SELECT results_eq('test',ARRAY[-130.],'Cleared balance post-approval is 130');
-    DEALLOCATE test;
+        PREPARE test AS SELECT count(*)::int
+                          FROM acc_trans
+                          JOIN account a ON (acc_trans.chart_id = a.id)
+                          WHERE accno = '-11112'
+                          AND NOT cleared;
+        RETURN NEXT results_eq('test',ARRAY[2],'Transactions closed');
+        DEALLOCATE test;
 
-    -- Finish the tests and clean up.
-    SELECT * FROM finish();
+        PREPARE test AS SELECT reconciliation__get_cleared_balance(test_get_account_id('-11112'));
+        RETURN NEXT results_eq('test',ARRAY[-130.],'Cleared balance post-approval is 130');
+        DEALLOCATE test;
+    END;
+    $$ LANGUAGE plpgsql;
+
+    -- Run all tests
+    SELECT * FROM runtests('lsmb_pgtap','^(_table_*|reconciliation_test*)');
 
 ROLLBACK;

--- a/xt/pgtap/schema.sql.pg_include
+++ b/xt/pgtap/schema.sql.pg_include
@@ -1,0 +1,1036 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._schema()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT schemas_are(ARRAY[
+    'public'
+]);
+
+RETURN NEXT schema_owner_is('public','postgres');
+RETURN NEXT tables_are('public', ARRAY[
+    'ac_tax_form',
+    'acc_trans',
+    'account',
+    'account_checkpoint',
+    'account_heading',
+    'account_heading_translation',
+    'account_link',
+    'account_link_description',
+    'account_translation',
+    'ap',
+    'ar',
+    'assembly',
+    'asset_class',
+    'asset_dep_method',
+    'asset_disposal_method',
+    'asset_item',
+    'asset_note',
+    'asset_report',
+    'asset_report_class',
+    'asset_report_line',
+    'asset_rl_to_disposal_method',
+    'asset_unit_class',
+    'audittrail',
+    'batch',
+    'batch_class',
+    'bu_class_to_module',
+    'budget_info',
+    'budget_line',
+    'budget_note',
+    'budget_to_business_unit',
+    'business',
+    'business_unit',
+    'business_unit_ac',
+    'business_unit_class',
+    'business_unit_inv',
+    'business_unit_jl',
+    'business_unit_oitem',
+    'business_unit_translation',
+    'company',
+    'contact_class',
+    'country',
+    'country_tax_form',
+    'cr_coa_to_account',
+    'cr_report',
+    'cr_report_line',
+    'custom_field_catalog',
+    'custom_table_catalog',
+    'db_patch_log',
+    'db_patches',
+    'defaults',
+    'eca_invoice',
+    'eca_note',
+    'eca_tax',
+    'eca_to_contact',
+    'eca_to_location',
+    'employee_class',
+    'employee_to_ec',
+    'entity',
+    'entity_bank_account',
+    'entity_class',
+    'entity_credit_account',
+    'entity_employee',
+    'entity_note',
+    'entity_other_name',
+    'entity_to_contact',
+    'entity_to_location',
+    'exchangerate',
+    'file_base',
+    'file_class',
+    'file_eca',
+    'file_entity',
+    'file_incoming',
+    'file_internal',
+    'file_order',
+    'file_order_to_order',
+    'file_order_to_tx',
+    'file_part',
+    'file_secondary_attachment',
+    'file_transaction',
+    'file_tx_to_order',
+    'file_view_catalog',
+    'fixes',
+    'gifi',
+    'gl',
+    'inventory_report',
+    'inventory_report_line',
+    'invoice',
+    'invoice_note',
+    'invoice_tax_form',
+    'jcitems',
+    'jctype',
+    'job',
+    'journal_entry',
+    'journal_line',
+    'journal_note',
+    'journal_type',
+    'language',
+    'location',
+    'location_class',
+    'location_class_to_entity_class',
+    'lsmb_group',
+    'lsmb_group_grants',
+    'lsmb_module',
+    'lsmb_sequence',
+    'makemodel',
+    'menu_acl',
+    'menu_attribute',
+    'menu_node',
+    'mfg_lot',
+    'mfg_lot_item',
+    'mime_type',
+    'new_shipto',
+    'note',
+    'note_class',
+    'oe',
+    'oe_class',
+    'open_forms',
+    'orderitems',
+    'parts',
+    'parts_translation',
+    'partscustomer',
+    'partsgroup',
+    'partsgroup_translation',
+    'partstax',
+    'partsvendor',
+    'payment',
+    'payment_links',
+    'payment_map',
+    'payment_type',
+    'payroll_deduction',
+    'payroll_deduction_class',
+    'payroll_deduction_type',
+    'payroll_employee_class',
+    'payroll_employee_class_to_income_type',
+    'payroll_income_category',
+    'payroll_income_class',
+    'payroll_income_type',
+    'payroll_paid_timeoff',
+    'payroll_pto_class',
+    'payroll_report',
+    'payroll_report_line',
+    'payroll_wage',
+    'person',
+    'person_to_company',
+    'pricegroup',
+    'recurring',
+    'recurringemail',
+    'recurringprint',
+    'robot',
+    'salutation',
+    'session',
+    'sic',
+    'status',
+    'tax',
+    'tax_extended',
+    'taxcategory',
+    'taxmodule',
+    'template',
+    'trans_type',
+    'transactions',
+    'translation',
+    'trial_balance__yearend_types',
+    'user_preference',
+    'users',
+    'voucher',
+    'warehouse',
+    'warehouse_inventory',
+    'yearend'
+]);
+
+RETURN NEXT table_owner_is('public','ac_tax_form','postgres','public.ac_tax_form owner is postgres');
+RETURN NEXT table_owner_is('public','acc_trans','postgres','public.acc_trans owner is postgres');
+RETURN NEXT table_owner_is('public','account','postgres','public.account owner is postgres');
+RETURN NEXT table_owner_is('public','account_checkpoint','postgres','public.account_checkpoint owner is postgres');
+RETURN NEXT table_owner_is('public','account_heading','postgres','public.account_heading owner is postgres');
+RETURN NEXT table_owner_is('public','account_heading_translation','postgres','public.account_heading_translation owner is postgres');
+RETURN NEXT table_owner_is('public','account_link','postgres','public.account_link owner is postgres');
+RETURN NEXT table_owner_is('public','account_link_description','postgres','public.account_link_description owner is postgres');
+RETURN NEXT table_owner_is('public','account_translation','postgres','public.account_translation owner is postgres');
+RETURN NEXT table_owner_is('public','ap','postgres','public.ap owner is postgres');
+RETURN NEXT table_owner_is('public','ar','postgres','public.ar owner is postgres');
+RETURN NEXT table_owner_is('public','assembly','postgres','public.assembly owner is postgres');
+RETURN NEXT table_owner_is('public','asset_class','postgres','public.asset_class owner is postgres');
+RETURN NEXT table_owner_is('public','asset_dep_method','postgres','public.asset_dep_method owner is postgres');
+RETURN NEXT table_owner_is('public','asset_disposal_method','postgres','public.asset_disposal_method owner is postgres');
+RETURN NEXT table_owner_is('public','asset_item','postgres','public.asset_item owner is postgres');
+RETURN NEXT table_owner_is('public','asset_note','postgres','public.asset_note owner is postgres');
+RETURN NEXT table_owner_is('public','asset_report','postgres','public.asset_report owner is postgres');
+RETURN NEXT table_owner_is('public','asset_report_class','postgres','public.asset_report_class owner is postgres');
+RETURN NEXT table_owner_is('public','asset_report_line','postgres','public.asset_report_line owner is postgres');
+RETURN NEXT table_owner_is('public','asset_rl_to_disposal_method','postgres','public.asset_rl_to_disposal_method owner is postgres');
+RETURN NEXT table_owner_is('public','asset_unit_class','postgres','public.asset_unit_class owner is postgres');
+RETURN NEXT table_owner_is('public','audittrail','postgres','public.audittrail owner is postgres');
+RETURN NEXT table_owner_is('public','batch','postgres','public.batch owner is postgres');
+RETURN NEXT table_owner_is('public','batch_class','postgres','public.batch_class owner is postgres');
+RETURN NEXT table_owner_is('public','bu_class_to_module','postgres','public.bu_class_to_module owner is postgres');
+RETURN NEXT table_owner_is('public','budget_info','postgres','public.budget_info owner is postgres');
+RETURN NEXT table_owner_is('public','budget_line','postgres','public.budget_line owner is postgres');
+RETURN NEXT table_owner_is('public','budget_note','postgres','public.budget_note owner is postgres');
+RETURN NEXT table_owner_is('public','budget_to_business_unit','postgres','public.budget_to_business_unit owner is postgres');
+RETURN NEXT table_owner_is('public','business','postgres','public.business owner is postgres');
+RETURN NEXT table_owner_is('public','business_unit','postgres','public.business_unit owner is postgres');
+RETURN NEXT table_owner_is('public','business_unit_ac','postgres','public.business_unit_ac owner is postgres');
+RETURN NEXT table_owner_is('public','business_unit_class','postgres','public.business_unit_class owner is postgres');
+RETURN NEXT table_owner_is('public','business_unit_inv','postgres','public.business_unit_inv owner is postgres');
+RETURN NEXT table_owner_is('public','business_unit_jl','postgres','public.business_unit_jl owner is postgres');
+RETURN NEXT table_owner_is('public','business_unit_oitem','postgres','public.business_unit_oitem owner is postgres');
+RETURN NEXT table_owner_is('public','business_unit_translation','postgres','public.business_unit_translation owner is postgres');
+RETURN NEXT table_owner_is('public','company','postgres','public.company owner is postgres');
+RETURN NEXT table_owner_is('public','contact_class','postgres','public.contact_class owner is postgres');
+RETURN NEXT table_owner_is('public','country','postgres','public.country owner is postgres');
+RETURN NEXT table_owner_is('public','country_tax_form','postgres','public.country_tax_form owner is postgres');
+RETURN NEXT table_owner_is('public','cr_coa_to_account','postgres','public.cr_coa_to_account owner is postgres');
+RETURN NEXT table_owner_is('public','cr_report','postgres','public.cr_report owner is postgres');
+RETURN NEXT table_owner_is('public','cr_report_line','postgres','public.cr_report_line owner is postgres');
+RETURN NEXT table_owner_is('public','custom_field_catalog','postgres','public.custom_field_catalog owner is postgres');
+RETURN NEXT table_owner_is('public','custom_table_catalog','postgres','public.custom_table_catalog owner is postgres');
+RETURN NEXT table_owner_is('public','db_patch_log','postgres','public.db_patch_log owner is postgres');
+RETURN NEXT table_owner_is('public','db_patches','postgres','public.db_patches owner is postgres');
+RETURN NEXT table_owner_is('public','defaults','postgres','public.defaults owner is postgres');
+RETURN NEXT table_owner_is('public','eca_invoice','postgres','public.eca_invoice owner is postgres');
+RETURN NEXT table_owner_is('public','eca_note','postgres','public.eca_note owner is postgres');
+RETURN NEXT table_owner_is('public','eca_tax','postgres','public.eca_tax owner is postgres');
+RETURN NEXT table_owner_is('public','eca_to_contact','postgres','public.eca_to_contact owner is postgres');
+RETURN NEXT table_owner_is('public','eca_to_location','postgres','public.eca_to_location owner is postgres');
+RETURN NEXT table_owner_is('public','employee_class','postgres','public.employee_class owner is postgres');
+RETURN NEXT table_owner_is('public','employee_to_ec','postgres','public.employee_to_ec owner is postgres');
+RETURN NEXT table_owner_is('public','entity','postgres','public.entity owner is postgres');
+RETURN NEXT table_owner_is('public','entity_bank_account','postgres','public.entity_bank_account owner is postgres');
+RETURN NEXT table_owner_is('public','entity_class','postgres','public.entity_class owner is postgres');
+RETURN NEXT table_owner_is('public','entity_credit_account','postgres','public.entity_credit_account owner is postgres');
+RETURN NEXT table_owner_is('public','entity_employee','postgres','public.entity_employee owner is postgres');
+RETURN NEXT table_owner_is('public','entity_note','postgres','public.entity_note owner is postgres');
+RETURN NEXT table_owner_is('public','entity_other_name','postgres','public.entity_other_name owner is postgres');
+RETURN NEXT table_owner_is('public','entity_to_contact','postgres','public.entity_to_contact owner is postgres');
+RETURN NEXT table_owner_is('public','entity_to_location','postgres','public.entity_to_location owner is postgres');
+RETURN NEXT table_owner_is('public','exchangerate','postgres','public.exchangerate owner is postgres');
+RETURN NEXT table_owner_is('public','file_base','postgres','public.file_base owner is postgres');
+RETURN NEXT table_owner_is('public','file_class','postgres','public.file_class owner is postgres');
+RETURN NEXT table_owner_is('public','file_eca','postgres','public.file_eca owner is postgres');
+RETURN NEXT table_owner_is('public','file_entity','postgres','public.file_entity owner is postgres');
+RETURN NEXT table_owner_is('public','file_incoming','postgres','public.file_incoming owner is postgres');
+RETURN NEXT table_owner_is('public','file_internal','postgres','public.file_internal owner is postgres');
+RETURN NEXT table_owner_is('public','file_order','postgres','public.file_order owner is postgres');
+RETURN NEXT table_owner_is('public','file_order_to_order','postgres','public.file_order_to_order owner is postgres');
+RETURN NEXT table_owner_is('public','file_order_to_tx','postgres','public.file_order_to_tx owner is postgres');
+RETURN NEXT table_owner_is('public','file_part','postgres','public.file_part owner is postgres');
+RETURN NEXT table_owner_is('public','file_secondary_attachment','postgres','public.file_secondary_attachment owner is postgres');
+RETURN NEXT table_owner_is('public','file_transaction','postgres','public.file_transaction owner is postgres');
+RETURN NEXT table_owner_is('public','file_tx_to_order','postgres','public.file_tx_to_order owner is postgres');
+RETURN NEXT table_owner_is('public','file_view_catalog','postgres','public.file_view_catalog owner is postgres');
+RETURN NEXT table_owner_is('public','fixes','postgres','public.fixes owner is postgres');
+RETURN NEXT table_owner_is('public','gifi','postgres','public.gifi owner is postgres');
+RETURN NEXT table_owner_is('public','gl','postgres','public.gl owner is postgres');
+RETURN NEXT table_owner_is('public','inventory_report','postgres','public.inventory_report owner is postgres');
+RETURN NEXT table_owner_is('public','inventory_report_line','postgres','public.inventory_report_line owner is postgres');
+RETURN NEXT table_owner_is('public','invoice','postgres','public.invoice owner is postgres');
+RETURN NEXT table_owner_is('public','invoice_note','postgres','public.invoice_note owner is postgres');
+RETURN NEXT table_owner_is('public','invoice_tax_form','postgres','public.invoice_tax_form owner is postgres');
+RETURN NEXT table_owner_is('public','jcitems','postgres','public.jcitems owner is postgres');
+RETURN NEXT table_owner_is('public','jctype','postgres','public.jctype owner is postgres');
+RETURN NEXT table_owner_is('public','job','postgres','public.job owner is postgres');
+RETURN NEXT table_owner_is('public','journal_entry','postgres','public.journal_entry owner is postgres');
+RETURN NEXT table_owner_is('public','journal_line','postgres','public.journal_line owner is postgres');
+RETURN NEXT table_owner_is('public','journal_note','postgres','public.journal_note owner is postgres');
+RETURN NEXT table_owner_is('public','journal_type','postgres','public.journal_type owner is postgres');
+RETURN NEXT table_owner_is('public','language','postgres','public.language owner is postgres');
+RETURN NEXT table_owner_is('public','location','postgres','public.location owner is postgres');
+RETURN NEXT table_owner_is('public','location_class','postgres','public.location_class owner is postgres');
+RETURN NEXT table_owner_is('public','location_class_to_entity_class','postgres','public.location_class_to_entity_class owner is postgres');
+RETURN NEXT table_owner_is('public','lsmb_group','postgres','public.lsmb_group owner is postgres');
+RETURN NEXT table_owner_is('public','lsmb_group_grants','postgres','public.lsmb_group_grants owner is postgres');
+RETURN NEXT table_owner_is('public','lsmb_module','postgres','public.lsmb_module owner is postgres');
+RETURN NEXT table_owner_is('public','lsmb_sequence','postgres','public.lsmb_sequence owner is postgres');
+RETURN NEXT table_owner_is('public','makemodel','postgres','public.makemodel owner is postgres');
+RETURN NEXT table_owner_is('public','menu_acl','postgres','public.menu_acl owner is postgres');
+RETURN NEXT table_owner_is('public','menu_attribute','postgres','public.menu_attribute owner is postgres');
+RETURN NEXT table_owner_is('public','menu_node','postgres','public.menu_node owner is postgres');
+RETURN NEXT table_owner_is('public','mfg_lot','postgres','public.mfg_lot owner is postgres');
+RETURN NEXT table_owner_is('public','mfg_lot_item','postgres','public.mfg_lot_item owner is postgres');
+RETURN NEXT table_owner_is('public','mime_type','postgres','public.mime_type owner is postgres');
+RETURN NEXT table_owner_is('public','new_shipto','postgres','public.new_shipto owner is postgres');
+RETURN NEXT table_owner_is('public','note','postgres','public.note owner is postgres');
+RETURN NEXT table_owner_is('public','note_class','postgres','public.note_class owner is postgres');
+RETURN NEXT table_owner_is('public','oe','postgres','public.oe owner is postgres');
+RETURN NEXT table_owner_is('public','oe_class','postgres','public.oe_class owner is postgres');
+RETURN NEXT table_owner_is('public','open_forms','postgres','public.open_forms owner is postgres');
+RETURN NEXT table_owner_is('public','orderitems','postgres','public.orderitems owner is postgres');
+RETURN NEXT table_owner_is('public','parts','postgres','public.parts owner is postgres');
+RETURN NEXT table_owner_is('public','parts_translation','postgres','public.parts_translation owner is postgres');
+RETURN NEXT table_owner_is('public','partscustomer','postgres','public.partscustomer owner is postgres');
+RETURN NEXT table_owner_is('public','partsgroup','postgres','public.partsgroup owner is postgres');
+RETURN NEXT table_owner_is('public','partsgroup_translation','postgres','public.partsgroup_translation owner is postgres');
+RETURN NEXT table_owner_is('public','partstax','postgres','public.partstax owner is postgres');
+RETURN NEXT table_owner_is('public','partsvendor','postgres','public.partsvendor owner is postgres');
+RETURN NEXT table_owner_is('public','payment','postgres','public.payment owner is postgres');
+RETURN NEXT table_owner_is('public','payment_links','postgres','public.payment_links owner is postgres');
+RETURN NEXT table_owner_is('public','payment_map','postgres','public.payment_map owner is postgres');
+RETURN NEXT table_owner_is('public','payment_type','postgres','public.payment_type owner is postgres');
+RETURN NEXT table_owner_is('public','payroll_deduction','postgres','public.payroll_deduction owner is postgres');
+RETURN NEXT table_owner_is('public','payroll_deduction_class','postgres','public.payroll_deduction_class owner is postgres');
+RETURN NEXT table_owner_is('public','payroll_deduction_type','postgres','public.payroll_deduction_type owner is postgres');
+RETURN NEXT table_owner_is('public','payroll_employee_class','postgres','public.payroll_employee_class owner is postgres');
+RETURN NEXT table_owner_is('public','payroll_employee_class_to_income_type','postgres','public.payroll_employee_class_to_income_type owner is postgres');
+RETURN NEXT table_owner_is('public','payroll_income_category','postgres','public.payroll_income_category owner is postgres');
+RETURN NEXT table_owner_is('public','payroll_income_class','postgres','public.payroll_income_class owner is postgres');
+RETURN NEXT table_owner_is('public','payroll_income_type','postgres','public.payroll_income_type owner is postgres');
+RETURN NEXT table_owner_is('public','payroll_paid_timeoff','postgres','public.payroll_paid_timeoff owner is postgres');
+RETURN NEXT table_owner_is('public','payroll_pto_class','postgres','public.payroll_pto_class owner is postgres');
+RETURN NEXT table_owner_is('public','payroll_report','postgres','public.payroll_report owner is postgres');
+RETURN NEXT table_owner_is('public','payroll_report_line','postgres','public.payroll_report_line owner is postgres');
+RETURN NEXT table_owner_is('public','payroll_wage','postgres','public.payroll_wage owner is postgres');
+RETURN NEXT table_owner_is('public','person','postgres','public.person owner is postgres');
+RETURN NEXT table_owner_is('public','person_to_company','postgres','public.person_to_company owner is postgres');
+RETURN NEXT table_owner_is('public','pricegroup','postgres','public.pricegroup owner is postgres');
+RETURN NEXT table_owner_is('public','recurring','postgres','public.recurring owner is postgres');
+RETURN NEXT table_owner_is('public','recurringemail','postgres','public.recurringemail owner is postgres');
+RETURN NEXT table_owner_is('public','recurringprint','postgres','public.recurringprint owner is postgres');
+RETURN NEXT table_owner_is('public','robot','postgres','public.robot owner is postgres');
+RETURN NEXT table_owner_is('public','salutation','postgres','public.salutation owner is postgres');
+RETURN NEXT table_owner_is('public','session','postgres','public.session owner is postgres');
+RETURN NEXT table_owner_is('public','sic','postgres','public.sic owner is postgres');
+RETURN NEXT table_owner_is('public','status','postgres','public.status owner is postgres');
+RETURN NEXT table_owner_is('public','tax','postgres','public.tax owner is postgres');
+RETURN NEXT table_owner_is('public','tax_extended','postgres','public.tax_extended owner is postgres');
+RETURN NEXT table_owner_is('public','taxcategory','postgres','public.taxcategory owner is postgres');
+RETURN NEXT table_owner_is('public','taxmodule','postgres','public.taxmodule owner is postgres');
+RETURN NEXT table_owner_is('public','template','postgres','public.template owner is postgres');
+RETURN NEXT table_owner_is('public','trans_type','postgres','public.trans_type owner is postgres');
+RETURN NEXT table_owner_is('public','transactions','postgres','public.transactions owner is postgres');
+RETURN NEXT table_owner_is('public','translation','postgres','public.translation owner is postgres');
+RETURN NEXT table_owner_is('public','trial_balance__yearend_types','postgres','public.trial_balance__yearend_types owner is postgres');
+RETURN NEXT table_owner_is('public','user_preference','postgres','public.user_preference owner is postgres');
+RETURN NEXT table_owner_is('public','users','postgres','public.users owner is postgres');
+RETURN NEXT table_owner_is('public','voucher','postgres','public.voucher owner is postgres');
+RETURN NEXT table_owner_is('public','warehouse','postgres','public.warehouse owner is postgres');
+RETURN NEXT table_owner_is('public','warehouse_inventory','postgres','public.warehouse_inventory owner is postgres');
+RETURN NEXT table_owner_is('public','yearend','postgres','public.yearend owner is postgres');
+RETURN NEXT views_are('public', ARRAY[
+    'account_heading_derived_category',
+    'account_heading_descendant',
+    'account_heading_tree',
+    'cash_impact',
+    'employee_search',
+    'employees',
+    'file_links',
+    'file_order_links',
+    'file_tx_links',
+    'menu_friendly',
+    'overpayments',
+    'periods',
+    'recon_payee',
+    'role_view',
+    'tx_report',
+    'user_listable'
+]);
+
+RETURN NEXT view_owner_is('public','account_heading_derived_category','postgres', 'public.account_heading_derived_category owner is postgres');
+RETURN NEXT view_owner_is('public','account_heading_descendant','postgres', 'public.account_heading_descendant owner is postgres');
+RETURN NEXT view_owner_is('public','account_heading_tree','postgres', 'public.account_heading_tree owner is postgres');
+RETURN NEXT view_owner_is('public','cash_impact','postgres', 'public.cash_impact owner is postgres');
+RETURN NEXT view_owner_is('public','employee_search','postgres', 'public.employee_search owner is postgres');
+RETURN NEXT view_owner_is('public','employees','postgres', 'public.employees owner is postgres');
+RETURN NEXT view_owner_is('public','file_links','postgres', 'public.file_links owner is postgres');
+RETURN NEXT view_owner_is('public','file_order_links','postgres', 'public.file_order_links owner is postgres');
+RETURN NEXT view_owner_is('public','file_tx_links','postgres', 'public.file_tx_links owner is postgres');
+RETURN NEXT view_owner_is('public','menu_friendly','postgres', 'public.menu_friendly owner is postgres');
+RETURN NEXT view_owner_is('public','overpayments','postgres', 'public.overpayments owner is postgres');
+RETURN NEXT view_owner_is('public','periods','postgres', 'public.periods owner is postgres');
+RETURN NEXT view_owner_is('public','recon_payee','postgres', 'public.recon_payee owner is postgres');
+RETURN NEXT view_owner_is('public','role_view','postgres', 'public.role_view owner is postgres');
+RETURN NEXT view_owner_is('public','tx_report','postgres', 'public.tx_report owner is postgres');
+RETURN NEXT view_owner_is('public','user_listable','postgres', 'public.user_listable owner is postgres');
+RETURN NEXT sequences_are('public', ARRAY[
+    'acc_trans_entry_id_seq',
+    'account_checkpoint_id_seq',
+    'account_heading_id_seq',
+    'account_id_seq',
+    'asset_class_id_seq',
+    'asset_dep_method_id_seq',
+    'asset_disposal_method_id_seq',
+    'asset_item_id_seq',
+    'asset_report_id_seq',
+    'audittrail_entry_id_seq',
+    'batch_class_id_seq',
+    'batch_id_seq',
+    'budget_info_id_seq',
+    'business_id_seq',
+    'business_unit_class_id_seq',
+    'business_unit_id_seq',
+    'company_id_seq',
+    'contact_class_id_seq',
+    'country_id_seq',
+    'country_tax_form_id_seq',
+    'cr_report_id_seq',
+    'cr_report_line_id_seq',
+    'custom_field_catalog_field_id_seq',
+    'custom_table_catalog_table_id_seq',
+    'employee_class_id_seq',
+    'entity_bank_account_id_seq',
+    'entity_class_id_seq',
+    'entity_credit_account_id_seq',
+    'entity_id_seq',
+    'file_base_id_seq',
+    'file_class_id_seq',
+    'id',
+    'inventory_report_id_seq',
+    'invoice_id_seq',
+    'jcitems_id_seq',
+    'journal_entry_id_seq',
+    'journal_line_id_seq',
+    'journal_type_id_seq',
+    'location_class_id_seq',
+    'location_class_to_entity_class_id_seq',
+    'location_id_seq',
+    'lot_tracking_number',
+    'menu_acl_id_seq',
+    'menu_attribute_id_seq',
+    'menu_node_id_seq',
+    'mfg_lot_id_seq',
+    'mfg_lot_item_id_seq',
+    'mime_type_id_seq',
+    'new_shipto_id_seq',
+    'note_class_id_seq',
+    'note_id_seq',
+    'oe_id_seq',
+    'open_forms_id_seq',
+    'orderitems_id_seq',
+    'parts_id_seq',
+    'partscustomer_entry_id_seq',
+    'partsgroup_id_seq',
+    'partsvendor_entry_id_seq',
+    'payment_id_seq',
+    'payment_type_id_seq',
+    'payroll_deduction_entry_id_seq',
+    'payroll_deduction_type_id_seq',
+    'payroll_employee_class_id_seq',
+    'payroll_income_category_id_seq',
+    'payroll_income_type_id_seq',
+    'payroll_pto_class_id_seq',
+    'payroll_report_id_seq',
+    'payroll_report_line_id_seq',
+    'payroll_wage_entry_id_seq',
+    'person_id_seq',
+    'pricegroup_id_seq',
+    'robot_id_seq',
+    'salutation_id_seq',
+    'session_session_id_seq',
+    'taxcategory_taxcategory_id_seq',
+    'taxmodule_taxmodule_id_seq',
+    'template_id_seq',
+    'users_id_seq',
+    'voucher_id_seq',
+    'warehouse_id_seq',
+    'warehouse_inventory_entry_id_seq'
+]);
+
+RETURN NEXT sequence_owner_is('public','acc_trans_entry_id_seq','postgres','public.acc_trans_entry_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','account_checkpoint_id_seq','postgres','public.account_checkpoint_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','account_heading_id_seq','postgres','public.account_heading_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','account_id_seq','postgres','public.account_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','asset_class_id_seq','postgres','public.asset_class_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','asset_dep_method_id_seq','postgres','public.asset_dep_method_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','asset_disposal_method_id_seq','postgres','public.asset_disposal_method_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','asset_item_id_seq','postgres','public.asset_item_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','asset_report_id_seq','postgres','public.asset_report_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','audittrail_entry_id_seq','postgres','public.audittrail_entry_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','batch_class_id_seq','postgres','public.batch_class_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','batch_id_seq','postgres','public.batch_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','budget_info_id_seq','postgres','public.budget_info_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','business_id_seq','postgres','public.business_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','business_unit_class_id_seq','postgres','public.business_unit_class_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','business_unit_id_seq','postgres','public.business_unit_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','company_id_seq','postgres','public.company_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','contact_class_id_seq','postgres','public.contact_class_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','country_id_seq','postgres','public.country_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','country_tax_form_id_seq','postgres','public.country_tax_form_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','cr_report_id_seq','postgres','public.cr_report_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','cr_report_line_id_seq','postgres','public.cr_report_line_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','custom_field_catalog_field_id_seq','postgres','public.custom_field_catalog_field_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','custom_table_catalog_table_id_seq','postgres','public.custom_table_catalog_table_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','employee_class_id_seq','postgres','public.employee_class_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','entity_bank_account_id_seq','postgres','public.entity_bank_account_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','entity_class_id_seq','postgres','public.entity_class_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','entity_credit_account_id_seq','postgres','public.entity_credit_account_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','entity_id_seq','postgres','public.entity_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','file_base_id_seq','postgres','public.file_base_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','file_class_id_seq','postgres','public.file_class_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','id','postgres','public.id owner is postgres');
+RETURN NEXT sequence_owner_is('public','inventory_report_id_seq','postgres','public.inventory_report_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','invoice_id_seq','postgres','public.invoice_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','jcitems_id_seq','postgres','public.jcitems_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','journal_entry_id_seq','postgres','public.journal_entry_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','journal_line_id_seq','postgres','public.journal_line_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','journal_type_id_seq','postgres','public.journal_type_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','location_class_id_seq','postgres','public.location_class_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','location_class_to_entity_class_id_seq','postgres','public.location_class_to_entity_class_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','location_id_seq','postgres','public.location_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','lot_tracking_number','postgres','public.lot_tracking_number owner is postgres');
+RETURN NEXT sequence_owner_is('public','menu_acl_id_seq','postgres','public.menu_acl_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','menu_attribute_id_seq','postgres','public.menu_attribute_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','menu_node_id_seq','postgres','public.menu_node_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','mfg_lot_id_seq','postgres','public.mfg_lot_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','mfg_lot_item_id_seq','postgres','public.mfg_lot_item_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','mime_type_id_seq','postgres','public.mime_type_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','new_shipto_id_seq','postgres','public.new_shipto_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','note_class_id_seq','postgres','public.note_class_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','note_id_seq','postgres','public.note_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','oe_id_seq','postgres','public.oe_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','open_forms_id_seq','postgres','public.open_forms_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','orderitems_id_seq','postgres','public.orderitems_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','parts_id_seq','postgres','public.parts_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','partscustomer_entry_id_seq','postgres','public.partscustomer_entry_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','partsgroup_id_seq','postgres','public.partsgroup_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','partsvendor_entry_id_seq','postgres','public.partsvendor_entry_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','payment_id_seq','postgres','public.payment_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','payment_type_id_seq','postgres','public.payment_type_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','payroll_deduction_entry_id_seq','postgres','public.payroll_deduction_entry_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','payroll_deduction_type_id_seq','postgres','public.payroll_deduction_type_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','payroll_employee_class_id_seq','postgres','public.payroll_employee_class_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','payroll_income_category_id_seq','postgres','public.payroll_income_category_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','payroll_income_type_id_seq','postgres','public.payroll_income_type_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','payroll_pto_class_id_seq','postgres','public.payroll_pto_class_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','payroll_report_id_seq','postgres','public.payroll_report_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','payroll_report_line_id_seq','postgres','public.payroll_report_line_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','payroll_wage_entry_id_seq','postgres','public.payroll_wage_entry_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','person_id_seq','postgres','public.person_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','pricegroup_id_seq','postgres','public.pricegroup_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','robot_id_seq','postgres','public.robot_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','salutation_id_seq','postgres','public.salutation_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','session_session_id_seq','postgres','public.session_session_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','taxcategory_taxcategory_id_seq','postgres','public.taxcategory_taxcategory_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','taxmodule_taxmodule_id_seq','postgres','public.taxmodule_taxmodule_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','template_id_seq','postgres','public.template_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','users_id_seq','postgres','public.users_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','voucher_id_seq','postgres','public.voucher_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','warehouse_id_seq','postgres','public.warehouse_id_seq owner is postgres');
+RETURN NEXT sequence_owner_is('public','warehouse_inventory_entry_id_seq','postgres','public.warehouse_inventory_entry_id_seq owner is postgres');
+RETURN NEXT functions_are('public', ARRAY[
+    '_entity_location_save',
+    'account__all_headings',
+    'account__delete',
+    'account__delete_translation',
+    'account__get_by_link_desc',
+    'account__get_from_accno',
+    'account__get_taxes',
+    'account__is_recon',
+    'account__list_by_heading',
+    'account__list_translations',
+    'account__obtain_balance',
+    'account__obtain_starting_balance',
+    'account__save',
+    'account__save_tax',
+    'account__save_translation',
+    'account_get',
+    'account_has_transactions',
+    'account_heading__check_tree',
+    'account_heading__delete',
+    'account_heading__delete_translation',
+    'account_heading__list',
+    'account_heading__list_translations',
+    'account_heading__save_translation',
+    'account_heading_get',
+    'account_heading_list',
+    'account_heading_save',
+    'add_custom_field',
+    'admin__add_function_to_group',
+    'admin__add_group_to_role',
+    'admin__add_user_to_role',
+    'admin__create_group',
+    'admin__delete_group',
+    'admin__delete_user',
+    'admin__drop_session',
+    'admin__get_roles',
+    'admin__get_roles_for_user',
+    'admin__get_roles_for_user_by_entity',
+    'admin__get_user',
+    'admin__get_user_by_entity',
+    'admin__is_group',
+    'admin__is_user',
+    'admin__list_group_grants',
+    'admin__list_sessions',
+    'admin__remove_function_from_group',
+    'admin__remove_group_from_role',
+    'admin__remove_user_from_role',
+    'admin__save_user',
+    'admin__search_users',
+    'ap_simple_post',
+    'ar_ap__transaction_search',
+    'ar_ap__transaction_search_summary',
+    'array_endswith',
+    'array_splice_from',
+    'array_splice_to',
+    'as_array',
+    'assembly__stock',
+    'asset__get',
+    'asset__import_from_disposal',
+    'asset__save',
+    'asset__search',
+    'asset_class__get',
+    'asset_class__get_asset_accounts',
+    'asset_class__get_dep_accounts',
+    'asset_class__get_dep_method',
+    'asset_class__get_dep_methods',
+    'asset_class__list',
+    'asset_class__save',
+    'asset_class__search',
+    'asset_dep__straight_line_base',
+    'asset_dep__used_months',
+    'asset_dep_get_usable_life_yr',
+    'asset_dep_straight_line_month',
+    'asset_dep_straight_line_yr_d',
+    'asset_dep_straight_line_yr_m',
+    'asset_depreciation__approve',
+    'asset_disposal__approve',
+    'asset_item__add_note',
+    'asset_item__search',
+    'asset_nbv_report',
+    'asset_report__approve',
+    'asset_report__begin_disposal',
+    'asset_report__begin_import',
+    'asset_report__disposal_gl',
+    'asset_report__dispose',
+    'asset_report__generate',
+    'asset_report__generate_gl',
+    'asset_report__get',
+    'asset_report__get_disposal',
+    'asset_report__get_disposal_methods',
+    'asset_report__get_expense_accts',
+    'asset_report__get_gain_accts',
+    'asset_report__get_lines',
+    'asset_report__get_loss_accts',
+    'asset_report__import',
+    'asset_report__record_approve',
+    'asset_report__save',
+    'asset_report__search',
+    'asset_report_partial_disposal_details',
+    'avgcost',
+    'batch__lock',
+    'batch__lock_for_update',
+    'batch__search',
+    'batch__unlock',
+    'batch_create',
+    'batch_delete',
+    'batch_get_class_id',
+    'batch_get_users',
+    'batch_list_classes',
+    'batch_post',
+    'batch_search_empty',
+    'batch_search_mini',
+    'budget__approve',
+    'budget__get_business_units',
+    'budget__get_details',
+    'budget__get_info',
+    'budget__get_notes',
+    'budget__mark_obsolete',
+    'budget__reject',
+    'budget__save_details',
+    'budget__save_info',
+    'budget__save_note',
+    'budget__search',
+    'budget__variance_report',
+    'business_type__list',
+    'business_unit__get',
+    'business_unit__get_tree_for',
+    'business_unit__list_by_class',
+    'business_unit__list_classes',
+    'business_unit__save',
+    'business_unit_class__get_modules',
+    'business_unit_class__save',
+    'business_unit_class__save_modules',
+    'business_unit_get',
+    'chart_get_ar_ap',
+    'chart_list_all',
+    'chart_list_cash',
+    'chart_list_discount',
+    'chart_list_overpayment',
+    'chart_list_search',
+    'check_expiration',
+    'cogs__add_for_ap',
+    'cogs__add_for_ap_line',
+    'cogs__add_for_ar',
+    'cogs__add_for_ar_line',
+    'cogs__reverse_ap',
+    'cogs__reverse_ar',
+    'company__get',
+    'company__get_all_accounts',
+    'company__get_by_cc',
+    'company__next_id',
+    'company__save',
+    'company_get_billing_info',
+    'compound_array',
+    'concat_colon',
+    'concat_colon',
+    'contact__search',
+    'contact_class__list',
+    'cr_coa_to_account_save',
+    'cr_report_block_changing_approved',
+    'currency_get_exchangerate',
+    'customer_location_save',
+    'date_get_all_years',
+    'days_in_month',
+    'deduction__list_for_entity',
+    'deduction__list_types',
+    'deduction__save',
+    'defaults__get_contra_accounts',
+    'defaults_get_defaultcurrency',
+    'del_recurring',
+    'del_yearend',
+    'draft__search',
+    'draft_approve',
+    'draft_delete',
+    'drop_custom_field',
+    'eca__delete_contact',
+    'eca__delete_location',
+    'eca__delete_pricematrix',
+    'eca__get_by_meta_number',
+    'eca__get_entity',
+    'eca__get_pricematrix',
+    'eca__get_pricematrix_by_pricegroup',
+    'eca__get_taxes',
+    'eca__history',
+    'eca__history_summary',
+    'eca__list_contacts',
+    'eca__list_locations',
+    'eca__list_notes',
+    'eca__location_save',
+    'eca__save',
+    'eca__save_contact',
+    'eca__save_notes',
+    'eca__save_pricematrix',
+    'eca__set_taxes',
+    'eca_bu_trigger',
+    'employee__all_managers',
+    'employee__all_salespeople',
+    'employee__get',
+    'employee__get_user',
+    'employee__list_managers',
+    'employee__save',
+    'employee__search',
+    'employee_search',
+    'entity__delete_bank_account',
+    'entity__delete_contact',
+    'entity__delete_location',
+    'entity__get',
+    'entity__get_bank_account',
+    'entity__list_bank_account',
+    'entity__list_classes',
+    'entity__list_contacts',
+    'entity__list_credit',
+    'entity__list_locations',
+    'entity__list_notes',
+    'entity__location_save',
+    'entity__save_bank_account',
+    'entity__save_contact',
+    'entity__save_notes',
+    'entity_credit__get',
+    'entity_credit_get_id',
+    'entity_credit_get_id_by_meta_number',
+    'entity_save',
+    'eoy__latest_checkpoint',
+    'eoy__reopen_books_at',
+    'eoy_close_books',
+    'eoy_create_checkpoint',
+    'eoy_earnings_accounts',
+    'eoy_reopen_books',
+    'eoy_zero_accounts',
+    'file__attach_to_eca',
+    'file__attach_to_entity',
+    'file__attach_to_order',
+    'file__attach_to_part',
+    'file__attach_to_tx',
+    'file__get',
+    'file__get_for_template',
+    'file__get_mime_type',
+    'file__list_by',
+    'file__list_links',
+    'file__save_incoming',
+    'file__save_internal',
+    'file_links_vrebuild',
+    'form_check',
+    'form_close',
+    'form_open',
+    'full_ilike_match',
+    'get_default_lang',
+    'get_fractional_month',
+    'get_fractional_year',
+    'get_link_descriptions',
+    'gifi__list',
+    'gl_audit_trail_append',
+    'goods__history',
+    'goods__search',
+    'in_tree',
+    'in_tree',
+    'inventory__activity',
+    'inventory__get_item_by_id',
+    'inventory__get_item_by_partnumber',
+    'inventory__search_part',
+    'inventory_adjust__approve',
+    'inventory_adjust__create',
+    'inventory_adjust__delete',
+    'inventory_adjust__get',
+    'inventory_adjust__get_lines',
+    'inventory_adjust__list',
+    'inventory_adjust__save_info',
+    'inventory_adjust__save_line',
+    'inventory_adjust__search',
+    'inventory_get_item_at_day',
+    'invoice__get_by_vendor_number',
+    'is_leapyear',
+    'is_same_month',
+    'is_same_year',
+    'journal__add',
+    'journal__add_line',
+    'journal__delete',
+    'journal__get_entry',
+    'journal__get_invoice',
+    'journal__lines',
+    'journal__make_invoice',
+    'journal__save_recurring_print',
+    'journal__search',
+    'journal__validate_entry',
+    'lastcost',
+    'leap_days',
+    'list_taxforms',
+    'location__get',
+    'location_delete',
+    'location_list_class',
+    'location_list_country',
+    'location_save',
+    'lock_record',
+    'lsmb__backup_roles',
+    'lsmb__clear_role_backup',
+    'lsmb__create_role',
+    'lsmb__decompose_timestamp',
+    'lsmb__global_role',
+    'lsmb__grant_exec',
+    'lsmb__grant_menu',
+    'lsmb__grant_perms',
+    'lsmb__grant_perms',
+    'lsmb__grant_role',
+    'lsmb__is_allowed_role',
+    'lsmb__max_date',
+    'lsmb__min_date',
+    'lsmb__restore_roles',
+    'lsmb__role',
+    'lsmb__role_prefix',
+    'lsmb_module__get',
+    'lsmb_module__list',
+    'menu_children',
+    'menu_generate',
+    'menu_insert',
+    'mfg_lot__commit',
+    'months_passed',
+    'next_leap_year_calc',
+    'order__combine',
+    'order__search',
+    'overpayment__reverse',
+    'parse_date',
+    'part__get_by_id',
+    'parts__get_by_id',
+    'parts__get_by_partnumber',
+    'parts__search_lite',
+    'partsgroup__search',
+    'payment__get_gl',
+    'payment__overpayments_list',
+    'payment__reverse',
+    'payment__search',
+    'payment_bulk_post',
+    'payment_gather_header_info',
+    'payment_gather_line_info',
+    'payment_get_all_accounts',
+    'payment_get_all_contact_invoices',
+    'payment_get_available_overpayment_amount',
+    'payment_get_entity_account_payment_info',
+    'payment_get_entity_accounts',
+    'payment_get_open_accounts',
+    'payment_get_open_invoice',
+    'payment_get_open_invoices',
+    'payment_get_open_overpayment_entities',
+    'payment_get_unused_overpayment',
+    'payment_get_vc_info',
+    'payment_post',
+    'payment_type__get_label',
+    'payment_type__list',
+    'payments_get_open_currencies',
+    'payments_set_exchangerate',
+    'payroll_deduction_type__search',
+    'payroll_income_category__list',
+    'payroll_income_class__for_country',
+    'payroll_income_type__get',
+    'payroll_income_type__save',
+    'payroll_income_type__search',
+    'periods_get',
+    'person__delete_contact',
+    'person__delete_location',
+    'person__get',
+    'person__get_by_cc',
+    'person__get_my_entity_id',
+    'person__get_my_id',
+    'person__list_bank_account',
+    'person__list_contacts',
+    'person__list_languages',
+    'person__list_locations',
+    'person__list_notes',
+    'person__list_salutations',
+    'person__save',
+    'person__save_contact',
+    'person__save_location',
+    'pnl__customer',
+    'pnl__income_statement_accrual',
+    'pnl__income_statement_cash',
+    'pnl__invoice',
+    'pnl__product',
+    'prevent_closed_transactions',
+    'pricegroup__list',
+    'pricegroup__search',
+    'pricegroups__list',
+    'pricelist__delete',
+    'pricelist__save',
+    'pricematrix__for_customer',
+    'pricematrix__for_vendor',
+    'quote_ident_array',
+    'reconciliation__account_list',
+    'reconciliation__add_entry',
+    'reconciliation__check',
+    'reconciliation__check_balanced',
+    'reconciliation__delete_my_report',
+    'reconciliation__delete_unapproved',
+    'reconciliation__get_cleared_balance',
+    'reconciliation__get_current_balance',
+    'reconciliation__new_report_id',
+    'reconciliation__pending_transactions',
+    'reconciliation__previous_report_date',
+    'reconciliation__reject_set',
+    'reconciliation__report_approve',
+    'reconciliation__report_details',
+    'reconciliation__report_details_payee',
+    'reconciliation__report_details_payee_with_days',
+    'reconciliation__report_summary',
+    'reconciliation__save_set',
+    'reconciliation__search',
+    'reconciliation__submit_set',
+    'report__aa_outstanding',
+    'report__aa_outstanding_details',
+    'report__aa_transactions',
+    'report__balance_sheet',
+    'report__cash_summary',
+    'report__coa',
+    'report__general_balance',
+    'report__gl',
+    'report__incoming_cogs_line',
+    'report__invoice_aging_detail',
+    'report__invoice_aging_summary',
+    'report_trial_balance',
+    'robot__get',
+    'robot__get_by_cc',
+    'robot__get_my_entity_id',
+    'robot__list_notes',
+    'robot__save',
+    'save_taxform',
+    'sequence__delete',
+    'sequence__get',
+    'sequence__increment',
+    'sequence__list',
+    'sequence__list_by_key',
+    'sequence__save',
+    'session_check',
+    'session_create',
+    'session_delete',
+    'setting__get_currencies',
+    'setting__increment_base',
+    'setting__set',
+    'setting_get',
+    'setting_get_default_accounts',
+    'setting_increment',
+    'sic__list',
+    'tax_form__get',
+    'tax_form__list_all',
+    'tax_form__list_ext',
+    'tax_form__save',
+    'tax_form_details_report',
+    'tax_form_details_report_accrual',
+    'tax_form_summary_report',
+    'tax_form_summary_report_accrual',
+    'template__get',
+    'template__get_by_id',
+    'template__list',
+    'template__save',
+    'tg_enforce_perms_eclass',
+    'timecard__allocate',
+    'timecard__bu_class',
+    'timecard__get',
+    'timecard__parts',
+    'timecard__report',
+    'timecard__save',
+    'timecard_type__get',
+    'timecard_type__list',
+    'to_args',
+    'to_args',
+    'track_global_sequence',
+    'trial_balance__generate',
+    'trial_balance__heading_accounts',
+    'trial_balance__list_headings',
+    'trigger_parts_short',
+    'unlock',
+    'unlock_all',
+    'user__change_password',
+    'user__check_my_expiration',
+    'user__expires_soon',
+    'user__get_all_users',
+    'user__get_preferences',
+    'user__save_preferences',
+    'voucher__delete',
+    'voucher__list',
+    'voucher_get_batch',
+    'wage__list_for_entity',
+    'wage__list_types',
+    'wage__save',
+    'warehouse__list',
+    'warehouse__list_all'
+]);
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.ac_tax_form.sql.pg_include
+++ b/xt/pgtap/table_public.ac_tax_form.sql.pg_include
@@ -1,0 +1,32 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_ac_tax_form()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'ac_tax_form',
+    'Should have table public.ac_tax_form'
+);
+
+RETURN NEXT has_pk(
+    'public', 'ac_tax_form',
+    'Table public.ac_tax_form should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'ac_tax_form'::name, ARRAY[
+    'entry_id'::name,
+    'reportable'::name
+]);
+
+RETURN NEXT has_column(       'public', 'ac_tax_form', 'entry_id', 'Column public.ac_tax_form.entry_id should exist');
+RETURN NEXT col_type_is(      'public', 'ac_tax_form', 'entry_id', 'integer', 'Column public.ac_tax_form.entry_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'ac_tax_form', 'entry_id', 'Column public.ac_tax_form.entry_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'ac_tax_form', 'entry_id', 'Column public.ac_tax_form.entry_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'ac_tax_form', 'reportable', 'Column public.ac_tax_form.reportable should exist');
+RETURN NEXT col_type_is(      'public', 'ac_tax_form', 'reportable', 'boolean', 'Column public.ac_tax_form.reportable should be type boolean');
+RETURN NEXT col_is_null(      'public', 'ac_tax_form', 'reportable', 'Column public.ac_tax_form.reportable should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ac_tax_form', 'reportable', 'Column public.ac_tax_form.reportable should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.acc_trans.sql.pg_include
+++ b/xt/pgtap/table_public.acc_trans.sql.pg_include
@@ -1,0 +1,109 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_acc_trans()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'acc_trans',
+    'Should have table public.acc_trans'
+);
+
+RETURN NEXT has_pk(
+    'public', 'acc_trans',
+    'Table public.acc_trans should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'acc_trans'::name, ARRAY[
+    'trans_id'::name,
+    'chart_id'::name,
+    'amount'::name,
+    'transdate'::name,
+    'source'::name,
+    'cleared'::name,
+    'fx_transaction'::name,
+    'memo'::name,
+    'invoice_id'::name,
+    'approved'::name,
+    'cleared_on'::name,
+    'reconciled_on'::name,
+    'voucher_id'::name,
+    'entry_id'::name
+]);
+
+RETURN NEXT has_column(       'public', 'acc_trans', 'trans_id', 'Column public.acc_trans.trans_id should exist');
+RETURN NEXT col_type_is(      'public', 'acc_trans', 'trans_id', 'integer', 'Column public.acc_trans.trans_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'acc_trans', 'trans_id', 'Column public.acc_trans.trans_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'acc_trans', 'trans_id', 'Column public.acc_trans.trans_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'acc_trans', 'chart_id', 'Column public.acc_trans.chart_id should exist');
+RETURN NEXT col_type_is(      'public', 'acc_trans', 'chart_id', 'integer', 'Column public.acc_trans.chart_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'acc_trans', 'chart_id', 'Column public.acc_trans.chart_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'acc_trans', 'chart_id', 'Column public.acc_trans.chart_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'acc_trans', 'amount', 'Column public.acc_trans.amount should exist');
+RETURN NEXT col_type_is(      'public', 'acc_trans', 'amount', 'numeric', 'Column public.acc_trans.amount should be type numeric');
+RETURN NEXT col_not_null(     'public', 'acc_trans', 'amount', 'Column public.acc_trans.amount should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'acc_trans', 'amount', 'Column public.acc_trans.amount should not have a default');
+
+RETURN NEXT has_column(       'public', 'acc_trans', 'transdate', 'Column public.acc_trans.transdate should exist');
+RETURN NEXT col_type_is(      'public', 'acc_trans', 'transdate', 'date', 'Column public.acc_trans.transdate should be type date');
+RETURN NEXT col_is_null(      'public', 'acc_trans', 'transdate', 'Column public.acc_trans.transdate should allow NULL');
+RETURN NEXT col_has_default(  'public', 'acc_trans', 'transdate', 'Column public.acc_trans.transdate shouldhave a default');
+--SELECT col_default_is(   'public', 'acc_trans', 'transdate', '(''now''::text)::date', 'Column public.acc_trans.transdate default is');RETURN NEXT col_default_is(   'public', 'acc_trans', 'transdate', '(''now''::text)::date', 'Column public.acc_trans.transdate default is');
+
+RETURN NEXT has_column(       'public', 'acc_trans', 'source', 'Column public.acc_trans.source should exist');
+RETURN NEXT col_type_is(      'public', 'acc_trans', 'source', 'text', 'Column public.acc_trans.source should be type text');
+RETURN NEXT col_is_null(      'public', 'acc_trans', 'source', 'Column public.acc_trans.source should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'acc_trans', 'source', 'Column public.acc_trans.source should not have a default');
+
+RETURN NEXT has_column(       'public', 'acc_trans', 'cleared', 'Column public.acc_trans.cleared should exist');
+RETURN NEXT col_type_is(      'public', 'acc_trans', 'cleared', 'boolean', 'Column public.acc_trans.cleared should be type boolean');
+RETURN NEXT col_is_null(      'public', 'acc_trans', 'cleared', 'Column public.acc_trans.cleared should allow NULL');
+RETURN NEXT col_has_default(  'public', 'acc_trans', 'cleared', 'Column public.acc_trans.cleared shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'acc_trans', 'cleared', 'false', 'Column public.acc_trans.cleared default is');
+
+RETURN NEXT has_column(       'public', 'acc_trans', 'fx_transaction', 'Column public.acc_trans.fx_transaction should exist');
+RETURN NEXT col_type_is(      'public', 'acc_trans', 'fx_transaction', 'boolean', 'Column public.acc_trans.fx_transaction should be type boolean');
+RETURN NEXT col_is_null(      'public', 'acc_trans', 'fx_transaction', 'Column public.acc_trans.fx_transaction should allow NULL');
+RETURN NEXT col_has_default(  'public', 'acc_trans', 'fx_transaction', 'Column public.acc_trans.fx_transaction shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'acc_trans', 'fx_transaction', 'false', 'Column public.acc_trans.fx_transaction default is');
+
+RETURN NEXT has_column(       'public', 'acc_trans', 'memo', 'Column public.acc_trans.memo should exist');
+RETURN NEXT col_type_is(      'public', 'acc_trans', 'memo', 'text', 'Column public.acc_trans.memo should be type text');
+RETURN NEXT col_is_null(      'public', 'acc_trans', 'memo', 'Column public.acc_trans.memo should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'acc_trans', 'memo', 'Column public.acc_trans.memo should not have a default');
+
+RETURN NEXT has_column(       'public', 'acc_trans', 'invoice_id', 'Column public.acc_trans.invoice_id should exist');
+RETURN NEXT col_type_is(      'public', 'acc_trans', 'invoice_id', 'integer', 'Column public.acc_trans.invoice_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'acc_trans', 'invoice_id', 'Column public.acc_trans.invoice_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'acc_trans', 'invoice_id', 'Column public.acc_trans.invoice_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'acc_trans', 'approved', 'Column public.acc_trans.approved should exist');
+RETURN NEXT col_type_is(      'public', 'acc_trans', 'approved', 'boolean', 'Column public.acc_trans.approved should be type boolean');
+RETURN NEXT col_is_null(      'public', 'acc_trans', 'approved', 'Column public.acc_trans.approved should allow NULL');
+RETURN NEXT col_has_default(  'public', 'acc_trans', 'approved', 'Column public.acc_trans.approved shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'acc_trans', 'approved', 'true', 'Column public.acc_trans.approved default is');
+
+RETURN NEXT has_column(       'public', 'acc_trans', 'cleared_on', 'Column public.acc_trans.cleared_on should exist');
+RETURN NEXT col_type_is(      'public', 'acc_trans', 'cleared_on', 'date', 'Column public.acc_trans.cleared_on should be type date');
+RETURN NEXT col_is_null(      'public', 'acc_trans', 'cleared_on', 'Column public.acc_trans.cleared_on should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'acc_trans', 'cleared_on', 'Column public.acc_trans.cleared_on should not have a default');
+
+RETURN NEXT has_column(       'public', 'acc_trans', 'reconciled_on', 'Column public.acc_trans.reconciled_on should exist');
+RETURN NEXT col_type_is(      'public', 'acc_trans', 'reconciled_on', 'date', 'Column public.acc_trans.reconciled_on should be type date');
+RETURN NEXT col_is_null(      'public', 'acc_trans', 'reconciled_on', 'Column public.acc_trans.reconciled_on should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'acc_trans', 'reconciled_on', 'Column public.acc_trans.reconciled_on should not have a default');
+
+RETURN NEXT has_column(       'public', 'acc_trans', 'voucher_id', 'Column public.acc_trans.voucher_id should exist');
+RETURN NEXT col_type_is(      'public', 'acc_trans', 'voucher_id', 'integer', 'Column public.acc_trans.voucher_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'acc_trans', 'voucher_id', 'Column public.acc_trans.voucher_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'acc_trans', 'voucher_id', 'Column public.acc_trans.voucher_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'acc_trans', 'entry_id', 'Column public.acc_trans.entry_id should exist');
+RETURN NEXT col_type_is(      'public', 'acc_trans', 'entry_id', 'integer', 'Column public.acc_trans.entry_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'acc_trans', 'entry_id', 'Column public.acc_trans.entry_id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'acc_trans', 'entry_id', 'Column public.acc_trans.entry_id shouldhave a default');
+--SELECT col_default_is(   'public', 'acc_trans', 'entry_id', 'nextval(''acc_trans_entry_id_seq''::regclass)', 'Column public.acc_trans.entry_id default is');RETURN NEXT col_default_is(   'public', 'acc_trans', 'entry_id', 'nextval(''acc_trans_entry_id_seq''::regclass)', 'Column public.acc_trans.entry_id default is');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.account.sql.pg_include
+++ b/xt/pgtap/table_public.account.sql.pg_include
@@ -1,0 +1,85 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_account()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'account',
+    'Should have table public.account'
+);
+
+RETURN NEXT has_pk(
+    'public', 'account',
+    'Table public.account should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'account'::name, ARRAY[
+    'id'::name,
+    'accno'::name,
+    'description'::name,
+    'is_temp'::name,
+    'category'::name,
+    'gifi_accno'::name,
+    'heading'::name,
+    'contra'::name,
+    'tax'::name,
+    'obsolete'::name
+]);
+
+RETURN NEXT has_column(       'public', 'account', 'id', 'Column public.account.id should exist');
+RETURN NEXT col_type_is(      'public', 'account', 'id', 'integer', 'Column public.account.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'account', 'id', 'Column public.account.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'account', 'id', 'Column public.account.id shouldhave a default');
+--SELECT col_default_is(   'public', 'account', 'id', 'nextval(''account_id_seq''::regclass)', 'Column public.account.id default is');RETURN NEXT col_default_is(   'public', 'account', 'id', 'nextval(''account_id_seq''::regclass)', 'Column public.account.id default is');
+
+RETURN NEXT has_column(       'public', 'account', 'accno', 'Column public.account.accno should exist');
+RETURN NEXT col_type_is(      'public', 'account', 'accno', 'text', 'Column public.account.accno should be type text');
+RETURN NEXT col_not_null(     'public', 'account', 'accno', 'Column public.account.accno should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'account', 'accno', 'Column public.account.accno should not have a default');
+
+RETURN NEXT has_column(       'public', 'account', 'description', 'Column public.account.description should exist');
+RETURN NEXT col_type_is(      'public', 'account', 'description', 'text', 'Column public.account.description should be type text');
+RETURN NEXT col_is_null(      'public', 'account', 'description', 'Column public.account.description should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'account', 'description', 'Column public.account.description should not have a default');
+
+RETURN NEXT has_column(       'public', 'account', 'is_temp', 'Column public.account.is_temp should exist');
+RETURN NEXT col_type_is(      'public', 'account', 'is_temp', 'boolean', 'Column public.account.is_temp should be type boolean');
+RETURN NEXT col_not_null(     'public', 'account', 'is_temp', 'Column public.account.is_temp should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'account', 'is_temp', 'Column public.account.is_temp shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'account', 'is_temp', 'false', 'Column public.account.is_temp default is');
+
+RETURN NEXT has_column(       'public', 'account', 'category', 'Column public.account.category should exist');
+RETURN NEXT col_type_is(      'public', 'account', 'category', 'character(1)', 'Column public.account.category should be type character(1)');
+RETURN NEXT col_not_null(     'public', 'account', 'category', 'Column public.account.category should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'account', 'category', 'Column public.account.category should not have a default');
+
+RETURN NEXT has_column(       'public', 'account', 'gifi_accno', 'Column public.account.gifi_accno should exist');
+RETURN NEXT col_type_is(      'public', 'account', 'gifi_accno', 'text', 'Column public.account.gifi_accno should be type text');
+RETURN NEXT col_is_null(      'public', 'account', 'gifi_accno', 'Column public.account.gifi_accno should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'account', 'gifi_accno', 'Column public.account.gifi_accno should not have a default');
+
+RETURN NEXT has_column(       'public', 'account', 'heading', 'Column public.account.heading should exist');
+RETURN NEXT col_type_is(      'public', 'account', 'heading', 'integer', 'Column public.account.heading should be type integer');
+RETURN NEXT col_not_null(     'public', 'account', 'heading', 'Column public.account.heading should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'account', 'heading', 'Column public.account.heading should not have a default');
+
+RETURN NEXT has_column(       'public', 'account', 'contra', 'Column public.account.contra should exist');
+RETURN NEXT col_type_is(      'public', 'account', 'contra', 'boolean', 'Column public.account.contra should be type boolean');
+RETURN NEXT col_not_null(     'public', 'account', 'contra', 'Column public.account.contra should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'account', 'contra', 'Column public.account.contra shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'account', 'contra', 'false', 'Column public.account.contra default is');
+
+RETURN NEXT has_column(       'public', 'account', 'tax', 'Column public.account.tax should exist');
+RETURN NEXT col_type_is(      'public', 'account', 'tax', 'boolean', 'Column public.account.tax should be type boolean');
+RETURN NEXT col_not_null(     'public', 'account', 'tax', 'Column public.account.tax should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'account', 'tax', 'Column public.account.tax shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'account', 'tax', 'false', 'Column public.account.tax default is');
+
+RETURN NEXT has_column(       'public', 'account', 'obsolete', 'Column public.account.obsolete should exist');
+RETURN NEXT col_type_is(      'public', 'account', 'obsolete', 'boolean', 'Column public.account.obsolete should be type boolean');
+RETURN NEXT col_not_null(     'public', 'account', 'obsolete', 'Column public.account.obsolete should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'account', 'obsolete', 'Column public.account.obsolete shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'account', 'obsolete', 'false', 'Column public.account.obsolete default is');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.account_checkpoint.sql.pg_include
+++ b/xt/pgtap/table_public.account_checkpoint.sql.pg_include
@@ -1,0 +1,57 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_account_checkpoint()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'account_checkpoint',
+    'Should have table public.account_checkpoint'
+);
+
+RETURN NEXT has_pk(
+    'public', 'account_checkpoint',
+    'Table public.account_checkpoint should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'account_checkpoint'::name, ARRAY[
+    'end_date'::name,
+    'account_id'::name,
+    'amount'::name,
+    'id'::name,
+    'debits'::name,
+    'credits'::name
+]);
+
+RETURN NEXT has_column(       'public', 'account_checkpoint', 'end_date', 'Column public.account_checkpoint.end_date should exist');
+RETURN NEXT col_type_is(      'public', 'account_checkpoint', 'end_date', 'date', 'Column public.account_checkpoint.end_date should be type date');
+RETURN NEXT col_not_null(     'public', 'account_checkpoint', 'end_date', 'Column public.account_checkpoint.end_date should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'account_checkpoint', 'end_date', 'Column public.account_checkpoint.end_date should not have a default');
+
+RETURN NEXT has_column(       'public', 'account_checkpoint', 'account_id', 'Column public.account_checkpoint.account_id should exist');
+RETURN NEXT col_type_is(      'public', 'account_checkpoint', 'account_id', 'integer', 'Column public.account_checkpoint.account_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'account_checkpoint', 'account_id', 'Column public.account_checkpoint.account_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'account_checkpoint', 'account_id', 'Column public.account_checkpoint.account_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'account_checkpoint', 'amount', 'Column public.account_checkpoint.amount should exist');
+RETURN NEXT col_type_is(      'public', 'account_checkpoint', 'amount', 'numeric', 'Column public.account_checkpoint.amount should be type numeric');
+RETURN NEXT col_not_null(     'public', 'account_checkpoint', 'amount', 'Column public.account_checkpoint.amount should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'account_checkpoint', 'amount', 'Column public.account_checkpoint.amount should not have a default');
+
+RETURN NEXT has_column(       'public', 'account_checkpoint', 'id', 'Column public.account_checkpoint.id should exist');
+RETURN NEXT col_type_is(      'public', 'account_checkpoint', 'id', 'integer', 'Column public.account_checkpoint.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'account_checkpoint', 'id', 'Column public.account_checkpoint.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'account_checkpoint', 'id', 'Column public.account_checkpoint.id shouldhave a default');
+--SELECT col_default_is(   'public', 'account_checkpoint', 'id', 'nextval(''account_checkpoint_id_seq''::regclass)', 'Column public.account_checkpoint.id default is');RETURN NEXT col_default_is(   'public', 'account_checkpoint', 'id', 'nextval(''account_checkpoint_id_seq''::regclass)', 'Column public.account_checkpoint.id default is');
+
+RETURN NEXT has_column(       'public', 'account_checkpoint', 'debits', 'Column public.account_checkpoint.debits should exist');
+RETURN NEXT col_type_is(      'public', 'account_checkpoint', 'debits', 'numeric', 'Column public.account_checkpoint.debits should be type numeric');
+RETURN NEXT col_is_null(      'public', 'account_checkpoint', 'debits', 'Column public.account_checkpoint.debits should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'account_checkpoint', 'debits', 'Column public.account_checkpoint.debits should not have a default');
+
+RETURN NEXT has_column(       'public', 'account_checkpoint', 'credits', 'Column public.account_checkpoint.credits should exist');
+RETURN NEXT col_type_is(      'public', 'account_checkpoint', 'credits', 'numeric', 'Column public.account_checkpoint.credits should be type numeric');
+RETURN NEXT col_is_null(      'public', 'account_checkpoint', 'credits', 'Column public.account_checkpoint.credits should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'account_checkpoint', 'credits', 'Column public.account_checkpoint.credits should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.account_heading.sql.pg_include
+++ b/xt/pgtap/table_public.account_heading.sql.pg_include
@@ -1,0 +1,51 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_account_heading()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'account_heading',
+    'Should have table public.account_heading'
+);
+
+RETURN NEXT has_pk(
+    'public', 'account_heading',
+    'Table public.account_heading should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'account_heading'::name, ARRAY[
+    'id'::name,
+    'accno'::name,
+    'parent_id'::name,
+    'description'::name,
+    'category'::name
+]);
+
+RETURN NEXT has_column(       'public', 'account_heading', 'id', 'Column public.account_heading.id should exist');
+RETURN NEXT col_type_is(      'public', 'account_heading', 'id', 'integer', 'Column public.account_heading.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'account_heading', 'id', 'Column public.account_heading.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'account_heading', 'id', 'Column public.account_heading.id shouldhave a default');
+--SELECT col_default_is(   'public', 'account_heading', 'id', 'nextval(''account_heading_id_seq''::regclass)', 'Column public.account_heading.id default is');RETURN NEXT col_default_is(   'public', 'account_heading', 'id', 'nextval(''account_heading_id_seq''::regclass)', 'Column public.account_heading.id default is');
+
+RETURN NEXT has_column(       'public', 'account_heading', 'accno', 'Column public.account_heading.accno should exist');
+RETURN NEXT col_type_is(      'public', 'account_heading', 'accno', 'text', 'Column public.account_heading.accno should be type text');
+RETURN NEXT col_not_null(     'public', 'account_heading', 'accno', 'Column public.account_heading.accno should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'account_heading', 'accno', 'Column public.account_heading.accno should not have a default');
+
+RETURN NEXT has_column(       'public', 'account_heading', 'parent_id', 'Column public.account_heading.parent_id should exist');
+RETURN NEXT col_type_is(      'public', 'account_heading', 'parent_id', 'integer', 'Column public.account_heading.parent_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'account_heading', 'parent_id', 'Column public.account_heading.parent_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'account_heading', 'parent_id', 'Column public.account_heading.parent_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'account_heading', 'description', 'Column public.account_heading.description should exist');
+RETURN NEXT col_type_is(      'public', 'account_heading', 'description', 'text', 'Column public.account_heading.description should be type text');
+RETURN NEXT col_is_null(      'public', 'account_heading', 'description', 'Column public.account_heading.description should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'account_heading', 'description', 'Column public.account_heading.description should not have a default');
+
+RETURN NEXT has_column(       'public', 'account_heading', 'category', 'Column public.account_heading.category should exist');
+RETURN NEXT col_type_is(      'public', 'account_heading', 'category', 'character(1)', 'Column public.account_heading.category should be type character(1)');
+RETURN NEXT col_is_null(      'public', 'account_heading', 'category', 'Column public.account_heading.category should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'account_heading', 'category', 'Column public.account_heading.category should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.account_heading_translation.sql.pg_include
+++ b/xt/pgtap/table_public.account_heading_translation.sql.pg_include
@@ -1,0 +1,38 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_account_heading_translation()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'account_heading_translation',
+    'Should have table public.account_heading_translation'
+);
+
+RETURN NEXT has_pk(
+    'public', 'account_heading_translation',
+    'Table public.account_heading_translation should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'account_heading_translation'::name, ARRAY[
+    'trans_id'::name,
+    'language_code'::name,
+    'description'::name
+]);
+
+RETURN NEXT has_column(       'public', 'account_heading_translation', 'trans_id', 'Column public.account_heading_translation.trans_id should exist');
+RETURN NEXT col_type_is(      'public', 'account_heading_translation', 'trans_id', 'integer', 'Column public.account_heading_translation.trans_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'account_heading_translation', 'trans_id', 'Column public.account_heading_translation.trans_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'account_heading_translation', 'trans_id', 'Column public.account_heading_translation.trans_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'account_heading_translation', 'language_code', 'Column public.account_heading_translation.language_code should exist');
+RETURN NEXT col_type_is(      'public', 'account_heading_translation', 'language_code', 'character varying(6)', 'Column public.account_heading_translation.language_code should be type character varying(6)');
+RETURN NEXT col_not_null(     'public', 'account_heading_translation', 'language_code', 'Column public.account_heading_translation.language_code should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'account_heading_translation', 'language_code', 'Column public.account_heading_translation.language_code should not have a default');
+
+RETURN NEXT has_column(       'public', 'account_heading_translation', 'description', 'Column public.account_heading_translation.description should exist');
+RETURN NEXT col_type_is(      'public', 'account_heading_translation', 'description', 'text', 'Column public.account_heading_translation.description should be type text');
+RETURN NEXT col_is_null(      'public', 'account_heading_translation', 'description', 'Column public.account_heading_translation.description should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'account_heading_translation', 'description', 'Column public.account_heading_translation.description should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.account_link.sql.pg_include
+++ b/xt/pgtap/table_public.account_link.sql.pg_include
@@ -1,0 +1,32 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_account_link()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'account_link',
+    'Should have table public.account_link'
+);
+
+RETURN NEXT has_pk(
+    'public', 'account_link',
+    'Table public.account_link should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'account_link'::name, ARRAY[
+    'account_id'::name,
+    'description'::name
+]);
+
+RETURN NEXT has_column(       'public', 'account_link', 'account_id', 'Column public.account_link.account_id should exist');
+RETURN NEXT col_type_is(      'public', 'account_link', 'account_id', 'integer', 'Column public.account_link.account_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'account_link', 'account_id', 'Column public.account_link.account_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'account_link', 'account_id', 'Column public.account_link.account_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'account_link', 'description', 'Column public.account_link.description should exist');
+RETURN NEXT col_type_is(      'public', 'account_link', 'description', 'text', 'Column public.account_link.description should be type text');
+RETURN NEXT col_not_null(     'public', 'account_link', 'description', 'Column public.account_link.description should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'account_link', 'description', 'Column public.account_link.description should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.account_link_description.sql.pg_include
+++ b/xt/pgtap/table_public.account_link_description.sql.pg_include
@@ -1,0 +1,38 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_account_link_description()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'account_link_description',
+    'Should have table public.account_link_description'
+);
+
+RETURN NEXT has_pk(
+    'public', 'account_link_description',
+    'Table public.account_link_description should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'account_link_description'::name, ARRAY[
+    'description'::name,
+    'summary'::name,
+    'custom'::name
+]);
+
+RETURN NEXT has_column(       'public', 'account_link_description', 'description', 'Column public.account_link_description.description should exist');
+RETURN NEXT col_type_is(      'public', 'account_link_description', 'description', 'text', 'Column public.account_link_description.description should be type text');
+RETURN NEXT col_not_null(     'public', 'account_link_description', 'description', 'Column public.account_link_description.description should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'account_link_description', 'description', 'Column public.account_link_description.description should not have a default');
+
+RETURN NEXT has_column(       'public', 'account_link_description', 'summary', 'Column public.account_link_description.summary should exist');
+RETURN NEXT col_type_is(      'public', 'account_link_description', 'summary', 'boolean', 'Column public.account_link_description.summary should be type boolean');
+RETURN NEXT col_not_null(     'public', 'account_link_description', 'summary', 'Column public.account_link_description.summary should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'account_link_description', 'summary', 'Column public.account_link_description.summary should not have a default');
+
+RETURN NEXT has_column(       'public', 'account_link_description', 'custom', 'Column public.account_link_description.custom should exist');
+RETURN NEXT col_type_is(      'public', 'account_link_description', 'custom', 'boolean', 'Column public.account_link_description.custom should be type boolean');
+RETURN NEXT col_not_null(     'public', 'account_link_description', 'custom', 'Column public.account_link_description.custom should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'account_link_description', 'custom', 'Column public.account_link_description.custom should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.account_translation.sql.pg_include
+++ b/xt/pgtap/table_public.account_translation.sql.pg_include
@@ -1,0 +1,38 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_account_translation()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'account_translation',
+    'Should have table public.account_translation'
+);
+
+RETURN NEXT has_pk(
+    'public', 'account_translation',
+    'Table public.account_translation should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'account_translation'::name, ARRAY[
+    'trans_id'::name,
+    'language_code'::name,
+    'description'::name
+]);
+
+RETURN NEXT has_column(       'public', 'account_translation', 'trans_id', 'Column public.account_translation.trans_id should exist');
+RETURN NEXT col_type_is(      'public', 'account_translation', 'trans_id', 'integer', 'Column public.account_translation.trans_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'account_translation', 'trans_id', 'Column public.account_translation.trans_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'account_translation', 'trans_id', 'Column public.account_translation.trans_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'account_translation', 'language_code', 'Column public.account_translation.language_code should exist');
+RETURN NEXT col_type_is(      'public', 'account_translation', 'language_code', 'character varying(6)', 'Column public.account_translation.language_code should be type character varying(6)');
+RETURN NEXT col_not_null(     'public', 'account_translation', 'language_code', 'Column public.account_translation.language_code should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'account_translation', 'language_code', 'Column public.account_translation.language_code should not have a default');
+
+RETURN NEXT has_column(       'public', 'account_translation', 'description', 'Column public.account_translation.description should exist');
+RETURN NEXT col_type_is(      'public', 'account_translation', 'description', 'text', 'Column public.account_translation.description should be type text');
+RETURN NEXT col_is_null(      'public', 'account_translation', 'description', 'Column public.account_translation.description should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'account_translation', 'description', 'Column public.account_translation.description should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.ap.sql.pg_include
+++ b/xt/pgtap/table_public.ap.sql.pg_include
@@ -1,0 +1,203 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_ap()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'ap',
+    'Should have table public.ap'
+);
+
+RETURN NEXT has_pk(
+    'public', 'ap',
+    'Table public.ap should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'ap'::name, ARRAY[
+    'id'::name,
+    'invnumber'::name,
+    'transdate'::name,
+    'entity_id'::name,
+    'taxincluded'::name,
+    'amount'::name,
+    'netamount'::name,
+    'duedate'::name,
+    'invoice'::name,
+    'ordnumber'::name,
+    'curr'::name,
+    'notes'::name,
+    'person_id'::name,
+    'till'::name,
+    'quonumber'::name,
+    'intnotes'::name,
+    'shipvia'::name,
+    'language_code'::name,
+    'ponumber'::name,
+    'shippingpoint'::name,
+    'on_hold'::name,
+    'approved'::name,
+    'reverse'::name,
+    'terms'::name,
+    'description'::name,
+    'force_closed'::name,
+    'crdate'::name,
+    'is_return'::name,
+    'entity_credit_account'::name
+]);
+
+RETURN NEXT has_column(       'public', 'ap', 'id', 'Column public.ap.id should exist');
+RETURN NEXT col_type_is(      'public', 'ap', 'id', 'integer', 'Column public.ap.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'ap', 'id', 'Column public.ap.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'ap', 'id', 'Column public.ap.id shouldhave a default');
+--SELECT col_default_is(   'public', 'ap', 'id', 'nextval(''id''::regclass)', 'Column public.ap.id default is');RETURN NEXT col_default_is(   'public', 'ap', 'id', 'nextval(''id''::regclass)', 'Column public.ap.id default is');
+
+RETURN NEXT has_column(       'public', 'ap', 'invnumber', 'Column public.ap.invnumber should exist');
+RETURN NEXT col_type_is(      'public', 'ap', 'invnumber', 'text', 'Column public.ap.invnumber should be type text');
+RETURN NEXT col_is_null(      'public', 'ap', 'invnumber', 'Column public.ap.invnumber should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ap', 'invnumber', 'Column public.ap.invnumber should not have a default');
+
+RETURN NEXT has_column(       'public', 'ap', 'transdate', 'Column public.ap.transdate should exist');
+RETURN NEXT col_type_is(      'public', 'ap', 'transdate', 'date', 'Column public.ap.transdate should be type date');
+RETURN NEXT col_is_null(      'public', 'ap', 'transdate', 'Column public.ap.transdate should allow NULL');
+RETURN NEXT col_has_default(  'public', 'ap', 'transdate', 'Column public.ap.transdate shouldhave a default');
+--SELECT col_default_is(   'public', 'ap', 'transdate', '(''now''::text)::date', 'Column public.ap.transdate default is');RETURN NEXT col_default_is(   'public', 'ap', 'transdate', '(''now''::text)::date', 'Column public.ap.transdate default is');
+
+RETURN NEXT has_column(       'public', 'ap', 'entity_id', 'Column public.ap.entity_id should exist');
+RETURN NEXT col_type_is(      'public', 'ap', 'entity_id', 'integer', 'Column public.ap.entity_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'ap', 'entity_id', 'Column public.ap.entity_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ap', 'entity_id', 'Column public.ap.entity_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'ap', 'taxincluded', 'Column public.ap.taxincluded should exist');
+RETURN NEXT col_type_is(      'public', 'ap', 'taxincluded', 'boolean', 'Column public.ap.taxincluded should be type boolean');
+RETURN NEXT col_is_null(      'public', 'ap', 'taxincluded', 'Column public.ap.taxincluded should allow NULL');
+RETURN NEXT col_has_default(  'public', 'ap', 'taxincluded', 'Column public.ap.taxincluded shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'ap', 'taxincluded', 'false', 'Column public.ap.taxincluded default is');
+
+RETURN NEXT has_column(       'public', 'ap', 'amount', 'Column public.ap.amount should exist');
+RETURN NEXT col_type_is(      'public', 'ap', 'amount', 'numeric', 'Column public.ap.amount should be type numeric');
+RETURN NEXT col_is_null(      'public', 'ap', 'amount', 'Column public.ap.amount should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ap', 'amount', 'Column public.ap.amount should not have a default');
+
+RETURN NEXT has_column(       'public', 'ap', 'netamount', 'Column public.ap.netamount should exist');
+RETURN NEXT col_type_is(      'public', 'ap', 'netamount', 'numeric', 'Column public.ap.netamount should be type numeric');
+RETURN NEXT col_is_null(      'public', 'ap', 'netamount', 'Column public.ap.netamount should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ap', 'netamount', 'Column public.ap.netamount should not have a default');
+
+RETURN NEXT has_column(       'public', 'ap', 'duedate', 'Column public.ap.duedate should exist');
+RETURN NEXT col_type_is(      'public', 'ap', 'duedate', 'date', 'Column public.ap.duedate should be type date');
+RETURN NEXT col_is_null(      'public', 'ap', 'duedate', 'Column public.ap.duedate should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ap', 'duedate', 'Column public.ap.duedate should not have a default');
+
+RETURN NEXT has_column(       'public', 'ap', 'invoice', 'Column public.ap.invoice should exist');
+RETURN NEXT col_type_is(      'public', 'ap', 'invoice', 'boolean', 'Column public.ap.invoice should be type boolean');
+RETURN NEXT col_is_null(      'public', 'ap', 'invoice', 'Column public.ap.invoice should allow NULL');
+RETURN NEXT col_has_default(  'public', 'ap', 'invoice', 'Column public.ap.invoice shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'ap', 'invoice', 'false', 'Column public.ap.invoice default is');
+
+RETURN NEXT has_column(       'public', 'ap', 'ordnumber', 'Column public.ap.ordnumber should exist');
+RETURN NEXT col_type_is(      'public', 'ap', 'ordnumber', 'text', 'Column public.ap.ordnumber should be type text');
+RETURN NEXT col_is_null(      'public', 'ap', 'ordnumber', 'Column public.ap.ordnumber should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ap', 'ordnumber', 'Column public.ap.ordnumber should not have a default');
+
+RETURN NEXT has_column(       'public', 'ap', 'curr', 'Column public.ap.curr should exist');
+RETURN NEXT col_type_is(      'public', 'ap', 'curr', 'character(3)', 'Column public.ap.curr should be type character(3)');
+RETURN NEXT col_is_null(      'public', 'ap', 'curr', 'Column public.ap.curr should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ap', 'curr', 'Column public.ap.curr should not have a default');
+
+RETURN NEXT has_column(       'public', 'ap', 'notes', 'Column public.ap.notes should exist');
+RETURN NEXT col_type_is(      'public', 'ap', 'notes', 'text', 'Column public.ap.notes should be type text');
+RETURN NEXT col_is_null(      'public', 'ap', 'notes', 'Column public.ap.notes should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ap', 'notes', 'Column public.ap.notes should not have a default');
+
+RETURN NEXT has_column(       'public', 'ap', 'person_id', 'Column public.ap.person_id should exist');
+RETURN NEXT col_type_is(      'public', 'ap', 'person_id', 'integer', 'Column public.ap.person_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'ap', 'person_id', 'Column public.ap.person_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ap', 'person_id', 'Column public.ap.person_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'ap', 'till', 'Column public.ap.till should exist');
+RETURN NEXT col_type_is(      'public', 'ap', 'till', 'character varying(20)', 'Column public.ap.till should be type character varying(20)');
+RETURN NEXT col_is_null(      'public', 'ap', 'till', 'Column public.ap.till should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ap', 'till', 'Column public.ap.till should not have a default');
+
+RETURN NEXT has_column(       'public', 'ap', 'quonumber', 'Column public.ap.quonumber should exist');
+RETURN NEXT col_type_is(      'public', 'ap', 'quonumber', 'text', 'Column public.ap.quonumber should be type text');
+RETURN NEXT col_is_null(      'public', 'ap', 'quonumber', 'Column public.ap.quonumber should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ap', 'quonumber', 'Column public.ap.quonumber should not have a default');
+
+RETURN NEXT has_column(       'public', 'ap', 'intnotes', 'Column public.ap.intnotes should exist');
+RETURN NEXT col_type_is(      'public', 'ap', 'intnotes', 'text', 'Column public.ap.intnotes should be type text');
+RETURN NEXT col_is_null(      'public', 'ap', 'intnotes', 'Column public.ap.intnotes should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ap', 'intnotes', 'Column public.ap.intnotes should not have a default');
+
+RETURN NEXT has_column(       'public', 'ap', 'shipvia', 'Column public.ap.shipvia should exist');
+RETURN NEXT col_type_is(      'public', 'ap', 'shipvia', 'text', 'Column public.ap.shipvia should be type text');
+RETURN NEXT col_is_null(      'public', 'ap', 'shipvia', 'Column public.ap.shipvia should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ap', 'shipvia', 'Column public.ap.shipvia should not have a default');
+
+RETURN NEXT has_column(       'public', 'ap', 'language_code', 'Column public.ap.language_code should exist');
+RETURN NEXT col_type_is(      'public', 'ap', 'language_code', 'character varying(6)', 'Column public.ap.language_code should be type character varying(6)');
+RETURN NEXT col_is_null(      'public', 'ap', 'language_code', 'Column public.ap.language_code should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ap', 'language_code', 'Column public.ap.language_code should not have a default');
+
+RETURN NEXT has_column(       'public', 'ap', 'ponumber', 'Column public.ap.ponumber should exist');
+RETURN NEXT col_type_is(      'public', 'ap', 'ponumber', 'text', 'Column public.ap.ponumber should be type text');
+RETURN NEXT col_is_null(      'public', 'ap', 'ponumber', 'Column public.ap.ponumber should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ap', 'ponumber', 'Column public.ap.ponumber should not have a default');
+
+RETURN NEXT has_column(       'public', 'ap', 'shippingpoint', 'Column public.ap.shippingpoint should exist');
+RETURN NEXT col_type_is(      'public', 'ap', 'shippingpoint', 'text', 'Column public.ap.shippingpoint should be type text');
+RETURN NEXT col_is_null(      'public', 'ap', 'shippingpoint', 'Column public.ap.shippingpoint should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ap', 'shippingpoint', 'Column public.ap.shippingpoint should not have a default');
+
+RETURN NEXT has_column(       'public', 'ap', 'on_hold', 'Column public.ap.on_hold should exist');
+RETURN NEXT col_type_is(      'public', 'ap', 'on_hold', 'boolean', 'Column public.ap.on_hold should be type boolean');
+RETURN NEXT col_is_null(      'public', 'ap', 'on_hold', 'Column public.ap.on_hold should allow NULL');
+RETURN NEXT col_has_default(  'public', 'ap', 'on_hold', 'Column public.ap.on_hold shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'ap', 'on_hold', 'false', 'Column public.ap.on_hold default is');
+
+RETURN NEXT has_column(       'public', 'ap', 'approved', 'Column public.ap.approved should exist');
+RETURN NEXT col_type_is(      'public', 'ap', 'approved', 'boolean', 'Column public.ap.approved should be type boolean');
+RETURN NEXT col_is_null(      'public', 'ap', 'approved', 'Column public.ap.approved should allow NULL');
+RETURN NEXT col_has_default(  'public', 'ap', 'approved', 'Column public.ap.approved shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'ap', 'approved', 'true', 'Column public.ap.approved default is');
+
+RETURN NEXT has_column(       'public', 'ap', 'reverse', 'Column public.ap.reverse should exist');
+RETURN NEXT col_type_is(      'public', 'ap', 'reverse', 'boolean', 'Column public.ap.reverse should be type boolean');
+RETURN NEXT col_is_null(      'public', 'ap', 'reverse', 'Column public.ap.reverse should allow NULL');
+RETURN NEXT col_has_default(  'public', 'ap', 'reverse', 'Column public.ap.reverse shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'ap', 'reverse', 'false', 'Column public.ap.reverse default is');
+
+RETURN NEXT has_column(       'public', 'ap', 'terms', 'Column public.ap.terms should exist');
+RETURN NEXT col_type_is(      'public', 'ap', 'terms', 'smallint', 'Column public.ap.terms should be type smallint');
+RETURN NEXT col_is_null(      'public', 'ap', 'terms', 'Column public.ap.terms should allow NULL');
+RETURN NEXT col_has_default(  'public', 'ap', 'terms', 'Column public.ap.terms shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'ap', 'terms', '0', 'Column public.ap.terms default is');
+
+RETURN NEXT has_column(       'public', 'ap', 'description', 'Column public.ap.description should exist');
+RETURN NEXT col_type_is(      'public', 'ap', 'description', 'text', 'Column public.ap.description should be type text');
+RETURN NEXT col_is_null(      'public', 'ap', 'description', 'Column public.ap.description should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ap', 'description', 'Column public.ap.description should not have a default');
+
+RETURN NEXT has_column(       'public', 'ap', 'force_closed', 'Column public.ap.force_closed should exist');
+RETURN NEXT col_type_is(      'public', 'ap', 'force_closed', 'boolean', 'Column public.ap.force_closed should be type boolean');
+RETURN NEXT col_is_null(      'public', 'ap', 'force_closed', 'Column public.ap.force_closed should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ap', 'force_closed', 'Column public.ap.force_closed should not have a default');
+
+RETURN NEXT has_column(       'public', 'ap', 'crdate', 'Column public.ap.crdate should exist');
+RETURN NEXT col_type_is(      'public', 'ap', 'crdate', 'date', 'Column public.ap.crdate should be type date');
+RETURN NEXT col_is_null(      'public', 'ap', 'crdate', 'Column public.ap.crdate should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ap', 'crdate', 'Column public.ap.crdate should not have a default');
+
+RETURN NEXT has_column(       'public', 'ap', 'is_return', 'Column public.ap.is_return should exist');
+RETURN NEXT col_type_is(      'public', 'ap', 'is_return', 'boolean', 'Column public.ap.is_return should be type boolean');
+RETURN NEXT col_is_null(      'public', 'ap', 'is_return', 'Column public.ap.is_return should allow NULL');
+RETURN NEXT col_has_default(  'public', 'ap', 'is_return', 'Column public.ap.is_return shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'ap', 'is_return', 'false', 'Column public.ap.is_return default is');
+
+RETURN NEXT has_column(       'public', 'ap', 'entity_credit_account', 'Column public.ap.entity_credit_account should exist');
+RETURN NEXT col_type_is(      'public', 'ap', 'entity_credit_account', 'integer', 'Column public.ap.entity_credit_account should be type integer');
+RETURN NEXT col_not_null(     'public', 'ap', 'entity_credit_account', 'Column public.ap.entity_credit_account should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'ap', 'entity_credit_account', 'Column public.ap.entity_credit_account should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.ar.sql.pg_include
+++ b/xt/pgtap/table_public.ar.sql.pg_include
@@ -1,0 +1,208 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_ar()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'ar',
+    'Should have table public.ar'
+);
+
+RETURN NEXT has_pk(
+    'public', 'ar',
+    'Table public.ar should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'ar'::name, ARRAY[
+    'id'::name,
+    'invnumber'::name,
+    'transdate'::name,
+    'entity_id'::name,
+    'taxincluded'::name,
+    'amount'::name,
+    'netamount'::name,
+    'duedate'::name,
+    'invoice'::name,
+    'shippingpoint'::name,
+    'terms'::name,
+    'notes'::name,
+    'curr'::name,
+    'ordnumber'::name,
+    'person_id'::name,
+    'till'::name,
+    'quonumber'::name,
+    'intnotes'::name,
+    'shipvia'::name,
+    'language_code'::name,
+    'ponumber'::name,
+    'on_hold'::name,
+    'reverse'::name,
+    'approved'::name,
+    'entity_credit_account'::name,
+    'force_closed'::name,
+    'description'::name,
+    'is_return'::name,
+    'crdate'::name,
+    'setting_sequence'::name
+]);
+
+RETURN NEXT has_column(       'public', 'ar', 'id', 'Column public.ar.id should exist');
+RETURN NEXT col_type_is(      'public', 'ar', 'id', 'integer', 'Column public.ar.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'ar', 'id', 'Column public.ar.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'ar', 'id', 'Column public.ar.id shouldhave a default');
+--SELECT col_default_is(   'public', 'ar', 'id', 'nextval(''id''::regclass)', 'Column public.ar.id default is');RETURN NEXT col_default_is(   'public', 'ar', 'id', 'nextval(''id''::regclass)', 'Column public.ar.id default is');
+
+RETURN NEXT has_column(       'public', 'ar', 'invnumber', 'Column public.ar.invnumber should exist');
+RETURN NEXT col_type_is(      'public', 'ar', 'invnumber', 'text', 'Column public.ar.invnumber should be type text');
+RETURN NEXT col_is_null(      'public', 'ar', 'invnumber', 'Column public.ar.invnumber should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ar', 'invnumber', 'Column public.ar.invnumber should not have a default');
+
+RETURN NEXT has_column(       'public', 'ar', 'transdate', 'Column public.ar.transdate should exist');
+RETURN NEXT col_type_is(      'public', 'ar', 'transdate', 'date', 'Column public.ar.transdate should be type date');
+RETURN NEXT col_is_null(      'public', 'ar', 'transdate', 'Column public.ar.transdate should allow NULL');
+RETURN NEXT col_has_default(  'public', 'ar', 'transdate', 'Column public.ar.transdate shouldhave a default');
+--SELECT col_default_is(   'public', 'ar', 'transdate', '(''now''::text)::date', 'Column public.ar.transdate default is');RETURN NEXT col_default_is(   'public', 'ar', 'transdate', '(''now''::text)::date', 'Column public.ar.transdate default is');
+
+RETURN NEXT has_column(       'public', 'ar', 'entity_id', 'Column public.ar.entity_id should exist');
+RETURN NEXT col_type_is(      'public', 'ar', 'entity_id', 'integer', 'Column public.ar.entity_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'ar', 'entity_id', 'Column public.ar.entity_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ar', 'entity_id', 'Column public.ar.entity_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'ar', 'taxincluded', 'Column public.ar.taxincluded should exist');
+RETURN NEXT col_type_is(      'public', 'ar', 'taxincluded', 'boolean', 'Column public.ar.taxincluded should be type boolean');
+RETURN NEXT col_is_null(      'public', 'ar', 'taxincluded', 'Column public.ar.taxincluded should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ar', 'taxincluded', 'Column public.ar.taxincluded should not have a default');
+
+RETURN NEXT has_column(       'public', 'ar', 'amount', 'Column public.ar.amount should exist');
+RETURN NEXT col_type_is(      'public', 'ar', 'amount', 'numeric', 'Column public.ar.amount should be type numeric');
+RETURN NEXT col_is_null(      'public', 'ar', 'amount', 'Column public.ar.amount should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ar', 'amount', 'Column public.ar.amount should not have a default');
+
+RETURN NEXT has_column(       'public', 'ar', 'netamount', 'Column public.ar.netamount should exist');
+RETURN NEXT col_type_is(      'public', 'ar', 'netamount', 'numeric', 'Column public.ar.netamount should be type numeric');
+RETURN NEXT col_is_null(      'public', 'ar', 'netamount', 'Column public.ar.netamount should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ar', 'netamount', 'Column public.ar.netamount should not have a default');
+
+RETURN NEXT has_column(       'public', 'ar', 'duedate', 'Column public.ar.duedate should exist');
+RETURN NEXT col_type_is(      'public', 'ar', 'duedate', 'date', 'Column public.ar.duedate should be type date');
+RETURN NEXT col_is_null(      'public', 'ar', 'duedate', 'Column public.ar.duedate should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ar', 'duedate', 'Column public.ar.duedate should not have a default');
+
+RETURN NEXT has_column(       'public', 'ar', 'invoice', 'Column public.ar.invoice should exist');
+RETURN NEXT col_type_is(      'public', 'ar', 'invoice', 'boolean', 'Column public.ar.invoice should be type boolean');
+RETURN NEXT col_is_null(      'public', 'ar', 'invoice', 'Column public.ar.invoice should allow NULL');
+RETURN NEXT col_has_default(  'public', 'ar', 'invoice', 'Column public.ar.invoice shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'ar', 'invoice', 'false', 'Column public.ar.invoice default is');
+
+RETURN NEXT has_column(       'public', 'ar', 'shippingpoint', 'Column public.ar.shippingpoint should exist');
+RETURN NEXT col_type_is(      'public', 'ar', 'shippingpoint', 'text', 'Column public.ar.shippingpoint should be type text');
+RETURN NEXT col_is_null(      'public', 'ar', 'shippingpoint', 'Column public.ar.shippingpoint should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ar', 'shippingpoint', 'Column public.ar.shippingpoint should not have a default');
+
+RETURN NEXT has_column(       'public', 'ar', 'terms', 'Column public.ar.terms should exist');
+RETURN NEXT col_type_is(      'public', 'ar', 'terms', 'smallint', 'Column public.ar.terms should be type smallint');
+RETURN NEXT col_is_null(      'public', 'ar', 'terms', 'Column public.ar.terms should allow NULL');
+RETURN NEXT col_has_default(  'public', 'ar', 'terms', 'Column public.ar.terms shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'ar', 'terms', '0', 'Column public.ar.terms default is');
+
+RETURN NEXT has_column(       'public', 'ar', 'notes', 'Column public.ar.notes should exist');
+RETURN NEXT col_type_is(      'public', 'ar', 'notes', 'text', 'Column public.ar.notes should be type text');
+RETURN NEXT col_is_null(      'public', 'ar', 'notes', 'Column public.ar.notes should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ar', 'notes', 'Column public.ar.notes should not have a default');
+
+RETURN NEXT has_column(       'public', 'ar', 'curr', 'Column public.ar.curr should exist');
+RETURN NEXT col_type_is(      'public', 'ar', 'curr', 'character(3)', 'Column public.ar.curr should be type character(3)');
+RETURN NEXT col_is_null(      'public', 'ar', 'curr', 'Column public.ar.curr should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ar', 'curr', 'Column public.ar.curr should not have a default');
+
+RETURN NEXT has_column(       'public', 'ar', 'ordnumber', 'Column public.ar.ordnumber should exist');
+RETURN NEXT col_type_is(      'public', 'ar', 'ordnumber', 'text', 'Column public.ar.ordnumber should be type text');
+RETURN NEXT col_is_null(      'public', 'ar', 'ordnumber', 'Column public.ar.ordnumber should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ar', 'ordnumber', 'Column public.ar.ordnumber should not have a default');
+
+RETURN NEXT has_column(       'public', 'ar', 'person_id', 'Column public.ar.person_id should exist');
+RETURN NEXT col_type_is(      'public', 'ar', 'person_id', 'integer', 'Column public.ar.person_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'ar', 'person_id', 'Column public.ar.person_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ar', 'person_id', 'Column public.ar.person_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'ar', 'till', 'Column public.ar.till should exist');
+RETURN NEXT col_type_is(      'public', 'ar', 'till', 'character varying(20)', 'Column public.ar.till should be type character varying(20)');
+RETURN NEXT col_is_null(      'public', 'ar', 'till', 'Column public.ar.till should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ar', 'till', 'Column public.ar.till should not have a default');
+
+RETURN NEXT has_column(       'public', 'ar', 'quonumber', 'Column public.ar.quonumber should exist');
+RETURN NEXT col_type_is(      'public', 'ar', 'quonumber', 'text', 'Column public.ar.quonumber should be type text');
+RETURN NEXT col_is_null(      'public', 'ar', 'quonumber', 'Column public.ar.quonumber should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ar', 'quonumber', 'Column public.ar.quonumber should not have a default');
+
+RETURN NEXT has_column(       'public', 'ar', 'intnotes', 'Column public.ar.intnotes should exist');
+RETURN NEXT col_type_is(      'public', 'ar', 'intnotes', 'text', 'Column public.ar.intnotes should be type text');
+RETURN NEXT col_is_null(      'public', 'ar', 'intnotes', 'Column public.ar.intnotes should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ar', 'intnotes', 'Column public.ar.intnotes should not have a default');
+
+RETURN NEXT has_column(       'public', 'ar', 'shipvia', 'Column public.ar.shipvia should exist');
+RETURN NEXT col_type_is(      'public', 'ar', 'shipvia', 'text', 'Column public.ar.shipvia should be type text');
+RETURN NEXT col_is_null(      'public', 'ar', 'shipvia', 'Column public.ar.shipvia should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ar', 'shipvia', 'Column public.ar.shipvia should not have a default');
+
+RETURN NEXT has_column(       'public', 'ar', 'language_code', 'Column public.ar.language_code should exist');
+RETURN NEXT col_type_is(      'public', 'ar', 'language_code', 'character varying(6)', 'Column public.ar.language_code should be type character varying(6)');
+RETURN NEXT col_is_null(      'public', 'ar', 'language_code', 'Column public.ar.language_code should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ar', 'language_code', 'Column public.ar.language_code should not have a default');
+
+RETURN NEXT has_column(       'public', 'ar', 'ponumber', 'Column public.ar.ponumber should exist');
+RETURN NEXT col_type_is(      'public', 'ar', 'ponumber', 'text', 'Column public.ar.ponumber should be type text');
+RETURN NEXT col_is_null(      'public', 'ar', 'ponumber', 'Column public.ar.ponumber should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ar', 'ponumber', 'Column public.ar.ponumber should not have a default');
+
+RETURN NEXT has_column(       'public', 'ar', 'on_hold', 'Column public.ar.on_hold should exist');
+RETURN NEXT col_type_is(      'public', 'ar', 'on_hold', 'boolean', 'Column public.ar.on_hold should be type boolean');
+RETURN NEXT col_is_null(      'public', 'ar', 'on_hold', 'Column public.ar.on_hold should allow NULL');
+RETURN NEXT col_has_default(  'public', 'ar', 'on_hold', 'Column public.ar.on_hold shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'ar', 'on_hold', 'false', 'Column public.ar.on_hold default is');
+
+RETURN NEXT has_column(       'public', 'ar', 'reverse', 'Column public.ar.reverse should exist');
+RETURN NEXT col_type_is(      'public', 'ar', 'reverse', 'boolean', 'Column public.ar.reverse should be type boolean');
+RETURN NEXT col_is_null(      'public', 'ar', 'reverse', 'Column public.ar.reverse should allow NULL');
+RETURN NEXT col_has_default(  'public', 'ar', 'reverse', 'Column public.ar.reverse shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'ar', 'reverse', 'false', 'Column public.ar.reverse default is');
+
+RETURN NEXT has_column(       'public', 'ar', 'approved', 'Column public.ar.approved should exist');
+RETURN NEXT col_type_is(      'public', 'ar', 'approved', 'boolean', 'Column public.ar.approved should be type boolean');
+RETURN NEXT col_is_null(      'public', 'ar', 'approved', 'Column public.ar.approved should allow NULL');
+RETURN NEXT col_has_default(  'public', 'ar', 'approved', 'Column public.ar.approved shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'ar', 'approved', 'true', 'Column public.ar.approved default is');
+
+RETURN NEXT has_column(       'public', 'ar', 'entity_credit_account', 'Column public.ar.entity_credit_account should exist');
+RETURN NEXT col_type_is(      'public', 'ar', 'entity_credit_account', 'integer', 'Column public.ar.entity_credit_account should be type integer');
+RETURN NEXT col_not_null(     'public', 'ar', 'entity_credit_account', 'Column public.ar.entity_credit_account should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'ar', 'entity_credit_account', 'Column public.ar.entity_credit_account should not have a default');
+
+RETURN NEXT has_column(       'public', 'ar', 'force_closed', 'Column public.ar.force_closed should exist');
+RETURN NEXT col_type_is(      'public', 'ar', 'force_closed', 'boolean', 'Column public.ar.force_closed should be type boolean');
+RETURN NEXT col_is_null(      'public', 'ar', 'force_closed', 'Column public.ar.force_closed should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ar', 'force_closed', 'Column public.ar.force_closed should not have a default');
+
+RETURN NEXT has_column(       'public', 'ar', 'description', 'Column public.ar.description should exist');
+RETURN NEXT col_type_is(      'public', 'ar', 'description', 'text', 'Column public.ar.description should be type text');
+RETURN NEXT col_is_null(      'public', 'ar', 'description', 'Column public.ar.description should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ar', 'description', 'Column public.ar.description should not have a default');
+
+RETURN NEXT has_column(       'public', 'ar', 'is_return', 'Column public.ar.is_return should exist');
+RETURN NEXT col_type_is(      'public', 'ar', 'is_return', 'boolean', 'Column public.ar.is_return should be type boolean');
+RETURN NEXT col_is_null(      'public', 'ar', 'is_return', 'Column public.ar.is_return should allow NULL');
+RETURN NEXT col_has_default(  'public', 'ar', 'is_return', 'Column public.ar.is_return shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'ar', 'is_return', 'false', 'Column public.ar.is_return default is');
+
+RETURN NEXT has_column(       'public', 'ar', 'crdate', 'Column public.ar.crdate should exist');
+RETURN NEXT col_type_is(      'public', 'ar', 'crdate', 'date', 'Column public.ar.crdate should be type date');
+RETURN NEXT col_is_null(      'public', 'ar', 'crdate', 'Column public.ar.crdate should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ar', 'crdate', 'Column public.ar.crdate should not have a default');
+
+RETURN NEXT has_column(       'public', 'ar', 'setting_sequence', 'Column public.ar.setting_sequence should exist');
+RETURN NEXT col_type_is(      'public', 'ar', 'setting_sequence', 'text', 'Column public.ar.setting_sequence should be type text');
+RETURN NEXT col_is_null(      'public', 'ar', 'setting_sequence', 'Column public.ar.setting_sequence should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'ar', 'setting_sequence', 'Column public.ar.setting_sequence should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.assembly.sql.pg_include
+++ b/xt/pgtap/table_public.assembly.sql.pg_include
@@ -1,0 +1,50 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_assembly()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'assembly',
+    'Should have table public.assembly'
+);
+
+RETURN NEXT has_pk(
+    'public', 'assembly',
+    'Table public.assembly should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'assembly'::name, ARRAY[
+    'id'::name,
+    'parts_id'::name,
+    'qty'::name,
+    'bom'::name,
+    'adj'::name
+]);
+
+RETURN NEXT has_column(       'public', 'assembly', 'id', 'Column public.assembly.id should exist');
+RETURN NEXT col_type_is(      'public', 'assembly', 'id', 'integer', 'Column public.assembly.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'assembly', 'id', 'Column public.assembly.id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'assembly', 'id', 'Column public.assembly.id should not have a default');
+
+RETURN NEXT has_column(       'public', 'assembly', 'parts_id', 'Column public.assembly.parts_id should exist');
+RETURN NEXT col_type_is(      'public', 'assembly', 'parts_id', 'integer', 'Column public.assembly.parts_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'assembly', 'parts_id', 'Column public.assembly.parts_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'assembly', 'parts_id', 'Column public.assembly.parts_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'assembly', 'qty', 'Column public.assembly.qty should exist');
+RETURN NEXT col_type_is(      'public', 'assembly', 'qty', 'numeric', 'Column public.assembly.qty should be type numeric');
+RETURN NEXT col_is_null(      'public', 'assembly', 'qty', 'Column public.assembly.qty should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'assembly', 'qty', 'Column public.assembly.qty should not have a default');
+
+RETURN NEXT has_column(       'public', 'assembly', 'bom', 'Column public.assembly.bom should exist');
+RETURN NEXT col_type_is(      'public', 'assembly', 'bom', 'boolean', 'Column public.assembly.bom should be type boolean');
+RETURN NEXT col_is_null(      'public', 'assembly', 'bom', 'Column public.assembly.bom should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'assembly', 'bom', 'Column public.assembly.bom should not have a default');
+
+RETURN NEXT has_column(       'public', 'assembly', 'adj', 'Column public.assembly.adj should exist');
+RETURN NEXT col_type_is(      'public', 'assembly', 'adj', 'boolean', 'Column public.assembly.adj should be type boolean');
+RETURN NEXT col_is_null(      'public', 'assembly', 'adj', 'Column public.assembly.adj should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'assembly', 'adj', 'Column public.assembly.adj should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.asset_class.sql.pg_include
+++ b/xt/pgtap/table_public.asset_class.sql.pg_include
@@ -1,0 +1,51 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_asset_class()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'asset_class',
+    'Should have table public.asset_class'
+);
+
+RETURN NEXT has_pk(
+    'public', 'asset_class',
+    'Table public.asset_class should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'asset_class'::name, ARRAY[
+    'id'::name,
+    'label'::name,
+    'asset_account_id'::name,
+    'dep_account_id'::name,
+    'method'::name
+]);
+
+RETURN NEXT has_column(       'public', 'asset_class', 'id', 'Column public.asset_class.id should exist');
+RETURN NEXT col_type_is(      'public', 'asset_class', 'id', 'integer', 'Column public.asset_class.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'asset_class', 'id', 'Column public.asset_class.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'asset_class', 'id', 'Column public.asset_class.id shouldhave a default');
+--SELECT col_default_is(   'public', 'asset_class', 'id', 'nextval(''asset_class_id_seq''::regclass)', 'Column public.asset_class.id default is');RETURN NEXT col_default_is(   'public', 'asset_class', 'id', 'nextval(''asset_class_id_seq''::regclass)', 'Column public.asset_class.id default is');
+
+RETURN NEXT has_column(       'public', 'asset_class', 'label', 'Column public.asset_class.label should exist');
+RETURN NEXT col_type_is(      'public', 'asset_class', 'label', 'text', 'Column public.asset_class.label should be type text');
+RETURN NEXT col_not_null(     'public', 'asset_class', 'label', 'Column public.asset_class.label should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_class', 'label', 'Column public.asset_class.label should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_class', 'asset_account_id', 'Column public.asset_class.asset_account_id should exist');
+RETURN NEXT col_type_is(      'public', 'asset_class', 'asset_account_id', 'integer', 'Column public.asset_class.asset_account_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'asset_class', 'asset_account_id', 'Column public.asset_class.asset_account_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_class', 'asset_account_id', 'Column public.asset_class.asset_account_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_class', 'dep_account_id', 'Column public.asset_class.dep_account_id should exist');
+RETURN NEXT col_type_is(      'public', 'asset_class', 'dep_account_id', 'integer', 'Column public.asset_class.dep_account_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'asset_class', 'dep_account_id', 'Column public.asset_class.dep_account_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_class', 'dep_account_id', 'Column public.asset_class.dep_account_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_class', 'method', 'Column public.asset_class.method should exist');
+RETURN NEXT col_type_is(      'public', 'asset_class', 'method', 'integer', 'Column public.asset_class.method should be type integer');
+RETURN NEXT col_is_null(      'public', 'asset_class', 'method', 'Column public.asset_class.method should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_class', 'method', 'Column public.asset_class.method should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.asset_dep_method.sql.pg_include
+++ b/xt/pgtap/table_public.asset_dep_method.sql.pg_include
@@ -1,0 +1,57 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_asset_dep_method()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'asset_dep_method',
+    'Should have table public.asset_dep_method'
+);
+
+RETURN NEXT has_pk(
+    'public', 'asset_dep_method',
+    'Table public.asset_dep_method should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'asset_dep_method'::name, ARRAY[
+    'id'::name,
+    'method'::name,
+    'sproc'::name,
+    'unit_label'::name,
+    'short_name'::name,
+    'unit_class'::name
+]);
+
+RETURN NEXT has_column(       'public', 'asset_dep_method', 'id', 'Column public.asset_dep_method.id should exist');
+RETURN NEXT col_type_is(      'public', 'asset_dep_method', 'id', 'integer', 'Column public.asset_dep_method.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'asset_dep_method', 'id', 'Column public.asset_dep_method.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'asset_dep_method', 'id', 'Column public.asset_dep_method.id shouldhave a default');
+--SELECT col_default_is(   'public', 'asset_dep_method', 'id', 'nextval(''asset_dep_method_id_seq''::regclass)', 'Column public.asset_dep_method.id default is');RETURN NEXT col_default_is(   'public', 'asset_dep_method', 'id', 'nextval(''asset_dep_method_id_seq''::regclass)', 'Column public.asset_dep_method.id default is');
+
+RETURN NEXT has_column(       'public', 'asset_dep_method', 'method', 'Column public.asset_dep_method.method should exist');
+RETURN NEXT col_type_is(      'public', 'asset_dep_method', 'method', 'text', 'Column public.asset_dep_method.method should be type text');
+RETURN NEXT col_not_null(     'public', 'asset_dep_method', 'method', 'Column public.asset_dep_method.method should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_dep_method', 'method', 'Column public.asset_dep_method.method should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_dep_method', 'sproc', 'Column public.asset_dep_method.sproc should exist');
+RETURN NEXT col_type_is(      'public', 'asset_dep_method', 'sproc', 'text', 'Column public.asset_dep_method.sproc should be type text');
+RETURN NEXT col_not_null(     'public', 'asset_dep_method', 'sproc', 'Column public.asset_dep_method.sproc should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_dep_method', 'sproc', 'Column public.asset_dep_method.sproc should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_dep_method', 'unit_label', 'Column public.asset_dep_method.unit_label should exist');
+RETURN NEXT col_type_is(      'public', 'asset_dep_method', 'unit_label', 'text', 'Column public.asset_dep_method.unit_label should be type text');
+RETURN NEXT col_not_null(     'public', 'asset_dep_method', 'unit_label', 'Column public.asset_dep_method.unit_label should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_dep_method', 'unit_label', 'Column public.asset_dep_method.unit_label should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_dep_method', 'short_name', 'Column public.asset_dep_method.short_name should exist');
+RETURN NEXT col_type_is(      'public', 'asset_dep_method', 'short_name', 'text', 'Column public.asset_dep_method.short_name should be type text');
+RETURN NEXT col_not_null(     'public', 'asset_dep_method', 'short_name', 'Column public.asset_dep_method.short_name should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_dep_method', 'short_name', 'Column public.asset_dep_method.short_name should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_dep_method', 'unit_class', 'Column public.asset_dep_method.unit_class should exist');
+RETURN NEXT col_type_is(      'public', 'asset_dep_method', 'unit_class', 'integer', 'Column public.asset_dep_method.unit_class should be type integer');
+RETURN NEXT col_not_null(     'public', 'asset_dep_method', 'unit_class', 'Column public.asset_dep_method.unit_class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_dep_method', 'unit_class', 'Column public.asset_dep_method.unit_class should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.asset_disposal_method.sql.pg_include
+++ b/xt/pgtap/table_public.asset_disposal_method.sql.pg_include
@@ -1,0 +1,45 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_asset_disposal_method()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'asset_disposal_method',
+    'Should have table public.asset_disposal_method'
+);
+
+RETURN NEXT has_pk(
+    'public', 'asset_disposal_method',
+    'Table public.asset_disposal_method should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'asset_disposal_method'::name, ARRAY[
+    'label'::name,
+    'id'::name,
+    'multiple'::name,
+    'short_label'::name
+]);
+
+RETURN NEXT has_column(       'public', 'asset_disposal_method', 'label', 'Column public.asset_disposal_method.label should exist');
+RETURN NEXT col_type_is(      'public', 'asset_disposal_method', 'label', 'text', 'Column public.asset_disposal_method.label should be type text');
+RETURN NEXT col_not_null(     'public', 'asset_disposal_method', 'label', 'Column public.asset_disposal_method.label should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_disposal_method', 'label', 'Column public.asset_disposal_method.label should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_disposal_method', 'id', 'Column public.asset_disposal_method.id should exist');
+RETURN NEXT col_type_is(      'public', 'asset_disposal_method', 'id', 'integer', 'Column public.asset_disposal_method.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'asset_disposal_method', 'id', 'Column public.asset_disposal_method.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'asset_disposal_method', 'id', 'Column public.asset_disposal_method.id shouldhave a default');
+--SELECT col_default_is(   'public', 'asset_disposal_method', 'id', 'nextval(''asset_disposal_method_id_seq''::regclass)', 'Column public.asset_disposal_method.id default is');RETURN NEXT col_default_is(   'public', 'asset_disposal_method', 'id', 'nextval(''asset_disposal_method_id_seq''::regclass)', 'Column public.asset_disposal_method.id default is');
+
+RETURN NEXT has_column(       'public', 'asset_disposal_method', 'multiple', 'Column public.asset_disposal_method.multiple should exist');
+RETURN NEXT col_type_is(      'public', 'asset_disposal_method', 'multiple', 'integer', 'Column public.asset_disposal_method.multiple should be type integer');
+RETURN NEXT col_is_null(      'public', 'asset_disposal_method', 'multiple', 'Column public.asset_disposal_method.multiple should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_disposal_method', 'multiple', 'Column public.asset_disposal_method.multiple should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_disposal_method', 'short_label', 'Column public.asset_disposal_method.short_label should exist');
+RETURN NEXT col_type_is(      'public', 'asset_disposal_method', 'short_label', 'character(1)', 'Column public.asset_disposal_method.short_label should be type character(1)');
+RETURN NEXT col_is_null(      'public', 'asset_disposal_method', 'short_label', 'Column public.asset_disposal_method.short_label should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_disposal_method', 'short_label', 'Column public.asset_disposal_method.short_label should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.asset_item.sql.pg_include
+++ b/xt/pgtap/table_public.asset_item.sql.pg_include
@@ -1,0 +1,117 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_asset_item()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'asset_item',
+    'Should have table public.asset_item'
+);
+
+RETURN NEXT has_pk(
+    'public', 'asset_item',
+    'Table public.asset_item should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'asset_item'::name, ARRAY[
+    'id'::name,
+    'description'::name,
+    'tag'::name,
+    'purchase_value'::name,
+    'salvage_value'::name,
+    'usable_life'::name,
+    'purchase_date'::name,
+    'start_depreciation'::name,
+    'location_id'::name,
+    'department_id'::name,
+    'invoice_id'::name,
+    'asset_account_id'::name,
+    'dep_account_id'::name,
+    'exp_account_id'::name,
+    'obsolete_by'::name,
+    'asset_class_id'::name
+]);
+
+RETURN NEXT has_column(       'public', 'asset_item', 'id', 'Column public.asset_item.id should exist');
+RETURN NEXT col_type_is(      'public', 'asset_item', 'id', 'integer', 'Column public.asset_item.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'asset_item', 'id', 'Column public.asset_item.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'asset_item', 'id', 'Column public.asset_item.id shouldhave a default');
+--SELECT col_default_is(   'public', 'asset_item', 'id', 'nextval(''asset_item_id_seq''::regclass)', 'Column public.asset_item.id default is');RETURN NEXT col_default_is(   'public', 'asset_item', 'id', 'nextval(''asset_item_id_seq''::regclass)', 'Column public.asset_item.id default is');
+
+RETURN NEXT has_column(       'public', 'asset_item', 'description', 'Column public.asset_item.description should exist');
+RETURN NEXT col_type_is(      'public', 'asset_item', 'description', 'text', 'Column public.asset_item.description should be type text');
+RETURN NEXT col_is_null(      'public', 'asset_item', 'description', 'Column public.asset_item.description should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_item', 'description', 'Column public.asset_item.description should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_item', 'tag', 'Column public.asset_item.tag should exist');
+RETURN NEXT col_type_is(      'public', 'asset_item', 'tag', 'text', 'Column public.asset_item.tag should be type text');
+RETURN NEXT col_not_null(     'public', 'asset_item', 'tag', 'Column public.asset_item.tag should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_item', 'tag', 'Column public.asset_item.tag should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_item', 'purchase_value', 'Column public.asset_item.purchase_value should exist');
+RETURN NEXT col_type_is(      'public', 'asset_item', 'purchase_value', 'numeric', 'Column public.asset_item.purchase_value should be type numeric');
+RETURN NEXT col_not_null(     'public', 'asset_item', 'purchase_value', 'Column public.asset_item.purchase_value should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_item', 'purchase_value', 'Column public.asset_item.purchase_value should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_item', 'salvage_value', 'Column public.asset_item.salvage_value should exist');
+RETURN NEXT col_type_is(      'public', 'asset_item', 'salvage_value', 'numeric', 'Column public.asset_item.salvage_value should be type numeric');
+RETURN NEXT col_not_null(     'public', 'asset_item', 'salvage_value', 'Column public.asset_item.salvage_value should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_item', 'salvage_value', 'Column public.asset_item.salvage_value should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_item', 'usable_life', 'Column public.asset_item.usable_life should exist');
+RETURN NEXT col_type_is(      'public', 'asset_item', 'usable_life', 'numeric', 'Column public.asset_item.usable_life should be type numeric');
+RETURN NEXT col_not_null(     'public', 'asset_item', 'usable_life', 'Column public.asset_item.usable_life should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_item', 'usable_life', 'Column public.asset_item.usable_life should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_item', 'purchase_date', 'Column public.asset_item.purchase_date should exist');
+RETURN NEXT col_type_is(      'public', 'asset_item', 'purchase_date', 'date', 'Column public.asset_item.purchase_date should be type date');
+RETURN NEXT col_not_null(     'public', 'asset_item', 'purchase_date', 'Column public.asset_item.purchase_date should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_item', 'purchase_date', 'Column public.asset_item.purchase_date should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_item', 'start_depreciation', 'Column public.asset_item.start_depreciation should exist');
+RETURN NEXT col_type_is(      'public', 'asset_item', 'start_depreciation', 'date', 'Column public.asset_item.start_depreciation should be type date');
+RETURN NEXT col_not_null(     'public', 'asset_item', 'start_depreciation', 'Column public.asset_item.start_depreciation should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_item', 'start_depreciation', 'Column public.asset_item.start_depreciation should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_item', 'location_id', 'Column public.asset_item.location_id should exist');
+RETURN NEXT col_type_is(      'public', 'asset_item', 'location_id', 'integer', 'Column public.asset_item.location_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'asset_item', 'location_id', 'Column public.asset_item.location_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_item', 'location_id', 'Column public.asset_item.location_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_item', 'department_id', 'Column public.asset_item.department_id should exist');
+RETURN NEXT col_type_is(      'public', 'asset_item', 'department_id', 'integer', 'Column public.asset_item.department_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'asset_item', 'department_id', 'Column public.asset_item.department_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_item', 'department_id', 'Column public.asset_item.department_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_item', 'invoice_id', 'Column public.asset_item.invoice_id should exist');
+RETURN NEXT col_type_is(      'public', 'asset_item', 'invoice_id', 'integer', 'Column public.asset_item.invoice_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'asset_item', 'invoice_id', 'Column public.asset_item.invoice_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_item', 'invoice_id', 'Column public.asset_item.invoice_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_item', 'asset_account_id', 'Column public.asset_item.asset_account_id should exist');
+RETURN NEXT col_type_is(      'public', 'asset_item', 'asset_account_id', 'integer', 'Column public.asset_item.asset_account_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'asset_item', 'asset_account_id', 'Column public.asset_item.asset_account_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_item', 'asset_account_id', 'Column public.asset_item.asset_account_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_item', 'dep_account_id', 'Column public.asset_item.dep_account_id should exist');
+RETURN NEXT col_type_is(      'public', 'asset_item', 'dep_account_id', 'integer', 'Column public.asset_item.dep_account_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'asset_item', 'dep_account_id', 'Column public.asset_item.dep_account_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_item', 'dep_account_id', 'Column public.asset_item.dep_account_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_item', 'exp_account_id', 'Column public.asset_item.exp_account_id should exist');
+RETURN NEXT col_type_is(      'public', 'asset_item', 'exp_account_id', 'integer', 'Column public.asset_item.exp_account_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'asset_item', 'exp_account_id', 'Column public.asset_item.exp_account_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_item', 'exp_account_id', 'Column public.asset_item.exp_account_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_item', 'obsolete_by', 'Column public.asset_item.obsolete_by should exist');
+RETURN NEXT col_type_is(      'public', 'asset_item', 'obsolete_by', 'integer', 'Column public.asset_item.obsolete_by should be type integer');
+RETURN NEXT col_is_null(      'public', 'asset_item', 'obsolete_by', 'Column public.asset_item.obsolete_by should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_item', 'obsolete_by', 'Column public.asset_item.obsolete_by should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_item', 'asset_class_id', 'Column public.asset_item.asset_class_id should exist');
+RETURN NEXT col_type_is(      'public', 'asset_item', 'asset_class_id', 'integer', 'Column public.asset_item.asset_class_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'asset_item', 'asset_class_id', 'Column public.asset_item.asset_class_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_item', 'asset_class_id', 'Column public.asset_item.asset_class_id should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.asset_note.sql.pg_include
+++ b/xt/pgtap/table_public.asset_note.sql.pg_include
@@ -1,0 +1,73 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_asset_note()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'asset_note',
+    'Should have table public.asset_note'
+);
+
+RETURN NEXT hasnt_pk(
+    'public', 'asset_note',
+    'Table public.asset_note should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'asset_note'::name, ARRAY[
+    'id'::name,
+    'note_class'::name,
+    'note'::name,
+    'vector'::name,
+    'created'::name,
+    'created_by'::name,
+    'ref_key'::name,
+    'subject'::name
+]);
+
+RETURN NEXT has_column(       'public', 'asset_note', 'id', 'Column public.asset_note.id should exist');
+RETURN NEXT col_type_is(      'public', 'asset_note', 'id', 'integer', 'Column public.asset_note.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'asset_note', 'id', 'Column public.asset_note.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'asset_note', 'id', 'Column public.asset_note.id shouldhave a default');
+--SELECT col_default_is(   'public', 'asset_note', 'id', 'nextval(''note_id_seq''::regclass)', 'Column public.asset_note.id default is');RETURN NEXT col_default_is(   'public', 'asset_note', 'id', 'nextval(''note_id_seq''::regclass)', 'Column public.asset_note.id default is');
+
+RETURN NEXT has_column(       'public', 'asset_note', 'note_class', 'Column public.asset_note.note_class should exist');
+RETURN NEXT col_type_is(      'public', 'asset_note', 'note_class', 'integer', 'Column public.asset_note.note_class should be type integer');
+RETURN NEXT col_not_null(     'public', 'asset_note', 'note_class', 'Column public.asset_note.note_class should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'asset_note', 'note_class', 'Column public.asset_note.note_class shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'asset_note', 'note_class', '4', 'Column public.asset_note.note_class default is');
+
+RETURN NEXT has_column(       'public', 'asset_note', 'note', 'Column public.asset_note.note should exist');
+RETURN NEXT col_type_is(      'public', 'asset_note', 'note', 'text', 'Column public.asset_note.note should be type text');
+RETURN NEXT col_not_null(     'public', 'asset_note', 'note', 'Column public.asset_note.note should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_note', 'note', 'Column public.asset_note.note should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_note', 'vector', 'Column public.asset_note.vector should exist');
+RETURN NEXT col_type_is(      'public', 'asset_note', 'vector', 'tsvector', 'Column public.asset_note.vector should be type tsvector');
+RETURN NEXT col_not_null(     'public', 'asset_note', 'vector', 'Column public.asset_note.vector should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'asset_note', 'vector', 'Column public.asset_note.vector shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'asset_note', 'vector', ''::tsvector, 'Column public.asset_note.vector default is');
+
+RETURN NEXT has_column(       'public', 'asset_note', 'created', 'Column public.asset_note.created should exist');
+RETURN NEXT col_type_is(      'public', 'asset_note', 'created', 'timestamp without time zone', 'Column public.asset_note.created should be type timestamp without time zone');
+RETURN NEXT col_not_null(     'public', 'asset_note', 'created', 'Column public.asset_note.created should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'asset_note', 'created', 'Column public.asset_note.created shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'asset_note', 'created', 'now()', 'Column public.asset_note.created default is');
+
+RETURN NEXT has_column(       'public', 'asset_note', 'created_by', 'Column public.asset_note.created_by should exist');
+RETURN NEXT col_type_is(      'public', 'asset_note', 'created_by', 'text', 'Column public.asset_note.created_by should be type text');
+RETURN NEXT col_is_null(      'public', 'asset_note', 'created_by', 'Column public.asset_note.created_by should allow NULL');
+RETURN NEXT col_has_default(  'public', 'asset_note', 'created_by', 'Column public.asset_note.created_by shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'asset_note', 'created_by', '"session_user"()', 'Column public.asset_note.created_by default is');
+
+RETURN NEXT has_column(       'public', 'asset_note', 'ref_key', 'Column public.asset_note.ref_key should exist');
+RETURN NEXT col_type_is(      'public', 'asset_note', 'ref_key', 'integer', 'Column public.asset_note.ref_key should be type integer');
+RETURN NEXT col_not_null(     'public', 'asset_note', 'ref_key', 'Column public.asset_note.ref_key should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_note', 'ref_key', 'Column public.asset_note.ref_key should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_note', 'subject', 'Column public.asset_note.subject should exist');
+RETURN NEXT col_type_is(      'public', 'asset_note', 'subject', 'text', 'Column public.asset_note.subject should be type text');
+RETURN NEXT col_is_null(      'public', 'asset_note', 'subject', 'Column public.asset_note.subject should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_note', 'subject', 'Column public.asset_note.subject should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.asset_report.sql.pg_include
+++ b/xt/pgtap/table_public.asset_report.sql.pg_include
@@ -1,0 +1,97 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_asset_report()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'asset_report',
+    'Should have table public.asset_report'
+);
+
+RETURN NEXT has_pk(
+    'public', 'asset_report',
+    'Table public.asset_report should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'asset_report'::name, ARRAY[
+    'id'::name,
+    'report_date'::name,
+    'gl_id'::name,
+    'asset_class'::name,
+    'report_class'::name,
+    'entered_by'::name,
+    'approved_by'::name,
+    'entered_at'::name,
+    'approved_at'::name,
+    'depreciated_qty'::name,
+    'dont_approve'::name,
+    'submitted'::name
+]);
+
+RETURN NEXT has_column(       'public', 'asset_report', 'id', 'Column public.asset_report.id should exist');
+RETURN NEXT col_type_is(      'public', 'asset_report', 'id', 'integer', 'Column public.asset_report.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'asset_report', 'id', 'Column public.asset_report.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'asset_report', 'id', 'Column public.asset_report.id shouldhave a default');
+--SELECT col_default_is(   'public', 'asset_report', 'id', 'nextval(''asset_report_id_seq''::regclass)', 'Column public.asset_report.id default is');RETURN NEXT col_default_is(   'public', 'asset_report', 'id', 'nextval(''asset_report_id_seq''::regclass)', 'Column public.asset_report.id default is');
+
+RETURN NEXT has_column(       'public', 'asset_report', 'report_date', 'Column public.asset_report.report_date should exist');
+RETURN NEXT col_type_is(      'public', 'asset_report', 'report_date', 'date', 'Column public.asset_report.report_date should be type date');
+RETURN NEXT col_is_null(      'public', 'asset_report', 'report_date', 'Column public.asset_report.report_date should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_report', 'report_date', 'Column public.asset_report.report_date should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_report', 'gl_id', 'Column public.asset_report.gl_id should exist');
+RETURN NEXT col_type_is(      'public', 'asset_report', 'gl_id', 'bigint', 'Column public.asset_report.gl_id should be type bigint');
+RETURN NEXT col_is_null(      'public', 'asset_report', 'gl_id', 'Column public.asset_report.gl_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_report', 'gl_id', 'Column public.asset_report.gl_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_report', 'asset_class', 'Column public.asset_report.asset_class should exist');
+RETURN NEXT col_type_is(      'public', 'asset_report', 'asset_class', 'bigint', 'Column public.asset_report.asset_class should be type bigint');
+RETURN NEXT col_is_null(      'public', 'asset_report', 'asset_class', 'Column public.asset_report.asset_class should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_report', 'asset_class', 'Column public.asset_report.asset_class should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_report', 'report_class', 'Column public.asset_report.report_class should exist');
+RETURN NEXT col_type_is(      'public', 'asset_report', 'report_class', 'integer', 'Column public.asset_report.report_class should be type integer');
+RETURN NEXT col_is_null(      'public', 'asset_report', 'report_class', 'Column public.asset_report.report_class should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_report', 'report_class', 'Column public.asset_report.report_class should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_report', 'entered_by', 'Column public.asset_report.entered_by should exist');
+RETURN NEXT col_type_is(      'public', 'asset_report', 'entered_by', 'bigint', 'Column public.asset_report.entered_by should be type bigint');
+RETURN NEXT col_not_null(     'public', 'asset_report', 'entered_by', 'Column public.asset_report.entered_by should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'asset_report', 'entered_by', 'Column public.asset_report.entered_by shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'asset_report', 'entered_by', 'person__get_my_entity_id()', 'Column public.asset_report.entered_by default is');
+
+RETURN NEXT has_column(       'public', 'asset_report', 'approved_by', 'Column public.asset_report.approved_by should exist');
+RETURN NEXT col_type_is(      'public', 'asset_report', 'approved_by', 'bigint', 'Column public.asset_report.approved_by should be type bigint');
+RETURN NEXT col_is_null(      'public', 'asset_report', 'approved_by', 'Column public.asset_report.approved_by should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_report', 'approved_by', 'Column public.asset_report.approved_by should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_report', 'entered_at', 'Column public.asset_report.entered_at should exist');
+RETURN NEXT col_type_is(      'public', 'asset_report', 'entered_at', 'timestamp without time zone', 'Column public.asset_report.entered_at should be type timestamp without time zone');
+RETURN NEXT col_is_null(      'public', 'asset_report', 'entered_at', 'Column public.asset_report.entered_at should allow NULL');
+RETURN NEXT col_has_default(  'public', 'asset_report', 'entered_at', 'Column public.asset_report.entered_at shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'asset_report', 'entered_at', 'now()', 'Column public.asset_report.entered_at default is');
+
+RETURN NEXT has_column(       'public', 'asset_report', 'approved_at', 'Column public.asset_report.approved_at should exist');
+RETURN NEXT col_type_is(      'public', 'asset_report', 'approved_at', 'timestamp without time zone', 'Column public.asset_report.approved_at should be type timestamp without time zone');
+RETURN NEXT col_is_null(      'public', 'asset_report', 'approved_at', 'Column public.asset_report.approved_at should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_report', 'approved_at', 'Column public.asset_report.approved_at should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_report', 'depreciated_qty', 'Column public.asset_report.depreciated_qty should exist');
+RETURN NEXT col_type_is(      'public', 'asset_report', 'depreciated_qty', 'numeric', 'Column public.asset_report.depreciated_qty should be type numeric');
+RETURN NEXT col_is_null(      'public', 'asset_report', 'depreciated_qty', 'Column public.asset_report.depreciated_qty should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_report', 'depreciated_qty', 'Column public.asset_report.depreciated_qty should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_report', 'dont_approve', 'Column public.asset_report.dont_approve should exist');
+RETURN NEXT col_type_is(      'public', 'asset_report', 'dont_approve', 'boolean', 'Column public.asset_report.dont_approve should be type boolean');
+RETURN NEXT col_is_null(      'public', 'asset_report', 'dont_approve', 'Column public.asset_report.dont_approve should allow NULL');
+RETURN NEXT col_has_default(  'public', 'asset_report', 'dont_approve', 'Column public.asset_report.dont_approve shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'asset_report', 'dont_approve', 'false', 'Column public.asset_report.dont_approve default is');
+
+RETURN NEXT has_column(       'public', 'asset_report', 'submitted', 'Column public.asset_report.submitted should exist');
+RETURN NEXT col_type_is(      'public', 'asset_report', 'submitted', 'boolean', 'Column public.asset_report.submitted should be type boolean');
+RETURN NEXT col_not_null(     'public', 'asset_report', 'submitted', 'Column public.asset_report.submitted should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'asset_report', 'submitted', 'Column public.asset_report.submitted shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'asset_report', 'submitted', 'false', 'Column public.asset_report.submitted default is');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.asset_report_class.sql.pg_include
+++ b/xt/pgtap/table_public.asset_report_class.sql.pg_include
@@ -1,0 +1,32 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_asset_report_class()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'asset_report_class',
+    'Should have table public.asset_report_class'
+);
+
+RETURN NEXT has_pk(
+    'public', 'asset_report_class',
+    'Table public.asset_report_class should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'asset_report_class'::name, ARRAY[
+    'id'::name,
+    'class'::name
+]);
+
+RETURN NEXT has_column(       'public', 'asset_report_class', 'id', 'Column public.asset_report_class.id should exist');
+RETURN NEXT col_type_is(      'public', 'asset_report_class', 'id', 'integer', 'Column public.asset_report_class.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'asset_report_class', 'id', 'Column public.asset_report_class.id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_report_class', 'id', 'Column public.asset_report_class.id should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_report_class', 'class', 'Column public.asset_report_class.class should exist');
+RETURN NEXT col_type_is(      'public', 'asset_report_class', 'class', 'text', 'Column public.asset_report_class.class should be type text');
+RETURN NEXT col_not_null(     'public', 'asset_report_class', 'class', 'Column public.asset_report_class.class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_report_class', 'class', 'Column public.asset_report_class.class should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.asset_report_line.sql.pg_include
+++ b/xt/pgtap/table_public.asset_report_line.sql.pg_include
@@ -1,0 +1,50 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_asset_report_line()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'asset_report_line',
+    'Should have table public.asset_report_line'
+);
+
+RETURN NEXT has_pk(
+    'public', 'asset_report_line',
+    'Table public.asset_report_line should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'asset_report_line'::name, ARRAY[
+    'asset_id'::name,
+    'report_id'::name,
+    'amount'::name,
+    'department_id'::name,
+    'warehouse_id'::name
+]);
+
+RETURN NEXT has_column(       'public', 'asset_report_line', 'asset_id', 'Column public.asset_report_line.asset_id should exist');
+RETURN NEXT col_type_is(      'public', 'asset_report_line', 'asset_id', 'bigint', 'Column public.asset_report_line.asset_id should be type bigint');
+RETURN NEXT col_not_null(     'public', 'asset_report_line', 'asset_id', 'Column public.asset_report_line.asset_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_report_line', 'asset_id', 'Column public.asset_report_line.asset_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_report_line', 'report_id', 'Column public.asset_report_line.report_id should exist');
+RETURN NEXT col_type_is(      'public', 'asset_report_line', 'report_id', 'bigint', 'Column public.asset_report_line.report_id should be type bigint');
+RETURN NEXT col_not_null(     'public', 'asset_report_line', 'report_id', 'Column public.asset_report_line.report_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_report_line', 'report_id', 'Column public.asset_report_line.report_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_report_line', 'amount', 'Column public.asset_report_line.amount should exist');
+RETURN NEXT col_type_is(      'public', 'asset_report_line', 'amount', 'numeric', 'Column public.asset_report_line.amount should be type numeric');
+RETURN NEXT col_is_null(      'public', 'asset_report_line', 'amount', 'Column public.asset_report_line.amount should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_report_line', 'amount', 'Column public.asset_report_line.amount should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_report_line', 'department_id', 'Column public.asset_report_line.department_id should exist');
+RETURN NEXT col_type_is(      'public', 'asset_report_line', 'department_id', 'integer', 'Column public.asset_report_line.department_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'asset_report_line', 'department_id', 'Column public.asset_report_line.department_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_report_line', 'department_id', 'Column public.asset_report_line.department_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_report_line', 'warehouse_id', 'Column public.asset_report_line.warehouse_id should exist');
+RETURN NEXT col_type_is(      'public', 'asset_report_line', 'warehouse_id', 'integer', 'Column public.asset_report_line.warehouse_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'asset_report_line', 'warehouse_id', 'Column public.asset_report_line.warehouse_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_report_line', 'warehouse_id', 'Column public.asset_report_line.warehouse_id should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.asset_rl_to_disposal_method.sql.pg_include
+++ b/xt/pgtap/table_public.asset_rl_to_disposal_method.sql.pg_include
@@ -1,0 +1,44 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_asset_rl_to_disposal_method()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'asset_rl_to_disposal_method',
+    'Should have table public.asset_rl_to_disposal_method'
+);
+
+RETURN NEXT has_pk(
+    'public', 'asset_rl_to_disposal_method',
+    'Table public.asset_rl_to_disposal_method should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'asset_rl_to_disposal_method'::name, ARRAY[
+    'report_id'::name,
+    'asset_id'::name,
+    'disposal_method_id'::name,
+    'percent_disposed'::name
+]);
+
+RETURN NEXT has_column(       'public', 'asset_rl_to_disposal_method', 'report_id', 'Column public.asset_rl_to_disposal_method.report_id should exist');
+RETURN NEXT col_type_is(      'public', 'asset_rl_to_disposal_method', 'report_id', 'integer', 'Column public.asset_rl_to_disposal_method.report_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'asset_rl_to_disposal_method', 'report_id', 'Column public.asset_rl_to_disposal_method.report_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_rl_to_disposal_method', 'report_id', 'Column public.asset_rl_to_disposal_method.report_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_rl_to_disposal_method', 'asset_id', 'Column public.asset_rl_to_disposal_method.asset_id should exist');
+RETURN NEXT col_type_is(      'public', 'asset_rl_to_disposal_method', 'asset_id', 'integer', 'Column public.asset_rl_to_disposal_method.asset_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'asset_rl_to_disposal_method', 'asset_id', 'Column public.asset_rl_to_disposal_method.asset_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_rl_to_disposal_method', 'asset_id', 'Column public.asset_rl_to_disposal_method.asset_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_rl_to_disposal_method', 'disposal_method_id', 'Column public.asset_rl_to_disposal_method.disposal_method_id should exist');
+RETURN NEXT col_type_is(      'public', 'asset_rl_to_disposal_method', 'disposal_method_id', 'integer', 'Column public.asset_rl_to_disposal_method.disposal_method_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'asset_rl_to_disposal_method', 'disposal_method_id', 'Column public.asset_rl_to_disposal_method.disposal_method_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_rl_to_disposal_method', 'disposal_method_id', 'Column public.asset_rl_to_disposal_method.disposal_method_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_rl_to_disposal_method', 'percent_disposed', 'Column public.asset_rl_to_disposal_method.percent_disposed should exist');
+RETURN NEXT col_type_is(      'public', 'asset_rl_to_disposal_method', 'percent_disposed', 'numeric', 'Column public.asset_rl_to_disposal_method.percent_disposed should be type numeric');
+RETURN NEXT col_is_null(      'public', 'asset_rl_to_disposal_method', 'percent_disposed', 'Column public.asset_rl_to_disposal_method.percent_disposed should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_rl_to_disposal_method', 'percent_disposed', 'Column public.asset_rl_to_disposal_method.percent_disposed should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.asset_unit_class.sql.pg_include
+++ b/xt/pgtap/table_public.asset_unit_class.sql.pg_include
@@ -1,0 +1,32 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_asset_unit_class()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'asset_unit_class',
+    'Should have table public.asset_unit_class'
+);
+
+RETURN NEXT has_pk(
+    'public', 'asset_unit_class',
+    'Table public.asset_unit_class should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'asset_unit_class'::name, ARRAY[
+    'id'::name,
+    'class'::name
+]);
+
+RETURN NEXT has_column(       'public', 'asset_unit_class', 'id', 'Column public.asset_unit_class.id should exist');
+RETURN NEXT col_type_is(      'public', 'asset_unit_class', 'id', 'integer', 'Column public.asset_unit_class.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'asset_unit_class', 'id', 'Column public.asset_unit_class.id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_unit_class', 'id', 'Column public.asset_unit_class.id should not have a default');
+
+RETURN NEXT has_column(       'public', 'asset_unit_class', 'class', 'Column public.asset_unit_class.class should exist');
+RETURN NEXT col_type_is(      'public', 'asset_unit_class', 'class', 'text', 'Column public.asset_unit_class.class should be type text');
+RETURN NEXT col_not_null(     'public', 'asset_unit_class', 'class', 'Column public.asset_unit_class.class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'asset_unit_class', 'class', 'Column public.asset_unit_class.class should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.audittrail.sql.pg_include
+++ b/xt/pgtap/table_public.audittrail.sql.pg_include
@@ -1,0 +1,70 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_audittrail()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'audittrail',
+    'Should have table public.audittrail'
+);
+
+RETURN NEXT has_pk(
+    'public', 'audittrail',
+    'Table public.audittrail should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'audittrail'::name, ARRAY[
+    'trans_id'::name,
+    'tablename'::name,
+    'reference'::name,
+    'formname'::name,
+    'action'::name,
+    'transdate'::name,
+    'person_id'::name,
+    'entry_id'::name
+]);
+
+RETURN NEXT has_column(       'public', 'audittrail', 'trans_id', 'Column public.audittrail.trans_id should exist');
+RETURN NEXT col_type_is(      'public', 'audittrail', 'trans_id', 'integer', 'Column public.audittrail.trans_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'audittrail', 'trans_id', 'Column public.audittrail.trans_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'audittrail', 'trans_id', 'Column public.audittrail.trans_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'audittrail', 'tablename', 'Column public.audittrail.tablename should exist');
+RETURN NEXT col_type_is(      'public', 'audittrail', 'tablename', 'text', 'Column public.audittrail.tablename should be type text');
+RETURN NEXT col_is_null(      'public', 'audittrail', 'tablename', 'Column public.audittrail.tablename should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'audittrail', 'tablename', 'Column public.audittrail.tablename should not have a default');
+
+RETURN NEXT has_column(       'public', 'audittrail', 'reference', 'Column public.audittrail.reference should exist');
+RETURN NEXT col_type_is(      'public', 'audittrail', 'reference', 'text', 'Column public.audittrail.reference should be type text');
+RETURN NEXT col_is_null(      'public', 'audittrail', 'reference', 'Column public.audittrail.reference should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'audittrail', 'reference', 'Column public.audittrail.reference should not have a default');
+
+RETURN NEXT has_column(       'public', 'audittrail', 'formname', 'Column public.audittrail.formname should exist');
+RETURN NEXT col_type_is(      'public', 'audittrail', 'formname', 'text', 'Column public.audittrail.formname should be type text');
+RETURN NEXT col_is_null(      'public', 'audittrail', 'formname', 'Column public.audittrail.formname should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'audittrail', 'formname', 'Column public.audittrail.formname should not have a default');
+
+RETURN NEXT has_column(       'public', 'audittrail', 'action', 'Column public.audittrail.action should exist');
+RETURN NEXT col_type_is(      'public', 'audittrail', 'action', 'text', 'Column public.audittrail.action should be type text');
+RETURN NEXT col_is_null(      'public', 'audittrail', 'action', 'Column public.audittrail.action should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'audittrail', 'action', 'Column public.audittrail.action should not have a default');
+
+RETURN NEXT has_column(       'public', 'audittrail', 'transdate', 'Column public.audittrail.transdate should exist');
+RETURN NEXT col_type_is(      'public', 'audittrail', 'transdate', 'timestamp without time zone', 'Column public.audittrail.transdate should be type timestamp without time zone');
+RETURN NEXT col_is_null(      'public', 'audittrail', 'transdate', 'Column public.audittrail.transdate should allow NULL');
+RETURN NEXT col_has_default(  'public', 'audittrail', 'transdate', 'Column public.audittrail.transdate shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'audittrail', 'transdate', 'now()', 'Column public.audittrail.transdate default is');
+
+RETURN NEXT has_column(       'public', 'audittrail', 'person_id', 'Column public.audittrail.person_id should exist');
+RETURN NEXT col_type_is(      'public', 'audittrail', 'person_id', 'integer', 'Column public.audittrail.person_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'audittrail', 'person_id', 'Column public.audittrail.person_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'audittrail', 'person_id', 'Column public.audittrail.person_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'audittrail', 'entry_id', 'Column public.audittrail.entry_id should exist');
+RETURN NEXT col_type_is(      'public', 'audittrail', 'entry_id', 'bigint', 'Column public.audittrail.entry_id should be type bigint');
+RETURN NEXT col_not_null(     'public', 'audittrail', 'entry_id', 'Column public.audittrail.entry_id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'audittrail', 'entry_id', 'Column public.audittrail.entry_id shouldhave a default');
+--SELECT col_default_is(   'public', 'audittrail', 'entry_id', 'nextval(''audittrail_entry_id_seq''::regclass)', 'Column public.audittrail.entry_id default is');RETURN NEXT col_default_is(   'public', 'audittrail', 'entry_id', 'nextval(''audittrail_entry_id_seq''::regclass)', 'Column public.audittrail.entry_id default is');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.batch.sql.pg_include
+++ b/xt/pgtap/table_public.batch.sql.pg_include
@@ -1,0 +1,82 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_batch()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'batch',
+    'Should have table public.batch'
+);
+
+RETURN NEXT has_pk(
+    'public', 'batch',
+    'Table public.batch should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'batch'::name, ARRAY[
+    'id'::name,
+    'batch_class_id'::name,
+    'control_code'::name,
+    'description'::name,
+    'default_date'::name,
+    'approved_on'::name,
+    'approved_by'::name,
+    'created_by'::name,
+    'locked_by'::name,
+    'created_on'::name
+]);
+
+RETURN NEXT has_column(       'public', 'batch', 'id', 'Column public.batch.id should exist');
+RETURN NEXT col_type_is(      'public', 'batch', 'id', 'integer', 'Column public.batch.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'batch', 'id', 'Column public.batch.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'batch', 'id', 'Column public.batch.id shouldhave a default');
+--SELECT col_default_is(   'public', 'batch', 'id', 'nextval(''batch_id_seq''::regclass)', 'Column public.batch.id default is');RETURN NEXT col_default_is(   'public', 'batch', 'id', 'nextval(''batch_id_seq''::regclass)', 'Column public.batch.id default is');
+
+RETURN NEXT has_column(       'public', 'batch', 'batch_class_id', 'Column public.batch.batch_class_id should exist');
+RETURN NEXT col_type_is(      'public', 'batch', 'batch_class_id', 'integer', 'Column public.batch.batch_class_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'batch', 'batch_class_id', 'Column public.batch.batch_class_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'batch', 'batch_class_id', 'Column public.batch.batch_class_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'batch', 'control_code', 'Column public.batch.control_code should exist');
+RETURN NEXT col_type_is(      'public', 'batch', 'control_code', 'text', 'Column public.batch.control_code should be type text');
+RETURN NEXT col_not_null(     'public', 'batch', 'control_code', 'Column public.batch.control_code should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'batch', 'control_code', 'Column public.batch.control_code should not have a default');
+
+RETURN NEXT has_column(       'public', 'batch', 'description', 'Column public.batch.description should exist');
+RETURN NEXT col_type_is(      'public', 'batch', 'description', 'text', 'Column public.batch.description should be type text');
+RETURN NEXT col_is_null(      'public', 'batch', 'description', 'Column public.batch.description should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'batch', 'description', 'Column public.batch.description should not have a default');
+
+RETURN NEXT has_column(       'public', 'batch', 'default_date', 'Column public.batch.default_date should exist');
+RETURN NEXT col_type_is(      'public', 'batch', 'default_date', 'date', 'Column public.batch.default_date should be type date');
+RETURN NEXT col_not_null(     'public', 'batch', 'default_date', 'Column public.batch.default_date should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'batch', 'default_date', 'Column public.batch.default_date should not have a default');
+
+RETURN NEXT has_column(       'public', 'batch', 'approved_on', 'Column public.batch.approved_on should exist');
+RETURN NEXT col_type_is(      'public', 'batch', 'approved_on', 'date', 'Column public.batch.approved_on should be type date');
+RETURN NEXT col_is_null(      'public', 'batch', 'approved_on', 'Column public.batch.approved_on should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'batch', 'approved_on', 'Column public.batch.approved_on should not have a default');
+
+RETURN NEXT has_column(       'public', 'batch', 'approved_by', 'Column public.batch.approved_by should exist');
+RETURN NEXT col_type_is(      'public', 'batch', 'approved_by', 'integer', 'Column public.batch.approved_by should be type integer');
+RETURN NEXT col_is_null(      'public', 'batch', 'approved_by', 'Column public.batch.approved_by should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'batch', 'approved_by', 'Column public.batch.approved_by should not have a default');
+
+RETURN NEXT has_column(       'public', 'batch', 'created_by', 'Column public.batch.created_by should exist');
+RETURN NEXT col_type_is(      'public', 'batch', 'created_by', 'integer', 'Column public.batch.created_by should be type integer');
+RETURN NEXT col_is_null(      'public', 'batch', 'created_by', 'Column public.batch.created_by should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'batch', 'created_by', 'Column public.batch.created_by should not have a default');
+
+RETURN NEXT has_column(       'public', 'batch', 'locked_by', 'Column public.batch.locked_by should exist');
+RETURN NEXT col_type_is(      'public', 'batch', 'locked_by', 'integer', 'Column public.batch.locked_by should be type integer');
+RETURN NEXT col_is_null(      'public', 'batch', 'locked_by', 'Column public.batch.locked_by should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'batch', 'locked_by', 'Column public.batch.locked_by should not have a default');
+
+RETURN NEXT has_column(       'public', 'batch', 'created_on', 'Column public.batch.created_on should exist');
+RETURN NEXT col_type_is(      'public', 'batch', 'created_on', 'date', 'Column public.batch.created_on should be type date');
+RETURN NEXT col_is_null(      'public', 'batch', 'created_on', 'Column public.batch.created_on should allow NULL');
+RETURN NEXT col_has_default(  'public', 'batch', 'created_on', 'Column public.batch.created_on shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'batch', 'created_on', 'now()', 'Column public.batch.created_on default is');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.batch_class.sql.pg_include
+++ b/xt/pgtap/table_public.batch_class.sql.pg_include
@@ -1,0 +1,33 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_batch_class()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'batch_class',
+    'Should have table public.batch_class'
+);
+
+RETURN NEXT has_pk(
+    'public', 'batch_class',
+    'Table public.batch_class should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'batch_class'::name, ARRAY[
+    'id'::name,
+    'class'::name
+]);
+
+RETURN NEXT has_column(       'public', 'batch_class', 'id', 'Column public.batch_class.id should exist');
+RETURN NEXT col_type_is(      'public', 'batch_class', 'id', 'integer', 'Column public.batch_class.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'batch_class', 'id', 'Column public.batch_class.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'batch_class', 'id', 'Column public.batch_class.id shouldhave a default');
+--SELECT col_default_is(   'public', 'batch_class', 'id', 'nextval(''batch_class_id_seq''::regclass)', 'Column public.batch_class.id default is');RETURN NEXT col_default_is(   'public', 'batch_class', 'id', 'nextval(''batch_class_id_seq''::regclass)', 'Column public.batch_class.id default is');
+
+RETURN NEXT has_column(       'public', 'batch_class', 'class', 'Column public.batch_class.class should exist');
+RETURN NEXT col_type_is(      'public', 'batch_class', 'class', 'character varying', 'Column public.batch_class.class should be type character varying');
+RETURN NEXT col_not_null(     'public', 'batch_class', 'class', 'Column public.batch_class.class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'batch_class', 'class', 'Column public.batch_class.class should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.bu_class_to_module.sql.pg_include
+++ b/xt/pgtap/table_public.bu_class_to_module.sql.pg_include
@@ -1,0 +1,32 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_bu_class_to_module()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'bu_class_to_module',
+    'Should have table public.bu_class_to_module'
+);
+
+RETURN NEXT has_pk(
+    'public', 'bu_class_to_module',
+    'Table public.bu_class_to_module should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'bu_class_to_module'::name, ARRAY[
+    'bu_class_id'::name,
+    'module_id'::name
+]);
+
+RETURN NEXT has_column(       'public', 'bu_class_to_module', 'bu_class_id', 'Column public.bu_class_to_module.bu_class_id should exist');
+RETURN NEXT col_type_is(      'public', 'bu_class_to_module', 'bu_class_id', 'integer', 'Column public.bu_class_to_module.bu_class_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'bu_class_to_module', 'bu_class_id', 'Column public.bu_class_to_module.bu_class_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'bu_class_to_module', 'bu_class_id', 'Column public.bu_class_to_module.bu_class_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'bu_class_to_module', 'module_id', 'Column public.bu_class_to_module.module_id should exist');
+RETURN NEXT col_type_is(      'public', 'bu_class_to_module', 'module_id', 'integer', 'Column public.bu_class_to_module.module_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'bu_class_to_module', 'module_id', 'Column public.bu_class_to_module.module_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'bu_class_to_module', 'module_id', 'Column public.bu_class_to_module.module_id should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.budget_info.sql.pg_include
+++ b/xt/pgtap/table_public.budget_info.sql.pg_include
@@ -1,0 +1,89 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_budget_info()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'budget_info',
+    'Should have table public.budget_info'
+);
+
+RETURN NEXT has_pk(
+    'public', 'budget_info',
+    'Table public.budget_info should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'budget_info'::name, ARRAY[
+    'id'::name,
+    'start_date'::name,
+    'end_date'::name,
+    'reference'::name,
+    'description'::name,
+    'entered_by'::name,
+    'approved_by'::name,
+    'obsolete_by'::name,
+    'entered_at'::name,
+    'approved_at'::name,
+    'obsolete_at'::name
+]);
+
+RETURN NEXT has_column(       'public', 'budget_info', 'id', 'Column public.budget_info.id should exist');
+RETURN NEXT col_type_is(      'public', 'budget_info', 'id', 'integer', 'Column public.budget_info.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'budget_info', 'id', 'Column public.budget_info.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'budget_info', 'id', 'Column public.budget_info.id shouldhave a default');
+--SELECT col_default_is(   'public', 'budget_info', 'id', 'nextval(''budget_info_id_seq''::regclass)', 'Column public.budget_info.id default is');RETURN NEXT col_default_is(   'public', 'budget_info', 'id', 'nextval(''budget_info_id_seq''::regclass)', 'Column public.budget_info.id default is');
+
+RETURN NEXT has_column(       'public', 'budget_info', 'start_date', 'Column public.budget_info.start_date should exist');
+RETURN NEXT col_type_is(      'public', 'budget_info', 'start_date', 'date', 'Column public.budget_info.start_date should be type date');
+RETURN NEXT col_not_null(     'public', 'budget_info', 'start_date', 'Column public.budget_info.start_date should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'budget_info', 'start_date', 'Column public.budget_info.start_date should not have a default');
+
+RETURN NEXT has_column(       'public', 'budget_info', 'end_date', 'Column public.budget_info.end_date should exist');
+RETURN NEXT col_type_is(      'public', 'budget_info', 'end_date', 'date', 'Column public.budget_info.end_date should be type date');
+RETURN NEXT col_not_null(     'public', 'budget_info', 'end_date', 'Column public.budget_info.end_date should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'budget_info', 'end_date', 'Column public.budget_info.end_date should not have a default');
+
+RETURN NEXT has_column(       'public', 'budget_info', 'reference', 'Column public.budget_info.reference should exist');
+RETURN NEXT col_type_is(      'public', 'budget_info', 'reference', 'text', 'Column public.budget_info.reference should be type text');
+RETURN NEXT col_not_null(     'public', 'budget_info', 'reference', 'Column public.budget_info.reference should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'budget_info', 'reference', 'Column public.budget_info.reference should not have a default');
+
+RETURN NEXT has_column(       'public', 'budget_info', 'description', 'Column public.budget_info.description should exist');
+RETURN NEXT col_type_is(      'public', 'budget_info', 'description', 'text', 'Column public.budget_info.description should be type text');
+RETURN NEXT col_not_null(     'public', 'budget_info', 'description', 'Column public.budget_info.description should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'budget_info', 'description', 'Column public.budget_info.description should not have a default');
+
+RETURN NEXT has_column(       'public', 'budget_info', 'entered_by', 'Column public.budget_info.entered_by should exist');
+RETURN NEXT col_type_is(      'public', 'budget_info', 'entered_by', 'integer', 'Column public.budget_info.entered_by should be type integer');
+RETURN NEXT col_not_null(     'public', 'budget_info', 'entered_by', 'Column public.budget_info.entered_by should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'budget_info', 'entered_by', 'Column public.budget_info.entered_by shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'budget_info', 'entered_by', 'person__get_my_entity_id()', 'Column public.budget_info.entered_by default is');
+
+RETURN NEXT has_column(       'public', 'budget_info', 'approved_by', 'Column public.budget_info.approved_by should exist');
+RETURN NEXT col_type_is(      'public', 'budget_info', 'approved_by', 'integer', 'Column public.budget_info.approved_by should be type integer');
+RETURN NEXT col_is_null(      'public', 'budget_info', 'approved_by', 'Column public.budget_info.approved_by should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'budget_info', 'approved_by', 'Column public.budget_info.approved_by should not have a default');
+
+RETURN NEXT has_column(       'public', 'budget_info', 'obsolete_by', 'Column public.budget_info.obsolete_by should exist');
+RETURN NEXT col_type_is(      'public', 'budget_info', 'obsolete_by', 'integer', 'Column public.budget_info.obsolete_by should be type integer');
+RETURN NEXT col_is_null(      'public', 'budget_info', 'obsolete_by', 'Column public.budget_info.obsolete_by should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'budget_info', 'obsolete_by', 'Column public.budget_info.obsolete_by should not have a default');
+
+RETURN NEXT has_column(       'public', 'budget_info', 'entered_at', 'Column public.budget_info.entered_at should exist');
+RETURN NEXT col_type_is(      'public', 'budget_info', 'entered_at', 'timestamp without time zone', 'Column public.budget_info.entered_at should be type timestamp without time zone');
+RETURN NEXT col_not_null(     'public', 'budget_info', 'entered_at', 'Column public.budget_info.entered_at should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'budget_info', 'entered_at', 'Column public.budget_info.entered_at shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'budget_info', 'entered_at', 'now()', 'Column public.budget_info.entered_at default is');
+
+RETURN NEXT has_column(       'public', 'budget_info', 'approved_at', 'Column public.budget_info.approved_at should exist');
+RETURN NEXT col_type_is(      'public', 'budget_info', 'approved_at', 'timestamp without time zone', 'Column public.budget_info.approved_at should be type timestamp without time zone');
+RETURN NEXT col_is_null(      'public', 'budget_info', 'approved_at', 'Column public.budget_info.approved_at should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'budget_info', 'approved_at', 'Column public.budget_info.approved_at should not have a default');
+
+RETURN NEXT has_column(       'public', 'budget_info', 'obsolete_at', 'Column public.budget_info.obsolete_at should exist');
+RETURN NEXT col_type_is(      'public', 'budget_info', 'obsolete_at', 'timestamp without time zone', 'Column public.budget_info.obsolete_at should be type timestamp without time zone');
+RETURN NEXT col_is_null(      'public', 'budget_info', 'obsolete_at', 'Column public.budget_info.obsolete_at should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'budget_info', 'obsolete_at', 'Column public.budget_info.obsolete_at should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.budget_line.sql.pg_include
+++ b/xt/pgtap/table_public.budget_line.sql.pg_include
@@ -1,0 +1,44 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_budget_line()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'budget_line',
+    'Should have table public.budget_line'
+);
+
+RETURN NEXT has_pk(
+    'public', 'budget_line',
+    'Table public.budget_line should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'budget_line'::name, ARRAY[
+    'budget_id'::name,
+    'account_id'::name,
+    'description'::name,
+    'amount'::name
+]);
+
+RETURN NEXT has_column(       'public', 'budget_line', 'budget_id', 'Column public.budget_line.budget_id should exist');
+RETURN NEXT col_type_is(      'public', 'budget_line', 'budget_id', 'integer', 'Column public.budget_line.budget_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'budget_line', 'budget_id', 'Column public.budget_line.budget_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'budget_line', 'budget_id', 'Column public.budget_line.budget_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'budget_line', 'account_id', 'Column public.budget_line.account_id should exist');
+RETURN NEXT col_type_is(      'public', 'budget_line', 'account_id', 'integer', 'Column public.budget_line.account_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'budget_line', 'account_id', 'Column public.budget_line.account_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'budget_line', 'account_id', 'Column public.budget_line.account_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'budget_line', 'description', 'Column public.budget_line.description should exist');
+RETURN NEXT col_type_is(      'public', 'budget_line', 'description', 'text', 'Column public.budget_line.description should be type text');
+RETURN NEXT col_is_null(      'public', 'budget_line', 'description', 'Column public.budget_line.description should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'budget_line', 'description', 'Column public.budget_line.description should not have a default');
+
+RETURN NEXT has_column(       'public', 'budget_line', 'amount', 'Column public.budget_line.amount should exist');
+RETURN NEXT col_type_is(      'public', 'budget_line', 'amount', 'numeric', 'Column public.budget_line.amount should be type numeric');
+RETURN NEXT col_not_null(     'public', 'budget_line', 'amount', 'Column public.budget_line.amount should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'budget_line', 'amount', 'Column public.budget_line.amount should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.budget_note.sql.pg_include
+++ b/xt/pgtap/table_public.budget_note.sql.pg_include
@@ -1,0 +1,73 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_budget_note()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'budget_note',
+    'Should have table public.budget_note'
+);
+
+RETURN NEXT has_pk(
+    'public', 'budget_note',
+    'Table public.budget_note should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'budget_note'::name, ARRAY[
+    'id'::name,
+    'note_class'::name,
+    'note'::name,
+    'vector'::name,
+    'created'::name,
+    'created_by'::name,
+    'ref_key'::name,
+    'subject'::name
+]);
+
+RETURN NEXT has_column(       'public', 'budget_note', 'id', 'Column public.budget_note.id should exist');
+RETURN NEXT col_type_is(      'public', 'budget_note', 'id', 'integer', 'Column public.budget_note.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'budget_note', 'id', 'Column public.budget_note.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'budget_note', 'id', 'Column public.budget_note.id shouldhave a default');
+--SELECT col_default_is(   'public', 'budget_note', 'id', 'nextval(''note_id_seq''::regclass)', 'Column public.budget_note.id default is');RETURN NEXT col_default_is(   'public', 'budget_note', 'id', 'nextval(''note_id_seq''::regclass)', 'Column public.budget_note.id default is');
+
+RETURN NEXT has_column(       'public', 'budget_note', 'note_class', 'Column public.budget_note.note_class should exist');
+RETURN NEXT col_type_is(      'public', 'budget_note', 'note_class', 'integer', 'Column public.budget_note.note_class should be type integer');
+RETURN NEXT col_not_null(     'public', 'budget_note', 'note_class', 'Column public.budget_note.note_class should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'budget_note', 'note_class', 'Column public.budget_note.note_class shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'budget_note', 'note_class', '6', 'Column public.budget_note.note_class default is');
+
+RETURN NEXT has_column(       'public', 'budget_note', 'note', 'Column public.budget_note.note should exist');
+RETURN NEXT col_type_is(      'public', 'budget_note', 'note', 'text', 'Column public.budget_note.note should be type text');
+RETURN NEXT col_not_null(     'public', 'budget_note', 'note', 'Column public.budget_note.note should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'budget_note', 'note', 'Column public.budget_note.note should not have a default');
+
+RETURN NEXT has_column(       'public', 'budget_note', 'vector', 'Column public.budget_note.vector should exist');
+RETURN NEXT col_type_is(      'public', 'budget_note', 'vector', 'tsvector', 'Column public.budget_note.vector should be type tsvector');
+RETURN NEXT col_not_null(     'public', 'budget_note', 'vector', 'Column public.budget_note.vector should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'budget_note', 'vector', 'Column public.budget_note.vector shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'budget_note', 'vector', ''::tsvector, 'Column public.budget_note.vector default is');
+
+RETURN NEXT has_column(       'public', 'budget_note', 'created', 'Column public.budget_note.created should exist');
+RETURN NEXT col_type_is(      'public', 'budget_note', 'created', 'timestamp without time zone', 'Column public.budget_note.created should be type timestamp without time zone');
+RETURN NEXT col_not_null(     'public', 'budget_note', 'created', 'Column public.budget_note.created should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'budget_note', 'created', 'Column public.budget_note.created shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'budget_note', 'created', 'now()', 'Column public.budget_note.created default is');
+
+RETURN NEXT has_column(       'public', 'budget_note', 'created_by', 'Column public.budget_note.created_by should exist');
+RETURN NEXT col_type_is(      'public', 'budget_note', 'created_by', 'text', 'Column public.budget_note.created_by should be type text');
+RETURN NEXT col_is_null(      'public', 'budget_note', 'created_by', 'Column public.budget_note.created_by should allow NULL');
+RETURN NEXT col_has_default(  'public', 'budget_note', 'created_by', 'Column public.budget_note.created_by shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'budget_note', 'created_by', '"session_user"()', 'Column public.budget_note.created_by default is');
+
+RETURN NEXT has_column(       'public', 'budget_note', 'ref_key', 'Column public.budget_note.ref_key should exist');
+RETURN NEXT col_type_is(      'public', 'budget_note', 'ref_key', 'integer', 'Column public.budget_note.ref_key should be type integer');
+RETURN NEXT col_not_null(     'public', 'budget_note', 'ref_key', 'Column public.budget_note.ref_key should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'budget_note', 'ref_key', 'Column public.budget_note.ref_key should not have a default');
+
+RETURN NEXT has_column(       'public', 'budget_note', 'subject', 'Column public.budget_note.subject should exist');
+RETURN NEXT col_type_is(      'public', 'budget_note', 'subject', 'text', 'Column public.budget_note.subject should be type text');
+RETURN NEXT col_is_null(      'public', 'budget_note', 'subject', 'Column public.budget_note.subject should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'budget_note', 'subject', 'Column public.budget_note.subject should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.budget_to_business_unit.sql.pg_include
+++ b/xt/pgtap/table_public.budget_to_business_unit.sql.pg_include
@@ -1,0 +1,38 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_budget_to_business_unit()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'budget_to_business_unit',
+    'Should have table public.budget_to_business_unit'
+);
+
+RETURN NEXT has_pk(
+    'public', 'budget_to_business_unit',
+    'Table public.budget_to_business_unit should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'budget_to_business_unit'::name, ARRAY[
+    'budget_id'::name,
+    'bu_id'::name,
+    'bu_class'::name
+]);
+
+RETURN NEXT has_column(       'public', 'budget_to_business_unit', 'budget_id', 'Column public.budget_to_business_unit.budget_id should exist');
+RETURN NEXT col_type_is(      'public', 'budget_to_business_unit', 'budget_id', 'integer', 'Column public.budget_to_business_unit.budget_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'budget_to_business_unit', 'budget_id', 'Column public.budget_to_business_unit.budget_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'budget_to_business_unit', 'budget_id', 'Column public.budget_to_business_unit.budget_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'budget_to_business_unit', 'bu_id', 'Column public.budget_to_business_unit.bu_id should exist');
+RETURN NEXT col_type_is(      'public', 'budget_to_business_unit', 'bu_id', 'integer', 'Column public.budget_to_business_unit.bu_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'budget_to_business_unit', 'bu_id', 'Column public.budget_to_business_unit.bu_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'budget_to_business_unit', 'bu_id', 'Column public.budget_to_business_unit.bu_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'budget_to_business_unit', 'bu_class', 'Column public.budget_to_business_unit.bu_class should exist');
+RETURN NEXT col_type_is(      'public', 'budget_to_business_unit', 'bu_class', 'integer', 'Column public.budget_to_business_unit.bu_class should be type integer');
+RETURN NEXT col_not_null(     'public', 'budget_to_business_unit', 'bu_class', 'Column public.budget_to_business_unit.bu_class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'budget_to_business_unit', 'bu_class', 'Column public.budget_to_business_unit.bu_class should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.business.sql.pg_include
+++ b/xt/pgtap/table_public.business.sql.pg_include
@@ -1,0 +1,39 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_business()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'business',
+    'Should have table public.business'
+);
+
+RETURN NEXT has_pk(
+    'public', 'business',
+    'Table public.business should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'business'::name, ARRAY[
+    'id'::name,
+    'description'::name,
+    'discount'::name
+]);
+
+RETURN NEXT has_column(       'public', 'business', 'id', 'Column public.business.id should exist');
+RETURN NEXT col_type_is(      'public', 'business', 'id', 'integer', 'Column public.business.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'business', 'id', 'Column public.business.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'business', 'id', 'Column public.business.id shouldhave a default');
+--SELECT col_default_is(   'public', 'business', 'id', 'nextval(''business_id_seq''::regclass)', 'Column public.business.id default is');RETURN NEXT col_default_is(   'public', 'business', 'id', 'nextval(''business_id_seq''::regclass)', 'Column public.business.id default is');
+
+RETURN NEXT has_column(       'public', 'business', 'description', 'Column public.business.description should exist');
+RETURN NEXT col_type_is(      'public', 'business', 'description', 'text', 'Column public.business.description should be type text');
+RETURN NEXT col_is_null(      'public', 'business', 'description', 'Column public.business.description should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'business', 'description', 'Column public.business.description should not have a default');
+
+RETURN NEXT has_column(       'public', 'business', 'discount', 'Column public.business.discount should exist');
+RETURN NEXT col_type_is(      'public', 'business', 'discount', 'numeric', 'Column public.business.discount should be type numeric');
+RETURN NEXT col_is_null(      'public', 'business', 'discount', 'Column public.business.discount should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'business', 'discount', 'Column public.business.discount should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.business_unit.sql.pg_include
+++ b/xt/pgtap/table_public.business_unit.sql.pg_include
@@ -1,0 +1,69 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_business_unit()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'business_unit',
+    'Should have table public.business_unit'
+);
+
+RETURN NEXT has_pk(
+    'public', 'business_unit',
+    'Table public.business_unit should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'business_unit'::name, ARRAY[
+    'id'::name,
+    'class_id'::name,
+    'control_code'::name,
+    'description'::name,
+    'start_date'::name,
+    'end_date'::name,
+    'parent_id'::name,
+    'credit_id'::name
+]);
+
+RETURN NEXT has_column(       'public', 'business_unit', 'id', 'Column public.business_unit.id should exist');
+RETURN NEXT col_type_is(      'public', 'business_unit', 'id', 'integer', 'Column public.business_unit.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'business_unit', 'id', 'Column public.business_unit.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'business_unit', 'id', 'Column public.business_unit.id shouldhave a default');
+--SELECT col_default_is(   'public', 'business_unit', 'id', 'nextval(''business_unit_id_seq''::regclass)', 'Column public.business_unit.id default is');RETURN NEXT col_default_is(   'public', 'business_unit', 'id', 'nextval(''business_unit_id_seq''::regclass)', 'Column public.business_unit.id default is');
+
+RETURN NEXT has_column(       'public', 'business_unit', 'class_id', 'Column public.business_unit.class_id should exist');
+RETURN NEXT col_type_is(      'public', 'business_unit', 'class_id', 'integer', 'Column public.business_unit.class_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'business_unit', 'class_id', 'Column public.business_unit.class_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'business_unit', 'class_id', 'Column public.business_unit.class_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'business_unit', 'control_code', 'Column public.business_unit.control_code should exist');
+RETURN NEXT col_type_is(      'public', 'business_unit', 'control_code', 'text', 'Column public.business_unit.control_code should be type text');
+RETURN NEXT col_is_null(      'public', 'business_unit', 'control_code', 'Column public.business_unit.control_code should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'business_unit', 'control_code', 'Column public.business_unit.control_code should not have a default');
+
+RETURN NEXT has_column(       'public', 'business_unit', 'description', 'Column public.business_unit.description should exist');
+RETURN NEXT col_type_is(      'public', 'business_unit', 'description', 'text', 'Column public.business_unit.description should be type text');
+RETURN NEXT col_is_null(      'public', 'business_unit', 'description', 'Column public.business_unit.description should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'business_unit', 'description', 'Column public.business_unit.description should not have a default');
+
+RETURN NEXT has_column(       'public', 'business_unit', 'start_date', 'Column public.business_unit.start_date should exist');
+RETURN NEXT col_type_is(      'public', 'business_unit', 'start_date', 'date', 'Column public.business_unit.start_date should be type date');
+RETURN NEXT col_is_null(      'public', 'business_unit', 'start_date', 'Column public.business_unit.start_date should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'business_unit', 'start_date', 'Column public.business_unit.start_date should not have a default');
+
+RETURN NEXT has_column(       'public', 'business_unit', 'end_date', 'Column public.business_unit.end_date should exist');
+RETURN NEXT col_type_is(      'public', 'business_unit', 'end_date', 'date', 'Column public.business_unit.end_date should be type date');
+RETURN NEXT col_is_null(      'public', 'business_unit', 'end_date', 'Column public.business_unit.end_date should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'business_unit', 'end_date', 'Column public.business_unit.end_date should not have a default');
+
+RETURN NEXT has_column(       'public', 'business_unit', 'parent_id', 'Column public.business_unit.parent_id should exist');
+RETURN NEXT col_type_is(      'public', 'business_unit', 'parent_id', 'integer', 'Column public.business_unit.parent_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'business_unit', 'parent_id', 'Column public.business_unit.parent_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'business_unit', 'parent_id', 'Column public.business_unit.parent_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'business_unit', 'credit_id', 'Column public.business_unit.credit_id should exist');
+RETURN NEXT col_type_is(      'public', 'business_unit', 'credit_id', 'integer', 'Column public.business_unit.credit_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'business_unit', 'credit_id', 'Column public.business_unit.credit_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'business_unit', 'credit_id', 'Column public.business_unit.credit_id should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.business_unit_ac.sql.pg_include
+++ b/xt/pgtap/table_public.business_unit_ac.sql.pg_include
@@ -1,0 +1,38 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_business_unit_ac()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'business_unit_ac',
+    'Should have table public.business_unit_ac'
+);
+
+RETURN NEXT has_pk(
+    'public', 'business_unit_ac',
+    'Table public.business_unit_ac should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'business_unit_ac'::name, ARRAY[
+    'entry_id'::name,
+    'class_id'::name,
+    'bu_id'::name
+]);
+
+RETURN NEXT has_column(       'public', 'business_unit_ac', 'entry_id', 'Column public.business_unit_ac.entry_id should exist');
+RETURN NEXT col_type_is(      'public', 'business_unit_ac', 'entry_id', 'integer', 'Column public.business_unit_ac.entry_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'business_unit_ac', 'entry_id', 'Column public.business_unit_ac.entry_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'business_unit_ac', 'entry_id', 'Column public.business_unit_ac.entry_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'business_unit_ac', 'class_id', 'Column public.business_unit_ac.class_id should exist');
+RETURN NEXT col_type_is(      'public', 'business_unit_ac', 'class_id', 'integer', 'Column public.business_unit_ac.class_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'business_unit_ac', 'class_id', 'Column public.business_unit_ac.class_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'business_unit_ac', 'class_id', 'Column public.business_unit_ac.class_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'business_unit_ac', 'bu_id', 'Column public.business_unit_ac.bu_id should exist');
+RETURN NEXT col_type_is(      'public', 'business_unit_ac', 'bu_id', 'integer', 'Column public.business_unit_ac.bu_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'business_unit_ac', 'bu_id', 'Column public.business_unit_ac.bu_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'business_unit_ac', 'bu_id', 'Column public.business_unit_ac.bu_id should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.business_unit_class.sql.pg_include
+++ b/xt/pgtap/table_public.business_unit_class.sql.pg_include
@@ -1,0 +1,46 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_business_unit_class()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'business_unit_class',
+    'Should have table public.business_unit_class'
+);
+
+RETURN NEXT has_pk(
+    'public', 'business_unit_class',
+    'Table public.business_unit_class should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'business_unit_class'::name, ARRAY[
+    'id'::name,
+    'label'::name,
+    'active'::name,
+    'ordering'::name
+]);
+
+RETURN NEXT has_column(       'public', 'business_unit_class', 'id', 'Column public.business_unit_class.id should exist');
+RETURN NEXT col_type_is(      'public', 'business_unit_class', 'id', 'integer', 'Column public.business_unit_class.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'business_unit_class', 'id', 'Column public.business_unit_class.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'business_unit_class', 'id', 'Column public.business_unit_class.id shouldhave a default');
+--SELECT col_default_is(   'public', 'business_unit_class', 'id', 'nextval(''business_unit_class_id_seq''::regclass)', 'Column public.business_unit_class.id default is');RETURN NEXT col_default_is(   'public', 'business_unit_class', 'id', 'nextval(''business_unit_class_id_seq''::regclass)', 'Column public.business_unit_class.id default is');
+
+RETURN NEXT has_column(       'public', 'business_unit_class', 'label', 'Column public.business_unit_class.label should exist');
+RETURN NEXT col_type_is(      'public', 'business_unit_class', 'label', 'text', 'Column public.business_unit_class.label should be type text');
+RETURN NEXT col_not_null(     'public', 'business_unit_class', 'label', 'Column public.business_unit_class.label should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'business_unit_class', 'label', 'Column public.business_unit_class.label should not have a default');
+
+RETURN NEXT has_column(       'public', 'business_unit_class', 'active', 'Column public.business_unit_class.active should exist');
+RETURN NEXT col_type_is(      'public', 'business_unit_class', 'active', 'boolean', 'Column public.business_unit_class.active should be type boolean');
+RETURN NEXT col_not_null(     'public', 'business_unit_class', 'active', 'Column public.business_unit_class.active should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'business_unit_class', 'active', 'Column public.business_unit_class.active shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'business_unit_class', 'active', 'false', 'Column public.business_unit_class.active default is');
+
+RETURN NEXT has_column(       'public', 'business_unit_class', 'ordering', 'Column public.business_unit_class.ordering should exist');
+RETURN NEXT col_type_is(      'public', 'business_unit_class', 'ordering', 'integer', 'Column public.business_unit_class.ordering should be type integer');
+RETURN NEXT col_is_null(      'public', 'business_unit_class', 'ordering', 'Column public.business_unit_class.ordering should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'business_unit_class', 'ordering', 'Column public.business_unit_class.ordering should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.business_unit_inv.sql.pg_include
+++ b/xt/pgtap/table_public.business_unit_inv.sql.pg_include
@@ -1,0 +1,38 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_business_unit_inv()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'business_unit_inv',
+    'Should have table public.business_unit_inv'
+);
+
+RETURN NEXT has_pk(
+    'public', 'business_unit_inv',
+    'Table public.business_unit_inv should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'business_unit_inv'::name, ARRAY[
+    'entry_id'::name,
+    'class_id'::name,
+    'bu_id'::name
+]);
+
+RETURN NEXT has_column(       'public', 'business_unit_inv', 'entry_id', 'Column public.business_unit_inv.entry_id should exist');
+RETURN NEXT col_type_is(      'public', 'business_unit_inv', 'entry_id', 'integer', 'Column public.business_unit_inv.entry_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'business_unit_inv', 'entry_id', 'Column public.business_unit_inv.entry_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'business_unit_inv', 'entry_id', 'Column public.business_unit_inv.entry_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'business_unit_inv', 'class_id', 'Column public.business_unit_inv.class_id should exist');
+RETURN NEXT col_type_is(      'public', 'business_unit_inv', 'class_id', 'integer', 'Column public.business_unit_inv.class_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'business_unit_inv', 'class_id', 'Column public.business_unit_inv.class_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'business_unit_inv', 'class_id', 'Column public.business_unit_inv.class_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'business_unit_inv', 'bu_id', 'Column public.business_unit_inv.bu_id should exist');
+RETURN NEXT col_type_is(      'public', 'business_unit_inv', 'bu_id', 'integer', 'Column public.business_unit_inv.bu_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'business_unit_inv', 'bu_id', 'Column public.business_unit_inv.bu_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'business_unit_inv', 'bu_id', 'Column public.business_unit_inv.bu_id should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.business_unit_jl.sql.pg_include
+++ b/xt/pgtap/table_public.business_unit_jl.sql.pg_include
@@ -1,0 +1,38 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_business_unit_jl()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'business_unit_jl',
+    'Should have table public.business_unit_jl'
+);
+
+RETURN NEXT has_pk(
+    'public', 'business_unit_jl',
+    'Table public.business_unit_jl should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'business_unit_jl'::name, ARRAY[
+    'entry_id'::name,
+    'bu_class'::name,
+    'bu_id'::name
+]);
+
+RETURN NEXT has_column(       'public', 'business_unit_jl', 'entry_id', 'Column public.business_unit_jl.entry_id should exist');
+RETURN NEXT col_type_is(      'public', 'business_unit_jl', 'entry_id', 'integer', 'Column public.business_unit_jl.entry_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'business_unit_jl', 'entry_id', 'Column public.business_unit_jl.entry_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'business_unit_jl', 'entry_id', 'Column public.business_unit_jl.entry_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'business_unit_jl', 'bu_class', 'Column public.business_unit_jl.bu_class should exist');
+RETURN NEXT col_type_is(      'public', 'business_unit_jl', 'bu_class', 'integer', 'Column public.business_unit_jl.bu_class should be type integer');
+RETURN NEXT col_not_null(     'public', 'business_unit_jl', 'bu_class', 'Column public.business_unit_jl.bu_class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'business_unit_jl', 'bu_class', 'Column public.business_unit_jl.bu_class should not have a default');
+
+RETURN NEXT has_column(       'public', 'business_unit_jl', 'bu_id', 'Column public.business_unit_jl.bu_id should exist');
+RETURN NEXT col_type_is(      'public', 'business_unit_jl', 'bu_id', 'integer', 'Column public.business_unit_jl.bu_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'business_unit_jl', 'bu_id', 'Column public.business_unit_jl.bu_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'business_unit_jl', 'bu_id', 'Column public.business_unit_jl.bu_id should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.business_unit_oitem.sql.pg_include
+++ b/xt/pgtap/table_public.business_unit_oitem.sql.pg_include
@@ -1,0 +1,38 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_business_unit_oitem()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'business_unit_oitem',
+    'Should have table public.business_unit_oitem'
+);
+
+RETURN NEXT has_pk(
+    'public', 'business_unit_oitem',
+    'Table public.business_unit_oitem should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'business_unit_oitem'::name, ARRAY[
+    'entry_id'::name,
+    'class_id'::name,
+    'bu_id'::name
+]);
+
+RETURN NEXT has_column(       'public', 'business_unit_oitem', 'entry_id', 'Column public.business_unit_oitem.entry_id should exist');
+RETURN NEXT col_type_is(      'public', 'business_unit_oitem', 'entry_id', 'integer', 'Column public.business_unit_oitem.entry_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'business_unit_oitem', 'entry_id', 'Column public.business_unit_oitem.entry_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'business_unit_oitem', 'entry_id', 'Column public.business_unit_oitem.entry_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'business_unit_oitem', 'class_id', 'Column public.business_unit_oitem.class_id should exist');
+RETURN NEXT col_type_is(      'public', 'business_unit_oitem', 'class_id', 'integer', 'Column public.business_unit_oitem.class_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'business_unit_oitem', 'class_id', 'Column public.business_unit_oitem.class_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'business_unit_oitem', 'class_id', 'Column public.business_unit_oitem.class_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'business_unit_oitem', 'bu_id', 'Column public.business_unit_oitem.bu_id should exist');
+RETURN NEXT col_type_is(      'public', 'business_unit_oitem', 'bu_id', 'integer', 'Column public.business_unit_oitem.bu_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'business_unit_oitem', 'bu_id', 'Column public.business_unit_oitem.bu_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'business_unit_oitem', 'bu_id', 'Column public.business_unit_oitem.bu_id should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.business_unit_translation.sql.pg_include
+++ b/xt/pgtap/table_public.business_unit_translation.sql.pg_include
@@ -1,0 +1,38 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_business_unit_translation()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'business_unit_translation',
+    'Should have table public.business_unit_translation'
+);
+
+RETURN NEXT has_pk(
+    'public', 'business_unit_translation',
+    'Table public.business_unit_translation should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'business_unit_translation'::name, ARRAY[
+    'trans_id'::name,
+    'language_code'::name,
+    'description'::name
+]);
+
+RETURN NEXT has_column(       'public', 'business_unit_translation', 'trans_id', 'Column public.business_unit_translation.trans_id should exist');
+RETURN NEXT col_type_is(      'public', 'business_unit_translation', 'trans_id', 'integer', 'Column public.business_unit_translation.trans_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'business_unit_translation', 'trans_id', 'Column public.business_unit_translation.trans_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'business_unit_translation', 'trans_id', 'Column public.business_unit_translation.trans_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'business_unit_translation', 'language_code', 'Column public.business_unit_translation.language_code should exist');
+RETURN NEXT col_type_is(      'public', 'business_unit_translation', 'language_code', 'character varying(6)', 'Column public.business_unit_translation.language_code should be type character varying(6)');
+RETURN NEXT col_not_null(     'public', 'business_unit_translation', 'language_code', 'Column public.business_unit_translation.language_code should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'business_unit_translation', 'language_code', 'Column public.business_unit_translation.language_code should not have a default');
+
+RETURN NEXT has_column(       'public', 'business_unit_translation', 'description', 'Column public.business_unit_translation.description should exist');
+RETURN NEXT col_type_is(      'public', 'business_unit_translation', 'description', 'text', 'Column public.business_unit_translation.description should be type text');
+RETURN NEXT col_is_null(      'public', 'business_unit_translation', 'description', 'Column public.business_unit_translation.description should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'business_unit_translation', 'description', 'Column public.business_unit_translation.description should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.company.sql.pg_include
+++ b/xt/pgtap/table_public.company.sql.pg_include
@@ -1,0 +1,70 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_company()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'company',
+    'Should have table public.company'
+);
+
+RETURN NEXT has_pk(
+    'public', 'company',
+    'Table public.company should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'company'::name, ARRAY[
+    'id'::name,
+    'entity_id'::name,
+    'legal_name'::name,
+    'tax_id'::name,
+    'sales_tax_id'::name,
+    'license_number'::name,
+    'sic_code'::name,
+    'created'::name
+]);
+
+RETURN NEXT has_column(       'public', 'company', 'id', 'Column public.company.id should exist');
+RETURN NEXT col_type_is(      'public', 'company', 'id', 'integer', 'Column public.company.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'company', 'id', 'Column public.company.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'company', 'id', 'Column public.company.id shouldhave a default');
+--SELECT col_default_is(   'public', 'company', 'id', 'nextval(''company_id_seq''::regclass)', 'Column public.company.id default is');RETURN NEXT col_default_is(   'public', 'company', 'id', 'nextval(''company_id_seq''::regclass)', 'Column public.company.id default is');
+
+RETURN NEXT has_column(       'public', 'company', 'entity_id', 'Column public.company.entity_id should exist');
+RETURN NEXT col_type_is(      'public', 'company', 'entity_id', 'integer', 'Column public.company.entity_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'company', 'entity_id', 'Column public.company.entity_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'company', 'entity_id', 'Column public.company.entity_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'company', 'legal_name', 'Column public.company.legal_name should exist');
+RETURN NEXT col_type_is(      'public', 'company', 'legal_name', 'text', 'Column public.company.legal_name should be type text');
+RETURN NEXT col_not_null(     'public', 'company', 'legal_name', 'Column public.company.legal_name should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'company', 'legal_name', 'Column public.company.legal_name should not have a default');
+
+RETURN NEXT has_column(       'public', 'company', 'tax_id', 'Column public.company.tax_id should exist');
+RETURN NEXT col_type_is(      'public', 'company', 'tax_id', 'text', 'Column public.company.tax_id should be type text');
+RETURN NEXT col_is_null(      'public', 'company', 'tax_id', 'Column public.company.tax_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'company', 'tax_id', 'Column public.company.tax_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'company', 'sales_tax_id', 'Column public.company.sales_tax_id should exist');
+RETURN NEXT col_type_is(      'public', 'company', 'sales_tax_id', 'text', 'Column public.company.sales_tax_id should be type text');
+RETURN NEXT col_is_null(      'public', 'company', 'sales_tax_id', 'Column public.company.sales_tax_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'company', 'sales_tax_id', 'Column public.company.sales_tax_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'company', 'license_number', 'Column public.company.license_number should exist');
+RETURN NEXT col_type_is(      'public', 'company', 'license_number', 'text', 'Column public.company.license_number should be type text');
+RETURN NEXT col_is_null(      'public', 'company', 'license_number', 'Column public.company.license_number should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'company', 'license_number', 'Column public.company.license_number should not have a default');
+
+RETURN NEXT has_column(       'public', 'company', 'sic_code', 'Column public.company.sic_code should exist');
+RETURN NEXT col_type_is(      'public', 'company', 'sic_code', 'character varying', 'Column public.company.sic_code should be type character varying');
+RETURN NEXT col_is_null(      'public', 'company', 'sic_code', 'Column public.company.sic_code should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'company', 'sic_code', 'Column public.company.sic_code should not have a default');
+
+RETURN NEXT has_column(       'public', 'company', 'created', 'Column public.company.created should exist');
+RETURN NEXT col_type_is(      'public', 'company', 'created', 'date', 'Column public.company.created should be type date');
+RETURN NEXT col_not_null(     'public', 'company', 'created', 'Column public.company.created should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'company', 'created', 'Column public.company.created shouldhave a default');
+--SELECT col_default_is(   'public', 'company', 'created', '(''now''::text)::date', 'Column public.company.created default is');RETURN NEXT col_default_is(   'public', 'company', 'created', '(''now''::text)::date', 'Column public.company.created default is');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.contact_class.sql.pg_include
+++ b/xt/pgtap/table_public.contact_class.sql.pg_include
@@ -1,0 +1,33 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_contact_class()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'contact_class',
+    'Should have table public.contact_class'
+);
+
+RETURN NEXT has_pk(
+    'public', 'contact_class',
+    'Table public.contact_class should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'contact_class'::name, ARRAY[
+    'id'::name,
+    'class'::name
+]);
+
+RETURN NEXT has_column(       'public', 'contact_class', 'id', 'Column public.contact_class.id should exist');
+RETURN NEXT col_type_is(      'public', 'contact_class', 'id', 'integer', 'Column public.contact_class.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'contact_class', 'id', 'Column public.contact_class.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'contact_class', 'id', 'Column public.contact_class.id shouldhave a default');
+--SELECT col_default_is(   'public', 'contact_class', 'id', 'nextval(''contact_class_id_seq''::regclass)', 'Column public.contact_class.id default is');RETURN NEXT col_default_is(   'public', 'contact_class', 'id', 'nextval(''contact_class_id_seq''::regclass)', 'Column public.contact_class.id default is');
+
+RETURN NEXT has_column(       'public', 'contact_class', 'class', 'Column public.contact_class.class should exist');
+RETURN NEXT col_type_is(      'public', 'contact_class', 'class', 'text', 'Column public.contact_class.class should be type text');
+RETURN NEXT col_not_null(     'public', 'contact_class', 'class', 'Column public.contact_class.class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'contact_class', 'class', 'Column public.contact_class.class should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.country.sql.pg_include
+++ b/xt/pgtap/table_public.country.sql.pg_include
@@ -1,0 +1,45 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_country()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'country',
+    'Should have table public.country'
+);
+
+RETURN NEXT has_pk(
+    'public', 'country',
+    'Table public.country should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'country'::name, ARRAY[
+    'id'::name,
+    'name'::name,
+    'short_name'::name,
+    'itu'::name
+]);
+
+RETURN NEXT has_column(       'public', 'country', 'id', 'Column public.country.id should exist');
+RETURN NEXT col_type_is(      'public', 'country', 'id', 'integer', 'Column public.country.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'country', 'id', 'Column public.country.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'country', 'id', 'Column public.country.id shouldhave a default');
+--SELECT col_default_is(   'public', 'country', 'id', 'nextval(''country_id_seq''::regclass)', 'Column public.country.id default is');RETURN NEXT col_default_is(   'public', 'country', 'id', 'nextval(''country_id_seq''::regclass)', 'Column public.country.id default is');
+
+RETURN NEXT has_column(       'public', 'country', 'name', 'Column public.country.name should exist');
+RETURN NEXT col_type_is(      'public', 'country', 'name', 'text', 'Column public.country.name should be type text');
+RETURN NEXT col_not_null(     'public', 'country', 'name', 'Column public.country.name should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'country', 'name', 'Column public.country.name should not have a default');
+
+RETURN NEXT has_column(       'public', 'country', 'short_name', 'Column public.country.short_name should exist');
+RETURN NEXT col_type_is(      'public', 'country', 'short_name', 'text', 'Column public.country.short_name should be type text');
+RETURN NEXT col_not_null(     'public', 'country', 'short_name', 'Column public.country.short_name should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'country', 'short_name', 'Column public.country.short_name should not have a default');
+
+RETURN NEXT has_column(       'public', 'country', 'itu', 'Column public.country.itu should exist');
+RETURN NEXT col_type_is(      'public', 'country', 'itu', 'text', 'Column public.country.itu should be type text');
+RETURN NEXT col_is_null(      'public', 'country', 'itu', 'Column public.country.itu should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'country', 'itu', 'Column public.country.itu should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.country_tax_form.sql.pg_include
+++ b/xt/pgtap/table_public.country_tax_form.sql.pg_include
@@ -1,0 +1,53 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_country_tax_form()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'country_tax_form',
+    'Should have table public.country_tax_form'
+);
+
+RETURN NEXT has_pk(
+    'public', 'country_tax_form',
+    'Table public.country_tax_form should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'country_tax_form'::name, ARRAY[
+    'country_id'::name,
+    'form_name'::name,
+    'id'::name,
+    'default_reportable'::name,
+    'is_accrual'::name
+]);
+
+RETURN NEXT has_column(       'public', 'country_tax_form', 'country_id', 'Column public.country_tax_form.country_id should exist');
+RETURN NEXT col_type_is(      'public', 'country_tax_form', 'country_id', 'integer', 'Column public.country_tax_form.country_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'country_tax_form', 'country_id', 'Column public.country_tax_form.country_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'country_tax_form', 'country_id', 'Column public.country_tax_form.country_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'country_tax_form', 'form_name', 'Column public.country_tax_form.form_name should exist');
+RETURN NEXT col_type_is(      'public', 'country_tax_form', 'form_name', 'text', 'Column public.country_tax_form.form_name should be type text');
+RETURN NEXT col_not_null(     'public', 'country_tax_form', 'form_name', 'Column public.country_tax_form.form_name should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'country_tax_form', 'form_name', 'Column public.country_tax_form.form_name should not have a default');
+
+RETURN NEXT has_column(       'public', 'country_tax_form', 'id', 'Column public.country_tax_form.id should exist');
+RETURN NEXT col_type_is(      'public', 'country_tax_form', 'id', 'integer', 'Column public.country_tax_form.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'country_tax_form', 'id', 'Column public.country_tax_form.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'country_tax_form', 'id', 'Column public.country_tax_form.id shouldhave a default');
+--SELECT col_default_is(   'public', 'country_tax_form', 'id', 'nextval(''country_tax_form_id_seq''::regclass)', 'Column public.country_tax_form.id default is');RETURN NEXT col_default_is(   'public', 'country_tax_form', 'id', 'nextval(''country_tax_form_id_seq''::regclass)', 'Column public.country_tax_form.id default is');
+
+RETURN NEXT has_column(       'public', 'country_tax_form', 'default_reportable', 'Column public.country_tax_form.default_reportable should exist');
+RETURN NEXT col_type_is(      'public', 'country_tax_form', 'default_reportable', 'boolean', 'Column public.country_tax_form.default_reportable should be type boolean');
+RETURN NEXT col_not_null(     'public', 'country_tax_form', 'default_reportable', 'Column public.country_tax_form.default_reportable should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'country_tax_form', 'default_reportable', 'Column public.country_tax_form.default_reportable shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'country_tax_form', 'default_reportable', 'false', 'Column public.country_tax_form.default_reportable default is');
+
+RETURN NEXT has_column(       'public', 'country_tax_form', 'is_accrual', 'Column public.country_tax_form.is_accrual should exist');
+RETURN NEXT col_type_is(      'public', 'country_tax_form', 'is_accrual', 'boolean', 'Column public.country_tax_form.is_accrual should be type boolean');
+RETURN NEXT col_not_null(     'public', 'country_tax_form', 'is_accrual', 'Column public.country_tax_form.is_accrual should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'country_tax_form', 'is_accrual', 'Column public.country_tax_form.is_accrual shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'country_tax_form', 'is_accrual', 'false', 'Column public.country_tax_form.is_accrual default is');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.cr_coa_to_account.sql.pg_include
+++ b/xt/pgtap/table_public.cr_coa_to_account.sql.pg_include
@@ -1,0 +1,32 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_cr_coa_to_account()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'cr_coa_to_account',
+    'Should have table public.cr_coa_to_account'
+);
+
+RETURN NEXT has_pk(
+    'public', 'cr_coa_to_account',
+    'Table public.cr_coa_to_account should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'cr_coa_to_account'::name, ARRAY[
+    'chart_id'::name,
+    'account'::name
+]);
+
+RETURN NEXT has_column(       'public', 'cr_coa_to_account', 'chart_id', 'Column public.cr_coa_to_account.chart_id should exist');
+RETURN NEXT col_type_is(      'public', 'cr_coa_to_account', 'chart_id', 'integer', 'Column public.cr_coa_to_account.chart_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'cr_coa_to_account', 'chart_id', 'Column public.cr_coa_to_account.chart_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'cr_coa_to_account', 'chart_id', 'Column public.cr_coa_to_account.chart_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'cr_coa_to_account', 'account', 'Column public.cr_coa_to_account.account should exist');
+RETURN NEXT col_type_is(      'public', 'cr_coa_to_account', 'account', 'text', 'Column public.cr_coa_to_account.account should be type text');
+RETURN NEXT col_not_null(     'public', 'cr_coa_to_account', 'account', 'Column public.cr_coa_to_account.account should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'cr_coa_to_account', 'account', 'Column public.cr_coa_to_account.account should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.cr_report.sql.pg_include
+++ b/xt/pgtap/table_public.cr_report.sql.pg_include
@@ -1,0 +1,119 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_cr_report()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'cr_report',
+    'Should have table public.cr_report'
+);
+
+RETURN NEXT has_pk(
+    'public', 'cr_report',
+    'Table public.cr_report should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'cr_report'::name, ARRAY[
+    'id'::name,
+    'chart_id'::name,
+    'their_total'::name,
+    'approved'::name,
+    'submitted'::name,
+    'end_date'::name,
+    'updated'::name,
+    'entered_by'::name,
+    'entered_username'::name,
+    'deleted'::name,
+    'deleted_by'::name,
+    'approved_by'::name,
+    'approved_username'::name,
+    'recon_fx'::name,
+    'max_ac_id'::name
+]);
+
+RETURN NEXT has_column(       'public', 'cr_report', 'id', 'Column public.cr_report.id should exist');
+RETURN NEXT col_type_is(      'public', 'cr_report', 'id', 'bigint', 'Column public.cr_report.id should be type bigint');
+RETURN NEXT col_not_null(     'public', 'cr_report', 'id', 'Column public.cr_report.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'cr_report', 'id', 'Column public.cr_report.id shouldhave a default');
+--SELECT col_default_is(   'public', 'cr_report', 'id', 'nextval(''cr_report_id_seq''::regclass)', 'Column public.cr_report.id default is');RETURN NEXT col_default_is(   'public', 'cr_report', 'id', 'nextval(''cr_report_id_seq''::regclass)', 'Column public.cr_report.id default is');
+
+RETURN NEXT has_column(       'public', 'cr_report', 'chart_id', 'Column public.cr_report.chart_id should exist');
+RETURN NEXT col_type_is(      'public', 'cr_report', 'chart_id', 'integer', 'Column public.cr_report.chart_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'cr_report', 'chart_id', 'Column public.cr_report.chart_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'cr_report', 'chart_id', 'Column public.cr_report.chart_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'cr_report', 'their_total', 'Column public.cr_report.their_total should exist');
+RETURN NEXT col_type_is(      'public', 'cr_report', 'their_total', 'numeric', 'Column public.cr_report.their_total should be type numeric');
+RETURN NEXT col_not_null(     'public', 'cr_report', 'their_total', 'Column public.cr_report.their_total should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'cr_report', 'their_total', 'Column public.cr_report.their_total should not have a default');
+
+RETURN NEXT has_column(       'public', 'cr_report', 'approved', 'Column public.cr_report.approved should exist');
+RETURN NEXT col_type_is(      'public', 'cr_report', 'approved', 'boolean', 'Column public.cr_report.approved should be type boolean');
+RETURN NEXT col_not_null(     'public', 'cr_report', 'approved', 'Column public.cr_report.approved should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'cr_report', 'approved', 'Column public.cr_report.approved shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'cr_report', 'approved', 'false', 'Column public.cr_report.approved default is');
+
+RETURN NEXT has_column(       'public', 'cr_report', 'submitted', 'Column public.cr_report.submitted should exist');
+RETURN NEXT col_type_is(      'public', 'cr_report', 'submitted', 'boolean', 'Column public.cr_report.submitted should be type boolean');
+RETURN NEXT col_not_null(     'public', 'cr_report', 'submitted', 'Column public.cr_report.submitted should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'cr_report', 'submitted', 'Column public.cr_report.submitted shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'cr_report', 'submitted', 'false', 'Column public.cr_report.submitted default is');
+
+RETURN NEXT has_column(       'public', 'cr_report', 'end_date', 'Column public.cr_report.end_date should exist');
+RETURN NEXT col_type_is(      'public', 'cr_report', 'end_date', 'date', 'Column public.cr_report.end_date should be type date');
+RETURN NEXT col_not_null(     'public', 'cr_report', 'end_date', 'Column public.cr_report.end_date should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'cr_report', 'end_date', 'Column public.cr_report.end_date shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'cr_report', 'end_date', 'now()', 'Column public.cr_report.end_date default is');
+
+RETURN NEXT has_column(       'public', 'cr_report', 'updated', 'Column public.cr_report.updated should exist');
+RETURN NEXT col_type_is(      'public', 'cr_report', 'updated', 'timestamp without time zone', 'Column public.cr_report.updated should be type timestamp without time zone');
+RETURN NEXT col_not_null(     'public', 'cr_report', 'updated', 'Column public.cr_report.updated should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'cr_report', 'updated', 'Column public.cr_report.updated shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'cr_report', 'updated', 'now()', 'Column public.cr_report.updated default is');
+
+RETURN NEXT has_column(       'public', 'cr_report', 'entered_by', 'Column public.cr_report.entered_by should exist');
+RETURN NEXT col_type_is(      'public', 'cr_report', 'entered_by', 'integer', 'Column public.cr_report.entered_by should be type integer');
+RETURN NEXT col_not_null(     'public', 'cr_report', 'entered_by', 'Column public.cr_report.entered_by should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'cr_report', 'entered_by', 'Column public.cr_report.entered_by shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'cr_report', 'entered_by', 'person__get_my_entity_id()', 'Column public.cr_report.entered_by default is');
+
+RETURN NEXT has_column(       'public', 'cr_report', 'entered_username', 'Column public.cr_report.entered_username should exist');
+RETURN NEXT col_type_is(      'public', 'cr_report', 'entered_username', 'text', 'Column public.cr_report.entered_username should be type text');
+RETURN NEXT col_not_null(     'public', 'cr_report', 'entered_username', 'Column public.cr_report.entered_username should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'cr_report', 'entered_username', 'Column public.cr_report.entered_username shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'cr_report', 'entered_username', '"session_user"()', 'Column public.cr_report.entered_username default is');
+
+RETURN NEXT has_column(       'public', 'cr_report', 'deleted', 'Column public.cr_report.deleted should exist');
+RETURN NEXT col_type_is(      'public', 'cr_report', 'deleted', 'boolean', 'Column public.cr_report.deleted should be type boolean');
+RETURN NEXT col_not_null(     'public', 'cr_report', 'deleted', 'Column public.cr_report.deleted should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'cr_report', 'deleted', 'Column public.cr_report.deleted shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'cr_report', 'deleted', 'false', 'Column public.cr_report.deleted default is');
+
+RETURN NEXT has_column(       'public', 'cr_report', 'deleted_by', 'Column public.cr_report.deleted_by should exist');
+RETURN NEXT col_type_is(      'public', 'cr_report', 'deleted_by', 'integer', 'Column public.cr_report.deleted_by should be type integer');
+RETURN NEXT col_is_null(      'public', 'cr_report', 'deleted_by', 'Column public.cr_report.deleted_by should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'cr_report', 'deleted_by', 'Column public.cr_report.deleted_by should not have a default');
+
+RETURN NEXT has_column(       'public', 'cr_report', 'approved_by', 'Column public.cr_report.approved_by should exist');
+RETURN NEXT col_type_is(      'public', 'cr_report', 'approved_by', 'integer', 'Column public.cr_report.approved_by should be type integer');
+RETURN NEXT col_is_null(      'public', 'cr_report', 'approved_by', 'Column public.cr_report.approved_by should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'cr_report', 'approved_by', 'Column public.cr_report.approved_by should not have a default');
+
+RETURN NEXT has_column(       'public', 'cr_report', 'approved_username', 'Column public.cr_report.approved_username should exist');
+RETURN NEXT col_type_is(      'public', 'cr_report', 'approved_username', 'text', 'Column public.cr_report.approved_username should be type text');
+RETURN NEXT col_is_null(      'public', 'cr_report', 'approved_username', 'Column public.cr_report.approved_username should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'cr_report', 'approved_username', 'Column public.cr_report.approved_username should not have a default');
+
+RETURN NEXT has_column(       'public', 'cr_report', 'recon_fx', 'Column public.cr_report.recon_fx should exist');
+RETURN NEXT col_type_is(      'public', 'cr_report', 'recon_fx', 'boolean', 'Column public.cr_report.recon_fx should be type boolean');
+RETURN NEXT col_is_null(      'public', 'cr_report', 'recon_fx', 'Column public.cr_report.recon_fx should allow NULL');
+RETURN NEXT col_has_default(  'public', 'cr_report', 'recon_fx', 'Column public.cr_report.recon_fx shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'cr_report', 'recon_fx', 'false', 'Column public.cr_report.recon_fx default is');
+
+RETURN NEXT has_column(       'public', 'cr_report', 'max_ac_id', 'Column public.cr_report.max_ac_id should exist');
+RETURN NEXT col_type_is(      'public', 'cr_report', 'max_ac_id', 'integer', 'Column public.cr_report.max_ac_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'cr_report', 'max_ac_id', 'Column public.cr_report.max_ac_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'cr_report', 'max_ac_id', 'Column public.cr_report.max_ac_id should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.cr_report_line.sql.pg_include
+++ b/xt/pgtap/table_public.cr_report_line.sql.pg_include
@@ -1,0 +1,114 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_cr_report_line()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'cr_report_line',
+    'Should have table public.cr_report_line'
+);
+
+RETURN NEXT has_pk(
+    'public', 'cr_report_line',
+    'Table public.cr_report_line should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'cr_report_line'::name, ARRAY[
+    'id'::name,
+    'report_id'::name,
+    'scn'::name,
+    'their_balance'::name,
+    'our_balance'::name,
+    'errorcode'::name,
+    'user'::name,
+    'clear_time'::name,
+    'insert_time'::name,
+    'trans_type'::name,
+    'post_date'::name,
+    'ledger_id'::name,
+    'voucher_id'::name,
+    'overlook'::name,
+    'cleared'::name
+]);
+
+RETURN NEXT has_column(       'public', 'cr_report_line', 'id', 'Column public.cr_report_line.id should exist');
+RETURN NEXT col_type_is(      'public', 'cr_report_line', 'id', 'bigint', 'Column public.cr_report_line.id should be type bigint');
+RETURN NEXT col_not_null(     'public', 'cr_report_line', 'id', 'Column public.cr_report_line.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'cr_report_line', 'id', 'Column public.cr_report_line.id shouldhave a default');
+--SELECT col_default_is(   'public', 'cr_report_line', 'id', 'nextval(''cr_report_line_id_seq''::regclass)', 'Column public.cr_report_line.id default is');RETURN NEXT col_default_is(   'public', 'cr_report_line', 'id', 'nextval(''cr_report_line_id_seq''::regclass)', 'Column public.cr_report_line.id default is');
+
+RETURN NEXT has_column(       'public', 'cr_report_line', 'report_id', 'Column public.cr_report_line.report_id should exist');
+RETURN NEXT col_type_is(      'public', 'cr_report_line', 'report_id', 'integer', 'Column public.cr_report_line.report_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'cr_report_line', 'report_id', 'Column public.cr_report_line.report_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'cr_report_line', 'report_id', 'Column public.cr_report_line.report_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'cr_report_line', 'scn', 'Column public.cr_report_line.scn should exist');
+RETURN NEXT col_type_is(      'public', 'cr_report_line', 'scn', 'text', 'Column public.cr_report_line.scn should be type text');
+RETURN NEXT col_is_null(      'public', 'cr_report_line', 'scn', 'Column public.cr_report_line.scn should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'cr_report_line', 'scn', 'Column public.cr_report_line.scn should not have a default');
+
+RETURN NEXT has_column(       'public', 'cr_report_line', 'their_balance', 'Column public.cr_report_line.their_balance should exist');
+RETURN NEXT col_type_is(      'public', 'cr_report_line', 'their_balance', 'numeric', 'Column public.cr_report_line.their_balance should be type numeric');
+RETURN NEXT col_is_null(      'public', 'cr_report_line', 'their_balance', 'Column public.cr_report_line.their_balance should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'cr_report_line', 'their_balance', 'Column public.cr_report_line.their_balance should not have a default');
+
+RETURN NEXT has_column(       'public', 'cr_report_line', 'our_balance', 'Column public.cr_report_line.our_balance should exist');
+RETURN NEXT col_type_is(      'public', 'cr_report_line', 'our_balance', 'numeric', 'Column public.cr_report_line.our_balance should be type numeric');
+RETURN NEXT col_is_null(      'public', 'cr_report_line', 'our_balance', 'Column public.cr_report_line.our_balance should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'cr_report_line', 'our_balance', 'Column public.cr_report_line.our_balance should not have a default');
+
+RETURN NEXT has_column(       'public', 'cr_report_line', 'errorcode', 'Column public.cr_report_line.errorcode should exist');
+RETURN NEXT col_type_is(      'public', 'cr_report_line', 'errorcode', 'integer', 'Column public.cr_report_line.errorcode should be type integer');
+RETURN NEXT col_is_null(      'public', 'cr_report_line', 'errorcode', 'Column public.cr_report_line.errorcode should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'cr_report_line', 'errorcode', 'Column public.cr_report_line.errorcode should not have a default');
+
+RETURN NEXT has_column(       'public', 'cr_report_line', 'user', 'Column public.cr_report_line."user" should exist');
+RETURN NEXT col_type_is(      'public', 'cr_report_line', 'user', 'integer', 'Column public.cr_report_line."user" should be type integer');
+RETURN NEXT col_not_null(     'public', 'cr_report_line', 'user', 'Column public.cr_report_line."user" should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'cr_report_line', 'user', 'Column public.cr_report_line."user" should not have a default');
+
+RETURN NEXT has_column(       'public', 'cr_report_line', 'clear_time', 'Column public.cr_report_line.clear_time should exist');
+RETURN NEXT col_type_is(      'public', 'cr_report_line', 'clear_time', 'date', 'Column public.cr_report_line.clear_time should be type date');
+RETURN NEXT col_is_null(      'public', 'cr_report_line', 'clear_time', 'Column public.cr_report_line.clear_time should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'cr_report_line', 'clear_time', 'Column public.cr_report_line.clear_time should not have a default');
+
+RETURN NEXT has_column(       'public', 'cr_report_line', 'insert_time', 'Column public.cr_report_line.insert_time should exist');
+RETURN NEXT col_type_is(      'public', 'cr_report_line', 'insert_time', 'timestamp with time zone', 'Column public.cr_report_line.insert_time should be type timestamp with time zone');
+RETURN NEXT col_not_null(     'public', 'cr_report_line', 'insert_time', 'Column public.cr_report_line.insert_time should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'cr_report_line', 'insert_time', 'Column public.cr_report_line.insert_time shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'cr_report_line', 'insert_time', 'now()', 'Column public.cr_report_line.insert_time default is');
+
+RETURN NEXT has_column(       'public', 'cr_report_line', 'trans_type', 'Column public.cr_report_line.trans_type should exist');
+RETURN NEXT col_type_is(      'public', 'cr_report_line', 'trans_type', 'text', 'Column public.cr_report_line.trans_type should be type text');
+RETURN NEXT col_is_null(      'public', 'cr_report_line', 'trans_type', 'Column public.cr_report_line.trans_type should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'cr_report_line', 'trans_type', 'Column public.cr_report_line.trans_type should not have a default');
+
+RETURN NEXT has_column(       'public', 'cr_report_line', 'post_date', 'Column public.cr_report_line.post_date should exist');
+RETURN NEXT col_type_is(      'public', 'cr_report_line', 'post_date', 'date', 'Column public.cr_report_line.post_date should be type date');
+RETURN NEXT col_is_null(      'public', 'cr_report_line', 'post_date', 'Column public.cr_report_line.post_date should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'cr_report_line', 'post_date', 'Column public.cr_report_line.post_date should not have a default');
+
+RETURN NEXT has_column(       'public', 'cr_report_line', 'ledger_id', 'Column public.cr_report_line.ledger_id should exist');
+RETURN NEXT col_type_is(      'public', 'cr_report_line', 'ledger_id', 'integer', 'Column public.cr_report_line.ledger_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'cr_report_line', 'ledger_id', 'Column public.cr_report_line.ledger_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'cr_report_line', 'ledger_id', 'Column public.cr_report_line.ledger_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'cr_report_line', 'voucher_id', 'Column public.cr_report_line.voucher_id should exist');
+RETURN NEXT col_type_is(      'public', 'cr_report_line', 'voucher_id', 'integer', 'Column public.cr_report_line.voucher_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'cr_report_line', 'voucher_id', 'Column public.cr_report_line.voucher_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'cr_report_line', 'voucher_id', 'Column public.cr_report_line.voucher_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'cr_report_line', 'overlook', 'Column public.cr_report_line.overlook should exist');
+RETURN NEXT col_type_is(      'public', 'cr_report_line', 'overlook', 'boolean', 'Column public.cr_report_line.overlook should be type boolean');
+RETURN NEXT col_not_null(     'public', 'cr_report_line', 'overlook', 'Column public.cr_report_line.overlook should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'cr_report_line', 'overlook', 'Column public.cr_report_line.overlook shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'cr_report_line', 'overlook', 'false', 'Column public.cr_report_line.overlook default is');
+
+RETURN NEXT has_column(       'public', 'cr_report_line', 'cleared', 'Column public.cr_report_line.cleared should exist');
+RETURN NEXT col_type_is(      'public', 'cr_report_line', 'cleared', 'boolean', 'Column public.cr_report_line.cleared should be type boolean');
+RETURN NEXT col_not_null(     'public', 'cr_report_line', 'cleared', 'Column public.cr_report_line.cleared should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'cr_report_line', 'cleared', 'Column public.cr_report_line.cleared shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'cr_report_line', 'cleared', 'false', 'Column public.cr_report_line.cleared default is');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.custom_field_catalog.sql.pg_include
+++ b/xt/pgtap/table_public.custom_field_catalog.sql.pg_include
@@ -1,0 +1,39 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_custom_field_catalog()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'custom_field_catalog',
+    'Should have table public.custom_field_catalog'
+);
+
+RETURN NEXT has_pk(
+    'public', 'custom_field_catalog',
+    'Table public.custom_field_catalog should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'custom_field_catalog'::name, ARRAY[
+    'field_id'::name,
+    'table_id'::name,
+    'field_name'::name
+]);
+
+RETURN NEXT has_column(       'public', 'custom_field_catalog', 'field_id', 'Column public.custom_field_catalog.field_id should exist');
+RETURN NEXT col_type_is(      'public', 'custom_field_catalog', 'field_id', 'integer', 'Column public.custom_field_catalog.field_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'custom_field_catalog', 'field_id', 'Column public.custom_field_catalog.field_id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'custom_field_catalog', 'field_id', 'Column public.custom_field_catalog.field_id shouldhave a default');
+--SELECT col_default_is(   'public', 'custom_field_catalog', 'field_id', 'nextval(''custom_field_catalog_field_id_seq''::regclass)', 'Column public.custom_field_catalog.field_id default is');RETURN NEXT col_default_is(   'public', 'custom_field_catalog', 'field_id', 'nextval(''custom_field_catalog_field_id_seq''::regclass)', 'Column public.custom_field_catalog.field_id default is');
+
+RETURN NEXT has_column(       'public', 'custom_field_catalog', 'table_id', 'Column public.custom_field_catalog.table_id should exist');
+RETURN NEXT col_type_is(      'public', 'custom_field_catalog', 'table_id', 'integer', 'Column public.custom_field_catalog.table_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'custom_field_catalog', 'table_id', 'Column public.custom_field_catalog.table_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'custom_field_catalog', 'table_id', 'Column public.custom_field_catalog.table_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'custom_field_catalog', 'field_name', 'Column public.custom_field_catalog.field_name should exist');
+RETURN NEXT col_type_is(      'public', 'custom_field_catalog', 'field_name', 'text', 'Column public.custom_field_catalog.field_name should be type text');
+RETURN NEXT col_is_null(      'public', 'custom_field_catalog', 'field_name', 'Column public.custom_field_catalog.field_name should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'custom_field_catalog', 'field_name', 'Column public.custom_field_catalog.field_name should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.custom_table_catalog.sql.pg_include
+++ b/xt/pgtap/table_public.custom_table_catalog.sql.pg_include
@@ -1,0 +1,39 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_custom_table_catalog()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'custom_table_catalog',
+    'Should have table public.custom_table_catalog'
+);
+
+RETURN NEXT has_pk(
+    'public', 'custom_table_catalog',
+    'Table public.custom_table_catalog should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'custom_table_catalog'::name, ARRAY[
+    'table_id'::name,
+    'extends'::name,
+    'table_name'::name
+]);
+
+RETURN NEXT has_column(       'public', 'custom_table_catalog', 'table_id', 'Column public.custom_table_catalog.table_id should exist');
+RETURN NEXT col_type_is(      'public', 'custom_table_catalog', 'table_id', 'integer', 'Column public.custom_table_catalog.table_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'custom_table_catalog', 'table_id', 'Column public.custom_table_catalog.table_id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'custom_table_catalog', 'table_id', 'Column public.custom_table_catalog.table_id shouldhave a default');
+--SELECT col_default_is(   'public', 'custom_table_catalog', 'table_id', 'nextval(''custom_table_catalog_table_id_seq''::regclass)', 'Column public.custom_table_catalog.table_id default is');RETURN NEXT col_default_is(   'public', 'custom_table_catalog', 'table_id', 'nextval(''custom_table_catalog_table_id_seq''::regclass)', 'Column public.custom_table_catalog.table_id default is');
+
+RETURN NEXT has_column(       'public', 'custom_table_catalog', 'extends', 'Column public.custom_table_catalog.extends should exist');
+RETURN NEXT col_type_is(      'public', 'custom_table_catalog', 'extends', 'text', 'Column public.custom_table_catalog.extends should be type text');
+RETURN NEXT col_is_null(      'public', 'custom_table_catalog', 'extends', 'Column public.custom_table_catalog.extends should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'custom_table_catalog', 'extends', 'Column public.custom_table_catalog.extends should not have a default');
+
+RETURN NEXT has_column(       'public', 'custom_table_catalog', 'table_name', 'Column public.custom_table_catalog.table_name should exist');
+RETURN NEXT col_type_is(      'public', 'custom_table_catalog', 'table_name', 'text', 'Column public.custom_table_catalog.table_name should be type text');
+RETURN NEXT col_is_null(      'public', 'custom_table_catalog', 'table_name', 'Column public.custom_table_catalog.table_name should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'custom_table_catalog', 'table_name', 'Column public.custom_table_catalog.table_name should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.db_patch_log.sql.pg_include
+++ b/xt/pgtap/table_public.db_patch_log.sql.pg_include
@@ -1,0 +1,50 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_db_patch_log()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'db_patch_log',
+    'Should have table public.db_patch_log'
+);
+
+RETURN NEXT has_pk(
+    'public', 'db_patch_log',
+    'Table public.db_patch_log should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'db_patch_log'::name, ARRAY[
+    'when_applied'::name,
+    'path'::name,
+    'sha'::name,
+    'sqlstate'::name,
+    'error'::name
+]);
+
+RETURN NEXT has_column(       'public', 'db_patch_log', 'when_applied', 'Column public.db_patch_log.when_applied should exist');
+RETURN NEXT col_type_is(      'public', 'db_patch_log', 'when_applied', 'timestamp without time zone', 'Column public.db_patch_log.when_applied should be type timestamp without time zone');
+RETURN NEXT col_not_null(     'public', 'db_patch_log', 'when_applied', 'Column public.db_patch_log.when_applied should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'db_patch_log', 'when_applied', 'Column public.db_patch_log.when_applied should not have a default');
+
+RETURN NEXT has_column(       'public', 'db_patch_log', 'path', 'Column public.db_patch_log.path should exist');
+RETURN NEXT col_type_is(      'public', 'db_patch_log', 'path', 'text', 'Column public.db_patch_log.path should be type text');
+RETURN NEXT col_not_null(     'public', 'db_patch_log', 'path', 'Column public.db_patch_log.path should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'db_patch_log', 'path', 'Column public.db_patch_log.path should not have a default');
+
+RETURN NEXT has_column(       'public', 'db_patch_log', 'sha', 'Column public.db_patch_log.sha should exist');
+RETURN NEXT col_type_is(      'public', 'db_patch_log', 'sha', 'text', 'Column public.db_patch_log.sha should be type text');
+RETURN NEXT col_not_null(     'public', 'db_patch_log', 'sha', 'Column public.db_patch_log.sha should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'db_patch_log', 'sha', 'Column public.db_patch_log.sha should not have a default');
+
+RETURN NEXT has_column(       'public', 'db_patch_log', 'sqlstate', 'Column public.db_patch_log.sqlstate should exist');
+RETURN NEXT col_type_is(      'public', 'db_patch_log', 'sqlstate', 'text', 'Column public.db_patch_log.sqlstate should be type text');
+RETURN NEXT col_not_null(     'public', 'db_patch_log', 'sqlstate', 'Column public.db_patch_log.sqlstate should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'db_patch_log', 'sqlstate', 'Column public.db_patch_log.sqlstate should not have a default');
+
+RETURN NEXT has_column(       'public', 'db_patch_log', 'error', 'Column public.db_patch_log.error should exist');
+RETURN NEXT col_type_is(      'public', 'db_patch_log', 'error', 'text', 'Column public.db_patch_log.error should be type text');
+RETURN NEXT col_is_null(      'public', 'db_patch_log', 'error', 'Column public.db_patch_log.error should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'db_patch_log', 'error', 'Column public.db_patch_log.error should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.db_patches.sql.pg_include
+++ b/xt/pgtap/table_public.db_patches.sql.pg_include
@@ -1,0 +1,38 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_db_patches()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'db_patches',
+    'Should have table public.db_patches'
+);
+
+RETURN NEXT has_pk(
+    'public', 'db_patches',
+    'Table public.db_patches should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'db_patches'::name, ARRAY[
+    'sha'::name,
+    'path'::name,
+    'last_updated'::name
+]);
+
+RETURN NEXT has_column(       'public', 'db_patches', 'sha', 'Column public.db_patches.sha should exist');
+RETURN NEXT col_type_is(      'public', 'db_patches', 'sha', 'text', 'Column public.db_patches.sha should be type text');
+RETURN NEXT col_not_null(     'public', 'db_patches', 'sha', 'Column public.db_patches.sha should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'db_patches', 'sha', 'Column public.db_patches.sha should not have a default');
+
+RETURN NEXT has_column(       'public', 'db_patches', 'path', 'Column public.db_patches.path should exist');
+RETURN NEXT col_type_is(      'public', 'db_patches', 'path', 'text', 'Column public.db_patches.path should be type text');
+RETURN NEXT col_not_null(     'public', 'db_patches', 'path', 'Column public.db_patches.path should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'db_patches', 'path', 'Column public.db_patches.path should not have a default');
+
+RETURN NEXT has_column(       'public', 'db_patches', 'last_updated', 'Column public.db_patches.last_updated should exist');
+RETURN NEXT col_type_is(      'public', 'db_patches', 'last_updated', 'timestamp without time zone', 'Column public.db_patches.last_updated should be type timestamp without time zone');
+RETURN NEXT col_not_null(     'public', 'db_patches', 'last_updated', 'Column public.db_patches.last_updated should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'db_patches', 'last_updated', 'Column public.db_patches.last_updated should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.defaults.sql.pg_include
+++ b/xt/pgtap/table_public.defaults.sql.pg_include
@@ -1,0 +1,32 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_defaults()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'defaults',
+    'Should have table public.defaults'
+);
+
+RETURN NEXT has_pk(
+    'public', 'defaults',
+    'Table public.defaults should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'defaults'::name, ARRAY[
+    'setting_key'::name,
+    'value'::name
+]);
+
+RETURN NEXT has_column(       'public', 'defaults', 'setting_key', 'Column public.defaults.setting_key should exist');
+RETURN NEXT col_type_is(      'public', 'defaults', 'setting_key', 'text', 'Column public.defaults.setting_key should be type text');
+RETURN NEXT col_not_null(     'public', 'defaults', 'setting_key', 'Column public.defaults.setting_key should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'defaults', 'setting_key', 'Column public.defaults.setting_key should not have a default');
+
+RETURN NEXT has_column(       'public', 'defaults', 'value', 'Column public.defaults.value should exist');
+RETURN NEXT col_type_is(      'public', 'defaults', 'value', 'text', 'Column public.defaults.value should be type text');
+RETURN NEXT col_is_null(      'public', 'defaults', 'value', 'Column public.defaults.value should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'defaults', 'value', 'Column public.defaults.value should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.eca_invoice.sql.pg_include
+++ b/xt/pgtap/table_public.eca_invoice.sql.pg_include
@@ -1,0 +1,77 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_eca_invoice()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'eca_invoice',
+    'Should have table public.eca_invoice'
+);
+
+RETURN NEXT has_pk(
+    'public', 'eca_invoice',
+    'Table public.eca_invoice should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'eca_invoice'::name, ARRAY[
+    'order_id'::name,
+    'journal_id'::name,
+    'on_hold'::name,
+    'reverse'::name,
+    'credit_id'::name,
+    'due'::name,
+    'language_code'::name,
+    'force_closed'::name,
+    'order_number'::name
+]);
+
+RETURN NEXT has_column(       'public', 'eca_invoice', 'order_id', 'Column public.eca_invoice.order_id should exist');
+RETURN NEXT col_type_is(      'public', 'eca_invoice', 'order_id', 'integer', 'Column public.eca_invoice.order_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'eca_invoice', 'order_id', 'Column public.eca_invoice.order_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'eca_invoice', 'order_id', 'Column public.eca_invoice.order_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'eca_invoice', 'journal_id', 'Column public.eca_invoice.journal_id should exist');
+RETURN NEXT col_type_is(      'public', 'eca_invoice', 'journal_id', 'integer', 'Column public.eca_invoice.journal_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'eca_invoice', 'journal_id', 'Column public.eca_invoice.journal_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'eca_invoice', 'journal_id', 'Column public.eca_invoice.journal_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'eca_invoice', 'on_hold', 'Column public.eca_invoice.on_hold should exist');
+RETURN NEXT col_type_is(      'public', 'eca_invoice', 'on_hold', 'boolean', 'Column public.eca_invoice.on_hold should be type boolean');
+RETURN NEXT col_is_null(      'public', 'eca_invoice', 'on_hold', 'Column public.eca_invoice.on_hold should allow NULL');
+RETURN NEXT col_has_default(  'public', 'eca_invoice', 'on_hold', 'Column public.eca_invoice.on_hold shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'eca_invoice', 'on_hold', 'false', 'Column public.eca_invoice.on_hold default is');
+
+RETURN NEXT has_column(       'public', 'eca_invoice', 'reverse', 'Column public.eca_invoice.reverse should exist');
+RETURN NEXT col_type_is(      'public', 'eca_invoice', 'reverse', 'boolean', 'Column public.eca_invoice.reverse should be type boolean');
+RETURN NEXT col_is_null(      'public', 'eca_invoice', 'reverse', 'Column public.eca_invoice.reverse should allow NULL');
+RETURN NEXT col_has_default(  'public', 'eca_invoice', 'reverse', 'Column public.eca_invoice.reverse shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'eca_invoice', 'reverse', 'false', 'Column public.eca_invoice.reverse default is');
+
+RETURN NEXT has_column(       'public', 'eca_invoice', 'credit_id', 'Column public.eca_invoice.credit_id should exist');
+RETURN NEXT col_type_is(      'public', 'eca_invoice', 'credit_id', 'integer', 'Column public.eca_invoice.credit_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'eca_invoice', 'credit_id', 'Column public.eca_invoice.credit_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'eca_invoice', 'credit_id', 'Column public.eca_invoice.credit_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'eca_invoice', 'due', 'Column public.eca_invoice.due should exist');
+RETURN NEXT col_type_is(      'public', 'eca_invoice', 'due', 'date', 'Column public.eca_invoice.due should be type date');
+RETURN NEXT col_not_null(     'public', 'eca_invoice', 'due', 'Column public.eca_invoice.due should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'eca_invoice', 'due', 'Column public.eca_invoice.due should not have a default');
+
+RETURN NEXT has_column(       'public', 'eca_invoice', 'language_code', 'Column public.eca_invoice.language_code should exist');
+RETURN NEXT col_type_is(      'public', 'eca_invoice', 'language_code', 'character(6)', 'Column public.eca_invoice.language_code should be type character(6)');
+RETURN NEXT col_is_null(      'public', 'eca_invoice', 'language_code', 'Column public.eca_invoice.language_code should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'eca_invoice', 'language_code', 'Column public.eca_invoice.language_code should not have a default');
+
+RETURN NEXT has_column(       'public', 'eca_invoice', 'force_closed', 'Column public.eca_invoice.force_closed should exist');
+RETURN NEXT col_type_is(      'public', 'eca_invoice', 'force_closed', 'boolean', 'Column public.eca_invoice.force_closed should be type boolean');
+RETURN NEXT col_not_null(     'public', 'eca_invoice', 'force_closed', 'Column public.eca_invoice.force_closed should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'eca_invoice', 'force_closed', 'Column public.eca_invoice.force_closed shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'eca_invoice', 'force_closed', 'false', 'Column public.eca_invoice.force_closed default is');
+
+RETURN NEXT has_column(       'public', 'eca_invoice', 'order_number', 'Column public.eca_invoice.order_number should exist');
+RETURN NEXT col_type_is(      'public', 'eca_invoice', 'order_number', 'text', 'Column public.eca_invoice.order_number should be type text');
+RETURN NEXT col_is_null(      'public', 'eca_invoice', 'order_number', 'Column public.eca_invoice.order_number should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'eca_invoice', 'order_number', 'Column public.eca_invoice.order_number should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.eca_note.sql.pg_include
+++ b/xt/pgtap/table_public.eca_note.sql.pg_include
@@ -1,0 +1,72 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_eca_note()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'eca_note',
+    'Should have table public.eca_note'
+);
+
+RETURN NEXT has_pk(
+    'public', 'eca_note',
+    'Table public.eca_note should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'eca_note'::name, ARRAY[
+    'id'::name,
+    'note_class'::name,
+    'note'::name,
+    'vector'::name,
+    'created'::name,
+    'created_by'::name,
+    'ref_key'::name,
+    'subject'::name
+]);
+
+RETURN NEXT has_column(       'public', 'eca_note', 'id', 'Column public.eca_note.id should exist');
+RETURN NEXT col_type_is(      'public', 'eca_note', 'id', 'integer', 'Column public.eca_note.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'eca_note', 'id', 'Column public.eca_note.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'eca_note', 'id', 'Column public.eca_note.id shouldhave a default');
+--SELECT col_default_is(   'public', 'eca_note', 'id', 'nextval(''note_id_seq''::regclass)', 'Column public.eca_note.id default is');RETURN NEXT col_default_is(   'public', 'eca_note', 'id', 'nextval(''note_id_seq''::regclass)', 'Column public.eca_note.id default is');
+
+RETURN NEXT has_column(       'public', 'eca_note', 'note_class', 'Column public.eca_note.note_class should exist');
+RETURN NEXT col_type_is(      'public', 'eca_note', 'note_class', 'integer', 'Column public.eca_note.note_class should be type integer');
+RETURN NEXT col_not_null(     'public', 'eca_note', 'note_class', 'Column public.eca_note.note_class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'eca_note', 'note_class', 'Column public.eca_note.note_class should not have a default');
+
+RETURN NEXT has_column(       'public', 'eca_note', 'note', 'Column public.eca_note.note should exist');
+RETURN NEXT col_type_is(      'public', 'eca_note', 'note', 'text', 'Column public.eca_note.note should be type text');
+RETURN NEXT col_not_null(     'public', 'eca_note', 'note', 'Column public.eca_note.note should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'eca_note', 'note', 'Column public.eca_note.note should not have a default');
+
+RETURN NEXT has_column(       'public', 'eca_note', 'vector', 'Column public.eca_note.vector should exist');
+RETURN NEXT col_type_is(      'public', 'eca_note', 'vector', 'tsvector', 'Column public.eca_note.vector should be type tsvector');
+RETURN NEXT col_not_null(     'public', 'eca_note', 'vector', 'Column public.eca_note.vector should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'eca_note', 'vector', 'Column public.eca_note.vector shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'eca_note', 'vector', ''::tsvector, 'Column public.eca_note.vector default is');
+
+RETURN NEXT has_column(       'public', 'eca_note', 'created', 'Column public.eca_note.created should exist');
+RETURN NEXT col_type_is(      'public', 'eca_note', 'created', 'timestamp without time zone', 'Column public.eca_note.created should be type timestamp without time zone');
+RETURN NEXT col_not_null(     'public', 'eca_note', 'created', 'Column public.eca_note.created should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'eca_note', 'created', 'Column public.eca_note.created shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'eca_note', 'created', 'now()', 'Column public.eca_note.created default is');
+
+RETURN NEXT has_column(       'public', 'eca_note', 'created_by', 'Column public.eca_note.created_by should exist');
+RETURN NEXT col_type_is(      'public', 'eca_note', 'created_by', 'text', 'Column public.eca_note.created_by should be type text');
+RETURN NEXT col_is_null(      'public', 'eca_note', 'created_by', 'Column public.eca_note.created_by should allow NULL');
+RETURN NEXT col_has_default(  'public', 'eca_note', 'created_by', 'Column public.eca_note.created_by shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'eca_note', 'created_by', '"session_user"()', 'Column public.eca_note.created_by default is');
+
+RETURN NEXT has_column(       'public', 'eca_note', 'ref_key', 'Column public.eca_note.ref_key should exist');
+RETURN NEXT col_type_is(      'public', 'eca_note', 'ref_key', 'integer', 'Column public.eca_note.ref_key should be type integer');
+RETURN NEXT col_not_null(     'public', 'eca_note', 'ref_key', 'Column public.eca_note.ref_key should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'eca_note', 'ref_key', 'Column public.eca_note.ref_key should not have a default');
+
+RETURN NEXT has_column(       'public', 'eca_note', 'subject', 'Column public.eca_note.subject should exist');
+RETURN NEXT col_type_is(      'public', 'eca_note', 'subject', 'text', 'Column public.eca_note.subject should be type text');
+RETURN NEXT col_is_null(      'public', 'eca_note', 'subject', 'Column public.eca_note.subject should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'eca_note', 'subject', 'Column public.eca_note.subject should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.eca_tax.sql.pg_include
+++ b/xt/pgtap/table_public.eca_tax.sql.pg_include
@@ -1,0 +1,32 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_eca_tax()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'eca_tax',
+    'Should have table public.eca_tax'
+);
+
+RETURN NEXT has_pk(
+    'public', 'eca_tax',
+    'Table public.eca_tax should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'eca_tax'::name, ARRAY[
+    'eca_id'::name,
+    'chart_id'::name
+]);
+
+RETURN NEXT has_column(       'public', 'eca_tax', 'eca_id', 'Column public.eca_tax.eca_id should exist');
+RETURN NEXT col_type_is(      'public', 'eca_tax', 'eca_id', 'integer', 'Column public.eca_tax.eca_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'eca_tax', 'eca_id', 'Column public.eca_tax.eca_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'eca_tax', 'eca_id', 'Column public.eca_tax.eca_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'eca_tax', 'chart_id', 'Column public.eca_tax.chart_id should exist');
+RETURN NEXT col_type_is(      'public', 'eca_tax', 'chart_id', 'integer', 'Column public.eca_tax.chart_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'eca_tax', 'chart_id', 'Column public.eca_tax.chart_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'eca_tax', 'chart_id', 'Column public.eca_tax.chart_id should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.eca_to_contact.sql.pg_include
+++ b/xt/pgtap/table_public.eca_to_contact.sql.pg_include
@@ -1,0 +1,44 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_eca_to_contact()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'eca_to_contact',
+    'Should have table public.eca_to_contact'
+);
+
+RETURN NEXT has_pk(
+    'public', 'eca_to_contact',
+    'Table public.eca_to_contact should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'eca_to_contact'::name, ARRAY[
+    'credit_id'::name,
+    'contact_class_id'::name,
+    'contact'::name,
+    'description'::name
+]);
+
+RETURN NEXT has_column(       'public', 'eca_to_contact', 'credit_id', 'Column public.eca_to_contact.credit_id should exist');
+RETURN NEXT col_type_is(      'public', 'eca_to_contact', 'credit_id', 'integer', 'Column public.eca_to_contact.credit_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'eca_to_contact', 'credit_id', 'Column public.eca_to_contact.credit_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'eca_to_contact', 'credit_id', 'Column public.eca_to_contact.credit_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'eca_to_contact', 'contact_class_id', 'Column public.eca_to_contact.contact_class_id should exist');
+RETURN NEXT col_type_is(      'public', 'eca_to_contact', 'contact_class_id', 'integer', 'Column public.eca_to_contact.contact_class_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'eca_to_contact', 'contact_class_id', 'Column public.eca_to_contact.contact_class_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'eca_to_contact', 'contact_class_id', 'Column public.eca_to_contact.contact_class_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'eca_to_contact', 'contact', 'Column public.eca_to_contact.contact should exist');
+RETURN NEXT col_type_is(      'public', 'eca_to_contact', 'contact', 'text', 'Column public.eca_to_contact.contact should be type text');
+RETURN NEXT col_not_null(     'public', 'eca_to_contact', 'contact', 'Column public.eca_to_contact.contact should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'eca_to_contact', 'contact', 'Column public.eca_to_contact.contact should not have a default');
+
+RETURN NEXT has_column(       'public', 'eca_to_contact', 'description', 'Column public.eca_to_contact.description should exist');
+RETURN NEXT col_type_is(      'public', 'eca_to_contact', 'description', 'text', 'Column public.eca_to_contact.description should be type text');
+RETURN NEXT col_is_null(      'public', 'eca_to_contact', 'description', 'Column public.eca_to_contact.description should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'eca_to_contact', 'description', 'Column public.eca_to_contact.description should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.eca_to_location.sql.pg_include
+++ b/xt/pgtap/table_public.eca_to_location.sql.pg_include
@@ -1,0 +1,38 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_eca_to_location()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'eca_to_location',
+    'Should have table public.eca_to_location'
+);
+
+RETURN NEXT has_pk(
+    'public', 'eca_to_location',
+    'Table public.eca_to_location should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'eca_to_location'::name, ARRAY[
+    'location_id'::name,
+    'location_class'::name,
+    'credit_id'::name
+]);
+
+RETURN NEXT has_column(       'public', 'eca_to_location', 'location_id', 'Column public.eca_to_location.location_id should exist');
+RETURN NEXT col_type_is(      'public', 'eca_to_location', 'location_id', 'integer', 'Column public.eca_to_location.location_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'eca_to_location', 'location_id', 'Column public.eca_to_location.location_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'eca_to_location', 'location_id', 'Column public.eca_to_location.location_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'eca_to_location', 'location_class', 'Column public.eca_to_location.location_class should exist');
+RETURN NEXT col_type_is(      'public', 'eca_to_location', 'location_class', 'integer', 'Column public.eca_to_location.location_class should be type integer');
+RETURN NEXT col_not_null(     'public', 'eca_to_location', 'location_class', 'Column public.eca_to_location.location_class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'eca_to_location', 'location_class', 'Column public.eca_to_location.location_class should not have a default');
+
+RETURN NEXT has_column(       'public', 'eca_to_location', 'credit_id', 'Column public.eca_to_location.credit_id should exist');
+RETURN NEXT col_type_is(      'public', 'eca_to_location', 'credit_id', 'integer', 'Column public.eca_to_location.credit_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'eca_to_location', 'credit_id', 'Column public.eca_to_location.credit_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'eca_to_location', 'credit_id', 'Column public.eca_to_location.credit_id should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.employee_class.sql.pg_include
+++ b/xt/pgtap/table_public.employee_class.sql.pg_include
@@ -1,0 +1,33 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_employee_class()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'employee_class',
+    'Should have table public.employee_class'
+);
+
+RETURN NEXT has_pk(
+    'public', 'employee_class',
+    'Table public.employee_class should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'employee_class'::name, ARRAY[
+    'label'::name,
+    'id'::name
+]);
+
+RETURN NEXT has_column(       'public', 'employee_class', 'label', 'Column public.employee_class.label should exist');
+RETURN NEXT col_type_is(      'public', 'employee_class', 'label', 'text', 'Column public.employee_class.label should be type text');
+RETURN NEXT col_not_null(     'public', 'employee_class', 'label', 'Column public.employee_class.label should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'employee_class', 'label', 'Column public.employee_class.label should not have a default');
+
+RETURN NEXT has_column(       'public', 'employee_class', 'id', 'Column public.employee_class.id should exist');
+RETURN NEXT col_type_is(      'public', 'employee_class', 'id', 'integer', 'Column public.employee_class.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'employee_class', 'id', 'Column public.employee_class.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'employee_class', 'id', 'Column public.employee_class.id shouldhave a default');
+--SELECT col_default_is(   'public', 'employee_class', 'id', 'nextval(''employee_class_id_seq''::regclass)', 'Column public.employee_class.id default is');RETURN NEXT col_default_is(   'public', 'employee_class', 'id', 'nextval(''employee_class_id_seq''::regclass)', 'Column public.employee_class.id default is');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.employee_to_ec.sql.pg_include
+++ b/xt/pgtap/table_public.employee_to_ec.sql.pg_include
@@ -1,0 +1,32 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_employee_to_ec()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'employee_to_ec',
+    'Should have table public.employee_to_ec'
+);
+
+RETURN NEXT has_pk(
+    'public', 'employee_to_ec',
+    'Table public.employee_to_ec should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'employee_to_ec'::name, ARRAY[
+    'employee_id'::name,
+    'ec_id'::name
+]);
+
+RETURN NEXT has_column(       'public', 'employee_to_ec', 'employee_id', 'Column public.employee_to_ec.employee_id should exist');
+RETURN NEXT col_type_is(      'public', 'employee_to_ec', 'employee_id', 'integer', 'Column public.employee_to_ec.employee_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'employee_to_ec', 'employee_id', 'Column public.employee_to_ec.employee_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'employee_to_ec', 'employee_id', 'Column public.employee_to_ec.employee_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'employee_to_ec', 'ec_id', 'Column public.employee_to_ec.ec_id should exist');
+RETURN NEXT col_type_is(      'public', 'employee_to_ec', 'ec_id', 'integer', 'Column public.employee_to_ec.ec_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'employee_to_ec', 'ec_id', 'Column public.employee_to_ec.ec_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'employee_to_ec', 'ec_id', 'Column public.employee_to_ec.ec_id should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.entity.sql.pg_include
+++ b/xt/pgtap/table_public.entity.sql.pg_include
@@ -1,0 +1,59 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_entity()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'entity',
+    'Should have table public.entity'
+);
+
+RETURN NEXT has_pk(
+    'public', 'entity',
+    'Table public.entity should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'entity'::name, ARRAY[
+    'id'::name,
+    'name'::name,
+    'entity_class'::name,
+    'created'::name,
+    'control_code'::name,
+    'country_id'::name
+]);
+
+RETURN NEXT has_column(       'public', 'entity', 'id', 'Column public.entity.id should exist');
+RETURN NEXT col_type_is(      'public', 'entity', 'id', 'integer', 'Column public.entity.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'entity', 'id', 'Column public.entity.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'entity', 'id', 'Column public.entity.id shouldhave a default');
+--SELECT col_default_is(   'public', 'entity', 'id', 'nextval(''entity_id_seq''::regclass)', 'Column public.entity.id default is');RETURN NEXT col_default_is(   'public', 'entity', 'id', 'nextval(''entity_id_seq''::regclass)', 'Column public.entity.id default is');
+
+RETURN NEXT has_column(       'public', 'entity', 'name', 'Column public.entity.name should exist');
+RETURN NEXT col_type_is(      'public', 'entity', 'name', 'text', 'Column public.entity.name should be type text');
+RETURN NEXT col_is_null(      'public', 'entity', 'name', 'Column public.entity.name should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'entity', 'name', 'Column public.entity.name should not have a default');
+
+RETURN NEXT has_column(       'public', 'entity', 'entity_class', 'Column public.entity.entity_class should exist');
+RETURN NEXT col_type_is(      'public', 'entity', 'entity_class', 'integer', 'Column public.entity.entity_class should be type integer');
+RETURN NEXT col_not_null(     'public', 'entity', 'entity_class', 'Column public.entity.entity_class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'entity', 'entity_class', 'Column public.entity.entity_class should not have a default');
+
+RETURN NEXT has_column(       'public', 'entity', 'created', 'Column public.entity.created should exist');
+RETURN NEXT col_type_is(      'public', 'entity', 'created', 'date', 'Column public.entity.created should be type date');
+RETURN NEXT col_not_null(     'public', 'entity', 'created', 'Column public.entity.created should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'entity', 'created', 'Column public.entity.created shouldhave a default');
+--SELECT col_default_is(   'public', 'entity', 'created', '(''now''::text)::date', 'Column public.entity.created default is');RETURN NEXT col_default_is(   'public', 'entity', 'created', '(''now''::text)::date', 'Column public.entity.created default is');
+
+RETURN NEXT has_column(       'public', 'entity', 'control_code', 'Column public.entity.control_code should exist');
+RETURN NEXT col_type_is(      'public', 'entity', 'control_code', 'text', 'Column public.entity.control_code should be type text');
+RETURN NEXT col_not_null(     'public', 'entity', 'control_code', 'Column public.entity.control_code should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'entity', 'control_code', 'Column public.entity.control_code shouldhave a default');
+--SELECT col_default_is(   'public', 'entity', 'control_code', 'setting_increment(''entity_control''::character varying)', 'Column public.entity.control_code default is');RETURN NEXT col_default_is(   'public', 'entity', 'control_code', 'setting_increment(''entity_control''::character varying)', 'Column public.entity.control_code default is');
+
+RETURN NEXT has_column(       'public', 'entity', 'country_id', 'Column public.entity.country_id should exist');
+RETURN NEXT col_type_is(      'public', 'entity', 'country_id', 'integer', 'Column public.entity.country_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'entity', 'country_id', 'Column public.entity.country_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'entity', 'country_id', 'Column public.entity.country_id should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.entity_bank_account.sql.pg_include
+++ b/xt/pgtap/table_public.entity_bank_account.sql.pg_include
@@ -1,0 +1,51 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_entity_bank_account()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'entity_bank_account',
+    'Should have table public.entity_bank_account'
+);
+
+RETURN NEXT has_pk(
+    'public', 'entity_bank_account',
+    'Table public.entity_bank_account should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'entity_bank_account'::name, ARRAY[
+    'id'::name,
+    'entity_id'::name,
+    'bic'::name,
+    'iban'::name,
+    'remark'::name
+]);
+
+RETURN NEXT has_column(       'public', 'entity_bank_account', 'id', 'Column public.entity_bank_account.id should exist');
+RETURN NEXT col_type_is(      'public', 'entity_bank_account', 'id', 'integer', 'Column public.entity_bank_account.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'entity_bank_account', 'id', 'Column public.entity_bank_account.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'entity_bank_account', 'id', 'Column public.entity_bank_account.id shouldhave a default');
+--SELECT col_default_is(   'public', 'entity_bank_account', 'id', 'nextval(''entity_bank_account_id_seq''::regclass)', 'Column public.entity_bank_account.id default is');RETURN NEXT col_default_is(   'public', 'entity_bank_account', 'id', 'nextval(''entity_bank_account_id_seq''::regclass)', 'Column public.entity_bank_account.id default is');
+
+RETURN NEXT has_column(       'public', 'entity_bank_account', 'entity_id', 'Column public.entity_bank_account.entity_id should exist');
+RETURN NEXT col_type_is(      'public', 'entity_bank_account', 'entity_id', 'integer', 'Column public.entity_bank_account.entity_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'entity_bank_account', 'entity_id', 'Column public.entity_bank_account.entity_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_bank_account', 'entity_id', 'Column public.entity_bank_account.entity_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'entity_bank_account', 'bic', 'Column public.entity_bank_account.bic should exist');
+RETURN NEXT col_type_is(      'public', 'entity_bank_account', 'bic', 'character varying', 'Column public.entity_bank_account.bic should be type character varying');
+RETURN NEXT col_not_null(     'public', 'entity_bank_account', 'bic', 'Column public.entity_bank_account.bic should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_bank_account', 'bic', 'Column public.entity_bank_account.bic should not have a default');
+
+RETURN NEXT has_column(       'public', 'entity_bank_account', 'iban', 'Column public.entity_bank_account.iban should exist');
+RETURN NEXT col_type_is(      'public', 'entity_bank_account', 'iban', 'character varying', 'Column public.entity_bank_account.iban should be type character varying');
+RETURN NEXT col_not_null(     'public', 'entity_bank_account', 'iban', 'Column public.entity_bank_account.iban should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_bank_account', 'iban', 'Column public.entity_bank_account.iban should not have a default');
+
+RETURN NEXT has_column(       'public', 'entity_bank_account', 'remark', 'Column public.entity_bank_account.remark should exist');
+RETURN NEXT col_type_is(      'public', 'entity_bank_account', 'remark', 'character varying', 'Column public.entity_bank_account.remark should be type character varying');
+RETURN NEXT col_is_null(      'public', 'entity_bank_account', 'remark', 'Column public.entity_bank_account.remark should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_bank_account', 'remark', 'Column public.entity_bank_account.remark should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.entity_class.sql.pg_include
+++ b/xt/pgtap/table_public.entity_class.sql.pg_include
@@ -1,0 +1,40 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_entity_class()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'entity_class',
+    'Should have table public.entity_class'
+);
+
+RETURN NEXT has_pk(
+    'public', 'entity_class',
+    'Table public.entity_class should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'entity_class'::name, ARRAY[
+    'id'::name,
+    'class'::name,
+    'active'::name
+]);
+
+RETURN NEXT has_column(       'public', 'entity_class', 'id', 'Column public.entity_class.id should exist');
+RETURN NEXT col_type_is(      'public', 'entity_class', 'id', 'integer', 'Column public.entity_class.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'entity_class', 'id', 'Column public.entity_class.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'entity_class', 'id', 'Column public.entity_class.id shouldhave a default');
+--SELECT col_default_is(   'public', 'entity_class', 'id', 'nextval(''entity_class_id_seq''::regclass)', 'Column public.entity_class.id default is');RETURN NEXT col_default_is(   'public', 'entity_class', 'id', 'nextval(''entity_class_id_seq''::regclass)', 'Column public.entity_class.id default is');
+
+RETURN NEXT has_column(       'public', 'entity_class', 'class', 'Column public.entity_class.class should exist');
+RETURN NEXT col_type_is(      'public', 'entity_class', 'class', 'text', 'Column public.entity_class.class should be type text');
+RETURN NEXT col_not_null(     'public', 'entity_class', 'class', 'Column public.entity_class.class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_class', 'class', 'Column public.entity_class.class should not have a default');
+
+RETURN NEXT has_column(       'public', 'entity_class', 'active', 'Column public.entity_class.active should exist');
+RETURN NEXT col_type_is(      'public', 'entity_class', 'active', 'boolean', 'Column public.entity_class.active should be type boolean');
+RETURN NEXT col_not_null(     'public', 'entity_class', 'active', 'Column public.entity_class.active should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'entity_class', 'active', 'Column public.entity_class.active shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'entity_class', 'active', 'true', 'Column public.entity_class.active default is');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.entity_credit_account.sql.pg_include
+++ b/xt/pgtap/table_public.entity_credit_account.sql.pg_include
@@ -1,0 +1,178 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_entity_credit_account()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'entity_credit_account',
+    'Should have table public.entity_credit_account'
+);
+
+RETURN NEXT has_pk(
+    'public', 'entity_credit_account',
+    'Table public.entity_credit_account should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'entity_credit_account'::name, ARRAY[
+    'id'::name,
+    'entity_id'::name,
+    'entity_class'::name,
+    'pay_to_name'::name,
+    'discount'::name,
+    'description'::name,
+    'discount_terms'::name,
+    'discount_account_id'::name,
+    'taxincluded'::name,
+    'creditlimit'::name,
+    'terms'::name,
+    'meta_number'::name,
+    'business_id'::name,
+    'language_code'::name,
+    'pricegroup_id'::name,
+    'curr'::name,
+    'startdate'::name,
+    'enddate'::name,
+    'threshold'::name,
+    'employee_id'::name,
+    'primary_contact'::name,
+    'ar_ap_account_id'::name,
+    'cash_account_id'::name,
+    'bank_account'::name,
+    'taxform_id'::name
+]);
+
+RETURN NEXT has_column(       'public', 'entity_credit_account', 'id', 'Column public.entity_credit_account.id should exist');
+RETURN NEXT col_type_is(      'public', 'entity_credit_account', 'id', 'integer', 'Column public.entity_credit_account.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'entity_credit_account', 'id', 'Column public.entity_credit_account.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'entity_credit_account', 'id', 'Column public.entity_credit_account.id shouldhave a default');
+--SELECT col_default_is(   'public', 'entity_credit_account', 'id', 'nextval(''entity_credit_account_id_seq''::regclass)', 'Column public.entity_credit_account.id default is');RETURN NEXT col_default_is(   'public', 'entity_credit_account', 'id', 'nextval(''entity_credit_account_id_seq''::regclass)', 'Column public.entity_credit_account.id default is');
+
+RETURN NEXT has_column(       'public', 'entity_credit_account', 'entity_id', 'Column public.entity_credit_account.entity_id should exist');
+RETURN NEXT col_type_is(      'public', 'entity_credit_account', 'entity_id', 'integer', 'Column public.entity_credit_account.entity_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'entity_credit_account', 'entity_id', 'Column public.entity_credit_account.entity_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_credit_account', 'entity_id', 'Column public.entity_credit_account.entity_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'entity_credit_account', 'entity_class', 'Column public.entity_credit_account.entity_class should exist');
+RETURN NEXT col_type_is(      'public', 'entity_credit_account', 'entity_class', 'integer', 'Column public.entity_credit_account.entity_class should be type integer');
+RETURN NEXT col_not_null(     'public', 'entity_credit_account', 'entity_class', 'Column public.entity_credit_account.entity_class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_credit_account', 'entity_class', 'Column public.entity_credit_account.entity_class should not have a default');
+
+RETURN NEXT has_column(       'public', 'entity_credit_account', 'pay_to_name', 'Column public.entity_credit_account.pay_to_name should exist');
+RETURN NEXT col_type_is(      'public', 'entity_credit_account', 'pay_to_name', 'text', 'Column public.entity_credit_account.pay_to_name should be type text');
+RETURN NEXT col_is_null(      'public', 'entity_credit_account', 'pay_to_name', 'Column public.entity_credit_account.pay_to_name should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_credit_account', 'pay_to_name', 'Column public.entity_credit_account.pay_to_name should not have a default');
+
+RETURN NEXT has_column(       'public', 'entity_credit_account', 'discount', 'Column public.entity_credit_account.discount should exist');
+RETURN NEXT col_type_is(      'public', 'entity_credit_account', 'discount', 'numeric', 'Column public.entity_credit_account.discount should be type numeric');
+RETURN NEXT col_is_null(      'public', 'entity_credit_account', 'discount', 'Column public.entity_credit_account.discount should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_credit_account', 'discount', 'Column public.entity_credit_account.discount should not have a default');
+
+RETURN NEXT has_column(       'public', 'entity_credit_account', 'description', 'Column public.entity_credit_account.description should exist');
+RETURN NEXT col_type_is(      'public', 'entity_credit_account', 'description', 'text', 'Column public.entity_credit_account.description should be type text');
+RETURN NEXT col_is_null(      'public', 'entity_credit_account', 'description', 'Column public.entity_credit_account.description should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_credit_account', 'description', 'Column public.entity_credit_account.description should not have a default');
+
+RETURN NEXT has_column(       'public', 'entity_credit_account', 'discount_terms', 'Column public.entity_credit_account.discount_terms should exist');
+RETURN NEXT col_type_is(      'public', 'entity_credit_account', 'discount_terms', 'integer', 'Column public.entity_credit_account.discount_terms should be type integer');
+RETURN NEXT col_is_null(      'public', 'entity_credit_account', 'discount_terms', 'Column public.entity_credit_account.discount_terms should allow NULL');
+RETURN NEXT col_has_default(  'public', 'entity_credit_account', 'discount_terms', 'Column public.entity_credit_account.discount_terms shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'entity_credit_account', 'discount_terms', '0', 'Column public.entity_credit_account.discount_terms default is');
+
+RETURN NEXT has_column(       'public', 'entity_credit_account', 'discount_account_id', 'Column public.entity_credit_account.discount_account_id should exist');
+RETURN NEXT col_type_is(      'public', 'entity_credit_account', 'discount_account_id', 'integer', 'Column public.entity_credit_account.discount_account_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'entity_credit_account', 'discount_account_id', 'Column public.entity_credit_account.discount_account_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_credit_account', 'discount_account_id', 'Column public.entity_credit_account.discount_account_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'entity_credit_account', 'taxincluded', 'Column public.entity_credit_account.taxincluded should exist');
+RETURN NEXT col_type_is(      'public', 'entity_credit_account', 'taxincluded', 'boolean', 'Column public.entity_credit_account.taxincluded should be type boolean');
+RETURN NEXT col_is_null(      'public', 'entity_credit_account', 'taxincluded', 'Column public.entity_credit_account.taxincluded should allow NULL');
+RETURN NEXT col_has_default(  'public', 'entity_credit_account', 'taxincluded', 'Column public.entity_credit_account.taxincluded shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'entity_credit_account', 'taxincluded', 'false', 'Column public.entity_credit_account.taxincluded default is');
+
+RETURN NEXT has_column(       'public', 'entity_credit_account', 'creditlimit', 'Column public.entity_credit_account.creditlimit should exist');
+RETURN NEXT col_type_is(      'public', 'entity_credit_account', 'creditlimit', 'numeric', 'Column public.entity_credit_account.creditlimit should be type numeric');
+RETURN NEXT col_is_null(      'public', 'entity_credit_account', 'creditlimit', 'Column public.entity_credit_account.creditlimit should allow NULL');
+RETURN NEXT col_has_default(  'public', 'entity_credit_account', 'creditlimit', 'Column public.entity_credit_account.creditlimit shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'entity_credit_account', 'creditlimit', '0', 'Column public.entity_credit_account.creditlimit default is');
+
+RETURN NEXT has_column(       'public', 'entity_credit_account', 'terms', 'Column public.entity_credit_account.terms should exist');
+RETURN NEXT col_type_is(      'public', 'entity_credit_account', 'terms', 'smallint', 'Column public.entity_credit_account.terms should be type smallint');
+RETURN NEXT col_is_null(      'public', 'entity_credit_account', 'terms', 'Column public.entity_credit_account.terms should allow NULL');
+RETURN NEXT col_has_default(  'public', 'entity_credit_account', 'terms', 'Column public.entity_credit_account.terms shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'entity_credit_account', 'terms', '0', 'Column public.entity_credit_account.terms default is');
+
+RETURN NEXT has_column(       'public', 'entity_credit_account', 'meta_number', 'Column public.entity_credit_account.meta_number should exist');
+RETURN NEXT col_type_is(      'public', 'entity_credit_account', 'meta_number', 'character varying(32)', 'Column public.entity_credit_account.meta_number should be type character varying(32)');
+RETURN NEXT col_not_null(     'public', 'entity_credit_account', 'meta_number', 'Column public.entity_credit_account.meta_number should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_credit_account', 'meta_number', 'Column public.entity_credit_account.meta_number should not have a default');
+
+RETURN NEXT has_column(       'public', 'entity_credit_account', 'business_id', 'Column public.entity_credit_account.business_id should exist');
+RETURN NEXT col_type_is(      'public', 'entity_credit_account', 'business_id', 'integer', 'Column public.entity_credit_account.business_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'entity_credit_account', 'business_id', 'Column public.entity_credit_account.business_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_credit_account', 'business_id', 'Column public.entity_credit_account.business_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'entity_credit_account', 'language_code', 'Column public.entity_credit_account.language_code should exist');
+RETURN NEXT col_type_is(      'public', 'entity_credit_account', 'language_code', 'character varying(6)', 'Column public.entity_credit_account.language_code should be type character varying(6)');
+RETURN NEXT col_is_null(      'public', 'entity_credit_account', 'language_code', 'Column public.entity_credit_account.language_code should allow NULL');
+RETURN NEXT col_has_default(  'public', 'entity_credit_account', 'language_code', 'Column public.entity_credit_account.language_code shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'entity_credit_account', 'language_code', 'en'::character varying, 'Column public.entity_credit_account.language_code default is');
+
+RETURN NEXT has_column(       'public', 'entity_credit_account', 'pricegroup_id', 'Column public.entity_credit_account.pricegroup_id should exist');
+RETURN NEXT col_type_is(      'public', 'entity_credit_account', 'pricegroup_id', 'integer', 'Column public.entity_credit_account.pricegroup_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'entity_credit_account', 'pricegroup_id', 'Column public.entity_credit_account.pricegroup_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_credit_account', 'pricegroup_id', 'Column public.entity_credit_account.pricegroup_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'entity_credit_account', 'curr', 'Column public.entity_credit_account.curr should exist');
+RETURN NEXT col_type_is(      'public', 'entity_credit_account', 'curr', 'character(3)', 'Column public.entity_credit_account.curr should be type character(3)');
+RETURN NEXT col_is_null(      'public', 'entity_credit_account', 'curr', 'Column public.entity_credit_account.curr should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_credit_account', 'curr', 'Column public.entity_credit_account.curr should not have a default');
+
+RETURN NEXT has_column(       'public', 'entity_credit_account', 'startdate', 'Column public.entity_credit_account.startdate should exist');
+RETURN NEXT col_type_is(      'public', 'entity_credit_account', 'startdate', 'date', 'Column public.entity_credit_account.startdate should be type date');
+RETURN NEXT col_is_null(      'public', 'entity_credit_account', 'startdate', 'Column public.entity_credit_account.startdate should allow NULL');
+RETURN NEXT col_has_default(  'public', 'entity_credit_account', 'startdate', 'Column public.entity_credit_account.startdate shouldhave a default');
+--SELECT col_default_is(   'public', 'entity_credit_account', 'startdate', '(''now''::text)::date', 'Column public.entity_credit_account.startdate default is');RETURN NEXT col_default_is(   'public', 'entity_credit_account', 'startdate', '(''now''::text)::date', 'Column public.entity_credit_account.startdate default is');
+
+RETURN NEXT has_column(       'public', 'entity_credit_account', 'enddate', 'Column public.entity_credit_account.enddate should exist');
+RETURN NEXT col_type_is(      'public', 'entity_credit_account', 'enddate', 'date', 'Column public.entity_credit_account.enddate should be type date');
+RETURN NEXT col_is_null(      'public', 'entity_credit_account', 'enddate', 'Column public.entity_credit_account.enddate should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_credit_account', 'enddate', 'Column public.entity_credit_account.enddate should not have a default');
+
+RETURN NEXT has_column(       'public', 'entity_credit_account', 'threshold', 'Column public.entity_credit_account.threshold should exist');
+RETURN NEXT col_type_is(      'public', 'entity_credit_account', 'threshold', 'numeric', 'Column public.entity_credit_account.threshold should be type numeric');
+RETURN NEXT col_is_null(      'public', 'entity_credit_account', 'threshold', 'Column public.entity_credit_account.threshold should allow NULL');
+RETURN NEXT col_has_default(  'public', 'entity_credit_account', 'threshold', 'Column public.entity_credit_account.threshold shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'entity_credit_account', 'threshold', '0', 'Column public.entity_credit_account.threshold default is');
+
+RETURN NEXT has_column(       'public', 'entity_credit_account', 'employee_id', 'Column public.entity_credit_account.employee_id should exist');
+RETURN NEXT col_type_is(      'public', 'entity_credit_account', 'employee_id', 'integer', 'Column public.entity_credit_account.employee_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'entity_credit_account', 'employee_id', 'Column public.entity_credit_account.employee_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_credit_account', 'employee_id', 'Column public.entity_credit_account.employee_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'entity_credit_account', 'primary_contact', 'Column public.entity_credit_account.primary_contact should exist');
+RETURN NEXT col_type_is(      'public', 'entity_credit_account', 'primary_contact', 'integer', 'Column public.entity_credit_account.primary_contact should be type integer');
+RETURN NEXT col_is_null(      'public', 'entity_credit_account', 'primary_contact', 'Column public.entity_credit_account.primary_contact should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_credit_account', 'primary_contact', 'Column public.entity_credit_account.primary_contact should not have a default');
+
+RETURN NEXT has_column(       'public', 'entity_credit_account', 'ar_ap_account_id', 'Column public.entity_credit_account.ar_ap_account_id should exist');
+RETURN NEXT col_type_is(      'public', 'entity_credit_account', 'ar_ap_account_id', 'integer', 'Column public.entity_credit_account.ar_ap_account_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'entity_credit_account', 'ar_ap_account_id', 'Column public.entity_credit_account.ar_ap_account_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_credit_account', 'ar_ap_account_id', 'Column public.entity_credit_account.ar_ap_account_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'entity_credit_account', 'cash_account_id', 'Column public.entity_credit_account.cash_account_id should exist');
+RETURN NEXT col_type_is(      'public', 'entity_credit_account', 'cash_account_id', 'integer', 'Column public.entity_credit_account.cash_account_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'entity_credit_account', 'cash_account_id', 'Column public.entity_credit_account.cash_account_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_credit_account', 'cash_account_id', 'Column public.entity_credit_account.cash_account_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'entity_credit_account', 'bank_account', 'Column public.entity_credit_account.bank_account should exist');
+RETURN NEXT col_type_is(      'public', 'entity_credit_account', 'bank_account', 'integer', 'Column public.entity_credit_account.bank_account should be type integer');
+RETURN NEXT col_is_null(      'public', 'entity_credit_account', 'bank_account', 'Column public.entity_credit_account.bank_account should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_credit_account', 'bank_account', 'Column public.entity_credit_account.bank_account should not have a default');
+
+RETURN NEXT has_column(       'public', 'entity_credit_account', 'taxform_id', 'Column public.entity_credit_account.taxform_id should exist');
+RETURN NEXT col_type_is(      'public', 'entity_credit_account', 'taxform_id', 'integer', 'Column public.entity_credit_account.taxform_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'entity_credit_account', 'taxform_id', 'Column public.entity_credit_account.taxform_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_credit_account', 'taxform_id', 'Column public.entity_credit_account.taxform_id should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.entity_employee.sql.pg_include
+++ b/xt/pgtap/table_public.entity_employee.sql.pg_include
@@ -1,0 +1,83 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_entity_employee()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'entity_employee',
+    'Should have table public.entity_employee'
+);
+
+RETURN NEXT has_pk(
+    'public', 'entity_employee',
+    'Table public.entity_employee should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'entity_employee'::name, ARRAY[
+    'entity_id'::name,
+    'startdate'::name,
+    'enddate'::name,
+    'role'::name,
+    'ssn'::name,
+    'sales'::name,
+    'manager_id'::name,
+    'employeenumber'::name,
+    'dob'::name,
+    'is_manager'::name
+]);
+
+RETURN NEXT has_column(       'public', 'entity_employee', 'entity_id', 'Column public.entity_employee.entity_id should exist');
+RETURN NEXT col_type_is(      'public', 'entity_employee', 'entity_id', 'integer', 'Column public.entity_employee.entity_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'entity_employee', 'entity_id', 'Column public.entity_employee.entity_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_employee', 'entity_id', 'Column public.entity_employee.entity_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'entity_employee', 'startdate', 'Column public.entity_employee.startdate should exist');
+RETURN NEXT col_type_is(      'public', 'entity_employee', 'startdate', 'date', 'Column public.entity_employee.startdate should be type date');
+RETURN NEXT col_not_null(     'public', 'entity_employee', 'startdate', 'Column public.entity_employee.startdate should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'entity_employee', 'startdate', 'Column public.entity_employee.startdate shouldhave a default');
+--SELECT col_default_is(   'public', 'entity_employee', 'startdate', '(''now''::text)::date', 'Column public.entity_employee.startdate default is');RETURN NEXT col_default_is(   'public', 'entity_employee', 'startdate', '(''now''::text)::date', 'Column public.entity_employee.startdate default is');
+
+RETURN NEXT has_column(       'public', 'entity_employee', 'enddate', 'Column public.entity_employee.enddate should exist');
+RETURN NEXT col_type_is(      'public', 'entity_employee', 'enddate', 'date', 'Column public.entity_employee.enddate should be type date');
+RETURN NEXT col_is_null(      'public', 'entity_employee', 'enddate', 'Column public.entity_employee.enddate should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_employee', 'enddate', 'Column public.entity_employee.enddate should not have a default');
+
+RETURN NEXT has_column(       'public', 'entity_employee', 'role', 'Column public.entity_employee.role should exist');
+RETURN NEXT col_type_is(      'public', 'entity_employee', 'role', 'character varying(20)', 'Column public.entity_employee.role should be type character varying(20)');
+RETURN NEXT col_is_null(      'public', 'entity_employee', 'role', 'Column public.entity_employee.role should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_employee', 'role', 'Column public.entity_employee.role should not have a default');
+
+RETURN NEXT has_column(       'public', 'entity_employee', 'ssn', 'Column public.entity_employee.ssn should exist');
+RETURN NEXT col_type_is(      'public', 'entity_employee', 'ssn', 'text', 'Column public.entity_employee.ssn should be type text');
+RETURN NEXT col_is_null(      'public', 'entity_employee', 'ssn', 'Column public.entity_employee.ssn should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_employee', 'ssn', 'Column public.entity_employee.ssn should not have a default');
+
+RETURN NEXT has_column(       'public', 'entity_employee', 'sales', 'Column public.entity_employee.sales should exist');
+RETURN NEXT col_type_is(      'public', 'entity_employee', 'sales', 'boolean', 'Column public.entity_employee.sales should be type boolean');
+RETURN NEXT col_is_null(      'public', 'entity_employee', 'sales', 'Column public.entity_employee.sales should allow NULL');
+RETURN NEXT col_has_default(  'public', 'entity_employee', 'sales', 'Column public.entity_employee.sales shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'entity_employee', 'sales', 'false', 'Column public.entity_employee.sales default is');
+
+RETURN NEXT has_column(       'public', 'entity_employee', 'manager_id', 'Column public.entity_employee.manager_id should exist');
+RETURN NEXT col_type_is(      'public', 'entity_employee', 'manager_id', 'integer', 'Column public.entity_employee.manager_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'entity_employee', 'manager_id', 'Column public.entity_employee.manager_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_employee', 'manager_id', 'Column public.entity_employee.manager_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'entity_employee', 'employeenumber', 'Column public.entity_employee.employeenumber should exist');
+RETURN NEXT col_type_is(      'public', 'entity_employee', 'employeenumber', 'character varying(32)', 'Column public.entity_employee.employeenumber should be type character varying(32)');
+RETURN NEXT col_is_null(      'public', 'entity_employee', 'employeenumber', 'Column public.entity_employee.employeenumber should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_employee', 'employeenumber', 'Column public.entity_employee.employeenumber should not have a default');
+
+RETURN NEXT has_column(       'public', 'entity_employee', 'dob', 'Column public.entity_employee.dob should exist');
+RETURN NEXT col_type_is(      'public', 'entity_employee', 'dob', 'date', 'Column public.entity_employee.dob should be type date');
+RETURN NEXT col_is_null(      'public', 'entity_employee', 'dob', 'Column public.entity_employee.dob should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_employee', 'dob', 'Column public.entity_employee.dob should not have a default');
+
+RETURN NEXT has_column(       'public', 'entity_employee', 'is_manager', 'Column public.entity_employee.is_manager should exist');
+RETURN NEXT col_type_is(      'public', 'entity_employee', 'is_manager', 'boolean', 'Column public.entity_employee.is_manager should be type boolean');
+RETURN NEXT col_is_null(      'public', 'entity_employee', 'is_manager', 'Column public.entity_employee.is_manager should allow NULL');
+RETURN NEXT col_has_default(  'public', 'entity_employee', 'is_manager', 'Column public.entity_employee.is_manager shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'entity_employee', 'is_manager', 'false', 'Column public.entity_employee.is_manager default is');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.entity_note.sql.pg_include
+++ b/xt/pgtap/table_public.entity_note.sql.pg_include
@@ -1,0 +1,78 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_entity_note()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'entity_note',
+    'Should have table public.entity_note'
+);
+
+RETURN NEXT has_pk(
+    'public', 'entity_note',
+    'Table public.entity_note should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'entity_note'::name, ARRAY[
+    'id'::name,
+    'note_class'::name,
+    'note'::name,
+    'vector'::name,
+    'created'::name,
+    'created_by'::name,
+    'ref_key'::name,
+    'subject'::name,
+    'entity_id'::name
+]);
+
+RETURN NEXT has_column(       'public', 'entity_note', 'id', 'Column public.entity_note.id should exist');
+RETURN NEXT col_type_is(      'public', 'entity_note', 'id', 'integer', 'Column public.entity_note.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'entity_note', 'id', 'Column public.entity_note.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'entity_note', 'id', 'Column public.entity_note.id shouldhave a default');
+--SELECT col_default_is(   'public', 'entity_note', 'id', 'nextval(''note_id_seq''::regclass)', 'Column public.entity_note.id default is');RETURN NEXT col_default_is(   'public', 'entity_note', 'id', 'nextval(''note_id_seq''::regclass)', 'Column public.entity_note.id default is');
+
+RETURN NEXT has_column(       'public', 'entity_note', 'note_class', 'Column public.entity_note.note_class should exist');
+RETURN NEXT col_type_is(      'public', 'entity_note', 'note_class', 'integer', 'Column public.entity_note.note_class should be type integer');
+RETURN NEXT col_not_null(     'public', 'entity_note', 'note_class', 'Column public.entity_note.note_class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_note', 'note_class', 'Column public.entity_note.note_class should not have a default');
+
+RETURN NEXT has_column(       'public', 'entity_note', 'note', 'Column public.entity_note.note should exist');
+RETURN NEXT col_type_is(      'public', 'entity_note', 'note', 'text', 'Column public.entity_note.note should be type text');
+RETURN NEXT col_not_null(     'public', 'entity_note', 'note', 'Column public.entity_note.note should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_note', 'note', 'Column public.entity_note.note should not have a default');
+
+RETURN NEXT has_column(       'public', 'entity_note', 'vector', 'Column public.entity_note.vector should exist');
+RETURN NEXT col_type_is(      'public', 'entity_note', 'vector', 'tsvector', 'Column public.entity_note.vector should be type tsvector');
+RETURN NEXT col_not_null(     'public', 'entity_note', 'vector', 'Column public.entity_note.vector should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'entity_note', 'vector', 'Column public.entity_note.vector shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'entity_note', 'vector', ''::tsvector, 'Column public.entity_note.vector default is');
+
+RETURN NEXT has_column(       'public', 'entity_note', 'created', 'Column public.entity_note.created should exist');
+RETURN NEXT col_type_is(      'public', 'entity_note', 'created', 'timestamp without time zone', 'Column public.entity_note.created should be type timestamp without time zone');
+RETURN NEXT col_not_null(     'public', 'entity_note', 'created', 'Column public.entity_note.created should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'entity_note', 'created', 'Column public.entity_note.created shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'entity_note', 'created', 'now()', 'Column public.entity_note.created default is');
+
+RETURN NEXT has_column(       'public', 'entity_note', 'created_by', 'Column public.entity_note.created_by should exist');
+RETURN NEXT col_type_is(      'public', 'entity_note', 'created_by', 'text', 'Column public.entity_note.created_by should be type text');
+RETURN NEXT col_is_null(      'public', 'entity_note', 'created_by', 'Column public.entity_note.created_by should allow NULL');
+RETURN NEXT col_has_default(  'public', 'entity_note', 'created_by', 'Column public.entity_note.created_by shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'entity_note', 'created_by', '"session_user"()', 'Column public.entity_note.created_by default is');
+
+RETURN NEXT has_column(       'public', 'entity_note', 'ref_key', 'Column public.entity_note.ref_key should exist');
+RETURN NEXT col_type_is(      'public', 'entity_note', 'ref_key', 'integer', 'Column public.entity_note.ref_key should be type integer');
+RETURN NEXT col_not_null(     'public', 'entity_note', 'ref_key', 'Column public.entity_note.ref_key should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_note', 'ref_key', 'Column public.entity_note.ref_key should not have a default');
+
+RETURN NEXT has_column(       'public', 'entity_note', 'subject', 'Column public.entity_note.subject should exist');
+RETURN NEXT col_type_is(      'public', 'entity_note', 'subject', 'text', 'Column public.entity_note.subject should be type text');
+RETURN NEXT col_is_null(      'public', 'entity_note', 'subject', 'Column public.entity_note.subject should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_note', 'subject', 'Column public.entity_note.subject should not have a default');
+
+RETURN NEXT has_column(       'public', 'entity_note', 'entity_id', 'Column public.entity_note.entity_id should exist');
+RETURN NEXT col_type_is(      'public', 'entity_note', 'entity_id', 'integer', 'Column public.entity_note.entity_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'entity_note', 'entity_id', 'Column public.entity_note.entity_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_note', 'entity_id', 'Column public.entity_note.entity_id should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.entity_other_name.sql.pg_include
+++ b/xt/pgtap/table_public.entity_other_name.sql.pg_include
@@ -1,0 +1,32 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_entity_other_name()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'entity_other_name',
+    'Should have table public.entity_other_name'
+);
+
+RETURN NEXT has_pk(
+    'public', 'entity_other_name',
+    'Table public.entity_other_name should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'entity_other_name'::name, ARRAY[
+    'entity_id'::name,
+    'other_name'::name
+]);
+
+RETURN NEXT has_column(       'public', 'entity_other_name', 'entity_id', 'Column public.entity_other_name.entity_id should exist');
+RETURN NEXT col_type_is(      'public', 'entity_other_name', 'entity_id', 'integer', 'Column public.entity_other_name.entity_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'entity_other_name', 'entity_id', 'Column public.entity_other_name.entity_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_other_name', 'entity_id', 'Column public.entity_other_name.entity_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'entity_other_name', 'other_name', 'Column public.entity_other_name.other_name should exist');
+RETURN NEXT col_type_is(      'public', 'entity_other_name', 'other_name', 'text', 'Column public.entity_other_name.other_name should be type text');
+RETURN NEXT col_not_null(     'public', 'entity_other_name', 'other_name', 'Column public.entity_other_name.other_name should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_other_name', 'other_name', 'Column public.entity_other_name.other_name should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.entity_to_contact.sql.pg_include
+++ b/xt/pgtap/table_public.entity_to_contact.sql.pg_include
@@ -1,0 +1,44 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_entity_to_contact()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'entity_to_contact',
+    'Should have table public.entity_to_contact'
+);
+
+RETURN NEXT has_pk(
+    'public', 'entity_to_contact',
+    'Table public.entity_to_contact should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'entity_to_contact'::name, ARRAY[
+    'entity_id'::name,
+    'contact_class_id'::name,
+    'contact'::name,
+    'description'::name
+]);
+
+RETURN NEXT has_column(       'public', 'entity_to_contact', 'entity_id', 'Column public.entity_to_contact.entity_id should exist');
+RETURN NEXT col_type_is(      'public', 'entity_to_contact', 'entity_id', 'integer', 'Column public.entity_to_contact.entity_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'entity_to_contact', 'entity_id', 'Column public.entity_to_contact.entity_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_to_contact', 'entity_id', 'Column public.entity_to_contact.entity_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'entity_to_contact', 'contact_class_id', 'Column public.entity_to_contact.contact_class_id should exist');
+RETURN NEXT col_type_is(      'public', 'entity_to_contact', 'contact_class_id', 'integer', 'Column public.entity_to_contact.contact_class_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'entity_to_contact', 'contact_class_id', 'Column public.entity_to_contact.contact_class_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_to_contact', 'contact_class_id', 'Column public.entity_to_contact.contact_class_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'entity_to_contact', 'contact', 'Column public.entity_to_contact.contact should exist');
+RETURN NEXT col_type_is(      'public', 'entity_to_contact', 'contact', 'text', 'Column public.entity_to_contact.contact should be type text');
+RETURN NEXT col_not_null(     'public', 'entity_to_contact', 'contact', 'Column public.entity_to_contact.contact should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_to_contact', 'contact', 'Column public.entity_to_contact.contact should not have a default');
+
+RETURN NEXT has_column(       'public', 'entity_to_contact', 'description', 'Column public.entity_to_contact.description should exist');
+RETURN NEXT col_type_is(      'public', 'entity_to_contact', 'description', 'text', 'Column public.entity_to_contact.description should be type text');
+RETURN NEXT col_is_null(      'public', 'entity_to_contact', 'description', 'Column public.entity_to_contact.description should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_to_contact', 'description', 'Column public.entity_to_contact.description should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.entity_to_location.sql.pg_include
+++ b/xt/pgtap/table_public.entity_to_location.sql.pg_include
@@ -1,0 +1,38 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_entity_to_location()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'entity_to_location',
+    'Should have table public.entity_to_location'
+);
+
+RETURN NEXT has_pk(
+    'public', 'entity_to_location',
+    'Table public.entity_to_location should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'entity_to_location'::name, ARRAY[
+    'location_id'::name,
+    'location_class'::name,
+    'entity_id'::name
+]);
+
+RETURN NEXT has_column(       'public', 'entity_to_location', 'location_id', 'Column public.entity_to_location.location_id should exist');
+RETURN NEXT col_type_is(      'public', 'entity_to_location', 'location_id', 'integer', 'Column public.entity_to_location.location_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'entity_to_location', 'location_id', 'Column public.entity_to_location.location_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_to_location', 'location_id', 'Column public.entity_to_location.location_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'entity_to_location', 'location_class', 'Column public.entity_to_location.location_class should exist');
+RETURN NEXT col_type_is(      'public', 'entity_to_location', 'location_class', 'integer', 'Column public.entity_to_location.location_class should be type integer');
+RETURN NEXT col_not_null(     'public', 'entity_to_location', 'location_class', 'Column public.entity_to_location.location_class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_to_location', 'location_class', 'Column public.entity_to_location.location_class should not have a default');
+
+RETURN NEXT has_column(       'public', 'entity_to_location', 'entity_id', 'Column public.entity_to_location.entity_id should exist');
+RETURN NEXT col_type_is(      'public', 'entity_to_location', 'entity_id', 'integer', 'Column public.entity_to_location.entity_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'entity_to_location', 'entity_id', 'Column public.entity_to_location.entity_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'entity_to_location', 'entity_id', 'Column public.entity_to_location.entity_id should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.exchangerate.sql.pg_include
+++ b/xt/pgtap/table_public.exchangerate.sql.pg_include
@@ -1,0 +1,44 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_exchangerate()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'exchangerate',
+    'Should have table public.exchangerate'
+);
+
+RETURN NEXT has_pk(
+    'public', 'exchangerate',
+    'Table public.exchangerate should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'exchangerate'::name, ARRAY[
+    'curr'::name,
+    'transdate'::name,
+    'buy'::name,
+    'sell'::name
+]);
+
+RETURN NEXT has_column(       'public', 'exchangerate', 'curr', 'Column public.exchangerate.curr should exist');
+RETURN NEXT col_type_is(      'public', 'exchangerate', 'curr', 'character(3)', 'Column public.exchangerate.curr should be type character(3)');
+RETURN NEXT col_not_null(     'public', 'exchangerate', 'curr', 'Column public.exchangerate.curr should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'exchangerate', 'curr', 'Column public.exchangerate.curr should not have a default');
+
+RETURN NEXT has_column(       'public', 'exchangerate', 'transdate', 'Column public.exchangerate.transdate should exist');
+RETURN NEXT col_type_is(      'public', 'exchangerate', 'transdate', 'date', 'Column public.exchangerate.transdate should be type date');
+RETURN NEXT col_not_null(     'public', 'exchangerate', 'transdate', 'Column public.exchangerate.transdate should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'exchangerate', 'transdate', 'Column public.exchangerate.transdate should not have a default');
+
+RETURN NEXT has_column(       'public', 'exchangerate', 'buy', 'Column public.exchangerate.buy should exist');
+RETURN NEXT col_type_is(      'public', 'exchangerate', 'buy', 'numeric', 'Column public.exchangerate.buy should be type numeric');
+RETURN NEXT col_is_null(      'public', 'exchangerate', 'buy', 'Column public.exchangerate.buy should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'exchangerate', 'buy', 'Column public.exchangerate.buy should not have a default');
+
+RETURN NEXT has_column(       'public', 'exchangerate', 'sell', 'Column public.exchangerate.sell should exist');
+RETURN NEXT col_type_is(      'public', 'exchangerate', 'sell', 'numeric', 'Column public.exchangerate.sell should be type numeric');
+RETURN NEXT col_is_null(      'public', 'exchangerate', 'sell', 'Column public.exchangerate.sell should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'exchangerate', 'sell', 'Column public.exchangerate.sell should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.file_base.sql.pg_include
+++ b/xt/pgtap/table_public.file_base.sql.pg_include
@@ -1,0 +1,76 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_file_base()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'file_base',
+    'Should have table public.file_base'
+);
+
+RETURN NEXT has_pk(
+    'public', 'file_base',
+    'Table public.file_base should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'file_base'::name, ARRAY[
+    'content'::name,
+    'mime_type_id'::name,
+    'file_name'::name,
+    'description'::name,
+    'uploaded_by'::name,
+    'uploaded_at'::name,
+    'id'::name,
+    'ref_key'::name,
+    'file_class'::name
+]);
+
+RETURN NEXT has_column(       'public', 'file_base', 'content', 'Column public.file_base.content should exist');
+RETURN NEXT col_type_is(      'public', 'file_base', 'content', 'bytea', 'Column public.file_base.content should be type bytea');
+RETURN NEXT col_not_null(     'public', 'file_base', 'content', 'Column public.file_base.content should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_base', 'content', 'Column public.file_base.content should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_base', 'mime_type_id', 'Column public.file_base.mime_type_id should exist');
+RETURN NEXT col_type_is(      'public', 'file_base', 'mime_type_id', 'integer', 'Column public.file_base.mime_type_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_base', 'mime_type_id', 'Column public.file_base.mime_type_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_base', 'mime_type_id', 'Column public.file_base.mime_type_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_base', 'file_name', 'Column public.file_base.file_name should exist');
+RETURN NEXT col_type_is(      'public', 'file_base', 'file_name', 'text', 'Column public.file_base.file_name should be type text');
+RETURN NEXT col_not_null(     'public', 'file_base', 'file_name', 'Column public.file_base.file_name should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_base', 'file_name', 'Column public.file_base.file_name should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_base', 'description', 'Column public.file_base.description should exist');
+RETURN NEXT col_type_is(      'public', 'file_base', 'description', 'text', 'Column public.file_base.description should be type text');
+RETURN NEXT col_is_null(      'public', 'file_base', 'description', 'Column public.file_base.description should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'file_base', 'description', 'Column public.file_base.description should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_base', 'uploaded_by', 'Column public.file_base.uploaded_by should exist');
+RETURN NEXT col_type_is(      'public', 'file_base', 'uploaded_by', 'integer', 'Column public.file_base.uploaded_by should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_base', 'uploaded_by', 'Column public.file_base.uploaded_by should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_base', 'uploaded_by', 'Column public.file_base.uploaded_by should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_base', 'uploaded_at', 'Column public.file_base.uploaded_at should exist');
+RETURN NEXT col_type_is(      'public', 'file_base', 'uploaded_at', 'timestamp without time zone', 'Column public.file_base.uploaded_at should be type timestamp without time zone');
+RETURN NEXT col_not_null(     'public', 'file_base', 'uploaded_at', 'Column public.file_base.uploaded_at should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'file_base', 'uploaded_at', 'Column public.file_base.uploaded_at shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'file_base', 'uploaded_at', 'now()', 'Column public.file_base.uploaded_at default is');
+
+RETURN NEXT has_column(       'public', 'file_base', 'id', 'Column public.file_base.id should exist');
+RETURN NEXT col_type_is(      'public', 'file_base', 'id', 'integer', 'Column public.file_base.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_base', 'id', 'Column public.file_base.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'file_base', 'id', 'Column public.file_base.id shouldhave a default');
+--SELECT col_default_is(   'public', 'file_base', 'id', 'nextval(''file_base_id_seq''::regclass)', 'Column public.file_base.id default is');RETURN NEXT col_default_is(   'public', 'file_base', 'id', 'nextval(''file_base_id_seq''::regclass)', 'Column public.file_base.id default is');
+
+RETURN NEXT has_column(       'public', 'file_base', 'ref_key', 'Column public.file_base.ref_key should exist');
+RETURN NEXT col_type_is(      'public', 'file_base', 'ref_key', 'integer', 'Column public.file_base.ref_key should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_base', 'ref_key', 'Column public.file_base.ref_key should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_base', 'ref_key', 'Column public.file_base.ref_key should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_base', 'file_class', 'Column public.file_base.file_class should exist');
+RETURN NEXT col_type_is(      'public', 'file_base', 'file_class', 'integer', 'Column public.file_base.file_class should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_base', 'file_class', 'Column public.file_base.file_class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_base', 'file_class', 'Column public.file_base.file_class should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.file_class.sql.pg_include
+++ b/xt/pgtap/table_public.file_class.sql.pg_include
@@ -1,0 +1,33 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_file_class()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'file_class',
+    'Should have table public.file_class'
+);
+
+RETURN NEXT has_pk(
+    'public', 'file_class',
+    'Table public.file_class should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'file_class'::name, ARRAY[
+    'id'::name,
+    'class'::name
+]);
+
+RETURN NEXT has_column(       'public', 'file_class', 'id', 'Column public.file_class.id should exist');
+RETURN NEXT col_type_is(      'public', 'file_class', 'id', 'integer', 'Column public.file_class.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_class', 'id', 'Column public.file_class.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'file_class', 'id', 'Column public.file_class.id shouldhave a default');
+--SELECT col_default_is(   'public', 'file_class', 'id', 'nextval(''file_class_id_seq''::regclass)', 'Column public.file_class.id default is');RETURN NEXT col_default_is(   'public', 'file_class', 'id', 'nextval(''file_class_id_seq''::regclass)', 'Column public.file_class.id default is');
+
+RETURN NEXT has_column(       'public', 'file_class', 'class', 'Column public.file_class.class should exist');
+RETURN NEXT col_type_is(      'public', 'file_class', 'class', 'text', 'Column public.file_class.class should be type text');
+RETURN NEXT col_not_null(     'public', 'file_class', 'class', 'Column public.file_class.class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_class', 'class', 'Column public.file_class.class should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.file_eca.sql.pg_include
+++ b/xt/pgtap/table_public.file_eca.sql.pg_include
@@ -1,0 +1,76 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_file_eca()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'file_eca',
+    'Should have table public.file_eca'
+);
+
+RETURN NEXT has_pk(
+    'public', 'file_eca',
+    'Table public.file_eca should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'file_eca'::name, ARRAY[
+    'content'::name,
+    'mime_type_id'::name,
+    'file_name'::name,
+    'description'::name,
+    'uploaded_by'::name,
+    'uploaded_at'::name,
+    'id'::name,
+    'ref_key'::name,
+    'file_class'::name
+]);
+
+RETURN NEXT has_column(       'public', 'file_eca', 'content', 'Column public.file_eca.content should exist');
+RETURN NEXT col_type_is(      'public', 'file_eca', 'content', 'bytea', 'Column public.file_eca.content should be type bytea');
+RETURN NEXT col_not_null(     'public', 'file_eca', 'content', 'Column public.file_eca.content should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_eca', 'content', 'Column public.file_eca.content should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_eca', 'mime_type_id', 'Column public.file_eca.mime_type_id should exist');
+RETURN NEXT col_type_is(      'public', 'file_eca', 'mime_type_id', 'integer', 'Column public.file_eca.mime_type_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_eca', 'mime_type_id', 'Column public.file_eca.mime_type_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_eca', 'mime_type_id', 'Column public.file_eca.mime_type_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_eca', 'file_name', 'Column public.file_eca.file_name should exist');
+RETURN NEXT col_type_is(      'public', 'file_eca', 'file_name', 'text', 'Column public.file_eca.file_name should be type text');
+RETURN NEXT col_not_null(     'public', 'file_eca', 'file_name', 'Column public.file_eca.file_name should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_eca', 'file_name', 'Column public.file_eca.file_name should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_eca', 'description', 'Column public.file_eca.description should exist');
+RETURN NEXT col_type_is(      'public', 'file_eca', 'description', 'text', 'Column public.file_eca.description should be type text');
+RETURN NEXT col_is_null(      'public', 'file_eca', 'description', 'Column public.file_eca.description should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'file_eca', 'description', 'Column public.file_eca.description should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_eca', 'uploaded_by', 'Column public.file_eca.uploaded_by should exist');
+RETURN NEXT col_type_is(      'public', 'file_eca', 'uploaded_by', 'integer', 'Column public.file_eca.uploaded_by should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_eca', 'uploaded_by', 'Column public.file_eca.uploaded_by should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_eca', 'uploaded_by', 'Column public.file_eca.uploaded_by should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_eca', 'uploaded_at', 'Column public.file_eca.uploaded_at should exist');
+RETURN NEXT col_type_is(      'public', 'file_eca', 'uploaded_at', 'timestamp without time zone', 'Column public.file_eca.uploaded_at should be type timestamp without time zone');
+RETURN NEXT col_not_null(     'public', 'file_eca', 'uploaded_at', 'Column public.file_eca.uploaded_at should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'file_eca', 'uploaded_at', 'Column public.file_eca.uploaded_at shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'file_eca', 'uploaded_at', 'now()', 'Column public.file_eca.uploaded_at default is');
+
+RETURN NEXT has_column(       'public', 'file_eca', 'id', 'Column public.file_eca.id should exist');
+RETURN NEXT col_type_is(      'public', 'file_eca', 'id', 'integer', 'Column public.file_eca.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_eca', 'id', 'Column public.file_eca.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'file_eca', 'id', 'Column public.file_eca.id shouldhave a default');
+--SELECT col_default_is(   'public', 'file_eca', 'id', 'nextval(''file_base_id_seq''::regclass)', 'Column public.file_eca.id default is');RETURN NEXT col_default_is(   'public', 'file_eca', 'id', 'nextval(''file_base_id_seq''::regclass)', 'Column public.file_eca.id default is');
+
+RETURN NEXT has_column(       'public', 'file_eca', 'ref_key', 'Column public.file_eca.ref_key should exist');
+RETURN NEXT col_type_is(      'public', 'file_eca', 'ref_key', 'integer', 'Column public.file_eca.ref_key should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_eca', 'ref_key', 'Column public.file_eca.ref_key should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_eca', 'ref_key', 'Column public.file_eca.ref_key should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_eca', 'file_class', 'Column public.file_eca.file_class should exist');
+RETURN NEXT col_type_is(      'public', 'file_eca', 'file_class', 'integer', 'Column public.file_eca.file_class should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_eca', 'file_class', 'Column public.file_eca.file_class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_eca', 'file_class', 'Column public.file_eca.file_class should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.file_entity.sql.pg_include
+++ b/xt/pgtap/table_public.file_entity.sql.pg_include
@@ -1,0 +1,76 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_file_entity()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'file_entity',
+    'Should have table public.file_entity'
+);
+
+RETURN NEXT has_pk(
+    'public', 'file_entity',
+    'Table public.file_entity should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'file_entity'::name, ARRAY[
+    'content'::name,
+    'mime_type_id'::name,
+    'file_name'::name,
+    'description'::name,
+    'uploaded_by'::name,
+    'uploaded_at'::name,
+    'id'::name,
+    'ref_key'::name,
+    'file_class'::name
+]);
+
+RETURN NEXT has_column(       'public', 'file_entity', 'content', 'Column public.file_entity.content should exist');
+RETURN NEXT col_type_is(      'public', 'file_entity', 'content', 'bytea', 'Column public.file_entity.content should be type bytea');
+RETURN NEXT col_not_null(     'public', 'file_entity', 'content', 'Column public.file_entity.content should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_entity', 'content', 'Column public.file_entity.content should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_entity', 'mime_type_id', 'Column public.file_entity.mime_type_id should exist');
+RETURN NEXT col_type_is(      'public', 'file_entity', 'mime_type_id', 'integer', 'Column public.file_entity.mime_type_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_entity', 'mime_type_id', 'Column public.file_entity.mime_type_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_entity', 'mime_type_id', 'Column public.file_entity.mime_type_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_entity', 'file_name', 'Column public.file_entity.file_name should exist');
+RETURN NEXT col_type_is(      'public', 'file_entity', 'file_name', 'text', 'Column public.file_entity.file_name should be type text');
+RETURN NEXT col_not_null(     'public', 'file_entity', 'file_name', 'Column public.file_entity.file_name should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_entity', 'file_name', 'Column public.file_entity.file_name should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_entity', 'description', 'Column public.file_entity.description should exist');
+RETURN NEXT col_type_is(      'public', 'file_entity', 'description', 'text', 'Column public.file_entity.description should be type text');
+RETURN NEXT col_is_null(      'public', 'file_entity', 'description', 'Column public.file_entity.description should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'file_entity', 'description', 'Column public.file_entity.description should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_entity', 'uploaded_by', 'Column public.file_entity.uploaded_by should exist');
+RETURN NEXT col_type_is(      'public', 'file_entity', 'uploaded_by', 'integer', 'Column public.file_entity.uploaded_by should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_entity', 'uploaded_by', 'Column public.file_entity.uploaded_by should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_entity', 'uploaded_by', 'Column public.file_entity.uploaded_by should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_entity', 'uploaded_at', 'Column public.file_entity.uploaded_at should exist');
+RETURN NEXT col_type_is(      'public', 'file_entity', 'uploaded_at', 'timestamp without time zone', 'Column public.file_entity.uploaded_at should be type timestamp without time zone');
+RETURN NEXT col_not_null(     'public', 'file_entity', 'uploaded_at', 'Column public.file_entity.uploaded_at should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'file_entity', 'uploaded_at', 'Column public.file_entity.uploaded_at shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'file_entity', 'uploaded_at', 'now()', 'Column public.file_entity.uploaded_at default is');
+
+RETURN NEXT has_column(       'public', 'file_entity', 'id', 'Column public.file_entity.id should exist');
+RETURN NEXT col_type_is(      'public', 'file_entity', 'id', 'integer', 'Column public.file_entity.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_entity', 'id', 'Column public.file_entity.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'file_entity', 'id', 'Column public.file_entity.id shouldhave a default');
+--SELECT col_default_is(   'public', 'file_entity', 'id', 'nextval(''file_base_id_seq''::regclass)', 'Column public.file_entity.id default is');RETURN NEXT col_default_is(   'public', 'file_entity', 'id', 'nextval(''file_base_id_seq''::regclass)', 'Column public.file_entity.id default is');
+
+RETURN NEXT has_column(       'public', 'file_entity', 'ref_key', 'Column public.file_entity.ref_key should exist');
+RETURN NEXT col_type_is(      'public', 'file_entity', 'ref_key', 'integer', 'Column public.file_entity.ref_key should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_entity', 'ref_key', 'Column public.file_entity.ref_key should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_entity', 'ref_key', 'Column public.file_entity.ref_key should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_entity', 'file_class', 'Column public.file_entity.file_class should exist');
+RETURN NEXT col_type_is(      'public', 'file_entity', 'file_class', 'integer', 'Column public.file_entity.file_class should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_entity', 'file_class', 'Column public.file_entity.file_class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_entity', 'file_class', 'Column public.file_entity.file_class should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.file_incoming.sql.pg_include
+++ b/xt/pgtap/table_public.file_incoming.sql.pg_include
@@ -1,0 +1,76 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_file_incoming()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'file_incoming',
+    'Should have table public.file_incoming'
+);
+
+RETURN NEXT has_pk(
+    'public', 'file_incoming',
+    'Table public.file_incoming should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'file_incoming'::name, ARRAY[
+    'content'::name,
+    'mime_type_id'::name,
+    'file_name'::name,
+    'description'::name,
+    'uploaded_by'::name,
+    'uploaded_at'::name,
+    'id'::name,
+    'ref_key'::name,
+    'file_class'::name
+]);
+
+RETURN NEXT has_column(       'public', 'file_incoming', 'content', 'Column public.file_incoming.content should exist');
+RETURN NEXT col_type_is(      'public', 'file_incoming', 'content', 'bytea', 'Column public.file_incoming.content should be type bytea');
+RETURN NEXT col_not_null(     'public', 'file_incoming', 'content', 'Column public.file_incoming.content should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_incoming', 'content', 'Column public.file_incoming.content should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_incoming', 'mime_type_id', 'Column public.file_incoming.mime_type_id should exist');
+RETURN NEXT col_type_is(      'public', 'file_incoming', 'mime_type_id', 'integer', 'Column public.file_incoming.mime_type_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_incoming', 'mime_type_id', 'Column public.file_incoming.mime_type_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_incoming', 'mime_type_id', 'Column public.file_incoming.mime_type_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_incoming', 'file_name', 'Column public.file_incoming.file_name should exist');
+RETURN NEXT col_type_is(      'public', 'file_incoming', 'file_name', 'text', 'Column public.file_incoming.file_name should be type text');
+RETURN NEXT col_not_null(     'public', 'file_incoming', 'file_name', 'Column public.file_incoming.file_name should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_incoming', 'file_name', 'Column public.file_incoming.file_name should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_incoming', 'description', 'Column public.file_incoming.description should exist');
+RETURN NEXT col_type_is(      'public', 'file_incoming', 'description', 'text', 'Column public.file_incoming.description should be type text');
+RETURN NEXT col_is_null(      'public', 'file_incoming', 'description', 'Column public.file_incoming.description should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'file_incoming', 'description', 'Column public.file_incoming.description should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_incoming', 'uploaded_by', 'Column public.file_incoming.uploaded_by should exist');
+RETURN NEXT col_type_is(      'public', 'file_incoming', 'uploaded_by', 'integer', 'Column public.file_incoming.uploaded_by should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_incoming', 'uploaded_by', 'Column public.file_incoming.uploaded_by should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_incoming', 'uploaded_by', 'Column public.file_incoming.uploaded_by should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_incoming', 'uploaded_at', 'Column public.file_incoming.uploaded_at should exist');
+RETURN NEXT col_type_is(      'public', 'file_incoming', 'uploaded_at', 'timestamp without time zone', 'Column public.file_incoming.uploaded_at should be type timestamp without time zone');
+RETURN NEXT col_not_null(     'public', 'file_incoming', 'uploaded_at', 'Column public.file_incoming.uploaded_at should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'file_incoming', 'uploaded_at', 'Column public.file_incoming.uploaded_at shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'file_incoming', 'uploaded_at', 'now()', 'Column public.file_incoming.uploaded_at default is');
+
+RETURN NEXT has_column(       'public', 'file_incoming', 'id', 'Column public.file_incoming.id should exist');
+RETURN NEXT col_type_is(      'public', 'file_incoming', 'id', 'integer', 'Column public.file_incoming.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_incoming', 'id', 'Column public.file_incoming.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'file_incoming', 'id', 'Column public.file_incoming.id shouldhave a default');
+--SELECT col_default_is(   'public', 'file_incoming', 'id', 'nextval(''file_base_id_seq''::regclass)', 'Column public.file_incoming.id default is');RETURN NEXT col_default_is(   'public', 'file_incoming', 'id', 'nextval(''file_base_id_seq''::regclass)', 'Column public.file_incoming.id default is');
+
+RETURN NEXT has_column(       'public', 'file_incoming', 'ref_key', 'Column public.file_incoming.ref_key should exist');
+RETURN NEXT col_type_is(      'public', 'file_incoming', 'ref_key', 'integer', 'Column public.file_incoming.ref_key should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_incoming', 'ref_key', 'Column public.file_incoming.ref_key should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_incoming', 'ref_key', 'Column public.file_incoming.ref_key should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_incoming', 'file_class', 'Column public.file_incoming.file_class should exist');
+RETURN NEXT col_type_is(      'public', 'file_incoming', 'file_class', 'integer', 'Column public.file_incoming.file_class should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_incoming', 'file_class', 'Column public.file_incoming.file_class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_incoming', 'file_class', 'Column public.file_incoming.file_class should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.file_internal.sql.pg_include
+++ b/xt/pgtap/table_public.file_internal.sql.pg_include
@@ -1,0 +1,76 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_file_internal()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'file_internal',
+    'Should have table public.file_internal'
+);
+
+RETURN NEXT has_pk(
+    'public', 'file_internal',
+    'Table public.file_internal should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'file_internal'::name, ARRAY[
+    'content'::name,
+    'mime_type_id'::name,
+    'file_name'::name,
+    'description'::name,
+    'uploaded_by'::name,
+    'uploaded_at'::name,
+    'id'::name,
+    'ref_key'::name,
+    'file_class'::name
+]);
+
+RETURN NEXT has_column(       'public', 'file_internal', 'content', 'Column public.file_internal.content should exist');
+RETURN NEXT col_type_is(      'public', 'file_internal', 'content', 'bytea', 'Column public.file_internal.content should be type bytea');
+RETURN NEXT col_not_null(     'public', 'file_internal', 'content', 'Column public.file_internal.content should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_internal', 'content', 'Column public.file_internal.content should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_internal', 'mime_type_id', 'Column public.file_internal.mime_type_id should exist');
+RETURN NEXT col_type_is(      'public', 'file_internal', 'mime_type_id', 'integer', 'Column public.file_internal.mime_type_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_internal', 'mime_type_id', 'Column public.file_internal.mime_type_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_internal', 'mime_type_id', 'Column public.file_internal.mime_type_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_internal', 'file_name', 'Column public.file_internal.file_name should exist');
+RETURN NEXT col_type_is(      'public', 'file_internal', 'file_name', 'text', 'Column public.file_internal.file_name should be type text');
+RETURN NEXT col_not_null(     'public', 'file_internal', 'file_name', 'Column public.file_internal.file_name should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_internal', 'file_name', 'Column public.file_internal.file_name should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_internal', 'description', 'Column public.file_internal.description should exist');
+RETURN NEXT col_type_is(      'public', 'file_internal', 'description', 'text', 'Column public.file_internal.description should be type text');
+RETURN NEXT col_is_null(      'public', 'file_internal', 'description', 'Column public.file_internal.description should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'file_internal', 'description', 'Column public.file_internal.description should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_internal', 'uploaded_by', 'Column public.file_internal.uploaded_by should exist');
+RETURN NEXT col_type_is(      'public', 'file_internal', 'uploaded_by', 'integer', 'Column public.file_internal.uploaded_by should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_internal', 'uploaded_by', 'Column public.file_internal.uploaded_by should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_internal', 'uploaded_by', 'Column public.file_internal.uploaded_by should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_internal', 'uploaded_at', 'Column public.file_internal.uploaded_at should exist');
+RETURN NEXT col_type_is(      'public', 'file_internal', 'uploaded_at', 'timestamp without time zone', 'Column public.file_internal.uploaded_at should be type timestamp without time zone');
+RETURN NEXT col_not_null(     'public', 'file_internal', 'uploaded_at', 'Column public.file_internal.uploaded_at should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'file_internal', 'uploaded_at', 'Column public.file_internal.uploaded_at shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'file_internal', 'uploaded_at', 'now()', 'Column public.file_internal.uploaded_at default is');
+
+RETURN NEXT has_column(       'public', 'file_internal', 'id', 'Column public.file_internal.id should exist');
+RETURN NEXT col_type_is(      'public', 'file_internal', 'id', 'integer', 'Column public.file_internal.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_internal', 'id', 'Column public.file_internal.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'file_internal', 'id', 'Column public.file_internal.id shouldhave a default');
+--SELECT col_default_is(   'public', 'file_internal', 'id', 'nextval(''file_base_id_seq''::regclass)', 'Column public.file_internal.id default is');RETURN NEXT col_default_is(   'public', 'file_internal', 'id', 'nextval(''file_base_id_seq''::regclass)', 'Column public.file_internal.id default is');
+
+RETURN NEXT has_column(       'public', 'file_internal', 'ref_key', 'Column public.file_internal.ref_key should exist');
+RETURN NEXT col_type_is(      'public', 'file_internal', 'ref_key', 'integer', 'Column public.file_internal.ref_key should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_internal', 'ref_key', 'Column public.file_internal.ref_key should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_internal', 'ref_key', 'Column public.file_internal.ref_key should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_internal', 'file_class', 'Column public.file_internal.file_class should exist');
+RETURN NEXT col_type_is(      'public', 'file_internal', 'file_class', 'integer', 'Column public.file_internal.file_class should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_internal', 'file_class', 'Column public.file_internal.file_class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_internal', 'file_class', 'Column public.file_internal.file_class should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.file_order.sql.pg_include
+++ b/xt/pgtap/table_public.file_order.sql.pg_include
@@ -1,0 +1,76 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_file_order()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'file_order',
+    'Should have table public.file_order'
+);
+
+RETURN NEXT has_pk(
+    'public', 'file_order',
+    'Table public.file_order should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'file_order'::name, ARRAY[
+    'content'::name,
+    'mime_type_id'::name,
+    'file_name'::name,
+    'description'::name,
+    'uploaded_by'::name,
+    'uploaded_at'::name,
+    'id'::name,
+    'ref_key'::name,
+    'file_class'::name
+]);
+
+RETURN NEXT has_column(       'public', 'file_order', 'content', 'Column public.file_order.content should exist');
+RETURN NEXT col_type_is(      'public', 'file_order', 'content', 'bytea', 'Column public.file_order.content should be type bytea');
+RETURN NEXT col_not_null(     'public', 'file_order', 'content', 'Column public.file_order.content should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_order', 'content', 'Column public.file_order.content should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_order', 'mime_type_id', 'Column public.file_order.mime_type_id should exist');
+RETURN NEXT col_type_is(      'public', 'file_order', 'mime_type_id', 'integer', 'Column public.file_order.mime_type_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_order', 'mime_type_id', 'Column public.file_order.mime_type_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_order', 'mime_type_id', 'Column public.file_order.mime_type_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_order', 'file_name', 'Column public.file_order.file_name should exist');
+RETURN NEXT col_type_is(      'public', 'file_order', 'file_name', 'text', 'Column public.file_order.file_name should be type text');
+RETURN NEXT col_not_null(     'public', 'file_order', 'file_name', 'Column public.file_order.file_name should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_order', 'file_name', 'Column public.file_order.file_name should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_order', 'description', 'Column public.file_order.description should exist');
+RETURN NEXT col_type_is(      'public', 'file_order', 'description', 'text', 'Column public.file_order.description should be type text');
+RETURN NEXT col_is_null(      'public', 'file_order', 'description', 'Column public.file_order.description should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'file_order', 'description', 'Column public.file_order.description should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_order', 'uploaded_by', 'Column public.file_order.uploaded_by should exist');
+RETURN NEXT col_type_is(      'public', 'file_order', 'uploaded_by', 'integer', 'Column public.file_order.uploaded_by should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_order', 'uploaded_by', 'Column public.file_order.uploaded_by should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_order', 'uploaded_by', 'Column public.file_order.uploaded_by should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_order', 'uploaded_at', 'Column public.file_order.uploaded_at should exist');
+RETURN NEXT col_type_is(      'public', 'file_order', 'uploaded_at', 'timestamp without time zone', 'Column public.file_order.uploaded_at should be type timestamp without time zone');
+RETURN NEXT col_not_null(     'public', 'file_order', 'uploaded_at', 'Column public.file_order.uploaded_at should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'file_order', 'uploaded_at', 'Column public.file_order.uploaded_at shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'file_order', 'uploaded_at', 'now()', 'Column public.file_order.uploaded_at default is');
+
+RETURN NEXT has_column(       'public', 'file_order', 'id', 'Column public.file_order.id should exist');
+RETURN NEXT col_type_is(      'public', 'file_order', 'id', 'integer', 'Column public.file_order.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_order', 'id', 'Column public.file_order.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'file_order', 'id', 'Column public.file_order.id shouldhave a default');
+--SELECT col_default_is(   'public', 'file_order', 'id', 'nextval(''file_base_id_seq''::regclass)', 'Column public.file_order.id default is');RETURN NEXT col_default_is(   'public', 'file_order', 'id', 'nextval(''file_base_id_seq''::regclass)', 'Column public.file_order.id default is');
+
+RETURN NEXT has_column(       'public', 'file_order', 'ref_key', 'Column public.file_order.ref_key should exist');
+RETURN NEXT col_type_is(      'public', 'file_order', 'ref_key', 'integer', 'Column public.file_order.ref_key should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_order', 'ref_key', 'Column public.file_order.ref_key should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_order', 'ref_key', 'Column public.file_order.ref_key should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_order', 'file_class', 'Column public.file_order.file_class should exist');
+RETURN NEXT col_type_is(      'public', 'file_order', 'file_class', 'integer', 'Column public.file_order.file_class should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_order', 'file_class', 'Column public.file_order.file_class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_order', 'file_class', 'Column public.file_order.file_class should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.file_order_to_order.sql.pg_include
+++ b/xt/pgtap/table_public.file_order_to_order.sql.pg_include
@@ -1,0 +1,57 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_file_order_to_order()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'file_order_to_order',
+    'Should have table public.file_order_to_order'
+);
+
+RETURN NEXT has_pk(
+    'public', 'file_order_to_order',
+    'Table public.file_order_to_order should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'file_order_to_order'::name, ARRAY[
+    'file_id'::name,
+    'source_class'::name,
+    'ref_key'::name,
+    'dest_class'::name,
+    'attached_by'::name,
+    'attached_at'::name
+]);
+
+RETURN NEXT has_column(       'public', 'file_order_to_order', 'file_id', 'Column public.file_order_to_order.file_id should exist');
+RETURN NEXT col_type_is(      'public', 'file_order_to_order', 'file_id', 'integer', 'Column public.file_order_to_order.file_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_order_to_order', 'file_id', 'Column public.file_order_to_order.file_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_order_to_order', 'file_id', 'Column public.file_order_to_order.file_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_order_to_order', 'source_class', 'Column public.file_order_to_order.source_class should exist');
+RETURN NEXT col_type_is(      'public', 'file_order_to_order', 'source_class', 'integer', 'Column public.file_order_to_order.source_class should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_order_to_order', 'source_class', 'Column public.file_order_to_order.source_class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_order_to_order', 'source_class', 'Column public.file_order_to_order.source_class should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_order_to_order', 'ref_key', 'Column public.file_order_to_order.ref_key should exist');
+RETURN NEXT col_type_is(      'public', 'file_order_to_order', 'ref_key', 'integer', 'Column public.file_order_to_order.ref_key should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_order_to_order', 'ref_key', 'Column public.file_order_to_order.ref_key should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_order_to_order', 'ref_key', 'Column public.file_order_to_order.ref_key should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_order_to_order', 'dest_class', 'Column public.file_order_to_order.dest_class should exist');
+RETURN NEXT col_type_is(      'public', 'file_order_to_order', 'dest_class', 'integer', 'Column public.file_order_to_order.dest_class should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_order_to_order', 'dest_class', 'Column public.file_order_to_order.dest_class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_order_to_order', 'dest_class', 'Column public.file_order_to_order.dest_class should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_order_to_order', 'attached_by', 'Column public.file_order_to_order.attached_by should exist');
+RETURN NEXT col_type_is(      'public', 'file_order_to_order', 'attached_by', 'integer', 'Column public.file_order_to_order.attached_by should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_order_to_order', 'attached_by', 'Column public.file_order_to_order.attached_by should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_order_to_order', 'attached_by', 'Column public.file_order_to_order.attached_by should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_order_to_order', 'attached_at', 'Column public.file_order_to_order.attached_at should exist');
+RETURN NEXT col_type_is(      'public', 'file_order_to_order', 'attached_at', 'timestamp without time zone', 'Column public.file_order_to_order.attached_at should be type timestamp without time zone');
+RETURN NEXT col_not_null(     'public', 'file_order_to_order', 'attached_at', 'Column public.file_order_to_order.attached_at should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'file_order_to_order', 'attached_at', 'Column public.file_order_to_order.attached_at shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'file_order_to_order', 'attached_at', 'now()', 'Column public.file_order_to_order.attached_at default is');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.file_order_to_tx.sql.pg_include
+++ b/xt/pgtap/table_public.file_order_to_tx.sql.pg_include
@@ -1,0 +1,57 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_file_order_to_tx()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'file_order_to_tx',
+    'Should have table public.file_order_to_tx'
+);
+
+RETURN NEXT has_pk(
+    'public', 'file_order_to_tx',
+    'Table public.file_order_to_tx should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'file_order_to_tx'::name, ARRAY[
+    'file_id'::name,
+    'source_class'::name,
+    'ref_key'::name,
+    'dest_class'::name,
+    'attached_by'::name,
+    'attached_at'::name
+]);
+
+RETURN NEXT has_column(       'public', 'file_order_to_tx', 'file_id', 'Column public.file_order_to_tx.file_id should exist');
+RETURN NEXT col_type_is(      'public', 'file_order_to_tx', 'file_id', 'integer', 'Column public.file_order_to_tx.file_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_order_to_tx', 'file_id', 'Column public.file_order_to_tx.file_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_order_to_tx', 'file_id', 'Column public.file_order_to_tx.file_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_order_to_tx', 'source_class', 'Column public.file_order_to_tx.source_class should exist');
+RETURN NEXT col_type_is(      'public', 'file_order_to_tx', 'source_class', 'integer', 'Column public.file_order_to_tx.source_class should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_order_to_tx', 'source_class', 'Column public.file_order_to_tx.source_class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_order_to_tx', 'source_class', 'Column public.file_order_to_tx.source_class should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_order_to_tx', 'ref_key', 'Column public.file_order_to_tx.ref_key should exist');
+RETURN NEXT col_type_is(      'public', 'file_order_to_tx', 'ref_key', 'integer', 'Column public.file_order_to_tx.ref_key should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_order_to_tx', 'ref_key', 'Column public.file_order_to_tx.ref_key should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_order_to_tx', 'ref_key', 'Column public.file_order_to_tx.ref_key should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_order_to_tx', 'dest_class', 'Column public.file_order_to_tx.dest_class should exist');
+RETURN NEXT col_type_is(      'public', 'file_order_to_tx', 'dest_class', 'integer', 'Column public.file_order_to_tx.dest_class should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_order_to_tx', 'dest_class', 'Column public.file_order_to_tx.dest_class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_order_to_tx', 'dest_class', 'Column public.file_order_to_tx.dest_class should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_order_to_tx', 'attached_by', 'Column public.file_order_to_tx.attached_by should exist');
+RETURN NEXT col_type_is(      'public', 'file_order_to_tx', 'attached_by', 'integer', 'Column public.file_order_to_tx.attached_by should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_order_to_tx', 'attached_by', 'Column public.file_order_to_tx.attached_by should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_order_to_tx', 'attached_by', 'Column public.file_order_to_tx.attached_by should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_order_to_tx', 'attached_at', 'Column public.file_order_to_tx.attached_at should exist');
+RETURN NEXT col_type_is(      'public', 'file_order_to_tx', 'attached_at', 'timestamp without time zone', 'Column public.file_order_to_tx.attached_at should be type timestamp without time zone');
+RETURN NEXT col_not_null(     'public', 'file_order_to_tx', 'attached_at', 'Column public.file_order_to_tx.attached_at should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'file_order_to_tx', 'attached_at', 'Column public.file_order_to_tx.attached_at shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'file_order_to_tx', 'attached_at', 'now()', 'Column public.file_order_to_tx.attached_at default is');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.file_part.sql.pg_include
+++ b/xt/pgtap/table_public.file_part.sql.pg_include
@@ -1,0 +1,76 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_file_part()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'file_part',
+    'Should have table public.file_part'
+);
+
+RETURN NEXT has_pk(
+    'public', 'file_part',
+    'Table public.file_part should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'file_part'::name, ARRAY[
+    'content'::name,
+    'mime_type_id'::name,
+    'file_name'::name,
+    'description'::name,
+    'uploaded_by'::name,
+    'uploaded_at'::name,
+    'id'::name,
+    'ref_key'::name,
+    'file_class'::name
+]);
+
+RETURN NEXT has_column(       'public', 'file_part', 'content', 'Column public.file_part.content should exist');
+RETURN NEXT col_type_is(      'public', 'file_part', 'content', 'bytea', 'Column public.file_part.content should be type bytea');
+RETURN NEXT col_not_null(     'public', 'file_part', 'content', 'Column public.file_part.content should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_part', 'content', 'Column public.file_part.content should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_part', 'mime_type_id', 'Column public.file_part.mime_type_id should exist');
+RETURN NEXT col_type_is(      'public', 'file_part', 'mime_type_id', 'integer', 'Column public.file_part.mime_type_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_part', 'mime_type_id', 'Column public.file_part.mime_type_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_part', 'mime_type_id', 'Column public.file_part.mime_type_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_part', 'file_name', 'Column public.file_part.file_name should exist');
+RETURN NEXT col_type_is(      'public', 'file_part', 'file_name', 'text', 'Column public.file_part.file_name should be type text');
+RETURN NEXT col_not_null(     'public', 'file_part', 'file_name', 'Column public.file_part.file_name should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_part', 'file_name', 'Column public.file_part.file_name should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_part', 'description', 'Column public.file_part.description should exist');
+RETURN NEXT col_type_is(      'public', 'file_part', 'description', 'text', 'Column public.file_part.description should be type text');
+RETURN NEXT col_is_null(      'public', 'file_part', 'description', 'Column public.file_part.description should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'file_part', 'description', 'Column public.file_part.description should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_part', 'uploaded_by', 'Column public.file_part.uploaded_by should exist');
+RETURN NEXT col_type_is(      'public', 'file_part', 'uploaded_by', 'integer', 'Column public.file_part.uploaded_by should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_part', 'uploaded_by', 'Column public.file_part.uploaded_by should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_part', 'uploaded_by', 'Column public.file_part.uploaded_by should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_part', 'uploaded_at', 'Column public.file_part.uploaded_at should exist');
+RETURN NEXT col_type_is(      'public', 'file_part', 'uploaded_at', 'timestamp without time zone', 'Column public.file_part.uploaded_at should be type timestamp without time zone');
+RETURN NEXT col_not_null(     'public', 'file_part', 'uploaded_at', 'Column public.file_part.uploaded_at should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'file_part', 'uploaded_at', 'Column public.file_part.uploaded_at shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'file_part', 'uploaded_at', 'now()', 'Column public.file_part.uploaded_at default is');
+
+RETURN NEXT has_column(       'public', 'file_part', 'id', 'Column public.file_part.id should exist');
+RETURN NEXT col_type_is(      'public', 'file_part', 'id', 'integer', 'Column public.file_part.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_part', 'id', 'Column public.file_part.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'file_part', 'id', 'Column public.file_part.id shouldhave a default');
+--SELECT col_default_is(   'public', 'file_part', 'id', 'nextval(''file_base_id_seq''::regclass)', 'Column public.file_part.id default is');RETURN NEXT col_default_is(   'public', 'file_part', 'id', 'nextval(''file_base_id_seq''::regclass)', 'Column public.file_part.id default is');
+
+RETURN NEXT has_column(       'public', 'file_part', 'ref_key', 'Column public.file_part.ref_key should exist');
+RETURN NEXT col_type_is(      'public', 'file_part', 'ref_key', 'integer', 'Column public.file_part.ref_key should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_part', 'ref_key', 'Column public.file_part.ref_key should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_part', 'ref_key', 'Column public.file_part.ref_key should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_part', 'file_class', 'Column public.file_part.file_class should exist');
+RETURN NEXT col_type_is(      'public', 'file_part', 'file_class', 'integer', 'Column public.file_part.file_class should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_part', 'file_class', 'Column public.file_part.file_class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_part', 'file_class', 'Column public.file_part.file_class should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.file_secondary_attachment.sql.pg_include
+++ b/xt/pgtap/table_public.file_secondary_attachment.sql.pg_include
@@ -1,0 +1,57 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_file_secondary_attachment()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'file_secondary_attachment',
+    'Should have table public.file_secondary_attachment'
+);
+
+RETURN NEXT has_pk(
+    'public', 'file_secondary_attachment',
+    'Table public.file_secondary_attachment should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'file_secondary_attachment'::name, ARRAY[
+    'file_id'::name,
+    'source_class'::name,
+    'ref_key'::name,
+    'dest_class'::name,
+    'attached_by'::name,
+    'attached_at'::name
+]);
+
+RETURN NEXT has_column(       'public', 'file_secondary_attachment', 'file_id', 'Column public.file_secondary_attachment.file_id should exist');
+RETURN NEXT col_type_is(      'public', 'file_secondary_attachment', 'file_id', 'integer', 'Column public.file_secondary_attachment.file_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_secondary_attachment', 'file_id', 'Column public.file_secondary_attachment.file_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_secondary_attachment', 'file_id', 'Column public.file_secondary_attachment.file_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_secondary_attachment', 'source_class', 'Column public.file_secondary_attachment.source_class should exist');
+RETURN NEXT col_type_is(      'public', 'file_secondary_attachment', 'source_class', 'integer', 'Column public.file_secondary_attachment.source_class should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_secondary_attachment', 'source_class', 'Column public.file_secondary_attachment.source_class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_secondary_attachment', 'source_class', 'Column public.file_secondary_attachment.source_class should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_secondary_attachment', 'ref_key', 'Column public.file_secondary_attachment.ref_key should exist');
+RETURN NEXT col_type_is(      'public', 'file_secondary_attachment', 'ref_key', 'integer', 'Column public.file_secondary_attachment.ref_key should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_secondary_attachment', 'ref_key', 'Column public.file_secondary_attachment.ref_key should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_secondary_attachment', 'ref_key', 'Column public.file_secondary_attachment.ref_key should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_secondary_attachment', 'dest_class', 'Column public.file_secondary_attachment.dest_class should exist');
+RETURN NEXT col_type_is(      'public', 'file_secondary_attachment', 'dest_class', 'integer', 'Column public.file_secondary_attachment.dest_class should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_secondary_attachment', 'dest_class', 'Column public.file_secondary_attachment.dest_class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_secondary_attachment', 'dest_class', 'Column public.file_secondary_attachment.dest_class should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_secondary_attachment', 'attached_by', 'Column public.file_secondary_attachment.attached_by should exist');
+RETURN NEXT col_type_is(      'public', 'file_secondary_attachment', 'attached_by', 'integer', 'Column public.file_secondary_attachment.attached_by should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_secondary_attachment', 'attached_by', 'Column public.file_secondary_attachment.attached_by should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_secondary_attachment', 'attached_by', 'Column public.file_secondary_attachment.attached_by should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_secondary_attachment', 'attached_at', 'Column public.file_secondary_attachment.attached_at should exist');
+RETURN NEXT col_type_is(      'public', 'file_secondary_attachment', 'attached_at', 'timestamp without time zone', 'Column public.file_secondary_attachment.attached_at should be type timestamp without time zone');
+RETURN NEXT col_not_null(     'public', 'file_secondary_attachment', 'attached_at', 'Column public.file_secondary_attachment.attached_at should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'file_secondary_attachment', 'attached_at', 'Column public.file_secondary_attachment.attached_at shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'file_secondary_attachment', 'attached_at', 'now()', 'Column public.file_secondary_attachment.attached_at default is');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.file_transaction.sql.pg_include
+++ b/xt/pgtap/table_public.file_transaction.sql.pg_include
@@ -1,0 +1,76 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_file_transaction()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'file_transaction',
+    'Should have table public.file_transaction'
+);
+
+RETURN NEXT has_pk(
+    'public', 'file_transaction',
+    'Table public.file_transaction should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'file_transaction'::name, ARRAY[
+    'content'::name,
+    'mime_type_id'::name,
+    'file_name'::name,
+    'description'::name,
+    'uploaded_by'::name,
+    'uploaded_at'::name,
+    'id'::name,
+    'ref_key'::name,
+    'file_class'::name
+]);
+
+RETURN NEXT has_column(       'public', 'file_transaction', 'content', 'Column public.file_transaction.content should exist');
+RETURN NEXT col_type_is(      'public', 'file_transaction', 'content', 'bytea', 'Column public.file_transaction.content should be type bytea');
+RETURN NEXT col_not_null(     'public', 'file_transaction', 'content', 'Column public.file_transaction.content should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_transaction', 'content', 'Column public.file_transaction.content should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_transaction', 'mime_type_id', 'Column public.file_transaction.mime_type_id should exist');
+RETURN NEXT col_type_is(      'public', 'file_transaction', 'mime_type_id', 'integer', 'Column public.file_transaction.mime_type_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_transaction', 'mime_type_id', 'Column public.file_transaction.mime_type_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_transaction', 'mime_type_id', 'Column public.file_transaction.mime_type_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_transaction', 'file_name', 'Column public.file_transaction.file_name should exist');
+RETURN NEXT col_type_is(      'public', 'file_transaction', 'file_name', 'text', 'Column public.file_transaction.file_name should be type text');
+RETURN NEXT col_not_null(     'public', 'file_transaction', 'file_name', 'Column public.file_transaction.file_name should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_transaction', 'file_name', 'Column public.file_transaction.file_name should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_transaction', 'description', 'Column public.file_transaction.description should exist');
+RETURN NEXT col_type_is(      'public', 'file_transaction', 'description', 'text', 'Column public.file_transaction.description should be type text');
+RETURN NEXT col_is_null(      'public', 'file_transaction', 'description', 'Column public.file_transaction.description should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'file_transaction', 'description', 'Column public.file_transaction.description should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_transaction', 'uploaded_by', 'Column public.file_transaction.uploaded_by should exist');
+RETURN NEXT col_type_is(      'public', 'file_transaction', 'uploaded_by', 'integer', 'Column public.file_transaction.uploaded_by should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_transaction', 'uploaded_by', 'Column public.file_transaction.uploaded_by should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_transaction', 'uploaded_by', 'Column public.file_transaction.uploaded_by should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_transaction', 'uploaded_at', 'Column public.file_transaction.uploaded_at should exist');
+RETURN NEXT col_type_is(      'public', 'file_transaction', 'uploaded_at', 'timestamp without time zone', 'Column public.file_transaction.uploaded_at should be type timestamp without time zone');
+RETURN NEXT col_not_null(     'public', 'file_transaction', 'uploaded_at', 'Column public.file_transaction.uploaded_at should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'file_transaction', 'uploaded_at', 'Column public.file_transaction.uploaded_at shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'file_transaction', 'uploaded_at', 'now()', 'Column public.file_transaction.uploaded_at default is');
+
+RETURN NEXT has_column(       'public', 'file_transaction', 'id', 'Column public.file_transaction.id should exist');
+RETURN NEXT col_type_is(      'public', 'file_transaction', 'id', 'integer', 'Column public.file_transaction.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_transaction', 'id', 'Column public.file_transaction.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'file_transaction', 'id', 'Column public.file_transaction.id shouldhave a default');
+--SELECT col_default_is(   'public', 'file_transaction', 'id', 'nextval(''file_base_id_seq''::regclass)', 'Column public.file_transaction.id default is');RETURN NEXT col_default_is(   'public', 'file_transaction', 'id', 'nextval(''file_base_id_seq''::regclass)', 'Column public.file_transaction.id default is');
+
+RETURN NEXT has_column(       'public', 'file_transaction', 'ref_key', 'Column public.file_transaction.ref_key should exist');
+RETURN NEXT col_type_is(      'public', 'file_transaction', 'ref_key', 'integer', 'Column public.file_transaction.ref_key should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_transaction', 'ref_key', 'Column public.file_transaction.ref_key should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_transaction', 'ref_key', 'Column public.file_transaction.ref_key should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_transaction', 'file_class', 'Column public.file_transaction.file_class should exist');
+RETURN NEXT col_type_is(      'public', 'file_transaction', 'file_class', 'integer', 'Column public.file_transaction.file_class should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_transaction', 'file_class', 'Column public.file_transaction.file_class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_transaction', 'file_class', 'Column public.file_transaction.file_class should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.file_tx_to_order.sql.pg_include
+++ b/xt/pgtap/table_public.file_tx_to_order.sql.pg_include
@@ -1,0 +1,57 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_file_tx_to_order()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'file_tx_to_order',
+    'Should have table public.file_tx_to_order'
+);
+
+RETURN NEXT has_pk(
+    'public', 'file_tx_to_order',
+    'Table public.file_tx_to_order should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'file_tx_to_order'::name, ARRAY[
+    'file_id'::name,
+    'source_class'::name,
+    'ref_key'::name,
+    'dest_class'::name,
+    'attached_by'::name,
+    'attached_at'::name
+]);
+
+RETURN NEXT has_column(       'public', 'file_tx_to_order', 'file_id', 'Column public.file_tx_to_order.file_id should exist');
+RETURN NEXT col_type_is(      'public', 'file_tx_to_order', 'file_id', 'integer', 'Column public.file_tx_to_order.file_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_tx_to_order', 'file_id', 'Column public.file_tx_to_order.file_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_tx_to_order', 'file_id', 'Column public.file_tx_to_order.file_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_tx_to_order', 'source_class', 'Column public.file_tx_to_order.source_class should exist');
+RETURN NEXT col_type_is(      'public', 'file_tx_to_order', 'source_class', 'integer', 'Column public.file_tx_to_order.source_class should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_tx_to_order', 'source_class', 'Column public.file_tx_to_order.source_class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_tx_to_order', 'source_class', 'Column public.file_tx_to_order.source_class should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_tx_to_order', 'ref_key', 'Column public.file_tx_to_order.ref_key should exist');
+RETURN NEXT col_type_is(      'public', 'file_tx_to_order', 'ref_key', 'integer', 'Column public.file_tx_to_order.ref_key should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_tx_to_order', 'ref_key', 'Column public.file_tx_to_order.ref_key should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_tx_to_order', 'ref_key', 'Column public.file_tx_to_order.ref_key should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_tx_to_order', 'dest_class', 'Column public.file_tx_to_order.dest_class should exist');
+RETURN NEXT col_type_is(      'public', 'file_tx_to_order', 'dest_class', 'integer', 'Column public.file_tx_to_order.dest_class should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_tx_to_order', 'dest_class', 'Column public.file_tx_to_order.dest_class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_tx_to_order', 'dest_class', 'Column public.file_tx_to_order.dest_class should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_tx_to_order', 'attached_by', 'Column public.file_tx_to_order.attached_by should exist');
+RETURN NEXT col_type_is(      'public', 'file_tx_to_order', 'attached_by', 'integer', 'Column public.file_tx_to_order.attached_by should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_tx_to_order', 'attached_by', 'Column public.file_tx_to_order.attached_by should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_tx_to_order', 'attached_by', 'Column public.file_tx_to_order.attached_by should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_tx_to_order', 'attached_at', 'Column public.file_tx_to_order.attached_at should exist');
+RETURN NEXT col_type_is(      'public', 'file_tx_to_order', 'attached_at', 'timestamp without time zone', 'Column public.file_tx_to_order.attached_at should be type timestamp without time zone');
+RETURN NEXT col_not_null(     'public', 'file_tx_to_order', 'attached_at', 'Column public.file_tx_to_order.attached_at should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'file_tx_to_order', 'attached_at', 'Column public.file_tx_to_order.attached_at shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'file_tx_to_order', 'attached_at', 'now()', 'Column public.file_tx_to_order.attached_at default is');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.file_view_catalog.sql.pg_include
+++ b/xt/pgtap/table_public.file_view_catalog.sql.pg_include
@@ -1,0 +1,32 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_file_view_catalog()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'file_view_catalog',
+    'Should have table public.file_view_catalog'
+);
+
+RETURN NEXT has_pk(
+    'public', 'file_view_catalog',
+    'Table public.file_view_catalog should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'file_view_catalog'::name, ARRAY[
+    'file_class'::name,
+    'view_name'::name
+]);
+
+RETURN NEXT has_column(       'public', 'file_view_catalog', 'file_class', 'Column public.file_view_catalog.file_class should exist');
+RETURN NEXT col_type_is(      'public', 'file_view_catalog', 'file_class', 'integer', 'Column public.file_view_catalog.file_class should be type integer');
+RETURN NEXT col_not_null(     'public', 'file_view_catalog', 'file_class', 'Column public.file_view_catalog.file_class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_view_catalog', 'file_class', 'Column public.file_view_catalog.file_class should not have a default');
+
+RETURN NEXT has_column(       'public', 'file_view_catalog', 'view_name', 'Column public.file_view_catalog.view_name should exist');
+RETURN NEXT col_type_is(      'public', 'file_view_catalog', 'view_name', 'text', 'Column public.file_view_catalog.view_name should be type text');
+RETURN NEXT col_not_null(     'public', 'file_view_catalog', 'view_name', 'Column public.file_view_catalog.view_name should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'file_view_catalog', 'view_name', 'Column public.file_view_catalog.view_name should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.fixes.sql.pg_include
+++ b/xt/pgtap/table_public.fixes.sql.pg_include
@@ -1,0 +1,51 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_fixes()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'fixes',
+    'Should have table public.fixes'
+);
+
+RETURN NEXT has_pk(
+    'public', 'fixes',
+    'Table public.fixes should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'fixes'::name, ARRAY[
+    'checksum'::name,
+    'path'::name,
+    'stdout'::name,
+    'stderr'::name,
+    'applied_at'::name
+]);
+
+RETURN NEXT has_column(       'public', 'fixes', 'checksum', 'Column public.fixes.checksum should exist');
+RETURN NEXT col_type_is(      'public', 'fixes', 'checksum', 'text', 'Column public.fixes.checksum should be type text');
+RETURN NEXT col_not_null(     'public', 'fixes', 'checksum', 'Column public.fixes.checksum should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'fixes', 'checksum', 'Column public.fixes.checksum should not have a default');
+
+RETURN NEXT has_column(       'public', 'fixes', 'path', 'Column public.fixes.path should exist');
+RETURN NEXT col_type_is(      'public', 'fixes', 'path', 'text', 'Column public.fixes.path should be type text');
+RETURN NEXT col_not_null(     'public', 'fixes', 'path', 'Column public.fixes.path should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'fixes', 'path', 'Column public.fixes.path should not have a default');
+
+RETURN NEXT has_column(       'public', 'fixes', 'stdout', 'Column public.fixes.stdout should exist');
+RETURN NEXT col_type_is(      'public', 'fixes', 'stdout', 'text', 'Column public.fixes.stdout should be type text');
+RETURN NEXT col_is_null(      'public', 'fixes', 'stdout', 'Column public.fixes.stdout should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'fixes', 'stdout', 'Column public.fixes.stdout should not have a default');
+
+RETURN NEXT has_column(       'public', 'fixes', 'stderr', 'Column public.fixes.stderr should exist');
+RETURN NEXT col_type_is(      'public', 'fixes', 'stderr', 'text', 'Column public.fixes.stderr should be type text');
+RETURN NEXT col_is_null(      'public', 'fixes', 'stderr', 'Column public.fixes.stderr should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'fixes', 'stderr', 'Column public.fixes.stderr should not have a default');
+
+RETURN NEXT has_column(       'public', 'fixes', 'applied_at', 'Column public.fixes.applied_at should exist');
+RETURN NEXT col_type_is(      'public', 'fixes', 'applied_at', 'timestamp without time zone', 'Column public.fixes.applied_at should be type timestamp without time zone');
+RETURN NEXT col_is_null(      'public', 'fixes', 'applied_at', 'Column public.fixes.applied_at should allow NULL');
+RETURN NEXT col_has_default(  'public', 'fixes', 'applied_at', 'Column public.fixes.applied_at shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'fixes', 'applied_at', 'now()', 'Column public.fixes.applied_at default is');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.gifi.sql.pg_include
+++ b/xt/pgtap/table_public.gifi.sql.pg_include
@@ -1,0 +1,32 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_gifi()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'gifi',
+    'Should have table public.gifi'
+);
+
+RETURN NEXT has_pk(
+    'public', 'gifi',
+    'Table public.gifi should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'gifi'::name, ARRAY[
+    'accno'::name,
+    'description'::name
+]);
+
+RETURN NEXT has_column(       'public', 'gifi', 'accno', 'Column public.gifi.accno should exist');
+RETURN NEXT col_type_is(      'public', 'gifi', 'accno', 'text', 'Column public.gifi.accno should be type text');
+RETURN NEXT col_not_null(     'public', 'gifi', 'accno', 'Column public.gifi.accno should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'gifi', 'accno', 'Column public.gifi.accno should not have a default');
+
+RETURN NEXT has_column(       'public', 'gifi', 'description', 'Column public.gifi.description should exist');
+RETURN NEXT col_type_is(      'public', 'gifi', 'description', 'text', 'Column public.gifi.description should be type text');
+RETURN NEXT col_is_null(      'public', 'gifi', 'description', 'Column public.gifi.description should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'gifi', 'description', 'Column public.gifi.description should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.gl.sql.pg_include
+++ b/xt/pgtap/table_public.gl.sql.pg_include
@@ -1,0 +1,72 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_gl()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'gl',
+    'Should have table public.gl'
+);
+
+RETURN NEXT has_pk(
+    'public', 'gl',
+    'Table public.gl should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'gl'::name, ARRAY[
+    'id'::name,
+    'reference'::name,
+    'description'::name,
+    'transdate'::name,
+    'person_id'::name,
+    'notes'::name,
+    'approved'::name,
+    'trans_type_code'::name
+]);
+
+RETURN NEXT has_column(       'public', 'gl', 'id', 'Column public.gl.id should exist');
+RETURN NEXT col_type_is(      'public', 'gl', 'id', 'integer', 'Column public.gl.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'gl', 'id', 'Column public.gl.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'gl', 'id', 'Column public.gl.id shouldhave a default');
+--SELECT col_default_is(   'public', 'gl', 'id', 'nextval(''id''::regclass)', 'Column public.gl.id default is');RETURN NEXT col_default_is(   'public', 'gl', 'id', 'nextval(''id''::regclass)', 'Column public.gl.id default is');
+
+RETURN NEXT has_column(       'public', 'gl', 'reference', 'Column public.gl.reference should exist');
+RETURN NEXT col_type_is(      'public', 'gl', 'reference', 'text', 'Column public.gl.reference should be type text');
+RETURN NEXT col_is_null(      'public', 'gl', 'reference', 'Column public.gl.reference should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'gl', 'reference', 'Column public.gl.reference should not have a default');
+
+RETURN NEXT has_column(       'public', 'gl', 'description', 'Column public.gl.description should exist');
+RETURN NEXT col_type_is(      'public', 'gl', 'description', 'text', 'Column public.gl.description should be type text');
+RETURN NEXT col_is_null(      'public', 'gl', 'description', 'Column public.gl.description should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'gl', 'description', 'Column public.gl.description should not have a default');
+
+RETURN NEXT has_column(       'public', 'gl', 'transdate', 'Column public.gl.transdate should exist');
+RETURN NEXT col_type_is(      'public', 'gl', 'transdate', 'date', 'Column public.gl.transdate should be type date');
+RETURN NEXT col_is_null(      'public', 'gl', 'transdate', 'Column public.gl.transdate should allow NULL');
+RETURN NEXT col_has_default(  'public', 'gl', 'transdate', 'Column public.gl.transdate shouldhave a default');
+--SELECT col_default_is(   'public', 'gl', 'transdate', '(''now''::text)::date', 'Column public.gl.transdate default is');RETURN NEXT col_default_is(   'public', 'gl', 'transdate', '(''now''::text)::date', 'Column public.gl.transdate default is');
+
+RETURN NEXT has_column(       'public', 'gl', 'person_id', 'Column public.gl.person_id should exist');
+RETURN NEXT col_type_is(      'public', 'gl', 'person_id', 'integer', 'Column public.gl.person_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'gl', 'person_id', 'Column public.gl.person_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'gl', 'person_id', 'Column public.gl.person_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'gl', 'notes', 'Column public.gl.notes should exist');
+RETURN NEXT col_type_is(      'public', 'gl', 'notes', 'text', 'Column public.gl.notes should be type text');
+RETURN NEXT col_is_null(      'public', 'gl', 'notes', 'Column public.gl.notes should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'gl', 'notes', 'Column public.gl.notes should not have a default');
+
+RETURN NEXT has_column(       'public', 'gl', 'approved', 'Column public.gl.approved should exist');
+RETURN NEXT col_type_is(      'public', 'gl', 'approved', 'boolean', 'Column public.gl.approved should be type boolean');
+RETURN NEXT col_is_null(      'public', 'gl', 'approved', 'Column public.gl.approved should allow NULL');
+RETURN NEXT col_has_default(  'public', 'gl', 'approved', 'Column public.gl.approved shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'gl', 'approved', 'true', 'Column public.gl.approved default is');
+
+RETURN NEXT has_column(       'public', 'gl', 'trans_type_code', 'Column public.gl.trans_type_code should exist');
+RETURN NEXT col_type_is(      'public', 'gl', 'trans_type_code', 'character(2)', 'Column public.gl.trans_type_code should be type character(2)');
+RETURN NEXT col_not_null(     'public', 'gl', 'trans_type_code', 'Column public.gl.trans_type_code should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'gl', 'trans_type_code', 'Column public.gl.trans_type_code shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'gl', 'trans_type_code', 'gl'::bpchar, 'Column public.gl.trans_type_code default is');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.inventory_report.sql.pg_include
+++ b/xt/pgtap/table_public.inventory_report.sql.pg_include
@@ -1,0 +1,45 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_inventory_report()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'inventory_report',
+    'Should have table public.inventory_report'
+);
+
+RETURN NEXT has_pk(
+    'public', 'inventory_report',
+    'Table public.inventory_report should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'inventory_report'::name, ARRAY[
+    'id'::name,
+    'transdate'::name,
+    'source'::name,
+    'trans_id'::name
+]);
+
+RETURN NEXT has_column(       'public', 'inventory_report', 'id', 'Column public.inventory_report.id should exist');
+RETURN NEXT col_type_is(      'public', 'inventory_report', 'id', 'integer', 'Column public.inventory_report.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'inventory_report', 'id', 'Column public.inventory_report.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'inventory_report', 'id', 'Column public.inventory_report.id shouldhave a default');
+--SELECT col_default_is(   'public', 'inventory_report', 'id', 'nextval(''inventory_report_id_seq''::regclass)', 'Column public.inventory_report.id default is');RETURN NEXT col_default_is(   'public', 'inventory_report', 'id', 'nextval(''inventory_report_id_seq''::regclass)', 'Column public.inventory_report.id default is');
+
+RETURN NEXT has_column(       'public', 'inventory_report', 'transdate', 'Column public.inventory_report.transdate should exist');
+RETURN NEXT col_type_is(      'public', 'inventory_report', 'transdate', 'date', 'Column public.inventory_report.transdate should be type date');
+RETURN NEXT col_not_null(     'public', 'inventory_report', 'transdate', 'Column public.inventory_report.transdate should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'inventory_report', 'transdate', 'Column public.inventory_report.transdate should not have a default');
+
+RETURN NEXT has_column(       'public', 'inventory_report', 'source', 'Column public.inventory_report.source should exist');
+RETURN NEXT col_type_is(      'public', 'inventory_report', 'source', 'text', 'Column public.inventory_report.source should be type text');
+RETURN NEXT col_is_null(      'public', 'inventory_report', 'source', 'Column public.inventory_report.source should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'inventory_report', 'source', 'Column public.inventory_report.source should not have a default');
+
+RETURN NEXT has_column(       'public', 'inventory_report', 'trans_id', 'Column public.inventory_report.trans_id should exist');
+RETURN NEXT col_type_is(      'public', 'inventory_report', 'trans_id', 'integer', 'Column public.inventory_report.trans_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'inventory_report', 'trans_id', 'Column public.inventory_report.trans_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'inventory_report', 'trans_id', 'Column public.inventory_report.trans_id should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.inventory_report_line.sql.pg_include
+++ b/xt/pgtap/table_public.inventory_report_line.sql.pg_include
@@ -1,0 +1,50 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_inventory_report_line()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'inventory_report_line',
+    'Should have table public.inventory_report_line'
+);
+
+RETURN NEXT has_pk(
+    'public', 'inventory_report_line',
+    'Table public.inventory_report_line should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'inventory_report_line'::name, ARRAY[
+    'adjust_id'::name,
+    'parts_id'::name,
+    'counted'::name,
+    'expected'::name,
+    'variance'::name
+]);
+
+RETURN NEXT has_column(       'public', 'inventory_report_line', 'adjust_id', 'Column public.inventory_report_line.adjust_id should exist');
+RETURN NEXT col_type_is(      'public', 'inventory_report_line', 'adjust_id', 'integer', 'Column public.inventory_report_line.adjust_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'inventory_report_line', 'adjust_id', 'Column public.inventory_report_line.adjust_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'inventory_report_line', 'adjust_id', 'Column public.inventory_report_line.adjust_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'inventory_report_line', 'parts_id', 'Column public.inventory_report_line.parts_id should exist');
+RETURN NEXT col_type_is(      'public', 'inventory_report_line', 'parts_id', 'integer', 'Column public.inventory_report_line.parts_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'inventory_report_line', 'parts_id', 'Column public.inventory_report_line.parts_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'inventory_report_line', 'parts_id', 'Column public.inventory_report_line.parts_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'inventory_report_line', 'counted', 'Column public.inventory_report_line.counted should exist');
+RETURN NEXT col_type_is(      'public', 'inventory_report_line', 'counted', 'numeric', 'Column public.inventory_report_line.counted should be type numeric');
+RETURN NEXT col_is_null(      'public', 'inventory_report_line', 'counted', 'Column public.inventory_report_line.counted should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'inventory_report_line', 'counted', 'Column public.inventory_report_line.counted should not have a default');
+
+RETURN NEXT has_column(       'public', 'inventory_report_line', 'expected', 'Column public.inventory_report_line.expected should exist');
+RETURN NEXT col_type_is(      'public', 'inventory_report_line', 'expected', 'numeric', 'Column public.inventory_report_line.expected should be type numeric');
+RETURN NEXT col_is_null(      'public', 'inventory_report_line', 'expected', 'Column public.inventory_report_line.expected should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'inventory_report_line', 'expected', 'Column public.inventory_report_line.expected should not have a default');
+
+RETURN NEXT has_column(       'public', 'inventory_report_line', 'variance', 'Column public.inventory_report_line.variance should exist');
+RETURN NEXT col_type_is(      'public', 'inventory_report_line', 'variance', 'numeric', 'Column public.inventory_report_line.variance should be type numeric');
+RETURN NEXT col_is_null(      'public', 'inventory_report_line', 'variance', 'Column public.inventory_report_line.variance should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'inventory_report_line', 'variance', 'Column public.inventory_report_line.variance should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.invoice.sql.pg_include
+++ b/xt/pgtap/table_public.invoice.sql.pg_include
@@ -1,0 +1,118 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_invoice()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'invoice',
+    'Should have table public.invoice'
+);
+
+RETURN NEXT has_pk(
+    'public', 'invoice',
+    'Table public.invoice should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'invoice'::name, ARRAY[
+    'id'::name,
+    'trans_id'::name,
+    'parts_id'::name,
+    'description'::name,
+    'qty'::name,
+    'allocated'::name,
+    'sellprice'::name,
+    'precision'::name,
+    'fxsellprice'::name,
+    'discount'::name,
+    'assemblyitem'::name,
+    'unit'::name,
+    'deliverydate'::name,
+    'serialnumber'::name,
+    'vendor_sku'::name,
+    'notes'::name
+]);
+
+RETURN NEXT has_column(       'public', 'invoice', 'id', 'Column public.invoice.id should exist');
+RETURN NEXT col_type_is(      'public', 'invoice', 'id', 'integer', 'Column public.invoice.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'invoice', 'id', 'Column public.invoice.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'invoice', 'id', 'Column public.invoice.id shouldhave a default');
+--SELECT col_default_is(   'public', 'invoice', 'id', 'nextval(''invoice_id_seq''::regclass)', 'Column public.invoice.id default is');RETURN NEXT col_default_is(   'public', 'invoice', 'id', 'nextval(''invoice_id_seq''::regclass)', 'Column public.invoice.id default is');
+
+RETURN NEXT has_column(       'public', 'invoice', 'trans_id', 'Column public.invoice.trans_id should exist');
+RETURN NEXT col_type_is(      'public', 'invoice', 'trans_id', 'integer', 'Column public.invoice.trans_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'invoice', 'trans_id', 'Column public.invoice.trans_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'invoice', 'trans_id', 'Column public.invoice.trans_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'invoice', 'parts_id', 'Column public.invoice.parts_id should exist');
+RETURN NEXT col_type_is(      'public', 'invoice', 'parts_id', 'integer', 'Column public.invoice.parts_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'invoice', 'parts_id', 'Column public.invoice.parts_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'invoice', 'parts_id', 'Column public.invoice.parts_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'invoice', 'description', 'Column public.invoice.description should exist');
+RETURN NEXT col_type_is(      'public', 'invoice', 'description', 'text', 'Column public.invoice.description should be type text');
+RETURN NEXT col_is_null(      'public', 'invoice', 'description', 'Column public.invoice.description should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'invoice', 'description', 'Column public.invoice.description should not have a default');
+
+RETURN NEXT has_column(       'public', 'invoice', 'qty', 'Column public.invoice.qty should exist');
+RETURN NEXT col_type_is(      'public', 'invoice', 'qty', 'numeric', 'Column public.invoice.qty should be type numeric');
+RETURN NEXT col_is_null(      'public', 'invoice', 'qty', 'Column public.invoice.qty should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'invoice', 'qty', 'Column public.invoice.qty should not have a default');
+
+RETURN NEXT has_column(       'public', 'invoice', 'allocated', 'Column public.invoice.allocated should exist');
+RETURN NEXT col_type_is(      'public', 'invoice', 'allocated', 'numeric', 'Column public.invoice.allocated should be type numeric');
+RETURN NEXT col_is_null(      'public', 'invoice', 'allocated', 'Column public.invoice.allocated should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'invoice', 'allocated', 'Column public.invoice.allocated should not have a default');
+
+RETURN NEXT has_column(       'public', 'invoice', 'sellprice', 'Column public.invoice.sellprice should exist');
+RETURN NEXT col_type_is(      'public', 'invoice', 'sellprice', 'numeric', 'Column public.invoice.sellprice should be type numeric');
+RETURN NEXT col_is_null(      'public', 'invoice', 'sellprice', 'Column public.invoice.sellprice should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'invoice', 'sellprice', 'Column public.invoice.sellprice should not have a default');
+
+RETURN NEXT has_column(       'public', 'invoice', 'precision', 'Column public.invoice."precision" should exist');
+RETURN NEXT col_type_is(      'public', 'invoice', 'precision', 'integer', 'Column public.invoice."precision" should be type integer');
+RETURN NEXT col_is_null(      'public', 'invoice', 'precision', 'Column public.invoice."precision" should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'invoice', 'precision', 'Column public.invoice."precision" should not have a default');
+
+RETURN NEXT has_column(       'public', 'invoice', 'fxsellprice', 'Column public.invoice.fxsellprice should exist');
+RETURN NEXT col_type_is(      'public', 'invoice', 'fxsellprice', 'numeric', 'Column public.invoice.fxsellprice should be type numeric');
+RETURN NEXT col_is_null(      'public', 'invoice', 'fxsellprice', 'Column public.invoice.fxsellprice should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'invoice', 'fxsellprice', 'Column public.invoice.fxsellprice should not have a default');
+
+RETURN NEXT has_column(       'public', 'invoice', 'discount', 'Column public.invoice.discount should exist');
+RETURN NEXT col_type_is(      'public', 'invoice', 'discount', 'numeric', 'Column public.invoice.discount should be type numeric');
+RETURN NEXT col_is_null(      'public', 'invoice', 'discount', 'Column public.invoice.discount should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'invoice', 'discount', 'Column public.invoice.discount should not have a default');
+
+RETURN NEXT has_column(       'public', 'invoice', 'assemblyitem', 'Column public.invoice.assemblyitem should exist');
+RETURN NEXT col_type_is(      'public', 'invoice', 'assemblyitem', 'boolean', 'Column public.invoice.assemblyitem should be type boolean');
+RETURN NEXT col_is_null(      'public', 'invoice', 'assemblyitem', 'Column public.invoice.assemblyitem should allow NULL');
+RETURN NEXT col_has_default(  'public', 'invoice', 'assemblyitem', 'Column public.invoice.assemblyitem shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'invoice', 'assemblyitem', 'false', 'Column public.invoice.assemblyitem default is');
+
+RETURN NEXT has_column(       'public', 'invoice', 'unit', 'Column public.invoice.unit should exist');
+RETURN NEXT col_type_is(      'public', 'invoice', 'unit', 'character varying', 'Column public.invoice.unit should be type character varying');
+RETURN NEXT col_is_null(      'public', 'invoice', 'unit', 'Column public.invoice.unit should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'invoice', 'unit', 'Column public.invoice.unit should not have a default');
+
+RETURN NEXT has_column(       'public', 'invoice', 'deliverydate', 'Column public.invoice.deliverydate should exist');
+RETURN NEXT col_type_is(      'public', 'invoice', 'deliverydate', 'date', 'Column public.invoice.deliverydate should be type date');
+RETURN NEXT col_is_null(      'public', 'invoice', 'deliverydate', 'Column public.invoice.deliverydate should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'invoice', 'deliverydate', 'Column public.invoice.deliverydate should not have a default');
+
+RETURN NEXT has_column(       'public', 'invoice', 'serialnumber', 'Column public.invoice.serialnumber should exist');
+RETURN NEXT col_type_is(      'public', 'invoice', 'serialnumber', 'text', 'Column public.invoice.serialnumber should be type text');
+RETURN NEXT col_is_null(      'public', 'invoice', 'serialnumber', 'Column public.invoice.serialnumber should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'invoice', 'serialnumber', 'Column public.invoice.serialnumber should not have a default');
+
+RETURN NEXT has_column(       'public', 'invoice', 'vendor_sku', 'Column public.invoice.vendor_sku should exist');
+RETURN NEXT col_type_is(      'public', 'invoice', 'vendor_sku', 'text', 'Column public.invoice.vendor_sku should be type text');
+RETURN NEXT col_is_null(      'public', 'invoice', 'vendor_sku', 'Column public.invoice.vendor_sku should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'invoice', 'vendor_sku', 'Column public.invoice.vendor_sku should not have a default');
+
+RETURN NEXT has_column(       'public', 'invoice', 'notes', 'Column public.invoice.notes should exist');
+RETURN NEXT col_type_is(      'public', 'invoice', 'notes', 'text', 'Column public.invoice.notes should be type text');
+RETURN NEXT col_is_null(      'public', 'invoice', 'notes', 'Column public.invoice.notes should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'invoice', 'notes', 'Column public.invoice.notes should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.invoice_note.sql.pg_include
+++ b/xt/pgtap/table_public.invoice_note.sql.pg_include
@@ -1,0 +1,72 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_invoice_note()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'invoice_note',
+    'Should have table public.invoice_note'
+);
+
+RETURN NEXT has_pk(
+    'public', 'invoice_note',
+    'Table public.invoice_note should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'invoice_note'::name, ARRAY[
+    'id'::name,
+    'note_class'::name,
+    'note'::name,
+    'vector'::name,
+    'created'::name,
+    'created_by'::name,
+    'ref_key'::name,
+    'subject'::name
+]);
+
+RETURN NEXT has_column(       'public', 'invoice_note', 'id', 'Column public.invoice_note.id should exist');
+RETURN NEXT col_type_is(      'public', 'invoice_note', 'id', 'integer', 'Column public.invoice_note.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'invoice_note', 'id', 'Column public.invoice_note.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'invoice_note', 'id', 'Column public.invoice_note.id shouldhave a default');
+--SELECT col_default_is(   'public', 'invoice_note', 'id', 'nextval(''note_id_seq''::regclass)', 'Column public.invoice_note.id default is');RETURN NEXT col_default_is(   'public', 'invoice_note', 'id', 'nextval(''note_id_seq''::regclass)', 'Column public.invoice_note.id default is');
+
+RETURN NEXT has_column(       'public', 'invoice_note', 'note_class', 'Column public.invoice_note.note_class should exist');
+RETURN NEXT col_type_is(      'public', 'invoice_note', 'note_class', 'integer', 'Column public.invoice_note.note_class should be type integer');
+RETURN NEXT col_not_null(     'public', 'invoice_note', 'note_class', 'Column public.invoice_note.note_class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'invoice_note', 'note_class', 'Column public.invoice_note.note_class should not have a default');
+
+RETURN NEXT has_column(       'public', 'invoice_note', 'note', 'Column public.invoice_note.note should exist');
+RETURN NEXT col_type_is(      'public', 'invoice_note', 'note', 'text', 'Column public.invoice_note.note should be type text');
+RETURN NEXT col_not_null(     'public', 'invoice_note', 'note', 'Column public.invoice_note.note should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'invoice_note', 'note', 'Column public.invoice_note.note should not have a default');
+
+RETURN NEXT has_column(       'public', 'invoice_note', 'vector', 'Column public.invoice_note.vector should exist');
+RETURN NEXT col_type_is(      'public', 'invoice_note', 'vector', 'tsvector', 'Column public.invoice_note.vector should be type tsvector');
+RETURN NEXT col_not_null(     'public', 'invoice_note', 'vector', 'Column public.invoice_note.vector should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'invoice_note', 'vector', 'Column public.invoice_note.vector shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'invoice_note', 'vector', ''::tsvector, 'Column public.invoice_note.vector default is');
+
+RETURN NEXT has_column(       'public', 'invoice_note', 'created', 'Column public.invoice_note.created should exist');
+RETURN NEXT col_type_is(      'public', 'invoice_note', 'created', 'timestamp without time zone', 'Column public.invoice_note.created should be type timestamp without time zone');
+RETURN NEXT col_not_null(     'public', 'invoice_note', 'created', 'Column public.invoice_note.created should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'invoice_note', 'created', 'Column public.invoice_note.created shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'invoice_note', 'created', 'now()', 'Column public.invoice_note.created default is');
+
+RETURN NEXT has_column(       'public', 'invoice_note', 'created_by', 'Column public.invoice_note.created_by should exist');
+RETURN NEXT col_type_is(      'public', 'invoice_note', 'created_by', 'text', 'Column public.invoice_note.created_by should be type text');
+RETURN NEXT col_is_null(      'public', 'invoice_note', 'created_by', 'Column public.invoice_note.created_by should allow NULL');
+RETURN NEXT col_has_default(  'public', 'invoice_note', 'created_by', 'Column public.invoice_note.created_by shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'invoice_note', 'created_by', '"session_user"()', 'Column public.invoice_note.created_by default is');
+
+RETURN NEXT has_column(       'public', 'invoice_note', 'ref_key', 'Column public.invoice_note.ref_key should exist');
+RETURN NEXT col_type_is(      'public', 'invoice_note', 'ref_key', 'integer', 'Column public.invoice_note.ref_key should be type integer');
+RETURN NEXT col_not_null(     'public', 'invoice_note', 'ref_key', 'Column public.invoice_note.ref_key should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'invoice_note', 'ref_key', 'Column public.invoice_note.ref_key should not have a default');
+
+RETURN NEXT has_column(       'public', 'invoice_note', 'subject', 'Column public.invoice_note.subject should exist');
+RETURN NEXT col_type_is(      'public', 'invoice_note', 'subject', 'text', 'Column public.invoice_note.subject should be type text');
+RETURN NEXT col_is_null(      'public', 'invoice_note', 'subject', 'Column public.invoice_note.subject should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'invoice_note', 'subject', 'Column public.invoice_note.subject should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.invoice_tax_form.sql.pg_include
+++ b/xt/pgtap/table_public.invoice_tax_form.sql.pg_include
@@ -1,0 +1,32 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_invoice_tax_form()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'invoice_tax_form',
+    'Should have table public.invoice_tax_form'
+);
+
+RETURN NEXT has_pk(
+    'public', 'invoice_tax_form',
+    'Table public.invoice_tax_form should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'invoice_tax_form'::name, ARRAY[
+    'invoice_id'::name,
+    'reportable'::name
+]);
+
+RETURN NEXT has_column(       'public', 'invoice_tax_form', 'invoice_id', 'Column public.invoice_tax_form.invoice_id should exist');
+RETURN NEXT col_type_is(      'public', 'invoice_tax_form', 'invoice_id', 'integer', 'Column public.invoice_tax_form.invoice_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'invoice_tax_form', 'invoice_id', 'Column public.invoice_tax_form.invoice_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'invoice_tax_form', 'invoice_id', 'Column public.invoice_tax_form.invoice_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'invoice_tax_form', 'reportable', 'Column public.invoice_tax_form.reportable should exist');
+RETURN NEXT col_type_is(      'public', 'invoice_tax_form', 'reportable', 'boolean', 'Column public.invoice_tax_form.reportable should be type boolean');
+RETURN NEXT col_is_null(      'public', 'invoice_tax_form', 'reportable', 'Column public.invoice_tax_form.reportable should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'invoice_tax_form', 'reportable', 'Column public.invoice_tax_form.reportable should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.jcitems.sql.pg_include
+++ b/xt/pgtap/table_public.jcitems.sql.pg_include
@@ -1,0 +1,124 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_jcitems()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'jcitems',
+    'Should have table public.jcitems'
+);
+
+RETURN NEXT has_pk(
+    'public', 'jcitems',
+    'Table public.jcitems should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'jcitems'::name, ARRAY[
+    'id'::name,
+    'business_unit_id'::name,
+    'parts_id'::name,
+    'description'::name,
+    'qty'::name,
+    'allocated'::name,
+    'sellprice'::name,
+    'fxsellprice'::name,
+    'serialnumber'::name,
+    'checkedin'::name,
+    'checkedout'::name,
+    'person_id'::name,
+    'notes'::name,
+    'total'::name,
+    'non_billable'::name,
+    'jctype'::name,
+    'curr'::name
+]);
+
+RETURN NEXT has_column(       'public', 'jcitems', 'id', 'Column public.jcitems.id should exist');
+RETURN NEXT col_type_is(      'public', 'jcitems', 'id', 'integer', 'Column public.jcitems.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'jcitems', 'id', 'Column public.jcitems.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'jcitems', 'id', 'Column public.jcitems.id shouldhave a default');
+--SELECT col_default_is(   'public', 'jcitems', 'id', 'nextval(''jcitems_id_seq''::regclass)', 'Column public.jcitems.id default is');RETURN NEXT col_default_is(   'public', 'jcitems', 'id', 'nextval(''jcitems_id_seq''::regclass)', 'Column public.jcitems.id default is');
+
+RETURN NEXT has_column(       'public', 'jcitems', 'business_unit_id', 'Column public.jcitems.business_unit_id should exist');
+RETURN NEXT col_type_is(      'public', 'jcitems', 'business_unit_id', 'integer', 'Column public.jcitems.business_unit_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'jcitems', 'business_unit_id', 'Column public.jcitems.business_unit_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'jcitems', 'business_unit_id', 'Column public.jcitems.business_unit_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'jcitems', 'parts_id', 'Column public.jcitems.parts_id should exist');
+RETURN NEXT col_type_is(      'public', 'jcitems', 'parts_id', 'integer', 'Column public.jcitems.parts_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'jcitems', 'parts_id', 'Column public.jcitems.parts_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'jcitems', 'parts_id', 'Column public.jcitems.parts_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'jcitems', 'description', 'Column public.jcitems.description should exist');
+RETURN NEXT col_type_is(      'public', 'jcitems', 'description', 'text', 'Column public.jcitems.description should be type text');
+RETURN NEXT col_is_null(      'public', 'jcitems', 'description', 'Column public.jcitems.description should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'jcitems', 'description', 'Column public.jcitems.description should not have a default');
+
+RETURN NEXT has_column(       'public', 'jcitems', 'qty', 'Column public.jcitems.qty should exist');
+RETURN NEXT col_type_is(      'public', 'jcitems', 'qty', 'numeric', 'Column public.jcitems.qty should be type numeric');
+RETURN NEXT col_is_null(      'public', 'jcitems', 'qty', 'Column public.jcitems.qty should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'jcitems', 'qty', 'Column public.jcitems.qty should not have a default');
+
+RETURN NEXT has_column(       'public', 'jcitems', 'allocated', 'Column public.jcitems.allocated should exist');
+RETURN NEXT col_type_is(      'public', 'jcitems', 'allocated', 'numeric', 'Column public.jcitems.allocated should be type numeric');
+RETURN NEXT col_is_null(      'public', 'jcitems', 'allocated', 'Column public.jcitems.allocated should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'jcitems', 'allocated', 'Column public.jcitems.allocated should not have a default');
+
+RETURN NEXT has_column(       'public', 'jcitems', 'sellprice', 'Column public.jcitems.sellprice should exist');
+RETURN NEXT col_type_is(      'public', 'jcitems', 'sellprice', 'numeric', 'Column public.jcitems.sellprice should be type numeric');
+RETURN NEXT col_is_null(      'public', 'jcitems', 'sellprice', 'Column public.jcitems.sellprice should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'jcitems', 'sellprice', 'Column public.jcitems.sellprice should not have a default');
+
+RETURN NEXT has_column(       'public', 'jcitems', 'fxsellprice', 'Column public.jcitems.fxsellprice should exist');
+RETURN NEXT col_type_is(      'public', 'jcitems', 'fxsellprice', 'numeric', 'Column public.jcitems.fxsellprice should be type numeric');
+RETURN NEXT col_is_null(      'public', 'jcitems', 'fxsellprice', 'Column public.jcitems.fxsellprice should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'jcitems', 'fxsellprice', 'Column public.jcitems.fxsellprice should not have a default');
+
+RETURN NEXT has_column(       'public', 'jcitems', 'serialnumber', 'Column public.jcitems.serialnumber should exist');
+RETURN NEXT col_type_is(      'public', 'jcitems', 'serialnumber', 'text', 'Column public.jcitems.serialnumber should be type text');
+RETURN NEXT col_is_null(      'public', 'jcitems', 'serialnumber', 'Column public.jcitems.serialnumber should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'jcitems', 'serialnumber', 'Column public.jcitems.serialnumber should not have a default');
+
+RETURN NEXT has_column(       'public', 'jcitems', 'checkedin', 'Column public.jcitems.checkedin should exist');
+RETURN NEXT col_type_is(      'public', 'jcitems', 'checkedin', 'timestamp with time zone', 'Column public.jcitems.checkedin should be type timestamp with time zone');
+RETURN NEXT col_is_null(      'public', 'jcitems', 'checkedin', 'Column public.jcitems.checkedin should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'jcitems', 'checkedin', 'Column public.jcitems.checkedin should not have a default');
+
+RETURN NEXT has_column(       'public', 'jcitems', 'checkedout', 'Column public.jcitems.checkedout should exist');
+RETURN NEXT col_type_is(      'public', 'jcitems', 'checkedout', 'timestamp with time zone', 'Column public.jcitems.checkedout should be type timestamp with time zone');
+RETURN NEXT col_is_null(      'public', 'jcitems', 'checkedout', 'Column public.jcitems.checkedout should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'jcitems', 'checkedout', 'Column public.jcitems.checkedout should not have a default');
+
+RETURN NEXT has_column(       'public', 'jcitems', 'person_id', 'Column public.jcitems.person_id should exist');
+RETURN NEXT col_type_is(      'public', 'jcitems', 'person_id', 'integer', 'Column public.jcitems.person_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'jcitems', 'person_id', 'Column public.jcitems.person_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'jcitems', 'person_id', 'Column public.jcitems.person_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'jcitems', 'notes', 'Column public.jcitems.notes should exist');
+RETURN NEXT col_type_is(      'public', 'jcitems', 'notes', 'text', 'Column public.jcitems.notes should be type text');
+RETURN NEXT col_is_null(      'public', 'jcitems', 'notes', 'Column public.jcitems.notes should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'jcitems', 'notes', 'Column public.jcitems.notes should not have a default');
+
+RETURN NEXT has_column(       'public', 'jcitems', 'total', 'Column public.jcitems.total should exist');
+RETURN NEXT col_type_is(      'public', 'jcitems', 'total', 'numeric', 'Column public.jcitems.total should be type numeric');
+RETURN NEXT col_not_null(     'public', 'jcitems', 'total', 'Column public.jcitems.total should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'jcitems', 'total', 'Column public.jcitems.total should not have a default');
+
+RETURN NEXT has_column(       'public', 'jcitems', 'non_billable', 'Column public.jcitems.non_billable should exist');
+RETURN NEXT col_type_is(      'public', 'jcitems', 'non_billable', 'numeric', 'Column public.jcitems.non_billable should be type numeric');
+RETURN NEXT col_not_null(     'public', 'jcitems', 'non_billable', 'Column public.jcitems.non_billable should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'jcitems', 'non_billable', 'Column public.jcitems.non_billable shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'jcitems', 'non_billable', '0', 'Column public.jcitems.non_billable default is');
+
+RETURN NEXT has_column(       'public', 'jcitems', 'jctype', 'Column public.jcitems.jctype should exist');
+RETURN NEXT col_type_is(      'public', 'jcitems', 'jctype', 'integer', 'Column public.jcitems.jctype should be type integer');
+RETURN NEXT col_not_null(     'public', 'jcitems', 'jctype', 'Column public.jcitems.jctype should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'jcitems', 'jctype', 'Column public.jcitems.jctype should not have a default');
+
+RETURN NEXT has_column(       'public', 'jcitems', 'curr', 'Column public.jcitems.curr should exist');
+RETURN NEXT col_type_is(      'public', 'jcitems', 'curr', 'character(3)', 'Column public.jcitems.curr should be type character(3)');
+RETURN NEXT col_not_null(     'public', 'jcitems', 'curr', 'Column public.jcitems.curr should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'jcitems', 'curr', 'Column public.jcitems.curr should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.jctype.sql.pg_include
+++ b/xt/pgtap/table_public.jctype.sql.pg_include
@@ -1,0 +1,52 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_jctype()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'jctype',
+    'Should have table public.jctype'
+);
+
+RETURN NEXT has_pk(
+    'public', 'jctype',
+    'Table public.jctype should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'jctype'::name, ARRAY[
+    'id'::name,
+    'label'::name,
+    'description'::name,
+    'is_service'::name,
+    'is_timecard'::name
+]);
+
+RETURN NEXT has_column(       'public', 'jctype', 'id', 'Column public.jctype.id should exist');
+RETURN NEXT col_type_is(      'public', 'jctype', 'id', 'integer', 'Column public.jctype.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'jctype', 'id', 'Column public.jctype.id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'jctype', 'id', 'Column public.jctype.id should not have a default');
+
+RETURN NEXT has_column(       'public', 'jctype', 'label', 'Column public.jctype.label should exist');
+RETURN NEXT col_type_is(      'public', 'jctype', 'label', 'text', 'Column public.jctype.label should be type text');
+RETURN NEXT col_not_null(     'public', 'jctype', 'label', 'Column public.jctype.label should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'jctype', 'label', 'Column public.jctype.label should not have a default');
+
+RETURN NEXT has_column(       'public', 'jctype', 'description', 'Column public.jctype.description should exist');
+RETURN NEXT col_type_is(      'public', 'jctype', 'description', 'text', 'Column public.jctype.description should be type text');
+RETURN NEXT col_not_null(     'public', 'jctype', 'description', 'Column public.jctype.description should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'jctype', 'description', 'Column public.jctype.description should not have a default');
+
+RETURN NEXT has_column(       'public', 'jctype', 'is_service', 'Column public.jctype.is_service should exist');
+RETURN NEXT col_type_is(      'public', 'jctype', 'is_service', 'boolean', 'Column public.jctype.is_service should be type boolean');
+RETURN NEXT col_is_null(      'public', 'jctype', 'is_service', 'Column public.jctype.is_service should allow NULL');
+RETURN NEXT col_has_default(  'public', 'jctype', 'is_service', 'Column public.jctype.is_service shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'jctype', 'is_service', 'true', 'Column public.jctype.is_service default is');
+
+RETURN NEXT has_column(       'public', 'jctype', 'is_timecard', 'Column public.jctype.is_timecard should exist');
+RETURN NEXT col_type_is(      'public', 'jctype', 'is_timecard', 'boolean', 'Column public.jctype.is_timecard should be type boolean');
+RETURN NEXT col_is_null(      'public', 'jctype', 'is_timecard', 'Column public.jctype.is_timecard should allow NULL');
+RETURN NEXT col_has_default(  'public', 'jctype', 'is_timecard', 'Column public.jctype.is_timecard shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'jctype', 'is_timecard', 'true', 'Column public.jctype.is_timecard default is');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.job.sql.pg_include
+++ b/xt/pgtap/table_public.job.sql.pg_include
@@ -1,0 +1,46 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_job()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'job',
+    'Should have table public.job'
+);
+
+RETURN NEXT has_pk(
+    'public', 'job',
+    'Table public.job should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'job'::name, ARRAY[
+    'bu_id'::name,
+    'parts_id'::name,
+    'production'::name,
+    'completed'::name
+]);
+
+RETURN NEXT has_column(       'public', 'job', 'bu_id', 'Column public.job.bu_id should exist');
+RETURN NEXT col_type_is(      'public', 'job', 'bu_id', 'integer', 'Column public.job.bu_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'job', 'bu_id', 'Column public.job.bu_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'job', 'bu_id', 'Column public.job.bu_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'job', 'parts_id', 'Column public.job.parts_id should exist');
+RETURN NEXT col_type_is(      'public', 'job', 'parts_id', 'integer', 'Column public.job.parts_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'job', 'parts_id', 'Column public.job.parts_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'job', 'parts_id', 'Column public.job.parts_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'job', 'production', 'Column public.job.production should exist');
+RETURN NEXT col_type_is(      'public', 'job', 'production', 'numeric', 'Column public.job.production should be type numeric');
+RETURN NEXT col_is_null(      'public', 'job', 'production', 'Column public.job.production should allow NULL');
+RETURN NEXT col_has_default(  'public', 'job', 'production', 'Column public.job.production shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'job', 'production', '0', 'Column public.job.production default is');
+
+RETURN NEXT has_column(       'public', 'job', 'completed', 'Column public.job.completed should exist');
+RETURN NEXT col_type_is(      'public', 'job', 'completed', 'numeric', 'Column public.job.completed should be type numeric');
+RETURN NEXT col_is_null(      'public', 'job', 'completed', 'Column public.job.completed should allow NULL');
+RETURN NEXT col_has_default(  'public', 'job', 'completed', 'Column public.job.completed shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'job', 'completed', '0', 'Column public.job.completed default is');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.journal_entry.sql.pg_include
+++ b/xt/pgtap/table_public.journal_entry.sql.pg_include
@@ -1,0 +1,102 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_journal_entry()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'journal_entry',
+    'Should have table public.journal_entry'
+);
+
+RETURN NEXT has_pk(
+    'public', 'journal_entry',
+    'Table public.journal_entry should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'journal_entry'::name, ARRAY[
+    'id'::name,
+    'reference'::name,
+    'description'::name,
+    'locked_by'::name,
+    'journal'::name,
+    'post_date'::name,
+    'effective_start'::name,
+    'effective_end'::name,
+    'currency'::name,
+    'approved'::name,
+    'is_template'::name,
+    'entered_by'::name,
+    'approved_by'::name
+]);
+
+RETURN NEXT has_column(       'public', 'journal_entry', 'id', 'Column public.journal_entry.id should exist');
+RETURN NEXT col_type_is(      'public', 'journal_entry', 'id', 'integer', 'Column public.journal_entry.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'journal_entry', 'id', 'Column public.journal_entry.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'journal_entry', 'id', 'Column public.journal_entry.id shouldhave a default');
+--SELECT col_default_is(   'public', 'journal_entry', 'id', 'nextval(''journal_entry_id_seq''::regclass)', 'Column public.journal_entry.id default is');RETURN NEXT col_default_is(   'public', 'journal_entry', 'id', 'nextval(''journal_entry_id_seq''::regclass)', 'Column public.journal_entry.id default is');
+
+RETURN NEXT has_column(       'public', 'journal_entry', 'reference', 'Column public.journal_entry.reference should exist');
+RETURN NEXT col_type_is(      'public', 'journal_entry', 'reference', 'text', 'Column public.journal_entry.reference should be type text');
+RETURN NEXT col_is_null(      'public', 'journal_entry', 'reference', 'Column public.journal_entry.reference should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'journal_entry', 'reference', 'Column public.journal_entry.reference should not have a default');
+
+RETURN NEXT has_column(       'public', 'journal_entry', 'description', 'Column public.journal_entry.description should exist');
+RETURN NEXT col_type_is(      'public', 'journal_entry', 'description', 'text', 'Column public.journal_entry.description should be type text');
+RETURN NEXT col_is_null(      'public', 'journal_entry', 'description', 'Column public.journal_entry.description should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'journal_entry', 'description', 'Column public.journal_entry.description should not have a default');
+
+RETURN NEXT has_column(       'public', 'journal_entry', 'locked_by', 'Column public.journal_entry.locked_by should exist');
+RETURN NEXT col_type_is(      'public', 'journal_entry', 'locked_by', 'integer', 'Column public.journal_entry.locked_by should be type integer');
+RETURN NEXT col_is_null(      'public', 'journal_entry', 'locked_by', 'Column public.journal_entry.locked_by should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'journal_entry', 'locked_by', 'Column public.journal_entry.locked_by should not have a default');
+
+RETURN NEXT has_column(       'public', 'journal_entry', 'journal', 'Column public.journal_entry.journal should exist');
+RETURN NEXT col_type_is(      'public', 'journal_entry', 'journal', 'integer', 'Column public.journal_entry.journal should be type integer');
+RETURN NEXT col_is_null(      'public', 'journal_entry', 'journal', 'Column public.journal_entry.journal should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'journal_entry', 'journal', 'Column public.journal_entry.journal should not have a default');
+
+RETURN NEXT has_column(       'public', 'journal_entry', 'post_date', 'Column public.journal_entry.post_date should exist');
+RETURN NEXT col_type_is(      'public', 'journal_entry', 'post_date', 'date', 'Column public.journal_entry.post_date should be type date');
+RETURN NEXT col_is_null(      'public', 'journal_entry', 'post_date', 'Column public.journal_entry.post_date should allow NULL');
+RETURN NEXT col_has_default(  'public', 'journal_entry', 'post_date', 'Column public.journal_entry.post_date shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'journal_entry', 'post_date', 'now()', 'Column public.journal_entry.post_date default is');
+
+RETURN NEXT has_column(       'public', 'journal_entry', 'effective_start', 'Column public.journal_entry.effective_start should exist');
+RETURN NEXT col_type_is(      'public', 'journal_entry', 'effective_start', 'date', 'Column public.journal_entry.effective_start should be type date');
+RETURN NEXT col_is_null(      'public', 'journal_entry', 'effective_start', 'Column public.journal_entry.effective_start should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'journal_entry', 'effective_start', 'Column public.journal_entry.effective_start should not have a default');
+
+RETURN NEXT has_column(       'public', 'journal_entry', 'effective_end', 'Column public.journal_entry.effective_end should exist');
+RETURN NEXT col_type_is(      'public', 'journal_entry', 'effective_end', 'date', 'Column public.journal_entry.effective_end should be type date');
+RETURN NEXT col_is_null(      'public', 'journal_entry', 'effective_end', 'Column public.journal_entry.effective_end should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'journal_entry', 'effective_end', 'Column public.journal_entry.effective_end should not have a default');
+
+RETURN NEXT has_column(       'public', 'journal_entry', 'currency', 'Column public.journal_entry.currency should exist');
+RETURN NEXT col_type_is(      'public', 'journal_entry', 'currency', 'character(3)', 'Column public.journal_entry.currency should be type character(3)');
+RETURN NEXT col_not_null(     'public', 'journal_entry', 'currency', 'Column public.journal_entry.currency should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'journal_entry', 'currency', 'Column public.journal_entry.currency should not have a default');
+
+RETURN NEXT has_column(       'public', 'journal_entry', 'approved', 'Column public.journal_entry.approved should exist');
+RETURN NEXT col_type_is(      'public', 'journal_entry', 'approved', 'boolean', 'Column public.journal_entry.approved should be type boolean');
+RETURN NEXT col_is_null(      'public', 'journal_entry', 'approved', 'Column public.journal_entry.approved should allow NULL');
+RETURN NEXT col_has_default(  'public', 'journal_entry', 'approved', 'Column public.journal_entry.approved shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'journal_entry', 'approved', 'false', 'Column public.journal_entry.approved default is');
+
+RETURN NEXT has_column(       'public', 'journal_entry', 'is_template', 'Column public.journal_entry.is_template should exist');
+RETURN NEXT col_type_is(      'public', 'journal_entry', 'is_template', 'boolean', 'Column public.journal_entry.is_template should be type boolean');
+RETURN NEXT col_is_null(      'public', 'journal_entry', 'is_template', 'Column public.journal_entry.is_template should allow NULL');
+RETURN NEXT col_has_default(  'public', 'journal_entry', 'is_template', 'Column public.journal_entry.is_template shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'journal_entry', 'is_template', 'false', 'Column public.journal_entry.is_template default is');
+
+RETURN NEXT has_column(       'public', 'journal_entry', 'entered_by', 'Column public.journal_entry.entered_by should exist');
+RETURN NEXT col_type_is(      'public', 'journal_entry', 'entered_by', 'integer', 'Column public.journal_entry.entered_by should be type integer');
+RETURN NEXT col_not_null(     'public', 'journal_entry', 'entered_by', 'Column public.journal_entry.entered_by should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'journal_entry', 'entered_by', 'Column public.journal_entry.entered_by should not have a default');
+
+RETURN NEXT has_column(       'public', 'journal_entry', 'approved_by', 'Column public.journal_entry.approved_by should exist');
+RETURN NEXT col_type_is(      'public', 'journal_entry', 'approved_by', 'integer', 'Column public.journal_entry.approved_by should be type integer');
+RETURN NEXT col_is_null(      'public', 'journal_entry', 'approved_by', 'Column public.journal_entry.approved_by should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'journal_entry', 'approved_by', 'Column public.journal_entry.approved_by should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.journal_line.sql.pg_include
+++ b/xt/pgtap/table_public.journal_line.sql.pg_include
@@ -1,0 +1,64 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_journal_line()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'journal_line',
+    'Should have table public.journal_line'
+);
+
+RETURN NEXT has_pk(
+    'public', 'journal_line',
+    'Table public.journal_line should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'journal_line'::name, ARRAY[
+    'id'::name,
+    'account_id'::name,
+    'journal_id'::name,
+    'amount'::name,
+    'cleared'::name,
+    'reconciliation_report'::name,
+    'line_type'::name
+]);
+
+RETURN NEXT has_column(       'public', 'journal_line', 'id', 'Column public.journal_line.id should exist');
+RETURN NEXT col_type_is(      'public', 'journal_line', 'id', 'integer', 'Column public.journal_line.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'journal_line', 'id', 'Column public.journal_line.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'journal_line', 'id', 'Column public.journal_line.id shouldhave a default');
+--SELECT col_default_is(   'public', 'journal_line', 'id', 'nextval(''journal_line_id_seq''::regclass)', 'Column public.journal_line.id default is');RETURN NEXT col_default_is(   'public', 'journal_line', 'id', 'nextval(''journal_line_id_seq''::regclass)', 'Column public.journal_line.id default is');
+
+RETURN NEXT has_column(       'public', 'journal_line', 'account_id', 'Column public.journal_line.account_id should exist');
+RETURN NEXT col_type_is(      'public', 'journal_line', 'account_id', 'integer', 'Column public.journal_line.account_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'journal_line', 'account_id', 'Column public.journal_line.account_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'journal_line', 'account_id', 'Column public.journal_line.account_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'journal_line', 'journal_id', 'Column public.journal_line.journal_id should exist');
+RETURN NEXT col_type_is(      'public', 'journal_line', 'journal_id', 'integer', 'Column public.journal_line.journal_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'journal_line', 'journal_id', 'Column public.journal_line.journal_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'journal_line', 'journal_id', 'Column public.journal_line.journal_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'journal_line', 'amount', 'Column public.journal_line.amount should exist');
+RETURN NEXT col_type_is(      'public', 'journal_line', 'amount', 'numeric', 'Column public.journal_line.amount should be type numeric');
+RETURN NEXT col_not_null(     'public', 'journal_line', 'amount', 'Column public.journal_line.amount should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'journal_line', 'amount', 'Column public.journal_line.amount should not have a default');
+
+RETURN NEXT has_column(       'public', 'journal_line', 'cleared', 'Column public.journal_line.cleared should exist');
+RETURN NEXT col_type_is(      'public', 'journal_line', 'cleared', 'boolean', 'Column public.journal_line.cleared should be type boolean');
+RETURN NEXT col_not_null(     'public', 'journal_line', 'cleared', 'Column public.journal_line.cleared should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'journal_line', 'cleared', 'Column public.journal_line.cleared shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'journal_line', 'cleared', 'false', 'Column public.journal_line.cleared default is');
+
+RETURN NEXT has_column(       'public', 'journal_line', 'reconciliation_report', 'Column public.journal_line.reconciliation_report should exist');
+RETURN NEXT col_type_is(      'public', 'journal_line', 'reconciliation_report', 'integer', 'Column public.journal_line.reconciliation_report should be type integer');
+RETURN NEXT col_is_null(      'public', 'journal_line', 'reconciliation_report', 'Column public.journal_line.reconciliation_report should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'journal_line', 'reconciliation_report', 'Column public.journal_line.reconciliation_report should not have a default');
+
+RETURN NEXT has_column(       'public', 'journal_line', 'line_type', 'Column public.journal_line.line_type should exist');
+RETURN NEXT col_type_is(      'public', 'journal_line', 'line_type', 'text', 'Column public.journal_line.line_type should be type text');
+RETURN NEXT col_is_null(      'public', 'journal_line', 'line_type', 'Column public.journal_line.line_type should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'journal_line', 'line_type', 'Column public.journal_line.line_type should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.journal_note.sql.pg_include
+++ b/xt/pgtap/table_public.journal_note.sql.pg_include
@@ -1,0 +1,79 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_journal_note()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'journal_note',
+    'Should have table public.journal_note'
+);
+
+RETURN NEXT has_pk(
+    'public', 'journal_note',
+    'Table public.journal_note should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'journal_note'::name, ARRAY[
+    'id'::name,
+    'note_class'::name,
+    'note'::name,
+    'vector'::name,
+    'created'::name,
+    'created_by'::name,
+    'ref_key'::name,
+    'subject'::name,
+    'internal_only'::name
+]);
+
+RETURN NEXT has_column(       'public', 'journal_note', 'id', 'Column public.journal_note.id should exist');
+RETURN NEXT col_type_is(      'public', 'journal_note', 'id', 'integer', 'Column public.journal_note.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'journal_note', 'id', 'Column public.journal_note.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'journal_note', 'id', 'Column public.journal_note.id shouldhave a default');
+--SELECT col_default_is(   'public', 'journal_note', 'id', 'nextval(''note_id_seq''::regclass)', 'Column public.journal_note.id default is');RETURN NEXT col_default_is(   'public', 'journal_note', 'id', 'nextval(''note_id_seq''::regclass)', 'Column public.journal_note.id default is');
+
+RETURN NEXT has_column(       'public', 'journal_note', 'note_class', 'Column public.journal_note.note_class should exist');
+RETURN NEXT col_type_is(      'public', 'journal_note', 'note_class', 'integer', 'Column public.journal_note.note_class should be type integer');
+RETURN NEXT col_not_null(     'public', 'journal_note', 'note_class', 'Column public.journal_note.note_class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'journal_note', 'note_class', 'Column public.journal_note.note_class should not have a default');
+
+RETURN NEXT has_column(       'public', 'journal_note', 'note', 'Column public.journal_note.note should exist');
+RETURN NEXT col_type_is(      'public', 'journal_note', 'note', 'text', 'Column public.journal_note.note should be type text');
+RETURN NEXT col_not_null(     'public', 'journal_note', 'note', 'Column public.journal_note.note should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'journal_note', 'note', 'Column public.journal_note.note should not have a default');
+
+RETURN NEXT has_column(       'public', 'journal_note', 'vector', 'Column public.journal_note.vector should exist');
+RETURN NEXT col_type_is(      'public', 'journal_note', 'vector', 'tsvector', 'Column public.journal_note.vector should be type tsvector');
+RETURN NEXT col_not_null(     'public', 'journal_note', 'vector', 'Column public.journal_note.vector should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'journal_note', 'vector', 'Column public.journal_note.vector shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'journal_note', 'vector', ''::tsvector, 'Column public.journal_note.vector default is');
+
+RETURN NEXT has_column(       'public', 'journal_note', 'created', 'Column public.journal_note.created should exist');
+RETURN NEXT col_type_is(      'public', 'journal_note', 'created', 'timestamp without time zone', 'Column public.journal_note.created should be type timestamp without time zone');
+RETURN NEXT col_not_null(     'public', 'journal_note', 'created', 'Column public.journal_note.created should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'journal_note', 'created', 'Column public.journal_note.created shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'journal_note', 'created', 'now()', 'Column public.journal_note.created default is');
+
+RETURN NEXT has_column(       'public', 'journal_note', 'created_by', 'Column public.journal_note.created_by should exist');
+RETURN NEXT col_type_is(      'public', 'journal_note', 'created_by', 'text', 'Column public.journal_note.created_by should be type text');
+RETURN NEXT col_is_null(      'public', 'journal_note', 'created_by', 'Column public.journal_note.created_by should allow NULL');
+RETURN NEXT col_has_default(  'public', 'journal_note', 'created_by', 'Column public.journal_note.created_by shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'journal_note', 'created_by', '"session_user"()', 'Column public.journal_note.created_by default is');
+
+RETURN NEXT has_column(       'public', 'journal_note', 'ref_key', 'Column public.journal_note.ref_key should exist');
+RETURN NEXT col_type_is(      'public', 'journal_note', 'ref_key', 'integer', 'Column public.journal_note.ref_key should be type integer');
+RETURN NEXT col_not_null(     'public', 'journal_note', 'ref_key', 'Column public.journal_note.ref_key should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'journal_note', 'ref_key', 'Column public.journal_note.ref_key should not have a default');
+
+RETURN NEXT has_column(       'public', 'journal_note', 'subject', 'Column public.journal_note.subject should exist');
+RETURN NEXT col_type_is(      'public', 'journal_note', 'subject', 'text', 'Column public.journal_note.subject should be type text');
+RETURN NEXT col_is_null(      'public', 'journal_note', 'subject', 'Column public.journal_note.subject should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'journal_note', 'subject', 'Column public.journal_note.subject should not have a default');
+
+RETURN NEXT has_column(       'public', 'journal_note', 'internal_only', 'Column public.journal_note.internal_only should exist');
+RETURN NEXT col_type_is(      'public', 'journal_note', 'internal_only', 'boolean', 'Column public.journal_note.internal_only should be type boolean');
+RETURN NEXT col_not_null(     'public', 'journal_note', 'internal_only', 'Column public.journal_note.internal_only should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'journal_note', 'internal_only', 'Column public.journal_note.internal_only shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'journal_note', 'internal_only', 'false', 'Column public.journal_note.internal_only default is');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.journal_type.sql.pg_include
+++ b/xt/pgtap/table_public.journal_type.sql.pg_include
@@ -1,0 +1,33 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_journal_type()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'journal_type',
+    'Should have table public.journal_type'
+);
+
+RETURN NEXT has_pk(
+    'public', 'journal_type',
+    'Table public.journal_type should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'journal_type'::name, ARRAY[
+    'id'::name,
+    'name'::name
+]);
+
+RETURN NEXT has_column(       'public', 'journal_type', 'id', 'Column public.journal_type.id should exist');
+RETURN NEXT col_type_is(      'public', 'journal_type', 'id', 'integer', 'Column public.journal_type.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'journal_type', 'id', 'Column public.journal_type.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'journal_type', 'id', 'Column public.journal_type.id shouldhave a default');
+--SELECT col_default_is(   'public', 'journal_type', 'id', 'nextval(''journal_type_id_seq''::regclass)', 'Column public.journal_type.id default is');RETURN NEXT col_default_is(   'public', 'journal_type', 'id', 'nextval(''journal_type_id_seq''::regclass)', 'Column public.journal_type.id default is');
+
+RETURN NEXT has_column(       'public', 'journal_type', 'name', 'Column public.journal_type.name should exist');
+RETURN NEXT col_type_is(      'public', 'journal_type', 'name', 'text', 'Column public.journal_type.name should be type text');
+RETURN NEXT col_not_null(     'public', 'journal_type', 'name', 'Column public.journal_type.name should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'journal_type', 'name', 'Column public.journal_type.name should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.language.sql.pg_include
+++ b/xt/pgtap/table_public.language.sql.pg_include
@@ -1,0 +1,32 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_language()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'language',
+    'Should have table public.language'
+);
+
+RETURN NEXT has_pk(
+    'public', 'language',
+    'Table public.language should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'language'::name, ARRAY[
+    'code'::name,
+    'description'::name
+]);
+
+RETURN NEXT has_column(       'public', 'language', 'code', 'Column public.language.code should exist');
+RETURN NEXT col_type_is(      'public', 'language', 'code', 'character varying(6)', 'Column public.language.code should be type character varying(6)');
+RETURN NEXT col_not_null(     'public', 'language', 'code', 'Column public.language.code should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'language', 'code', 'Column public.language.code should not have a default');
+
+RETURN NEXT has_column(       'public', 'language', 'description', 'Column public.language.description should exist');
+RETURN NEXT col_type_is(      'public', 'language', 'description', 'text', 'Column public.language.description should be type text');
+RETURN NEXT col_is_null(      'public', 'language', 'description', 'Column public.language.description should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'language', 'description', 'Column public.language.description should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.location.sql.pg_include
+++ b/xt/pgtap/table_public.location.sql.pg_include
@@ -1,0 +1,89 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_location()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'location',
+    'Should have table public.location'
+);
+
+RETURN NEXT has_pk(
+    'public', 'location',
+    'Table public.location should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'location'::name, ARRAY[
+    'id'::name,
+    'line_one'::name,
+    'line_two'::name,
+    'line_three'::name,
+    'city'::name,
+    'state'::name,
+    'country_id'::name,
+    'mail_code'::name,
+    'created'::name,
+    'inactive_date'::name,
+    'active'::name
+]);
+
+RETURN NEXT has_column(       'public', 'location', 'id', 'Column public.location.id should exist');
+RETURN NEXT col_type_is(      'public', 'location', 'id', 'integer', 'Column public.location.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'location', 'id', 'Column public.location.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'location', 'id', 'Column public.location.id shouldhave a default');
+--SELECT col_default_is(   'public', 'location', 'id', 'nextval(''location_id_seq''::regclass)', 'Column public.location.id default is');RETURN NEXT col_default_is(   'public', 'location', 'id', 'nextval(''location_id_seq''::regclass)', 'Column public.location.id default is');
+
+RETURN NEXT has_column(       'public', 'location', 'line_one', 'Column public.location.line_one should exist');
+RETURN NEXT col_type_is(      'public', 'location', 'line_one', 'text', 'Column public.location.line_one should be type text');
+RETURN NEXT col_not_null(     'public', 'location', 'line_one', 'Column public.location.line_one should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'location', 'line_one', 'Column public.location.line_one should not have a default');
+
+RETURN NEXT has_column(       'public', 'location', 'line_two', 'Column public.location.line_two should exist');
+RETURN NEXT col_type_is(      'public', 'location', 'line_two', 'text', 'Column public.location.line_two should be type text');
+RETURN NEXT col_is_null(      'public', 'location', 'line_two', 'Column public.location.line_two should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'location', 'line_two', 'Column public.location.line_two should not have a default');
+
+RETURN NEXT has_column(       'public', 'location', 'line_three', 'Column public.location.line_three should exist');
+RETURN NEXT col_type_is(      'public', 'location', 'line_three', 'text', 'Column public.location.line_three should be type text');
+RETURN NEXT col_is_null(      'public', 'location', 'line_three', 'Column public.location.line_three should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'location', 'line_three', 'Column public.location.line_three should not have a default');
+
+RETURN NEXT has_column(       'public', 'location', 'city', 'Column public.location.city should exist');
+RETURN NEXT col_type_is(      'public', 'location', 'city', 'text', 'Column public.location.city should be type text');
+RETURN NEXT col_not_null(     'public', 'location', 'city', 'Column public.location.city should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'location', 'city', 'Column public.location.city should not have a default');
+
+RETURN NEXT has_column(       'public', 'location', 'state', 'Column public.location.state should exist');
+RETURN NEXT col_type_is(      'public', 'location', 'state', 'text', 'Column public.location.state should be type text');
+RETURN NEXT col_is_null(      'public', 'location', 'state', 'Column public.location.state should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'location', 'state', 'Column public.location.state should not have a default');
+
+RETURN NEXT has_column(       'public', 'location', 'country_id', 'Column public.location.country_id should exist');
+RETURN NEXT col_type_is(      'public', 'location', 'country_id', 'integer', 'Column public.location.country_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'location', 'country_id', 'Column public.location.country_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'location', 'country_id', 'Column public.location.country_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'location', 'mail_code', 'Column public.location.mail_code should exist');
+RETURN NEXT col_type_is(      'public', 'location', 'mail_code', 'text', 'Column public.location.mail_code should be type text');
+RETURN NEXT col_is_null(      'public', 'location', 'mail_code', 'Column public.location.mail_code should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'location', 'mail_code', 'Column public.location.mail_code should not have a default');
+
+RETURN NEXT has_column(       'public', 'location', 'created', 'Column public.location.created should exist');
+RETURN NEXT col_type_is(      'public', 'location', 'created', 'date', 'Column public.location.created should be type date');
+RETURN NEXT col_not_null(     'public', 'location', 'created', 'Column public.location.created should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'location', 'created', 'Column public.location.created shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'location', 'created', 'now()', 'Column public.location.created default is');
+
+RETURN NEXT has_column(       'public', 'location', 'inactive_date', 'Column public.location.inactive_date should exist');
+RETURN NEXT col_type_is(      'public', 'location', 'inactive_date', 'timestamp without time zone', 'Column public.location.inactive_date should be type timestamp without time zone');
+RETURN NEXT col_is_null(      'public', 'location', 'inactive_date', 'Column public.location.inactive_date should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'location', 'inactive_date', 'Column public.location.inactive_date should not have a default');
+
+RETURN NEXT has_column(       'public', 'location', 'active', 'Column public.location.active should exist');
+RETURN NEXT col_type_is(      'public', 'location', 'active', 'boolean', 'Column public.location.active should be type boolean');
+RETURN NEXT col_not_null(     'public', 'location', 'active', 'Column public.location.active should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'location', 'active', 'Column public.location.active shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'location', 'active', 'true', 'Column public.location.active default is');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.location_class.sql.pg_include
+++ b/xt/pgtap/table_public.location_class.sql.pg_include
@@ -1,0 +1,39 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_location_class()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'location_class',
+    'Should have table public.location_class'
+);
+
+RETURN NEXT has_pk(
+    'public', 'location_class',
+    'Table public.location_class should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'location_class'::name, ARRAY[
+    'id'::name,
+    'class'::name,
+    'authoritative'::name
+]);
+
+RETURN NEXT has_column(       'public', 'location_class', 'id', 'Column public.location_class.id should exist');
+RETURN NEXT col_type_is(      'public', 'location_class', 'id', 'integer', 'Column public.location_class.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'location_class', 'id', 'Column public.location_class.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'location_class', 'id', 'Column public.location_class.id shouldhave a default');
+--SELECT col_default_is(   'public', 'location_class', 'id', 'nextval(''location_class_id_seq''::regclass)', 'Column public.location_class.id default is');RETURN NEXT col_default_is(   'public', 'location_class', 'id', 'nextval(''location_class_id_seq''::regclass)', 'Column public.location_class.id default is');
+
+RETURN NEXT has_column(       'public', 'location_class', 'class', 'Column public.location_class.class should exist');
+RETURN NEXT col_type_is(      'public', 'location_class', 'class', 'text', 'Column public.location_class.class should be type text');
+RETURN NEXT col_not_null(     'public', 'location_class', 'class', 'Column public.location_class.class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'location_class', 'class', 'Column public.location_class.class should not have a default');
+
+RETURN NEXT has_column(       'public', 'location_class', 'authoritative', 'Column public.location_class.authoritative should exist');
+RETURN NEXT col_type_is(      'public', 'location_class', 'authoritative', 'boolean', 'Column public.location_class.authoritative should be type boolean');
+RETURN NEXT col_not_null(     'public', 'location_class', 'authoritative', 'Column public.location_class.authoritative should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'location_class', 'authoritative', 'Column public.location_class.authoritative should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.location_class_to_entity_class.sql.pg_include
+++ b/xt/pgtap/table_public.location_class_to_entity_class.sql.pg_include
@@ -1,0 +1,39 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_location_class_to_entity_class()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'location_class_to_entity_class',
+    'Should have table public.location_class_to_entity_class'
+);
+
+RETURN NEXT hasnt_pk(
+    'public', 'location_class_to_entity_class',
+    'Table public.location_class_to_entity_class should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'location_class_to_entity_class'::name, ARRAY[
+    'id'::name,
+    'location_class'::name,
+    'entity_class'::name
+]);
+
+RETURN NEXT has_column(       'public', 'location_class_to_entity_class', 'id', 'Column public.location_class_to_entity_class.id should exist');
+RETURN NEXT col_type_is(      'public', 'location_class_to_entity_class', 'id', 'integer', 'Column public.location_class_to_entity_class.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'location_class_to_entity_class', 'id', 'Column public.location_class_to_entity_class.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'location_class_to_entity_class', 'id', 'Column public.location_class_to_entity_class.id shouldhave a default');
+--SELECT col_default_is(   'public', 'location_class_to_entity_class', 'id', 'nextval(''location_class_to_entity_class_id_seq''::regclass)', 'Column public.location_class_to_entity_class.id default is');RETURN NEXT col_default_is(   'public', 'location_class_to_entity_class', 'id', 'nextval(''location_class_to_entity_class_id_seq''::regclass)', 'Column public.location_class_to_entity_class.id default is');
+
+RETURN NEXT has_column(       'public', 'location_class_to_entity_class', 'location_class', 'Column public.location_class_to_entity_class.location_class should exist');
+RETURN NEXT col_type_is(      'public', 'location_class_to_entity_class', 'location_class', 'integer', 'Column public.location_class_to_entity_class.location_class should be type integer');
+RETURN NEXT col_not_null(     'public', 'location_class_to_entity_class', 'location_class', 'Column public.location_class_to_entity_class.location_class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'location_class_to_entity_class', 'location_class', 'Column public.location_class_to_entity_class.location_class should not have a default');
+
+RETURN NEXT has_column(       'public', 'location_class_to_entity_class', 'entity_class', 'Column public.location_class_to_entity_class.entity_class should exist');
+RETURN NEXT col_type_is(      'public', 'location_class_to_entity_class', 'entity_class', 'integer', 'Column public.location_class_to_entity_class.entity_class should be type integer');
+RETURN NEXT col_not_null(     'public', 'location_class_to_entity_class', 'entity_class', 'Column public.location_class_to_entity_class.entity_class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'location_class_to_entity_class', 'entity_class', 'Column public.location_class_to_entity_class.entity_class should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.lsmb_group.sql.pg_include
+++ b/xt/pgtap/table_public.lsmb_group.sql.pg_include
@@ -1,0 +1,26 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_lsmb_group()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'lsmb_group',
+    'Should have table public.lsmb_group'
+);
+
+RETURN NEXT has_pk(
+    'public', 'lsmb_group',
+    'Table public.lsmb_group should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'lsmb_group'::name, ARRAY[
+    'role_name'::name
+]);
+
+RETURN NEXT has_column(       'public', 'lsmb_group', 'role_name', 'Column public.lsmb_group.role_name should exist');
+RETURN NEXT col_type_is(      'public', 'lsmb_group', 'role_name', 'text', 'Column public.lsmb_group.role_name should be type text');
+RETURN NEXT col_not_null(     'public', 'lsmb_group', 'role_name', 'Column public.lsmb_group.role_name should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'lsmb_group', 'role_name', 'Column public.lsmb_group.role_name should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.lsmb_group_grants.sql.pg_include
+++ b/xt/pgtap/table_public.lsmb_group_grants.sql.pg_include
@@ -1,0 +1,32 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_lsmb_group_grants()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'lsmb_group_grants',
+    'Should have table public.lsmb_group_grants'
+);
+
+RETURN NEXT has_pk(
+    'public', 'lsmb_group_grants',
+    'Table public.lsmb_group_grants should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'lsmb_group_grants'::name, ARRAY[
+    'group_name'::name,
+    'granted_role'::name
+]);
+
+RETURN NEXT has_column(       'public', 'lsmb_group_grants', 'group_name', 'Column public.lsmb_group_grants.group_name should exist');
+RETURN NEXT col_type_is(      'public', 'lsmb_group_grants', 'group_name', 'text', 'Column public.lsmb_group_grants.group_name should be type text');
+RETURN NEXT col_not_null(     'public', 'lsmb_group_grants', 'group_name', 'Column public.lsmb_group_grants.group_name should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'lsmb_group_grants', 'group_name', 'Column public.lsmb_group_grants.group_name should not have a default');
+
+RETURN NEXT has_column(       'public', 'lsmb_group_grants', 'granted_role', 'Column public.lsmb_group_grants.granted_role should exist');
+RETURN NEXT col_type_is(      'public', 'lsmb_group_grants', 'granted_role', 'text', 'Column public.lsmb_group_grants.granted_role should be type text');
+RETURN NEXT col_not_null(     'public', 'lsmb_group_grants', 'granted_role', 'Column public.lsmb_group_grants.granted_role should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'lsmb_group_grants', 'granted_role', 'Column public.lsmb_group_grants.granted_role should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.lsmb_module.sql.pg_include
+++ b/xt/pgtap/table_public.lsmb_module.sql.pg_include
@@ -1,0 +1,32 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_lsmb_module()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'lsmb_module',
+    'Should have table public.lsmb_module'
+);
+
+RETURN NEXT has_pk(
+    'public', 'lsmb_module',
+    'Table public.lsmb_module should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'lsmb_module'::name, ARRAY[
+    'id'::name,
+    'label'::name
+]);
+
+RETURN NEXT has_column(       'public', 'lsmb_module', 'id', 'Column public.lsmb_module.id should exist');
+RETURN NEXT col_type_is(      'public', 'lsmb_module', 'id', 'integer', 'Column public.lsmb_module.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'lsmb_module', 'id', 'Column public.lsmb_module.id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'lsmb_module', 'id', 'Column public.lsmb_module.id should not have a default');
+
+RETURN NEXT has_column(       'public', 'lsmb_module', 'label', 'Column public.lsmb_module.label should exist');
+RETURN NEXT col_type_is(      'public', 'lsmb_module', 'label', 'text', 'Column public.lsmb_module.label should be type text');
+RETURN NEXT col_not_null(     'public', 'lsmb_module', 'label', 'Column public.lsmb_module.label should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'lsmb_module', 'label', 'Column public.lsmb_module.label should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.lsmb_sequence.sql.pg_include
+++ b/xt/pgtap/table_public.lsmb_sequence.sql.pg_include
@@ -1,0 +1,58 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_lsmb_sequence()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'lsmb_sequence',
+    'Should have table public.lsmb_sequence'
+);
+
+RETURN NEXT has_pk(
+    'public', 'lsmb_sequence',
+    'Table public.lsmb_sequence should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'lsmb_sequence'::name, ARRAY[
+    'label'::name,
+    'setting_key'::name,
+    'prefix'::name,
+    'suffix'::name,
+    'sequence'::name,
+    'accept_input'::name
+]);
+
+RETURN NEXT has_column(       'public', 'lsmb_sequence', 'label', 'Column public.lsmb_sequence.label should exist');
+RETURN NEXT col_type_is(      'public', 'lsmb_sequence', 'label', 'text', 'Column public.lsmb_sequence.label should be type text');
+RETURN NEXT col_not_null(     'public', 'lsmb_sequence', 'label', 'Column public.lsmb_sequence.label should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'lsmb_sequence', 'label', 'Column public.lsmb_sequence.label should not have a default');
+
+RETURN NEXT has_column(       'public', 'lsmb_sequence', 'setting_key', 'Column public.lsmb_sequence.setting_key should exist');
+RETURN NEXT col_type_is(      'public', 'lsmb_sequence', 'setting_key', 'text', 'Column public.lsmb_sequence.setting_key should be type text');
+RETURN NEXT col_not_null(     'public', 'lsmb_sequence', 'setting_key', 'Column public.lsmb_sequence.setting_key should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'lsmb_sequence', 'setting_key', 'Column public.lsmb_sequence.setting_key should not have a default');
+
+RETURN NEXT has_column(       'public', 'lsmb_sequence', 'prefix', 'Column public.lsmb_sequence.prefix should exist');
+RETURN NEXT col_type_is(      'public', 'lsmb_sequence', 'prefix', 'text', 'Column public.lsmb_sequence.prefix should be type text');
+RETURN NEXT col_is_null(      'public', 'lsmb_sequence', 'prefix', 'Column public.lsmb_sequence.prefix should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'lsmb_sequence', 'prefix', 'Column public.lsmb_sequence.prefix should not have a default');
+
+RETURN NEXT has_column(       'public', 'lsmb_sequence', 'suffix', 'Column public.lsmb_sequence.suffix should exist');
+RETURN NEXT col_type_is(      'public', 'lsmb_sequence', 'suffix', 'text', 'Column public.lsmb_sequence.suffix should be type text');
+RETURN NEXT col_is_null(      'public', 'lsmb_sequence', 'suffix', 'Column public.lsmb_sequence.suffix should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'lsmb_sequence', 'suffix', 'Column public.lsmb_sequence.suffix should not have a default');
+
+RETURN NEXT has_column(       'public', 'lsmb_sequence', 'sequence', 'Column public.lsmb_sequence.sequence should exist');
+RETURN NEXT col_type_is(      'public', 'lsmb_sequence', 'sequence', 'text', 'Column public.lsmb_sequence.sequence should be type text');
+RETURN NEXT col_not_null(     'public', 'lsmb_sequence', 'sequence', 'Column public.lsmb_sequence.sequence should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'lsmb_sequence', 'sequence', 'Column public.lsmb_sequence.sequence shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'lsmb_sequence', 'sequence', '1'::text, 'Column public.lsmb_sequence.sequence default is');
+
+RETURN NEXT has_column(       'public', 'lsmb_sequence', 'accept_input', 'Column public.lsmb_sequence.accept_input should exist');
+RETURN NEXT col_type_is(      'public', 'lsmb_sequence', 'accept_input', 'boolean', 'Column public.lsmb_sequence.accept_input should be type boolean');
+RETURN NEXT col_is_null(      'public', 'lsmb_sequence', 'accept_input', 'Column public.lsmb_sequence.accept_input should allow NULL');
+RETURN NEXT col_has_default(  'public', 'lsmb_sequence', 'accept_input', 'Column public.lsmb_sequence.accept_input shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'lsmb_sequence', 'accept_input', 'true', 'Column public.lsmb_sequence.accept_input default is');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.makemodel.sql.pg_include
+++ b/xt/pgtap/table_public.makemodel.sql.pg_include
@@ -1,0 +1,44 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_makemodel()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'makemodel',
+    'Should have table public.makemodel'
+);
+
+RETURN NEXT has_pk(
+    'public', 'makemodel',
+    'Table public.makemodel should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'makemodel'::name, ARRAY[
+    'parts_id'::name,
+    'barcode'::name,
+    'make'::name,
+    'model'::name
+]);
+
+RETURN NEXT has_column(       'public', 'makemodel', 'parts_id', 'Column public.makemodel.parts_id should exist');
+RETURN NEXT col_type_is(      'public', 'makemodel', 'parts_id', 'integer', 'Column public.makemodel.parts_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'makemodel', 'parts_id', 'Column public.makemodel.parts_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'makemodel', 'parts_id', 'Column public.makemodel.parts_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'makemodel', 'barcode', 'Column public.makemodel.barcode should exist');
+RETURN NEXT col_type_is(      'public', 'makemodel', 'barcode', 'text', 'Column public.makemodel.barcode should be type text');
+RETURN NEXT col_is_null(      'public', 'makemodel', 'barcode', 'Column public.makemodel.barcode should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'makemodel', 'barcode', 'Column public.makemodel.barcode should not have a default');
+
+RETURN NEXT has_column(       'public', 'makemodel', 'make', 'Column public.makemodel.make should exist');
+RETURN NEXT col_type_is(      'public', 'makemodel', 'make', 'text', 'Column public.makemodel.make should be type text');
+RETURN NEXT col_not_null(     'public', 'makemodel', 'make', 'Column public.makemodel.make should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'makemodel', 'make', 'Column public.makemodel.make should not have a default');
+
+RETURN NEXT has_column(       'public', 'makemodel', 'model', 'Column public.makemodel.model should exist');
+RETURN NEXT col_type_is(      'public', 'makemodel', 'model', 'text', 'Column public.makemodel.model should be type text');
+RETURN NEXT col_not_null(     'public', 'makemodel', 'model', 'Column public.makemodel.model should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'makemodel', 'model', 'Column public.makemodel.model should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.menu_acl.sql.pg_include
+++ b/xt/pgtap/table_public.menu_acl.sql.pg_include
@@ -1,0 +1,45 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_menu_acl()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'menu_acl',
+    'Should have table public.menu_acl'
+);
+
+RETURN NEXT has_pk(
+    'public', 'menu_acl',
+    'Table public.menu_acl should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'menu_acl'::name, ARRAY[
+    'id'::name,
+    'role_name'::name,
+    'acl_type'::name,
+    'node_id'::name
+]);
+
+RETURN NEXT has_column(       'public', 'menu_acl', 'id', 'Column public.menu_acl.id should exist');
+RETURN NEXT col_type_is(      'public', 'menu_acl', 'id', 'integer', 'Column public.menu_acl.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'menu_acl', 'id', 'Column public.menu_acl.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'menu_acl', 'id', 'Column public.menu_acl.id shouldhave a default');
+--SELECT col_default_is(   'public', 'menu_acl', 'id', 'nextval(''menu_acl_id_seq''::regclass)', 'Column public.menu_acl.id default is');RETURN NEXT col_default_is(   'public', 'menu_acl', 'id', 'nextval(''menu_acl_id_seq''::regclass)', 'Column public.menu_acl.id default is');
+
+RETURN NEXT has_column(       'public', 'menu_acl', 'role_name', 'Column public.menu_acl.role_name should exist');
+RETURN NEXT col_type_is(      'public', 'menu_acl', 'role_name', 'character varying', 'Column public.menu_acl.role_name should be type character varying');
+RETURN NEXT col_not_null(     'public', 'menu_acl', 'role_name', 'Column public.menu_acl.role_name should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'menu_acl', 'role_name', 'Column public.menu_acl.role_name should not have a default');
+
+RETURN NEXT has_column(       'public', 'menu_acl', 'acl_type', 'Column public.menu_acl.acl_type should exist');
+RETURN NEXT col_type_is(      'public', 'menu_acl', 'acl_type', 'character varying', 'Column public.menu_acl.acl_type should be type character varying');
+RETURN NEXT col_is_null(      'public', 'menu_acl', 'acl_type', 'Column public.menu_acl.acl_type should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'menu_acl', 'acl_type', 'Column public.menu_acl.acl_type should not have a default');
+
+RETURN NEXT has_column(       'public', 'menu_acl', 'node_id', 'Column public.menu_acl.node_id should exist');
+RETURN NEXT col_type_is(      'public', 'menu_acl', 'node_id', 'integer', 'Column public.menu_acl.node_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'menu_acl', 'node_id', 'Column public.menu_acl.node_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'menu_acl', 'node_id', 'Column public.menu_acl.node_id should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.menu_attribute.sql.pg_include
+++ b/xt/pgtap/table_public.menu_attribute.sql.pg_include
@@ -1,0 +1,45 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_menu_attribute()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'menu_attribute',
+    'Should have table public.menu_attribute'
+);
+
+RETURN NEXT has_pk(
+    'public', 'menu_attribute',
+    'Table public.menu_attribute should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'menu_attribute'::name, ARRAY[
+    'node_id'::name,
+    'attribute'::name,
+    'value'::name,
+    'id'::name
+]);
+
+RETURN NEXT has_column(       'public', 'menu_attribute', 'node_id', 'Column public.menu_attribute.node_id should exist');
+RETURN NEXT col_type_is(      'public', 'menu_attribute', 'node_id', 'integer', 'Column public.menu_attribute.node_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'menu_attribute', 'node_id', 'Column public.menu_attribute.node_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'menu_attribute', 'node_id', 'Column public.menu_attribute.node_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'menu_attribute', 'attribute', 'Column public.menu_attribute.attribute should exist');
+RETURN NEXT col_type_is(      'public', 'menu_attribute', 'attribute', 'character varying', 'Column public.menu_attribute.attribute should be type character varying');
+RETURN NEXT col_not_null(     'public', 'menu_attribute', 'attribute', 'Column public.menu_attribute.attribute should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'menu_attribute', 'attribute', 'Column public.menu_attribute.attribute should not have a default');
+
+RETURN NEXT has_column(       'public', 'menu_attribute', 'value', 'Column public.menu_attribute.value should exist');
+RETURN NEXT col_type_is(      'public', 'menu_attribute', 'value', 'character varying', 'Column public.menu_attribute.value should be type character varying');
+RETURN NEXT col_not_null(     'public', 'menu_attribute', 'value', 'Column public.menu_attribute.value should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'menu_attribute', 'value', 'Column public.menu_attribute.value should not have a default');
+
+RETURN NEXT has_column(       'public', 'menu_attribute', 'id', 'Column public.menu_attribute.id should exist');
+RETURN NEXT col_type_is(      'public', 'menu_attribute', 'id', 'integer', 'Column public.menu_attribute.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'menu_attribute', 'id', 'Column public.menu_attribute.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'menu_attribute', 'id', 'Column public.menu_attribute.id shouldhave a default');
+--SELECT col_default_is(   'public', 'menu_attribute', 'id', 'nextval(''menu_attribute_id_seq''::regclass)', 'Column public.menu_attribute.id default is');RETURN NEXT col_default_is(   'public', 'menu_attribute', 'id', 'nextval(''menu_attribute_id_seq''::regclass)', 'Column public.menu_attribute.id default is');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.menu_node.sql.pg_include
+++ b/xt/pgtap/table_public.menu_node.sql.pg_include
@@ -1,0 +1,45 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_menu_node()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'menu_node',
+    'Should have table public.menu_node'
+);
+
+RETURN NEXT has_pk(
+    'public', 'menu_node',
+    'Table public.menu_node should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'menu_node'::name, ARRAY[
+    'id'::name,
+    'label'::name,
+    'parent'::name,
+    'position'::name
+]);
+
+RETURN NEXT has_column(       'public', 'menu_node', 'id', 'Column public.menu_node.id should exist');
+RETURN NEXT col_type_is(      'public', 'menu_node', 'id', 'integer', 'Column public.menu_node.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'menu_node', 'id', 'Column public.menu_node.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'menu_node', 'id', 'Column public.menu_node.id shouldhave a default');
+--SELECT col_default_is(   'public', 'menu_node', 'id', 'nextval(''menu_node_id_seq''::regclass)', 'Column public.menu_node.id default is');RETURN NEXT col_default_is(   'public', 'menu_node', 'id', 'nextval(''menu_node_id_seq''::regclass)', 'Column public.menu_node.id default is');
+
+RETURN NEXT has_column(       'public', 'menu_node', 'label', 'Column public.menu_node.label should exist');
+RETURN NEXT col_type_is(      'public', 'menu_node', 'label', 'character varying', 'Column public.menu_node.label should be type character varying');
+RETURN NEXT col_not_null(     'public', 'menu_node', 'label', 'Column public.menu_node.label should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'menu_node', 'label', 'Column public.menu_node.label should not have a default');
+
+RETURN NEXT has_column(       'public', 'menu_node', 'parent', 'Column public.menu_node.parent should exist');
+RETURN NEXT col_type_is(      'public', 'menu_node', 'parent', 'integer', 'Column public.menu_node.parent should be type integer');
+RETURN NEXT col_is_null(      'public', 'menu_node', 'parent', 'Column public.menu_node.parent should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'menu_node', 'parent', 'Column public.menu_node.parent should not have a default');
+
+RETURN NEXT has_column(       'public', 'menu_node', 'position', 'Column public.menu_node."position" should exist');
+RETURN NEXT col_type_is(      'public', 'menu_node', 'position', 'integer', 'Column public.menu_node."position" should be type integer');
+RETURN NEXT col_not_null(     'public', 'menu_node', 'position', 'Column public.menu_node."position" should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'menu_node', 'position', 'Column public.menu_node."position" should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.mfg_lot.sql.pg_include
+++ b/xt/pgtap/table_public.mfg_lot.sql.pg_include
@@ -1,0 +1,53 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_mfg_lot()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'mfg_lot',
+    'Should have table public.mfg_lot'
+);
+
+RETURN NEXT hasnt_pk(
+    'public', 'mfg_lot',
+    'Table public.mfg_lot should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'mfg_lot'::name, ARRAY[
+    'id'::name,
+    'lot_number'::name,
+    'parts_id'::name,
+    'qty'::name,
+    'stock_date'::name
+]);
+
+RETURN NEXT has_column(       'public', 'mfg_lot', 'id', 'Column public.mfg_lot.id should exist');
+RETURN NEXT col_type_is(      'public', 'mfg_lot', 'id', 'integer', 'Column public.mfg_lot.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'mfg_lot', 'id', 'Column public.mfg_lot.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'mfg_lot', 'id', 'Column public.mfg_lot.id shouldhave a default');
+--SELECT col_default_is(   'public', 'mfg_lot', 'id', 'nextval(''mfg_lot_id_seq''::regclass)', 'Column public.mfg_lot.id default is');RETURN NEXT col_default_is(   'public', 'mfg_lot', 'id', 'nextval(''mfg_lot_id_seq''::regclass)', 'Column public.mfg_lot.id default is');
+
+RETURN NEXT has_column(       'public', 'mfg_lot', 'lot_number', 'Column public.mfg_lot.lot_number should exist');
+RETURN NEXT col_type_is(      'public', 'mfg_lot', 'lot_number', 'text', 'Column public.mfg_lot.lot_number should be type text');
+RETURN NEXT col_not_null(     'public', 'mfg_lot', 'lot_number', 'Column public.mfg_lot.lot_number should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'mfg_lot', 'lot_number', 'Column public.mfg_lot.lot_number shouldhave a default');
+--SELECT col_default_is(   'public', 'mfg_lot', 'lot_number', '(nextval(''lot_tracking_number''::regclass))::text', 'Column public.mfg_lot.lot_number default is');RETURN NEXT col_default_is(   'public', 'mfg_lot', 'lot_number', '(nextval(''lot_tracking_number''::regclass))::text', 'Column public.mfg_lot.lot_number default is');
+
+RETURN NEXT has_column(       'public', 'mfg_lot', 'parts_id', 'Column public.mfg_lot.parts_id should exist');
+RETURN NEXT col_type_is(      'public', 'mfg_lot', 'parts_id', 'integer', 'Column public.mfg_lot.parts_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'mfg_lot', 'parts_id', 'Column public.mfg_lot.parts_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'mfg_lot', 'parts_id', 'Column public.mfg_lot.parts_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'mfg_lot', 'qty', 'Column public.mfg_lot.qty should exist');
+RETURN NEXT col_type_is(      'public', 'mfg_lot', 'qty', 'numeric', 'Column public.mfg_lot.qty should be type numeric');
+RETURN NEXT col_not_null(     'public', 'mfg_lot', 'qty', 'Column public.mfg_lot.qty should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'mfg_lot', 'qty', 'Column public.mfg_lot.qty should not have a default');
+
+RETURN NEXT has_column(       'public', 'mfg_lot', 'stock_date', 'Column public.mfg_lot.stock_date should exist');
+RETURN NEXT col_type_is(      'public', 'mfg_lot', 'stock_date', 'date', 'Column public.mfg_lot.stock_date should be type date');
+RETURN NEXT col_not_null(     'public', 'mfg_lot', 'stock_date', 'Column public.mfg_lot.stock_date should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'mfg_lot', 'stock_date', 'Column public.mfg_lot.stock_date shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'mfg_lot', 'stock_date', '(now())::date', 'Column public.mfg_lot.stock_date default is');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.mfg_lot_item.sql.pg_include
+++ b/xt/pgtap/table_public.mfg_lot_item.sql.pg_include
@@ -1,0 +1,45 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_mfg_lot_item()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'mfg_lot_item',
+    'Should have table public.mfg_lot_item'
+);
+
+RETURN NEXT hasnt_pk(
+    'public', 'mfg_lot_item',
+    'Table public.mfg_lot_item should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'mfg_lot_item'::name, ARRAY[
+    'id'::name,
+    'mfg_lot_id'::name,
+    'parts_id'::name,
+    'qty'::name
+]);
+
+RETURN NEXT has_column(       'public', 'mfg_lot_item', 'id', 'Column public.mfg_lot_item.id should exist');
+RETURN NEXT col_type_is(      'public', 'mfg_lot_item', 'id', 'integer', 'Column public.mfg_lot_item.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'mfg_lot_item', 'id', 'Column public.mfg_lot_item.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'mfg_lot_item', 'id', 'Column public.mfg_lot_item.id shouldhave a default');
+--SELECT col_default_is(   'public', 'mfg_lot_item', 'id', 'nextval(''mfg_lot_item_id_seq''::regclass)', 'Column public.mfg_lot_item.id default is');RETURN NEXT col_default_is(   'public', 'mfg_lot_item', 'id', 'nextval(''mfg_lot_item_id_seq''::regclass)', 'Column public.mfg_lot_item.id default is');
+
+RETURN NEXT has_column(       'public', 'mfg_lot_item', 'mfg_lot_id', 'Column public.mfg_lot_item.mfg_lot_id should exist');
+RETURN NEXT col_type_is(      'public', 'mfg_lot_item', 'mfg_lot_id', 'integer', 'Column public.mfg_lot_item.mfg_lot_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'mfg_lot_item', 'mfg_lot_id', 'Column public.mfg_lot_item.mfg_lot_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'mfg_lot_item', 'mfg_lot_id', 'Column public.mfg_lot_item.mfg_lot_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'mfg_lot_item', 'parts_id', 'Column public.mfg_lot_item.parts_id should exist');
+RETURN NEXT col_type_is(      'public', 'mfg_lot_item', 'parts_id', 'integer', 'Column public.mfg_lot_item.parts_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'mfg_lot_item', 'parts_id', 'Column public.mfg_lot_item.parts_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'mfg_lot_item', 'parts_id', 'Column public.mfg_lot_item.parts_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'mfg_lot_item', 'qty', 'Column public.mfg_lot_item.qty should exist');
+RETURN NEXT col_type_is(      'public', 'mfg_lot_item', 'qty', 'numeric', 'Column public.mfg_lot_item.qty should be type numeric');
+RETURN NEXT col_not_null(     'public', 'mfg_lot_item', 'qty', 'Column public.mfg_lot_item.qty should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'mfg_lot_item', 'qty', 'Column public.mfg_lot_item.qty should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.mime_type.sql.pg_include
+++ b/xt/pgtap/table_public.mime_type.sql.pg_include
@@ -1,0 +1,40 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_mime_type()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'mime_type',
+    'Should have table public.mime_type'
+);
+
+RETURN NEXT has_pk(
+    'public', 'mime_type',
+    'Table public.mime_type should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'mime_type'::name, ARRAY[
+    'id'::name,
+    'mime_type'::name,
+    'invoice_include'::name
+]);
+
+RETURN NEXT has_column(       'public', 'mime_type', 'id', 'Column public.mime_type.id should exist');
+RETURN NEXT col_type_is(      'public', 'mime_type', 'id', 'integer', 'Column public.mime_type.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'mime_type', 'id', 'Column public.mime_type.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'mime_type', 'id', 'Column public.mime_type.id shouldhave a default');
+--SELECT col_default_is(   'public', 'mime_type', 'id', 'nextval(''mime_type_id_seq''::regclass)', 'Column public.mime_type.id default is');RETURN NEXT col_default_is(   'public', 'mime_type', 'id', 'nextval(''mime_type_id_seq''::regclass)', 'Column public.mime_type.id default is');
+
+RETURN NEXT has_column(       'public', 'mime_type', 'mime_type', 'Column public.mime_type.mime_type should exist');
+RETURN NEXT col_type_is(      'public', 'mime_type', 'mime_type', 'text', 'Column public.mime_type.mime_type should be type text');
+RETURN NEXT col_not_null(     'public', 'mime_type', 'mime_type', 'Column public.mime_type.mime_type should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'mime_type', 'mime_type', 'Column public.mime_type.mime_type should not have a default');
+
+RETURN NEXT has_column(       'public', 'mime_type', 'invoice_include', 'Column public.mime_type.invoice_include should exist');
+RETURN NEXT col_type_is(      'public', 'mime_type', 'invoice_include', 'boolean', 'Column public.mime_type.invoice_include should be type boolean');
+RETURN NEXT col_is_null(      'public', 'mime_type', 'invoice_include', 'Column public.mime_type.invoice_include should allow NULL');
+RETURN NEXT col_has_default(  'public', 'mime_type', 'invoice_include', 'Column public.mime_type.invoice_include shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'mime_type', 'invoice_include', 'false', 'Column public.mime_type.invoice_include default is');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.new_shipto.sql.pg_include
+++ b/xt/pgtap/table_public.new_shipto.sql.pg_include
@@ -1,0 +1,45 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_new_shipto()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'new_shipto',
+    'Should have table public.new_shipto'
+);
+
+RETURN NEXT has_pk(
+    'public', 'new_shipto',
+    'Table public.new_shipto should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'new_shipto'::name, ARRAY[
+    'id'::name,
+    'trans_id'::name,
+    'oe_id'::name,
+    'location_id'::name
+]);
+
+RETURN NEXT has_column(       'public', 'new_shipto', 'id', 'Column public.new_shipto.id should exist');
+RETURN NEXT col_type_is(      'public', 'new_shipto', 'id', 'integer', 'Column public.new_shipto.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'new_shipto', 'id', 'Column public.new_shipto.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'new_shipto', 'id', 'Column public.new_shipto.id shouldhave a default');
+--SELECT col_default_is(   'public', 'new_shipto', 'id', 'nextval(''new_shipto_id_seq''::regclass)', 'Column public.new_shipto.id default is');RETURN NEXT col_default_is(   'public', 'new_shipto', 'id', 'nextval(''new_shipto_id_seq''::regclass)', 'Column public.new_shipto.id default is');
+
+RETURN NEXT has_column(       'public', 'new_shipto', 'trans_id', 'Column public.new_shipto.trans_id should exist');
+RETURN NEXT col_type_is(      'public', 'new_shipto', 'trans_id', 'integer', 'Column public.new_shipto.trans_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'new_shipto', 'trans_id', 'Column public.new_shipto.trans_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'new_shipto', 'trans_id', 'Column public.new_shipto.trans_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'new_shipto', 'oe_id', 'Column public.new_shipto.oe_id should exist');
+RETURN NEXT col_type_is(      'public', 'new_shipto', 'oe_id', 'integer', 'Column public.new_shipto.oe_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'new_shipto', 'oe_id', 'Column public.new_shipto.oe_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'new_shipto', 'oe_id', 'Column public.new_shipto.oe_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'new_shipto', 'location_id', 'Column public.new_shipto.location_id should exist');
+RETURN NEXT col_type_is(      'public', 'new_shipto', 'location_id', 'integer', 'Column public.new_shipto.location_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'new_shipto', 'location_id', 'Column public.new_shipto.location_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'new_shipto', 'location_id', 'Column public.new_shipto.location_id should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.note.sql.pg_include
+++ b/xt/pgtap/table_public.note.sql.pg_include
@@ -1,0 +1,72 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_note()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'note',
+    'Should have table public.note'
+);
+
+RETURN NEXT has_pk(
+    'public', 'note',
+    'Table public.note should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'note'::name, ARRAY[
+    'id'::name,
+    'note_class'::name,
+    'note'::name,
+    'vector'::name,
+    'created'::name,
+    'created_by'::name,
+    'ref_key'::name,
+    'subject'::name
+]);
+
+RETURN NEXT has_column(       'public', 'note', 'id', 'Column public.note.id should exist');
+RETURN NEXT col_type_is(      'public', 'note', 'id', 'integer', 'Column public.note.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'note', 'id', 'Column public.note.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'note', 'id', 'Column public.note.id shouldhave a default');
+--SELECT col_default_is(   'public', 'note', 'id', 'nextval(''note_id_seq''::regclass)', 'Column public.note.id default is');RETURN NEXT col_default_is(   'public', 'note', 'id', 'nextval(''note_id_seq''::regclass)', 'Column public.note.id default is');
+
+RETURN NEXT has_column(       'public', 'note', 'note_class', 'Column public.note.note_class should exist');
+RETURN NEXT col_type_is(      'public', 'note', 'note_class', 'integer', 'Column public.note.note_class should be type integer');
+RETURN NEXT col_not_null(     'public', 'note', 'note_class', 'Column public.note.note_class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'note', 'note_class', 'Column public.note.note_class should not have a default');
+
+RETURN NEXT has_column(       'public', 'note', 'note', 'Column public.note.note should exist');
+RETURN NEXT col_type_is(      'public', 'note', 'note', 'text', 'Column public.note.note should be type text');
+RETURN NEXT col_not_null(     'public', 'note', 'note', 'Column public.note.note should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'note', 'note', 'Column public.note.note should not have a default');
+
+RETURN NEXT has_column(       'public', 'note', 'vector', 'Column public.note.vector should exist');
+RETURN NEXT col_type_is(      'public', 'note', 'vector', 'tsvector', 'Column public.note.vector should be type tsvector');
+RETURN NEXT col_not_null(     'public', 'note', 'vector', 'Column public.note.vector should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'note', 'vector', 'Column public.note.vector shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'note', 'vector', ''::tsvector, 'Column public.note.vector default is');
+
+RETURN NEXT has_column(       'public', 'note', 'created', 'Column public.note.created should exist');
+RETURN NEXT col_type_is(      'public', 'note', 'created', 'timestamp without time zone', 'Column public.note.created should be type timestamp without time zone');
+RETURN NEXT col_not_null(     'public', 'note', 'created', 'Column public.note.created should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'note', 'created', 'Column public.note.created shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'note', 'created', 'now()', 'Column public.note.created default is');
+
+RETURN NEXT has_column(       'public', 'note', 'created_by', 'Column public.note.created_by should exist');
+RETURN NEXT col_type_is(      'public', 'note', 'created_by', 'text', 'Column public.note.created_by should be type text');
+RETURN NEXT col_is_null(      'public', 'note', 'created_by', 'Column public.note.created_by should allow NULL');
+RETURN NEXT col_has_default(  'public', 'note', 'created_by', 'Column public.note.created_by shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'note', 'created_by', '"session_user"()', 'Column public.note.created_by default is');
+
+RETURN NEXT has_column(       'public', 'note', 'ref_key', 'Column public.note.ref_key should exist');
+RETURN NEXT col_type_is(      'public', 'note', 'ref_key', 'integer', 'Column public.note.ref_key should be type integer');
+RETURN NEXT col_not_null(     'public', 'note', 'ref_key', 'Column public.note.ref_key should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'note', 'ref_key', 'Column public.note.ref_key should not have a default');
+
+RETURN NEXT has_column(       'public', 'note', 'subject', 'Column public.note.subject should exist');
+RETURN NEXT col_type_is(      'public', 'note', 'subject', 'text', 'Column public.note.subject should be type text');
+RETURN NEXT col_is_null(      'public', 'note', 'subject', 'Column public.note.subject should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'note', 'subject', 'Column public.note.subject should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.note_class.sql.pg_include
+++ b/xt/pgtap/table_public.note_class.sql.pg_include
@@ -1,0 +1,33 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_note_class()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'note_class',
+    'Should have table public.note_class'
+);
+
+RETURN NEXT has_pk(
+    'public', 'note_class',
+    'Table public.note_class should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'note_class'::name, ARRAY[
+    'id'::name,
+    'class'::name
+]);
+
+RETURN NEXT has_column(       'public', 'note_class', 'id', 'Column public.note_class.id should exist');
+RETURN NEXT col_type_is(      'public', 'note_class', 'id', 'integer', 'Column public.note_class.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'note_class', 'id', 'Column public.note_class.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'note_class', 'id', 'Column public.note_class.id shouldhave a default');
+--SELECT col_default_is(   'public', 'note_class', 'id', 'nextval(''note_class_id_seq''::regclass)', 'Column public.note_class.id default is');RETURN NEXT col_default_is(   'public', 'note_class', 'id', 'nextval(''note_class_id_seq''::regclass)', 'Column public.note_class.id default is');
+
+RETURN NEXT has_column(       'public', 'note_class', 'class', 'Column public.note_class.class should exist');
+RETURN NEXT col_type_is(      'public', 'note_class', 'class', 'text', 'Column public.note_class.class should be type text');
+RETURN NEXT col_not_null(     'public', 'note_class', 'class', 'Column public.note_class.class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'note_class', 'class', 'Column public.note_class.class should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.oe.sql.pg_include
+++ b/xt/pgtap/table_public.oe.sql.pg_include
@@ -1,0 +1,157 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_oe()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'oe',
+    'Should have table public.oe'
+);
+
+RETURN NEXT has_pk(
+    'public', 'oe',
+    'Table public.oe should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'oe'::name, ARRAY[
+    'id'::name,
+    'ordnumber'::name,
+    'transdate'::name,
+    'entity_id'::name,
+    'amount'::name,
+    'netamount'::name,
+    'reqdate'::name,
+    'taxincluded'::name,
+    'shippingpoint'::name,
+    'notes'::name,
+    'curr'::name,
+    'person_id'::name,
+    'closed'::name,
+    'quotation'::name,
+    'quonumber'::name,
+    'intnotes'::name,
+    'shipvia'::name,
+    'language_code'::name,
+    'ponumber'::name,
+    'terms'::name,
+    'entity_credit_account'::name,
+    'oe_class_id'::name
+]);
+
+RETURN NEXT has_column(       'public', 'oe', 'id', 'Column public.oe.id should exist');
+RETURN NEXT col_type_is(      'public', 'oe', 'id', 'integer', 'Column public.oe.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'oe', 'id', 'Column public.oe.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'oe', 'id', 'Column public.oe.id shouldhave a default');
+--SELECT col_default_is(   'public', 'oe', 'id', 'nextval(''oe_id_seq''::regclass)', 'Column public.oe.id default is');RETURN NEXT col_default_is(   'public', 'oe', 'id', 'nextval(''oe_id_seq''::regclass)', 'Column public.oe.id default is');
+
+RETURN NEXT has_column(       'public', 'oe', 'ordnumber', 'Column public.oe.ordnumber should exist');
+RETURN NEXT col_type_is(      'public', 'oe', 'ordnumber', 'text', 'Column public.oe.ordnumber should be type text');
+RETURN NEXT col_is_null(      'public', 'oe', 'ordnumber', 'Column public.oe.ordnumber should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'oe', 'ordnumber', 'Column public.oe.ordnumber should not have a default');
+
+RETURN NEXT has_column(       'public', 'oe', 'transdate', 'Column public.oe.transdate should exist');
+RETURN NEXT col_type_is(      'public', 'oe', 'transdate', 'date', 'Column public.oe.transdate should be type date');
+RETURN NEXT col_is_null(      'public', 'oe', 'transdate', 'Column public.oe.transdate should allow NULL');
+RETURN NEXT col_has_default(  'public', 'oe', 'transdate', 'Column public.oe.transdate shouldhave a default');
+--SELECT col_default_is(   'public', 'oe', 'transdate', '(''now''::text)::date', 'Column public.oe.transdate default is');RETURN NEXT col_default_is(   'public', 'oe', 'transdate', '(''now''::text)::date', 'Column public.oe.transdate default is');
+
+RETURN NEXT has_column(       'public', 'oe', 'entity_id', 'Column public.oe.entity_id should exist');
+RETURN NEXT col_type_is(      'public', 'oe', 'entity_id', 'integer', 'Column public.oe.entity_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'oe', 'entity_id', 'Column public.oe.entity_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'oe', 'entity_id', 'Column public.oe.entity_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'oe', 'amount', 'Column public.oe.amount should exist');
+RETURN NEXT col_type_is(      'public', 'oe', 'amount', 'numeric', 'Column public.oe.amount should be type numeric');
+RETURN NEXT col_is_null(      'public', 'oe', 'amount', 'Column public.oe.amount should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'oe', 'amount', 'Column public.oe.amount should not have a default');
+
+RETURN NEXT has_column(       'public', 'oe', 'netamount', 'Column public.oe.netamount should exist');
+RETURN NEXT col_type_is(      'public', 'oe', 'netamount', 'numeric', 'Column public.oe.netamount should be type numeric');
+RETURN NEXT col_is_null(      'public', 'oe', 'netamount', 'Column public.oe.netamount should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'oe', 'netamount', 'Column public.oe.netamount should not have a default');
+
+RETURN NEXT has_column(       'public', 'oe', 'reqdate', 'Column public.oe.reqdate should exist');
+RETURN NEXT col_type_is(      'public', 'oe', 'reqdate', 'date', 'Column public.oe.reqdate should be type date');
+RETURN NEXT col_is_null(      'public', 'oe', 'reqdate', 'Column public.oe.reqdate should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'oe', 'reqdate', 'Column public.oe.reqdate should not have a default');
+
+RETURN NEXT has_column(       'public', 'oe', 'taxincluded', 'Column public.oe.taxincluded should exist');
+RETURN NEXT col_type_is(      'public', 'oe', 'taxincluded', 'boolean', 'Column public.oe.taxincluded should be type boolean');
+RETURN NEXT col_is_null(      'public', 'oe', 'taxincluded', 'Column public.oe.taxincluded should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'oe', 'taxincluded', 'Column public.oe.taxincluded should not have a default');
+
+RETURN NEXT has_column(       'public', 'oe', 'shippingpoint', 'Column public.oe.shippingpoint should exist');
+RETURN NEXT col_type_is(      'public', 'oe', 'shippingpoint', 'text', 'Column public.oe.shippingpoint should be type text');
+RETURN NEXT col_is_null(      'public', 'oe', 'shippingpoint', 'Column public.oe.shippingpoint should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'oe', 'shippingpoint', 'Column public.oe.shippingpoint should not have a default');
+
+RETURN NEXT has_column(       'public', 'oe', 'notes', 'Column public.oe.notes should exist');
+RETURN NEXT col_type_is(      'public', 'oe', 'notes', 'text', 'Column public.oe.notes should be type text');
+RETURN NEXT col_is_null(      'public', 'oe', 'notes', 'Column public.oe.notes should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'oe', 'notes', 'Column public.oe.notes should not have a default');
+
+RETURN NEXT has_column(       'public', 'oe', 'curr', 'Column public.oe.curr should exist');
+RETURN NEXT col_type_is(      'public', 'oe', 'curr', 'character(3)', 'Column public.oe.curr should be type character(3)');
+RETURN NEXT col_is_null(      'public', 'oe', 'curr', 'Column public.oe.curr should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'oe', 'curr', 'Column public.oe.curr should not have a default');
+
+RETURN NEXT has_column(       'public', 'oe', 'person_id', 'Column public.oe.person_id should exist');
+RETURN NEXT col_type_is(      'public', 'oe', 'person_id', 'integer', 'Column public.oe.person_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'oe', 'person_id', 'Column public.oe.person_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'oe', 'person_id', 'Column public.oe.person_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'oe', 'closed', 'Column public.oe.closed should exist');
+RETURN NEXT col_type_is(      'public', 'oe', 'closed', 'boolean', 'Column public.oe.closed should be type boolean');
+RETURN NEXT col_is_null(      'public', 'oe', 'closed', 'Column public.oe.closed should allow NULL');
+RETURN NEXT col_has_default(  'public', 'oe', 'closed', 'Column public.oe.closed shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'oe', 'closed', 'false', 'Column public.oe.closed default is');
+
+RETURN NEXT has_column(       'public', 'oe', 'quotation', 'Column public.oe.quotation should exist');
+RETURN NEXT col_type_is(      'public', 'oe', 'quotation', 'boolean', 'Column public.oe.quotation should be type boolean');
+RETURN NEXT col_is_null(      'public', 'oe', 'quotation', 'Column public.oe.quotation should allow NULL');
+RETURN NEXT col_has_default(  'public', 'oe', 'quotation', 'Column public.oe.quotation shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'oe', 'quotation', 'false', 'Column public.oe.quotation default is');
+
+RETURN NEXT has_column(       'public', 'oe', 'quonumber', 'Column public.oe.quonumber should exist');
+RETURN NEXT col_type_is(      'public', 'oe', 'quonumber', 'text', 'Column public.oe.quonumber should be type text');
+RETURN NEXT col_is_null(      'public', 'oe', 'quonumber', 'Column public.oe.quonumber should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'oe', 'quonumber', 'Column public.oe.quonumber should not have a default');
+
+RETURN NEXT has_column(       'public', 'oe', 'intnotes', 'Column public.oe.intnotes should exist');
+RETURN NEXT col_type_is(      'public', 'oe', 'intnotes', 'text', 'Column public.oe.intnotes should be type text');
+RETURN NEXT col_is_null(      'public', 'oe', 'intnotes', 'Column public.oe.intnotes should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'oe', 'intnotes', 'Column public.oe.intnotes should not have a default');
+
+RETURN NEXT has_column(       'public', 'oe', 'shipvia', 'Column public.oe.shipvia should exist');
+RETURN NEXT col_type_is(      'public', 'oe', 'shipvia', 'text', 'Column public.oe.shipvia should be type text');
+RETURN NEXT col_is_null(      'public', 'oe', 'shipvia', 'Column public.oe.shipvia should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'oe', 'shipvia', 'Column public.oe.shipvia should not have a default');
+
+RETURN NEXT has_column(       'public', 'oe', 'language_code', 'Column public.oe.language_code should exist');
+RETURN NEXT col_type_is(      'public', 'oe', 'language_code', 'character varying(6)', 'Column public.oe.language_code should be type character varying(6)');
+RETURN NEXT col_is_null(      'public', 'oe', 'language_code', 'Column public.oe.language_code should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'oe', 'language_code', 'Column public.oe.language_code should not have a default');
+
+RETURN NEXT has_column(       'public', 'oe', 'ponumber', 'Column public.oe.ponumber should exist');
+RETURN NEXT col_type_is(      'public', 'oe', 'ponumber', 'text', 'Column public.oe.ponumber should be type text');
+RETURN NEXT col_is_null(      'public', 'oe', 'ponumber', 'Column public.oe.ponumber should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'oe', 'ponumber', 'Column public.oe.ponumber should not have a default');
+
+RETURN NEXT has_column(       'public', 'oe', 'terms', 'Column public.oe.terms should exist');
+RETURN NEXT col_type_is(      'public', 'oe', 'terms', 'smallint', 'Column public.oe.terms should be type smallint');
+RETURN NEXT col_is_null(      'public', 'oe', 'terms', 'Column public.oe.terms should allow NULL');
+RETURN NEXT col_has_default(  'public', 'oe', 'terms', 'Column public.oe.terms shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'oe', 'terms', '0', 'Column public.oe.terms default is');
+
+RETURN NEXT has_column(       'public', 'oe', 'entity_credit_account', 'Column public.oe.entity_credit_account should exist');
+RETURN NEXT col_type_is(      'public', 'oe', 'entity_credit_account', 'integer', 'Column public.oe.entity_credit_account should be type integer');
+RETURN NEXT col_not_null(     'public', 'oe', 'entity_credit_account', 'Column public.oe.entity_credit_account should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'oe', 'entity_credit_account', 'Column public.oe.entity_credit_account should not have a default');
+
+RETURN NEXT has_column(       'public', 'oe', 'oe_class_id', 'Column public.oe.oe_class_id should exist');
+RETURN NEXT col_type_is(      'public', 'oe', 'oe_class_id', 'integer', 'Column public.oe.oe_class_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'oe', 'oe_class_id', 'Column public.oe.oe_class_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'oe', 'oe_class_id', 'Column public.oe.oe_class_id should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.oe_class.sql.pg_include
+++ b/xt/pgtap/table_public.oe_class.sql.pg_include
@@ -1,0 +1,32 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_oe_class()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'oe_class',
+    'Should have table public.oe_class'
+);
+
+RETURN NEXT has_pk(
+    'public', 'oe_class',
+    'Table public.oe_class should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'oe_class'::name, ARRAY[
+    'id'::name,
+    'oe_class'::name
+]);
+
+RETURN NEXT has_column(       'public', 'oe_class', 'id', 'Column public.oe_class.id should exist');
+RETURN NEXT col_type_is(      'public', 'oe_class', 'id', 'smallint', 'Column public.oe_class.id should be type smallint');
+RETURN NEXT col_is_null(      'public', 'oe_class', 'id', 'Column public.oe_class.id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'oe_class', 'id', 'Column public.oe_class.id should not have a default');
+
+RETURN NEXT has_column(       'public', 'oe_class', 'oe_class', 'Column public.oe_class.oe_class should exist');
+RETURN NEXT col_type_is(      'public', 'oe_class', 'oe_class', 'text', 'Column public.oe_class.oe_class should be type text');
+RETURN NEXT col_not_null(     'public', 'oe_class', 'oe_class', 'Column public.oe_class.oe_class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'oe_class', 'oe_class', 'Column public.oe_class.oe_class should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.open_forms.sql.pg_include
+++ b/xt/pgtap/table_public.open_forms.sql.pg_include
@@ -1,0 +1,45 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_open_forms()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'open_forms',
+    'Should have table public.open_forms'
+);
+
+RETURN NEXT has_pk(
+    'public', 'open_forms',
+    'Table public.open_forms should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'open_forms'::name, ARRAY[
+    'id'::name,
+    'session_id'::name,
+    'form_name'::name,
+    'last_used'::name
+]);
+
+RETURN NEXT has_column(       'public', 'open_forms', 'id', 'Column public.open_forms.id should exist');
+RETURN NEXT col_type_is(      'public', 'open_forms', 'id', 'integer', 'Column public.open_forms.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'open_forms', 'id', 'Column public.open_forms.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'open_forms', 'id', 'Column public.open_forms.id shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'open_forms', 'id', '(floor((random() * (1000000)::double precision)) + (1)::double precision)', 'Column public.open_forms.id default is');
+
+RETURN NEXT has_column(       'public', 'open_forms', 'session_id', 'Column public.open_forms.session_id should exist');
+RETURN NEXT col_type_is(      'public', 'open_forms', 'session_id', 'integer', 'Column public.open_forms.session_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'open_forms', 'session_id', 'Column public.open_forms.session_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'open_forms', 'session_id', 'Column public.open_forms.session_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'open_forms', 'form_name', 'Column public.open_forms.form_name should exist');
+RETURN NEXT col_type_is(      'public', 'open_forms', 'form_name', 'character varying(100)', 'Column public.open_forms.form_name should be type character varying(100)');
+RETURN NEXT col_is_null(      'public', 'open_forms', 'form_name', 'Column public.open_forms.form_name should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'open_forms', 'form_name', 'Column public.open_forms.form_name should not have a default');
+
+RETURN NEXT has_column(       'public', 'open_forms', 'last_used', 'Column public.open_forms.last_used should exist');
+RETURN NEXT col_type_is(      'public', 'open_forms', 'last_used', 'timestamp without time zone', 'Column public.open_forms.last_used should be type timestamp without time zone');
+RETURN NEXT col_is_null(      'public', 'open_forms', 'last_used', 'Column public.open_forms.last_used should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'open_forms', 'last_used', 'Column public.open_forms.last_used should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.orderitems.sql.pg_include
+++ b/xt/pgtap/table_public.orderitems.sql.pg_include
@@ -1,0 +1,99 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_orderitems()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'orderitems',
+    'Should have table public.orderitems'
+);
+
+RETURN NEXT has_pk(
+    'public', 'orderitems',
+    'Table public.orderitems should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'orderitems'::name, ARRAY[
+    'id'::name,
+    'trans_id'::name,
+    'parts_id'::name,
+    'description'::name,
+    'qty'::name,
+    'sellprice'::name,
+    'precision'::name,
+    'discount'::name,
+    'unit'::name,
+    'reqdate'::name,
+    'ship'::name,
+    'serialnumber'::name,
+    'notes'::name
+]);
+
+RETURN NEXT has_column(       'public', 'orderitems', 'id', 'Column public.orderitems.id should exist');
+RETURN NEXT col_type_is(      'public', 'orderitems', 'id', 'integer', 'Column public.orderitems.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'orderitems', 'id', 'Column public.orderitems.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'orderitems', 'id', 'Column public.orderitems.id shouldhave a default');
+--SELECT col_default_is(   'public', 'orderitems', 'id', 'nextval(''orderitems_id_seq''::regclass)', 'Column public.orderitems.id default is');RETURN NEXT col_default_is(   'public', 'orderitems', 'id', 'nextval(''orderitems_id_seq''::regclass)', 'Column public.orderitems.id default is');
+
+RETURN NEXT has_column(       'public', 'orderitems', 'trans_id', 'Column public.orderitems.trans_id should exist');
+RETURN NEXT col_type_is(      'public', 'orderitems', 'trans_id', 'integer', 'Column public.orderitems.trans_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'orderitems', 'trans_id', 'Column public.orderitems.trans_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'orderitems', 'trans_id', 'Column public.orderitems.trans_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'orderitems', 'parts_id', 'Column public.orderitems.parts_id should exist');
+RETURN NEXT col_type_is(      'public', 'orderitems', 'parts_id', 'integer', 'Column public.orderitems.parts_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'orderitems', 'parts_id', 'Column public.orderitems.parts_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'orderitems', 'parts_id', 'Column public.orderitems.parts_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'orderitems', 'description', 'Column public.orderitems.description should exist');
+RETURN NEXT col_type_is(      'public', 'orderitems', 'description', 'text', 'Column public.orderitems.description should be type text');
+RETURN NEXT col_is_null(      'public', 'orderitems', 'description', 'Column public.orderitems.description should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'orderitems', 'description', 'Column public.orderitems.description should not have a default');
+
+RETURN NEXT has_column(       'public', 'orderitems', 'qty', 'Column public.orderitems.qty should exist');
+RETURN NEXT col_type_is(      'public', 'orderitems', 'qty', 'numeric', 'Column public.orderitems.qty should be type numeric');
+RETURN NEXT col_is_null(      'public', 'orderitems', 'qty', 'Column public.orderitems.qty should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'orderitems', 'qty', 'Column public.orderitems.qty should not have a default');
+
+RETURN NEXT has_column(       'public', 'orderitems', 'sellprice', 'Column public.orderitems.sellprice should exist');
+RETURN NEXT col_type_is(      'public', 'orderitems', 'sellprice', 'numeric', 'Column public.orderitems.sellprice should be type numeric');
+RETURN NEXT col_is_null(      'public', 'orderitems', 'sellprice', 'Column public.orderitems.sellprice should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'orderitems', 'sellprice', 'Column public.orderitems.sellprice should not have a default');
+
+RETURN NEXT has_column(       'public', 'orderitems', 'precision', 'Column public.orderitems."precision" should exist');
+RETURN NEXT col_type_is(      'public', 'orderitems', 'precision', 'integer', 'Column public.orderitems."precision" should be type integer');
+RETURN NEXT col_is_null(      'public', 'orderitems', 'precision', 'Column public.orderitems."precision" should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'orderitems', 'precision', 'Column public.orderitems."precision" should not have a default');
+
+RETURN NEXT has_column(       'public', 'orderitems', 'discount', 'Column public.orderitems.discount should exist');
+RETURN NEXT col_type_is(      'public', 'orderitems', 'discount', 'numeric', 'Column public.orderitems.discount should be type numeric');
+RETURN NEXT col_is_null(      'public', 'orderitems', 'discount', 'Column public.orderitems.discount should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'orderitems', 'discount', 'Column public.orderitems.discount should not have a default');
+
+RETURN NEXT has_column(       'public', 'orderitems', 'unit', 'Column public.orderitems.unit should exist');
+RETURN NEXT col_type_is(      'public', 'orderitems', 'unit', 'character varying(5)', 'Column public.orderitems.unit should be type character varying(5)');
+RETURN NEXT col_is_null(      'public', 'orderitems', 'unit', 'Column public.orderitems.unit should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'orderitems', 'unit', 'Column public.orderitems.unit should not have a default');
+
+RETURN NEXT has_column(       'public', 'orderitems', 'reqdate', 'Column public.orderitems.reqdate should exist');
+RETURN NEXT col_type_is(      'public', 'orderitems', 'reqdate', 'date', 'Column public.orderitems.reqdate should be type date');
+RETURN NEXT col_is_null(      'public', 'orderitems', 'reqdate', 'Column public.orderitems.reqdate should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'orderitems', 'reqdate', 'Column public.orderitems.reqdate should not have a default');
+
+RETURN NEXT has_column(       'public', 'orderitems', 'ship', 'Column public.orderitems.ship should exist');
+RETURN NEXT col_type_is(      'public', 'orderitems', 'ship', 'numeric', 'Column public.orderitems.ship should be type numeric');
+RETURN NEXT col_is_null(      'public', 'orderitems', 'ship', 'Column public.orderitems.ship should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'orderitems', 'ship', 'Column public.orderitems.ship should not have a default');
+
+RETURN NEXT has_column(       'public', 'orderitems', 'serialnumber', 'Column public.orderitems.serialnumber should exist');
+RETURN NEXT col_type_is(      'public', 'orderitems', 'serialnumber', 'text', 'Column public.orderitems.serialnumber should be type text');
+RETURN NEXT col_is_null(      'public', 'orderitems', 'serialnumber', 'Column public.orderitems.serialnumber should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'orderitems', 'serialnumber', 'Column public.orderitems.serialnumber should not have a default');
+
+RETURN NEXT has_column(       'public', 'orderitems', 'notes', 'Column public.orderitems.notes should exist');
+RETURN NEXT col_type_is(      'public', 'orderitems', 'notes', 'text', 'Column public.orderitems.notes should be type text');
+RETURN NEXT col_is_null(      'public', 'orderitems', 'notes', 'Column public.orderitems.notes should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'orderitems', 'notes', 'Column public.orderitems.notes should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.parts.sql.pg_include
+++ b/xt/pgtap/table_public.parts.sql.pg_include
@@ -1,0 +1,190 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_parts()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'parts',
+    'Should have table public.parts'
+);
+
+RETURN NEXT has_pk(
+    'public', 'parts',
+    'Table public.parts should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'parts'::name, ARRAY[
+    'id'::name,
+    'partnumber'::name,
+    'description'::name,
+    'unit'::name,
+    'listprice'::name,
+    'sellprice'::name,
+    'lastcost'::name,
+    'priceupdate'::name,
+    'weight'::name,
+    'onhand'::name,
+    'notes'::name,
+    'makemodel'::name,
+    'assembly'::name,
+    'alternate'::name,
+    'rop'::name,
+    'inventory_accno_id'::name,
+    'income_accno_id'::name,
+    'expense_accno_id'::name,
+    'returns_accno_id'::name,
+    'bin'::name,
+    'obsolete'::name,
+    'bom'::name,
+    'image'::name,
+    'drawing'::name,
+    'microfiche'::name,
+    'partsgroup_id'::name,
+    'avgcost'::name
+]);
+
+RETURN NEXT has_column(       'public', 'parts', 'id', 'Column public.parts.id should exist');
+RETURN NEXT col_type_is(      'public', 'parts', 'id', 'integer', 'Column public.parts.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'parts', 'id', 'Column public.parts.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'parts', 'id', 'Column public.parts.id shouldhave a default');
+--SELECT col_default_is(   'public', 'parts', 'id', 'nextval(''parts_id_seq''::regclass)', 'Column public.parts.id default is');RETURN NEXT col_default_is(   'public', 'parts', 'id', 'nextval(''parts_id_seq''::regclass)', 'Column public.parts.id default is');
+
+RETURN NEXT has_column(       'public', 'parts', 'partnumber', 'Column public.parts.partnumber should exist');
+RETURN NEXT col_type_is(      'public', 'parts', 'partnumber', 'text', 'Column public.parts.partnumber should be type text');
+RETURN NEXT col_is_null(      'public', 'parts', 'partnumber', 'Column public.parts.partnumber should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'parts', 'partnumber', 'Column public.parts.partnumber should not have a default');
+
+RETURN NEXT has_column(       'public', 'parts', 'description', 'Column public.parts.description should exist');
+RETURN NEXT col_type_is(      'public', 'parts', 'description', 'text', 'Column public.parts.description should be type text');
+RETURN NEXT col_is_null(      'public', 'parts', 'description', 'Column public.parts.description should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'parts', 'description', 'Column public.parts.description should not have a default');
+
+RETURN NEXT has_column(       'public', 'parts', 'unit', 'Column public.parts.unit should exist');
+RETURN NEXT col_type_is(      'public', 'parts', 'unit', 'character varying(5)', 'Column public.parts.unit should be type character varying(5)');
+RETURN NEXT col_is_null(      'public', 'parts', 'unit', 'Column public.parts.unit should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'parts', 'unit', 'Column public.parts.unit should not have a default');
+
+RETURN NEXT has_column(       'public', 'parts', 'listprice', 'Column public.parts.listprice should exist');
+RETURN NEXT col_type_is(      'public', 'parts', 'listprice', 'numeric', 'Column public.parts.listprice should be type numeric');
+RETURN NEXT col_is_null(      'public', 'parts', 'listprice', 'Column public.parts.listprice should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'parts', 'listprice', 'Column public.parts.listprice should not have a default');
+
+RETURN NEXT has_column(       'public', 'parts', 'sellprice', 'Column public.parts.sellprice should exist');
+RETURN NEXT col_type_is(      'public', 'parts', 'sellprice', 'numeric', 'Column public.parts.sellprice should be type numeric');
+RETURN NEXT col_is_null(      'public', 'parts', 'sellprice', 'Column public.parts.sellprice should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'parts', 'sellprice', 'Column public.parts.sellprice should not have a default');
+
+RETURN NEXT has_column(       'public', 'parts', 'lastcost', 'Column public.parts.lastcost should exist');
+RETURN NEXT col_type_is(      'public', 'parts', 'lastcost', 'numeric', 'Column public.parts.lastcost should be type numeric');
+RETURN NEXT col_is_null(      'public', 'parts', 'lastcost', 'Column public.parts.lastcost should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'parts', 'lastcost', 'Column public.parts.lastcost should not have a default');
+
+RETURN NEXT has_column(       'public', 'parts', 'priceupdate', 'Column public.parts.priceupdate should exist');
+RETURN NEXT col_type_is(      'public', 'parts', 'priceupdate', 'date', 'Column public.parts.priceupdate should be type date');
+RETURN NEXT col_is_null(      'public', 'parts', 'priceupdate', 'Column public.parts.priceupdate should allow NULL');
+RETURN NEXT col_has_default(  'public', 'parts', 'priceupdate', 'Column public.parts.priceupdate shouldhave a default');
+--SELECT col_default_is(   'public', 'parts', 'priceupdate', '(''now''::text)::date', 'Column public.parts.priceupdate default is');RETURN NEXT col_default_is(   'public', 'parts', 'priceupdate', '(''now''::text)::date', 'Column public.parts.priceupdate default is');
+
+RETURN NEXT has_column(       'public', 'parts', 'weight', 'Column public.parts.weight should exist');
+RETURN NEXT col_type_is(      'public', 'parts', 'weight', 'numeric', 'Column public.parts.weight should be type numeric');
+RETURN NEXT col_is_null(      'public', 'parts', 'weight', 'Column public.parts.weight should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'parts', 'weight', 'Column public.parts.weight should not have a default');
+
+RETURN NEXT has_column(       'public', 'parts', 'onhand', 'Column public.parts.onhand should exist');
+RETURN NEXT col_type_is(      'public', 'parts', 'onhand', 'numeric', 'Column public.parts.onhand should be type numeric');
+RETURN NEXT col_is_null(      'public', 'parts', 'onhand', 'Column public.parts.onhand should allow NULL');
+RETURN NEXT col_has_default(  'public', 'parts', 'onhand', 'Column public.parts.onhand shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'parts', 'onhand', '0', 'Column public.parts.onhand default is');
+
+RETURN NEXT has_column(       'public', 'parts', 'notes', 'Column public.parts.notes should exist');
+RETURN NEXT col_type_is(      'public', 'parts', 'notes', 'text', 'Column public.parts.notes should be type text');
+RETURN NEXT col_is_null(      'public', 'parts', 'notes', 'Column public.parts.notes should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'parts', 'notes', 'Column public.parts.notes should not have a default');
+
+RETURN NEXT has_column(       'public', 'parts', 'makemodel', 'Column public.parts.makemodel should exist');
+RETURN NEXT col_type_is(      'public', 'parts', 'makemodel', 'boolean', 'Column public.parts.makemodel should be type boolean');
+RETURN NEXT col_is_null(      'public', 'parts', 'makemodel', 'Column public.parts.makemodel should allow NULL');
+RETURN NEXT col_has_default(  'public', 'parts', 'makemodel', 'Column public.parts.makemodel shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'parts', 'makemodel', 'false', 'Column public.parts.makemodel default is');
+
+RETURN NEXT has_column(       'public', 'parts', 'assembly', 'Column public.parts.assembly should exist');
+RETURN NEXT col_type_is(      'public', 'parts', 'assembly', 'boolean', 'Column public.parts.assembly should be type boolean');
+RETURN NEXT col_is_null(      'public', 'parts', 'assembly', 'Column public.parts.assembly should allow NULL');
+RETURN NEXT col_has_default(  'public', 'parts', 'assembly', 'Column public.parts.assembly shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'parts', 'assembly', 'false', 'Column public.parts.assembly default is');
+
+RETURN NEXT has_column(       'public', 'parts', 'alternate', 'Column public.parts.alternate should exist');
+RETURN NEXT col_type_is(      'public', 'parts', 'alternate', 'boolean', 'Column public.parts.alternate should be type boolean');
+RETURN NEXT col_is_null(      'public', 'parts', 'alternate', 'Column public.parts.alternate should allow NULL');
+RETURN NEXT col_has_default(  'public', 'parts', 'alternate', 'Column public.parts.alternate shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'parts', 'alternate', 'false', 'Column public.parts.alternate default is');
+
+RETURN NEXT has_column(       'public', 'parts', 'rop', 'Column public.parts.rop should exist');
+RETURN NEXT col_type_is(      'public', 'parts', 'rop', 'numeric', 'Column public.parts.rop should be type numeric');
+RETURN NEXT col_is_null(      'public', 'parts', 'rop', 'Column public.parts.rop should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'parts', 'rop', 'Column public.parts.rop should not have a default');
+
+RETURN NEXT has_column(       'public', 'parts', 'inventory_accno_id', 'Column public.parts.inventory_accno_id should exist');
+RETURN NEXT col_type_is(      'public', 'parts', 'inventory_accno_id', 'integer', 'Column public.parts.inventory_accno_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'parts', 'inventory_accno_id', 'Column public.parts.inventory_accno_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'parts', 'inventory_accno_id', 'Column public.parts.inventory_accno_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'parts', 'income_accno_id', 'Column public.parts.income_accno_id should exist');
+RETURN NEXT col_type_is(      'public', 'parts', 'income_accno_id', 'integer', 'Column public.parts.income_accno_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'parts', 'income_accno_id', 'Column public.parts.income_accno_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'parts', 'income_accno_id', 'Column public.parts.income_accno_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'parts', 'expense_accno_id', 'Column public.parts.expense_accno_id should exist');
+RETURN NEXT col_type_is(      'public', 'parts', 'expense_accno_id', 'integer', 'Column public.parts.expense_accno_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'parts', 'expense_accno_id', 'Column public.parts.expense_accno_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'parts', 'expense_accno_id', 'Column public.parts.expense_accno_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'parts', 'returns_accno_id', 'Column public.parts.returns_accno_id should exist');
+RETURN NEXT col_type_is(      'public', 'parts', 'returns_accno_id', 'integer', 'Column public.parts.returns_accno_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'parts', 'returns_accno_id', 'Column public.parts.returns_accno_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'parts', 'returns_accno_id', 'Column public.parts.returns_accno_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'parts', 'bin', 'Column public.parts.bin should exist');
+RETURN NEXT col_type_is(      'public', 'parts', 'bin', 'text', 'Column public.parts.bin should be type text');
+RETURN NEXT col_is_null(      'public', 'parts', 'bin', 'Column public.parts.bin should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'parts', 'bin', 'Column public.parts.bin should not have a default');
+
+RETURN NEXT has_column(       'public', 'parts', 'obsolete', 'Column public.parts.obsolete should exist');
+RETURN NEXT col_type_is(      'public', 'parts', 'obsolete', 'boolean', 'Column public.parts.obsolete should be type boolean');
+RETURN NEXT col_is_null(      'public', 'parts', 'obsolete', 'Column public.parts.obsolete should allow NULL');
+RETURN NEXT col_has_default(  'public', 'parts', 'obsolete', 'Column public.parts.obsolete shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'parts', 'obsolete', 'false', 'Column public.parts.obsolete default is');
+
+RETURN NEXT has_column(       'public', 'parts', 'bom', 'Column public.parts.bom should exist');
+RETURN NEXT col_type_is(      'public', 'parts', 'bom', 'boolean', 'Column public.parts.bom should be type boolean');
+RETURN NEXT col_is_null(      'public', 'parts', 'bom', 'Column public.parts.bom should allow NULL');
+RETURN NEXT col_has_default(  'public', 'parts', 'bom', 'Column public.parts.bom shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'parts', 'bom', 'false', 'Column public.parts.bom default is');
+
+RETURN NEXT has_column(       'public', 'parts', 'image', 'Column public.parts.image should exist');
+RETURN NEXT col_type_is(      'public', 'parts', 'image', 'text', 'Column public.parts.image should be type text');
+RETURN NEXT col_is_null(      'public', 'parts', 'image', 'Column public.parts.image should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'parts', 'image', 'Column public.parts.image should not have a default');
+
+RETURN NEXT has_column(       'public', 'parts', 'drawing', 'Column public.parts.drawing should exist');
+RETURN NEXT col_type_is(      'public', 'parts', 'drawing', 'text', 'Column public.parts.drawing should be type text');
+RETURN NEXT col_is_null(      'public', 'parts', 'drawing', 'Column public.parts.drawing should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'parts', 'drawing', 'Column public.parts.drawing should not have a default');
+
+RETURN NEXT has_column(       'public', 'parts', 'microfiche', 'Column public.parts.microfiche should exist');
+RETURN NEXT col_type_is(      'public', 'parts', 'microfiche', 'text', 'Column public.parts.microfiche should be type text');
+RETURN NEXT col_is_null(      'public', 'parts', 'microfiche', 'Column public.parts.microfiche should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'parts', 'microfiche', 'Column public.parts.microfiche should not have a default');
+
+RETURN NEXT has_column(       'public', 'parts', 'partsgroup_id', 'Column public.parts.partsgroup_id should exist');
+RETURN NEXT col_type_is(      'public', 'parts', 'partsgroup_id', 'integer', 'Column public.parts.partsgroup_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'parts', 'partsgroup_id', 'Column public.parts.partsgroup_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'parts', 'partsgroup_id', 'Column public.parts.partsgroup_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'parts', 'avgcost', 'Column public.parts.avgcost should exist');
+RETURN NEXT col_type_is(      'public', 'parts', 'avgcost', 'numeric', 'Column public.parts.avgcost should be type numeric');
+RETURN NEXT col_is_null(      'public', 'parts', 'avgcost', 'Column public.parts.avgcost should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'parts', 'avgcost', 'Column public.parts.avgcost should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.parts_translation.sql.pg_include
+++ b/xt/pgtap/table_public.parts_translation.sql.pg_include
@@ -1,0 +1,38 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_parts_translation()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'parts_translation',
+    'Should have table public.parts_translation'
+);
+
+RETURN NEXT has_pk(
+    'public', 'parts_translation',
+    'Table public.parts_translation should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'parts_translation'::name, ARRAY[
+    'trans_id'::name,
+    'language_code'::name,
+    'description'::name
+]);
+
+RETURN NEXT has_column(       'public', 'parts_translation', 'trans_id', 'Column public.parts_translation.trans_id should exist');
+RETURN NEXT col_type_is(      'public', 'parts_translation', 'trans_id', 'integer', 'Column public.parts_translation.trans_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'parts_translation', 'trans_id', 'Column public.parts_translation.trans_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'parts_translation', 'trans_id', 'Column public.parts_translation.trans_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'parts_translation', 'language_code', 'Column public.parts_translation.language_code should exist');
+RETURN NEXT col_type_is(      'public', 'parts_translation', 'language_code', 'character varying(6)', 'Column public.parts_translation.language_code should be type character varying(6)');
+RETURN NEXT col_not_null(     'public', 'parts_translation', 'language_code', 'Column public.parts_translation.language_code should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'parts_translation', 'language_code', 'Column public.parts_translation.language_code should not have a default');
+
+RETURN NEXT has_column(       'public', 'parts_translation', 'description', 'Column public.parts_translation.description should exist');
+RETURN NEXT col_type_is(      'public', 'parts_translation', 'description', 'text', 'Column public.parts_translation.description should be type text');
+RETURN NEXT col_is_null(      'public', 'parts_translation', 'description', 'Column public.parts_translation.description should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'parts_translation', 'description', 'Column public.parts_translation.description should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.partscustomer.sql.pg_include
+++ b/xt/pgtap/table_public.partscustomer.sql.pg_include
@@ -1,0 +1,82 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_partscustomer()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'partscustomer',
+    'Should have table public.partscustomer'
+);
+
+RETURN NEXT has_pk(
+    'public', 'partscustomer',
+    'Table public.partscustomer should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'partscustomer'::name, ARRAY[
+    'parts_id'::name,
+    'credit_id'::name,
+    'pricegroup_id'::name,
+    'pricebreak'::name,
+    'sellprice'::name,
+    'validfrom'::name,
+    'validto'::name,
+    'curr'::name,
+    'entry_id'::name,
+    'qty'::name
+]);
+
+RETURN NEXT has_column(       'public', 'partscustomer', 'parts_id', 'Column public.partscustomer.parts_id should exist');
+RETURN NEXT col_type_is(      'public', 'partscustomer', 'parts_id', 'integer', 'Column public.partscustomer.parts_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'partscustomer', 'parts_id', 'Column public.partscustomer.parts_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'partscustomer', 'parts_id', 'Column public.partscustomer.parts_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'partscustomer', 'credit_id', 'Column public.partscustomer.credit_id should exist');
+RETURN NEXT col_type_is(      'public', 'partscustomer', 'credit_id', 'integer', 'Column public.partscustomer.credit_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'partscustomer', 'credit_id', 'Column public.partscustomer.credit_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'partscustomer', 'credit_id', 'Column public.partscustomer.credit_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'partscustomer', 'pricegroup_id', 'Column public.partscustomer.pricegroup_id should exist');
+RETURN NEXT col_type_is(      'public', 'partscustomer', 'pricegroup_id', 'integer', 'Column public.partscustomer.pricegroup_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'partscustomer', 'pricegroup_id', 'Column public.partscustomer.pricegroup_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'partscustomer', 'pricegroup_id', 'Column public.partscustomer.pricegroup_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'partscustomer', 'pricebreak', 'Column public.partscustomer.pricebreak should exist');
+RETURN NEXT col_type_is(      'public', 'partscustomer', 'pricebreak', 'numeric', 'Column public.partscustomer.pricebreak should be type numeric');
+RETURN NEXT col_is_null(      'public', 'partscustomer', 'pricebreak', 'Column public.partscustomer.pricebreak should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'partscustomer', 'pricebreak', 'Column public.partscustomer.pricebreak should not have a default');
+
+RETURN NEXT has_column(       'public', 'partscustomer', 'sellprice', 'Column public.partscustomer.sellprice should exist');
+RETURN NEXT col_type_is(      'public', 'partscustomer', 'sellprice', 'numeric', 'Column public.partscustomer.sellprice should be type numeric');
+RETURN NEXT col_is_null(      'public', 'partscustomer', 'sellprice', 'Column public.partscustomer.sellprice should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'partscustomer', 'sellprice', 'Column public.partscustomer.sellprice should not have a default');
+
+RETURN NEXT has_column(       'public', 'partscustomer', 'validfrom', 'Column public.partscustomer.validfrom should exist');
+RETURN NEXT col_type_is(      'public', 'partscustomer', 'validfrom', 'date', 'Column public.partscustomer.validfrom should be type date');
+RETURN NEXT col_is_null(      'public', 'partscustomer', 'validfrom', 'Column public.partscustomer.validfrom should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'partscustomer', 'validfrom', 'Column public.partscustomer.validfrom should not have a default');
+
+RETURN NEXT has_column(       'public', 'partscustomer', 'validto', 'Column public.partscustomer.validto should exist');
+RETURN NEXT col_type_is(      'public', 'partscustomer', 'validto', 'date', 'Column public.partscustomer.validto should be type date');
+RETURN NEXT col_is_null(      'public', 'partscustomer', 'validto', 'Column public.partscustomer.validto should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'partscustomer', 'validto', 'Column public.partscustomer.validto should not have a default');
+
+RETURN NEXT has_column(       'public', 'partscustomer', 'curr', 'Column public.partscustomer.curr should exist');
+RETURN NEXT col_type_is(      'public', 'partscustomer', 'curr', 'character(3)', 'Column public.partscustomer.curr should be type character(3)');
+RETURN NEXT col_is_null(      'public', 'partscustomer', 'curr', 'Column public.partscustomer.curr should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'partscustomer', 'curr', 'Column public.partscustomer.curr should not have a default');
+
+RETURN NEXT has_column(       'public', 'partscustomer', 'entry_id', 'Column public.partscustomer.entry_id should exist');
+RETURN NEXT col_type_is(      'public', 'partscustomer', 'entry_id', 'integer', 'Column public.partscustomer.entry_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'partscustomer', 'entry_id', 'Column public.partscustomer.entry_id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'partscustomer', 'entry_id', 'Column public.partscustomer.entry_id shouldhave a default');
+--SELECT col_default_is(   'public', 'partscustomer', 'entry_id', 'nextval(''partscustomer_entry_id_seq''::regclass)', 'Column public.partscustomer.entry_id default is');RETURN NEXT col_default_is(   'public', 'partscustomer', 'entry_id', 'nextval(''partscustomer_entry_id_seq''::regclass)', 'Column public.partscustomer.entry_id default is');
+
+RETURN NEXT has_column(       'public', 'partscustomer', 'qty', 'Column public.partscustomer.qty should exist');
+RETURN NEXT col_type_is(      'public', 'partscustomer', 'qty', 'numeric', 'Column public.partscustomer.qty should be type numeric');
+RETURN NEXT col_is_null(      'public', 'partscustomer', 'qty', 'Column public.partscustomer.qty should allow NULL');
+RETURN NEXT col_has_default(  'public', 'partscustomer', 'qty', 'Column public.partscustomer.qty shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'partscustomer', 'qty', '0', 'Column public.partscustomer.qty default is');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.partsgroup.sql.pg_include
+++ b/xt/pgtap/table_public.partsgroup.sql.pg_include
@@ -1,0 +1,39 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_partsgroup()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'partsgroup',
+    'Should have table public.partsgroup'
+);
+
+RETURN NEXT has_pk(
+    'public', 'partsgroup',
+    'Table public.partsgroup should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'partsgroup'::name, ARRAY[
+    'id'::name,
+    'partsgroup'::name,
+    'parent'::name
+]);
+
+RETURN NEXT has_column(       'public', 'partsgroup', 'id', 'Column public.partsgroup.id should exist');
+RETURN NEXT col_type_is(      'public', 'partsgroup', 'id', 'integer', 'Column public.partsgroup.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'partsgroup', 'id', 'Column public.partsgroup.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'partsgroup', 'id', 'Column public.partsgroup.id shouldhave a default');
+--SELECT col_default_is(   'public', 'partsgroup', 'id', 'nextval(''partsgroup_id_seq''::regclass)', 'Column public.partsgroup.id default is');RETURN NEXT col_default_is(   'public', 'partsgroup', 'id', 'nextval(''partsgroup_id_seq''::regclass)', 'Column public.partsgroup.id default is');
+
+RETURN NEXT has_column(       'public', 'partsgroup', 'partsgroup', 'Column public.partsgroup.partsgroup should exist');
+RETURN NEXT col_type_is(      'public', 'partsgroup', 'partsgroup', 'text', 'Column public.partsgroup.partsgroup should be type text');
+RETURN NEXT col_is_null(      'public', 'partsgroup', 'partsgroup', 'Column public.partsgroup.partsgroup should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'partsgroup', 'partsgroup', 'Column public.partsgroup.partsgroup should not have a default');
+
+RETURN NEXT has_column(       'public', 'partsgroup', 'parent', 'Column public.partsgroup.parent should exist');
+RETURN NEXT col_type_is(      'public', 'partsgroup', 'parent', 'integer', 'Column public.partsgroup.parent should be type integer');
+RETURN NEXT col_is_null(      'public', 'partsgroup', 'parent', 'Column public.partsgroup.parent should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'partsgroup', 'parent', 'Column public.partsgroup.parent should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.partsgroup_translation.sql.pg_include
+++ b/xt/pgtap/table_public.partsgroup_translation.sql.pg_include
@@ -1,0 +1,38 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_partsgroup_translation()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'partsgroup_translation',
+    'Should have table public.partsgroup_translation'
+);
+
+RETURN NEXT has_pk(
+    'public', 'partsgroup_translation',
+    'Table public.partsgroup_translation should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'partsgroup_translation'::name, ARRAY[
+    'trans_id'::name,
+    'language_code'::name,
+    'description'::name
+]);
+
+RETURN NEXT has_column(       'public', 'partsgroup_translation', 'trans_id', 'Column public.partsgroup_translation.trans_id should exist');
+RETURN NEXT col_type_is(      'public', 'partsgroup_translation', 'trans_id', 'integer', 'Column public.partsgroup_translation.trans_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'partsgroup_translation', 'trans_id', 'Column public.partsgroup_translation.trans_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'partsgroup_translation', 'trans_id', 'Column public.partsgroup_translation.trans_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'partsgroup_translation', 'language_code', 'Column public.partsgroup_translation.language_code should exist');
+RETURN NEXT col_type_is(      'public', 'partsgroup_translation', 'language_code', 'character varying(6)', 'Column public.partsgroup_translation.language_code should be type character varying(6)');
+RETURN NEXT col_not_null(     'public', 'partsgroup_translation', 'language_code', 'Column public.partsgroup_translation.language_code should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'partsgroup_translation', 'language_code', 'Column public.partsgroup_translation.language_code should not have a default');
+
+RETURN NEXT has_column(       'public', 'partsgroup_translation', 'description', 'Column public.partsgroup_translation.description should exist');
+RETURN NEXT col_type_is(      'public', 'partsgroup_translation', 'description', 'text', 'Column public.partsgroup_translation.description should be type text');
+RETURN NEXT col_is_null(      'public', 'partsgroup_translation', 'description', 'Column public.partsgroup_translation.description should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'partsgroup_translation', 'description', 'Column public.partsgroup_translation.description should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.partstax.sql.pg_include
+++ b/xt/pgtap/table_public.partstax.sql.pg_include
@@ -1,0 +1,38 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_partstax()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'partstax',
+    'Should have table public.partstax'
+);
+
+RETURN NEXT has_pk(
+    'public', 'partstax',
+    'Table public.partstax should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'partstax'::name, ARRAY[
+    'parts_id'::name,
+    'chart_id'::name,
+    'taxcategory_id'::name
+]);
+
+RETURN NEXT has_column(       'public', 'partstax', 'parts_id', 'Column public.partstax.parts_id should exist');
+RETURN NEXT col_type_is(      'public', 'partstax', 'parts_id', 'integer', 'Column public.partstax.parts_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'partstax', 'parts_id', 'Column public.partstax.parts_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'partstax', 'parts_id', 'Column public.partstax.parts_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'partstax', 'chart_id', 'Column public.partstax.chart_id should exist');
+RETURN NEXT col_type_is(      'public', 'partstax', 'chart_id', 'integer', 'Column public.partstax.chart_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'partstax', 'chart_id', 'Column public.partstax.chart_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'partstax', 'chart_id', 'Column public.partstax.chart_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'partstax', 'taxcategory_id', 'Column public.partstax.taxcategory_id should exist');
+RETURN NEXT col_type_is(      'public', 'partstax', 'taxcategory_id', 'integer', 'Column public.partstax.taxcategory_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'partstax', 'taxcategory_id', 'Column public.partstax.taxcategory_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'partstax', 'taxcategory_id', 'Column public.partstax.taxcategory_id should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.partsvendor.sql.pg_include
+++ b/xt/pgtap/table_public.partsvendor.sql.pg_include
@@ -1,0 +1,63 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_partsvendor()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'partsvendor',
+    'Should have table public.partsvendor'
+);
+
+RETURN NEXT has_pk(
+    'public', 'partsvendor',
+    'Table public.partsvendor should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'partsvendor'::name, ARRAY[
+    'credit_id'::name,
+    'parts_id'::name,
+    'partnumber'::name,
+    'leadtime'::name,
+    'lastcost'::name,
+    'curr'::name,
+    'entry_id'::name
+]);
+
+RETURN NEXT has_column(       'public', 'partsvendor', 'credit_id', 'Column public.partsvendor.credit_id should exist');
+RETURN NEXT col_type_is(      'public', 'partsvendor', 'credit_id', 'integer', 'Column public.partsvendor.credit_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'partsvendor', 'credit_id', 'Column public.partsvendor.credit_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'partsvendor', 'credit_id', 'Column public.partsvendor.credit_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'partsvendor', 'parts_id', 'Column public.partsvendor.parts_id should exist');
+RETURN NEXT col_type_is(      'public', 'partsvendor', 'parts_id', 'integer', 'Column public.partsvendor.parts_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'partsvendor', 'parts_id', 'Column public.partsvendor.parts_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'partsvendor', 'parts_id', 'Column public.partsvendor.parts_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'partsvendor', 'partnumber', 'Column public.partsvendor.partnumber should exist');
+RETURN NEXT col_type_is(      'public', 'partsvendor', 'partnumber', 'text', 'Column public.partsvendor.partnumber should be type text');
+RETURN NEXT col_is_null(      'public', 'partsvendor', 'partnumber', 'Column public.partsvendor.partnumber should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'partsvendor', 'partnumber', 'Column public.partsvendor.partnumber should not have a default');
+
+RETURN NEXT has_column(       'public', 'partsvendor', 'leadtime', 'Column public.partsvendor.leadtime should exist');
+RETURN NEXT col_type_is(      'public', 'partsvendor', 'leadtime', 'smallint', 'Column public.partsvendor.leadtime should be type smallint');
+RETURN NEXT col_is_null(      'public', 'partsvendor', 'leadtime', 'Column public.partsvendor.leadtime should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'partsvendor', 'leadtime', 'Column public.partsvendor.leadtime should not have a default');
+
+RETURN NEXT has_column(       'public', 'partsvendor', 'lastcost', 'Column public.partsvendor.lastcost should exist');
+RETURN NEXT col_type_is(      'public', 'partsvendor', 'lastcost', 'numeric', 'Column public.partsvendor.lastcost should be type numeric');
+RETURN NEXT col_is_null(      'public', 'partsvendor', 'lastcost', 'Column public.partsvendor.lastcost should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'partsvendor', 'lastcost', 'Column public.partsvendor.lastcost should not have a default');
+
+RETURN NEXT has_column(       'public', 'partsvendor', 'curr', 'Column public.partsvendor.curr should exist');
+RETURN NEXT col_type_is(      'public', 'partsvendor', 'curr', 'character(3)', 'Column public.partsvendor.curr should be type character(3)');
+RETURN NEXT col_is_null(      'public', 'partsvendor', 'curr', 'Column public.partsvendor.curr should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'partsvendor', 'curr', 'Column public.partsvendor.curr should not have a default');
+
+RETURN NEXT has_column(       'public', 'partsvendor', 'entry_id', 'Column public.partsvendor.entry_id should exist');
+RETURN NEXT col_type_is(      'public', 'partsvendor', 'entry_id', 'integer', 'Column public.partsvendor.entry_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'partsvendor', 'entry_id', 'Column public.partsvendor.entry_id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'partsvendor', 'entry_id', 'Column public.partsvendor.entry_id shouldhave a default');
+--SELECT col_default_is(   'public', 'partsvendor', 'entry_id', 'nextval(''partsvendor_entry_id_seq''::regclass)', 'Column public.partsvendor.entry_id default is');RETURN NEXT col_default_is(   'public', 'partsvendor', 'entry_id', 'nextval(''partsvendor_entry_id_seq''::regclass)', 'Column public.partsvendor.entry_id default is');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.payment.sql.pg_include
+++ b/xt/pgtap/table_public.payment.sql.pg_include
@@ -1,0 +1,83 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_payment()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'payment',
+    'Should have table public.payment'
+);
+
+RETURN NEXT has_pk(
+    'public', 'payment',
+    'Table public.payment should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'payment'::name, ARRAY[
+    'id'::name,
+    'reference'::name,
+    'gl_id'::name,
+    'payment_class'::name,
+    'payment_date'::name,
+    'closed'::name,
+    'entity_credit_id'::name,
+    'employee_id'::name,
+    'currency'::name,
+    'notes'::name
+]);
+
+RETURN NEXT has_column(       'public', 'payment', 'id', 'Column public.payment.id should exist');
+RETURN NEXT col_type_is(      'public', 'payment', 'id', 'integer', 'Column public.payment.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'payment', 'id', 'Column public.payment.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'payment', 'id', 'Column public.payment.id shouldhave a default');
+--SELECT col_default_is(   'public', 'payment', 'id', 'nextval(''payment_id_seq''::regclass)', 'Column public.payment.id default is');RETURN NEXT col_default_is(   'public', 'payment', 'id', 'nextval(''payment_id_seq''::regclass)', 'Column public.payment.id default is');
+
+RETURN NEXT has_column(       'public', 'payment', 'reference', 'Column public.payment.reference should exist');
+RETURN NEXT col_type_is(      'public', 'payment', 'reference', 'text', 'Column public.payment.reference should be type text');
+RETURN NEXT col_not_null(     'public', 'payment', 'reference', 'Column public.payment.reference should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payment', 'reference', 'Column public.payment.reference should not have a default');
+
+RETURN NEXT has_column(       'public', 'payment', 'gl_id', 'Column public.payment.gl_id should exist');
+RETURN NEXT col_type_is(      'public', 'payment', 'gl_id', 'integer', 'Column public.payment.gl_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'payment', 'gl_id', 'Column public.payment.gl_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'payment', 'gl_id', 'Column public.payment.gl_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'payment', 'payment_class', 'Column public.payment.payment_class should exist');
+RETURN NEXT col_type_is(      'public', 'payment', 'payment_class', 'integer', 'Column public.payment.payment_class should be type integer');
+RETURN NEXT col_not_null(     'public', 'payment', 'payment_class', 'Column public.payment.payment_class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payment', 'payment_class', 'Column public.payment.payment_class should not have a default');
+
+RETURN NEXT has_column(       'public', 'payment', 'payment_date', 'Column public.payment.payment_date should exist');
+RETURN NEXT col_type_is(      'public', 'payment', 'payment_date', 'date', 'Column public.payment.payment_date should be type date');
+RETURN NEXT col_is_null(      'public', 'payment', 'payment_date', 'Column public.payment.payment_date should allow NULL');
+RETURN NEXT col_has_default(  'public', 'payment', 'payment_date', 'Column public.payment.payment_date shouldhave a default');
+--SELECT col_default_is(   'public', 'payment', 'payment_date', '(''now''::text)::date', 'Column public.payment.payment_date default is');RETURN NEXT col_default_is(   'public', 'payment', 'payment_date', '(''now''::text)::date', 'Column public.payment.payment_date default is');
+
+RETURN NEXT has_column(       'public', 'payment', 'closed', 'Column public.payment.closed should exist');
+RETURN NEXT col_type_is(      'public', 'payment', 'closed', 'boolean', 'Column public.payment.closed should be type boolean');
+RETURN NEXT col_is_null(      'public', 'payment', 'closed', 'Column public.payment.closed should allow NULL');
+RETURN NEXT col_has_default(  'public', 'payment', 'closed', 'Column public.payment.closed shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'payment', 'closed', 'false', 'Column public.payment.closed default is');
+
+RETURN NEXT has_column(       'public', 'payment', 'entity_credit_id', 'Column public.payment.entity_credit_id should exist');
+RETURN NEXT col_type_is(      'public', 'payment', 'entity_credit_id', 'integer', 'Column public.payment.entity_credit_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'payment', 'entity_credit_id', 'Column public.payment.entity_credit_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'payment', 'entity_credit_id', 'Column public.payment.entity_credit_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'payment', 'employee_id', 'Column public.payment.employee_id should exist');
+RETURN NEXT col_type_is(      'public', 'payment', 'employee_id', 'integer', 'Column public.payment.employee_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'payment', 'employee_id', 'Column public.payment.employee_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'payment', 'employee_id', 'Column public.payment.employee_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'payment', 'currency', 'Column public.payment.currency should exist');
+RETURN NEXT col_type_is(      'public', 'payment', 'currency', 'character(3)', 'Column public.payment.currency should be type character(3)');
+RETURN NEXT col_is_null(      'public', 'payment', 'currency', 'Column public.payment.currency should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'payment', 'currency', 'Column public.payment.currency should not have a default');
+
+RETURN NEXT has_column(       'public', 'payment', 'notes', 'Column public.payment.notes should exist');
+RETURN NEXT col_type_is(      'public', 'payment', 'notes', 'text', 'Column public.payment.notes should be type text');
+RETURN NEXT col_is_null(      'public', 'payment', 'notes', 'Column public.payment.notes should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'payment', 'notes', 'Column public.payment.notes should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.payment_links.sql.pg_include
+++ b/xt/pgtap/table_public.payment_links.sql.pg_include
@@ -1,0 +1,38 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_payment_links()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'payment_links',
+    'Should have table public.payment_links'
+);
+
+RETURN NEXT hasnt_pk(
+    'public', 'payment_links',
+    'Table public.payment_links should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'payment_links'::name, ARRAY[
+    'payment_id'::name,
+    'entry_id'::name,
+    'type'::name
+]);
+
+RETURN NEXT has_column(       'public', 'payment_links', 'payment_id', 'Column public.payment_links.payment_id should exist');
+RETURN NEXT col_type_is(      'public', 'payment_links', 'payment_id', 'integer', 'Column public.payment_links.payment_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'payment_links', 'payment_id', 'Column public.payment_links.payment_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'payment_links', 'payment_id', 'Column public.payment_links.payment_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'payment_links', 'entry_id', 'Column public.payment_links.entry_id should exist');
+RETURN NEXT col_type_is(      'public', 'payment_links', 'entry_id', 'integer', 'Column public.payment_links.entry_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'payment_links', 'entry_id', 'Column public.payment_links.entry_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'payment_links', 'entry_id', 'Column public.payment_links.entry_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'payment_links', 'type', 'Column public.payment_links.type should exist');
+RETURN NEXT col_type_is(      'public', 'payment_links', 'type', 'integer', 'Column public.payment_links.type should be type integer');
+RETURN NEXT col_is_null(      'public', 'payment_links', 'type', 'Column public.payment_links.type should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'payment_links', 'type', 'Column public.payment_links.type should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.payment_map.sql.pg_include
+++ b/xt/pgtap/table_public.payment_map.sql.pg_include
@@ -1,0 +1,32 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_payment_map()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'payment_map',
+    'Should have table public.payment_map'
+);
+
+RETURN NEXT has_pk(
+    'public', 'payment_map',
+    'Table public.payment_map should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'payment_map'::name, ARRAY[
+    'line_id'::name,
+    'pays'::name
+]);
+
+RETURN NEXT has_column(       'public', 'payment_map', 'line_id', 'Column public.payment_map.line_id should exist');
+RETURN NEXT col_type_is(      'public', 'payment_map', 'line_id', 'integer', 'Column public.payment_map.line_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'payment_map', 'line_id', 'Column public.payment_map.line_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payment_map', 'line_id', 'Column public.payment_map.line_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'payment_map', 'pays', 'Column public.payment_map.pays should exist');
+RETURN NEXT col_type_is(      'public', 'payment_map', 'pays', 'integer', 'Column public.payment_map.pays should be type integer');
+RETURN NEXT col_not_null(     'public', 'payment_map', 'pays', 'Column public.payment_map.pays should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payment_map', 'pays', 'Column public.payment_map.pays should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.payment_type.sql.pg_include
+++ b/xt/pgtap/table_public.payment_type.sql.pg_include
@@ -1,0 +1,33 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_payment_type()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'payment_type',
+    'Should have table public.payment_type'
+);
+
+RETURN NEXT has_pk(
+    'public', 'payment_type',
+    'Table public.payment_type should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'payment_type'::name, ARRAY[
+    'id'::name,
+    'label'::name
+]);
+
+RETURN NEXT has_column(       'public', 'payment_type', 'id', 'Column public.payment_type.id should exist');
+RETURN NEXT col_type_is(      'public', 'payment_type', 'id', 'integer', 'Column public.payment_type.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'payment_type', 'id', 'Column public.payment_type.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'payment_type', 'id', 'Column public.payment_type.id shouldhave a default');
+--SELECT col_default_is(   'public', 'payment_type', 'id', 'nextval(''payment_type_id_seq''::regclass)', 'Column public.payment_type.id default is');RETURN NEXT col_default_is(   'public', 'payment_type', 'id', 'nextval(''payment_type_id_seq''::regclass)', 'Column public.payment_type.id default is');
+
+RETURN NEXT has_column(       'public', 'payment_type', 'label', 'Column public.payment_type.label should exist');
+RETURN NEXT col_type_is(      'public', 'payment_type', 'label', 'text', 'Column public.payment_type.label should be type text');
+RETURN NEXT col_not_null(     'public', 'payment_type', 'label', 'Column public.payment_type.label should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payment_type', 'label', 'Column public.payment_type.label should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.payroll_deduction.sql.pg_include
+++ b/xt/pgtap/table_public.payroll_deduction.sql.pg_include
@@ -1,0 +1,45 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_payroll_deduction()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'payroll_deduction',
+    'Should have table public.payroll_deduction'
+);
+
+RETURN NEXT has_pk(
+    'public', 'payroll_deduction',
+    'Table public.payroll_deduction should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'payroll_deduction'::name, ARRAY[
+    'entry_id'::name,
+    'entity_id'::name,
+    'type_id'::name,
+    'rate'::name
+]);
+
+RETURN NEXT has_column(       'public', 'payroll_deduction', 'entry_id', 'Column public.payroll_deduction.entry_id should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_deduction', 'entry_id', 'integer', 'Column public.payroll_deduction.entry_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'payroll_deduction', 'entry_id', 'Column public.payroll_deduction.entry_id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'payroll_deduction', 'entry_id', 'Column public.payroll_deduction.entry_id shouldhave a default');
+--SELECT col_default_is(   'public', 'payroll_deduction', 'entry_id', 'nextval(''payroll_deduction_entry_id_seq''::regclass)', 'Column public.payroll_deduction.entry_id default is');RETURN NEXT col_default_is(   'public', 'payroll_deduction', 'entry_id', 'nextval(''payroll_deduction_entry_id_seq''::regclass)', 'Column public.payroll_deduction.entry_id default is');
+
+RETURN NEXT has_column(       'public', 'payroll_deduction', 'entity_id', 'Column public.payroll_deduction.entity_id should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_deduction', 'entity_id', 'integer', 'Column public.payroll_deduction.entity_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'payroll_deduction', 'entity_id', 'Column public.payroll_deduction.entity_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_deduction', 'entity_id', 'Column public.payroll_deduction.entity_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'payroll_deduction', 'type_id', 'Column public.payroll_deduction.type_id should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_deduction', 'type_id', 'integer', 'Column public.payroll_deduction.type_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'payroll_deduction', 'type_id', 'Column public.payroll_deduction.type_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_deduction', 'type_id', 'Column public.payroll_deduction.type_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'payroll_deduction', 'rate', 'Column public.payroll_deduction.rate should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_deduction', 'rate', 'numeric', 'Column public.payroll_deduction.rate should be type numeric');
+RETURN NEXT col_not_null(     'public', 'payroll_deduction', 'rate', 'Column public.payroll_deduction.rate should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_deduction', 'rate', 'Column public.payroll_deduction.rate should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.payroll_deduction_class.sql.pg_include
+++ b/xt/pgtap/table_public.payroll_deduction_class.sql.pg_include
@@ -1,0 +1,44 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_payroll_deduction_class()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'payroll_deduction_class',
+    'Should have table public.payroll_deduction_class'
+);
+
+RETURN NEXT has_pk(
+    'public', 'payroll_deduction_class',
+    'Table public.payroll_deduction_class should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'payroll_deduction_class'::name, ARRAY[
+    'id'::name,
+    'country_id'::name,
+    'label'::name,
+    'stored_proc_name'::name
+]);
+
+RETURN NEXT has_column(       'public', 'payroll_deduction_class', 'id', 'Column public.payroll_deduction_class.id should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_deduction_class', 'id', 'integer', 'Column public.payroll_deduction_class.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'payroll_deduction_class', 'id', 'Column public.payroll_deduction_class.id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_deduction_class', 'id', 'Column public.payroll_deduction_class.id should not have a default');
+
+RETURN NEXT has_column(       'public', 'payroll_deduction_class', 'country_id', 'Column public.payroll_deduction_class.country_id should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_deduction_class', 'country_id', 'integer', 'Column public.payroll_deduction_class.country_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'payroll_deduction_class', 'country_id', 'Column public.payroll_deduction_class.country_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_deduction_class', 'country_id', 'Column public.payroll_deduction_class.country_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'payroll_deduction_class', 'label', 'Column public.payroll_deduction_class.label should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_deduction_class', 'label', 'text', 'Column public.payroll_deduction_class.label should be type text');
+RETURN NEXT col_not_null(     'public', 'payroll_deduction_class', 'label', 'Column public.payroll_deduction_class.label should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_deduction_class', 'label', 'Column public.payroll_deduction_class.label should not have a default');
+
+RETURN NEXT has_column(       'public', 'payroll_deduction_class', 'stored_proc_name', 'Column public.payroll_deduction_class.stored_proc_name should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_deduction_class', 'stored_proc_name', 'name', 'Column public.payroll_deduction_class.stored_proc_name should be type name');
+RETURN NEXT col_not_null(     'public', 'payroll_deduction_class', 'stored_proc_name', 'Column public.payroll_deduction_class.stored_proc_name should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_deduction_class', 'stored_proc_name', 'Column public.payroll_deduction_class.stored_proc_name should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.payroll_deduction_type.sql.pg_include
+++ b/xt/pgtap/table_public.payroll_deduction_type.sql.pg_include
@@ -1,0 +1,69 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_payroll_deduction_type()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'payroll_deduction_type',
+    'Should have table public.payroll_deduction_type'
+);
+
+RETURN NEXT hasnt_pk(
+    'public', 'payroll_deduction_type',
+    'Table public.payroll_deduction_type should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'payroll_deduction_type'::name, ARRAY[
+    'id'::name,
+    'account_id'::name,
+    'pdc_id'::name,
+    'country_id'::name,
+    'label'::name,
+    'unit'::name,
+    'default_amount'::name,
+    'calc_percent'::name
+]);
+
+RETURN NEXT has_column(       'public', 'payroll_deduction_type', 'id', 'Column public.payroll_deduction_type.id should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_deduction_type', 'id', 'integer', 'Column public.payroll_deduction_type.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'payroll_deduction_type', 'id', 'Column public.payroll_deduction_type.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'payroll_deduction_type', 'id', 'Column public.payroll_deduction_type.id shouldhave a default');
+--SELECT col_default_is(   'public', 'payroll_deduction_type', 'id', 'nextval(''payroll_deduction_type_id_seq''::regclass)', 'Column public.payroll_deduction_type.id default is');RETURN NEXT col_default_is(   'public', 'payroll_deduction_type', 'id', 'nextval(''payroll_deduction_type_id_seq''::regclass)', 'Column public.payroll_deduction_type.id default is');
+
+RETURN NEXT has_column(       'public', 'payroll_deduction_type', 'account_id', 'Column public.payroll_deduction_type.account_id should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_deduction_type', 'account_id', 'integer', 'Column public.payroll_deduction_type.account_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'payroll_deduction_type', 'account_id', 'Column public.payroll_deduction_type.account_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_deduction_type', 'account_id', 'Column public.payroll_deduction_type.account_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'payroll_deduction_type', 'pdc_id', 'Column public.payroll_deduction_type.pdc_id should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_deduction_type', 'pdc_id', 'integer', 'Column public.payroll_deduction_type.pdc_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'payroll_deduction_type', 'pdc_id', 'Column public.payroll_deduction_type.pdc_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_deduction_type', 'pdc_id', 'Column public.payroll_deduction_type.pdc_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'payroll_deduction_type', 'country_id', 'Column public.payroll_deduction_type.country_id should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_deduction_type', 'country_id', 'integer', 'Column public.payroll_deduction_type.country_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'payroll_deduction_type', 'country_id', 'Column public.payroll_deduction_type.country_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_deduction_type', 'country_id', 'Column public.payroll_deduction_type.country_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'payroll_deduction_type', 'label', 'Column public.payroll_deduction_type.label should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_deduction_type', 'label', 'text', 'Column public.payroll_deduction_type.label should be type text');
+RETURN NEXT col_not_null(     'public', 'payroll_deduction_type', 'label', 'Column public.payroll_deduction_type.label should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_deduction_type', 'label', 'Column public.payroll_deduction_type.label should not have a default');
+
+RETURN NEXT has_column(       'public', 'payroll_deduction_type', 'unit', 'Column public.payroll_deduction_type.unit should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_deduction_type', 'unit', 'text', 'Column public.payroll_deduction_type.unit should be type text');
+RETURN NEXT col_not_null(     'public', 'payroll_deduction_type', 'unit', 'Column public.payroll_deduction_type.unit should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_deduction_type', 'unit', 'Column public.payroll_deduction_type.unit should not have a default');
+
+RETURN NEXT has_column(       'public', 'payroll_deduction_type', 'default_amount', 'Column public.payroll_deduction_type.default_amount should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_deduction_type', 'default_amount', 'numeric', 'Column public.payroll_deduction_type.default_amount should be type numeric');
+RETURN NEXT col_is_null(      'public', 'payroll_deduction_type', 'default_amount', 'Column public.payroll_deduction_type.default_amount should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_deduction_type', 'default_amount', 'Column public.payroll_deduction_type.default_amount should not have a default');
+
+RETURN NEXT has_column(       'public', 'payroll_deduction_type', 'calc_percent', 'Column public.payroll_deduction_type.calc_percent should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_deduction_type', 'calc_percent', 'boolean', 'Column public.payroll_deduction_type.calc_percent should be type boolean');
+RETURN NEXT col_not_null(     'public', 'payroll_deduction_type', 'calc_percent', 'Column public.payroll_deduction_type.calc_percent should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_deduction_type', 'calc_percent', 'Column public.payroll_deduction_type.calc_percent should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.payroll_employee_class.sql.pg_include
+++ b/xt/pgtap/table_public.payroll_employee_class.sql.pg_include
@@ -1,0 +1,33 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_payroll_employee_class()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'payroll_employee_class',
+    'Should have table public.payroll_employee_class'
+);
+
+RETURN NEXT has_pk(
+    'public', 'payroll_employee_class',
+    'Table public.payroll_employee_class should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'payroll_employee_class'::name, ARRAY[
+    'id'::name,
+    'label'::name
+]);
+
+RETURN NEXT has_column(       'public', 'payroll_employee_class', 'id', 'Column public.payroll_employee_class.id should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_employee_class', 'id', 'integer', 'Column public.payroll_employee_class.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'payroll_employee_class', 'id', 'Column public.payroll_employee_class.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'payroll_employee_class', 'id', 'Column public.payroll_employee_class.id shouldhave a default');
+--SELECT col_default_is(   'public', 'payroll_employee_class', 'id', 'nextval(''payroll_employee_class_id_seq''::regclass)', 'Column public.payroll_employee_class.id default is');RETURN NEXT col_default_is(   'public', 'payroll_employee_class', 'id', 'nextval(''payroll_employee_class_id_seq''::regclass)', 'Column public.payroll_employee_class.id default is');
+
+RETURN NEXT has_column(       'public', 'payroll_employee_class', 'label', 'Column public.payroll_employee_class.label should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_employee_class', 'label', 'text', 'Column public.payroll_employee_class.label should be type text');
+RETURN NEXT col_not_null(     'public', 'payroll_employee_class', 'label', 'Column public.payroll_employee_class.label should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_employee_class', 'label', 'Column public.payroll_employee_class.label should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.payroll_employee_class_to_income_type.sql.pg_include
+++ b/xt/pgtap/table_public.payroll_employee_class_to_income_type.sql.pg_include
@@ -1,0 +1,32 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_payroll_employee_class_to_income_type()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'payroll_employee_class_to_income_type',
+    'Should have table public.payroll_employee_class_to_income_type'
+);
+
+RETURN NEXT has_pk(
+    'public', 'payroll_employee_class_to_income_type',
+    'Table public.payroll_employee_class_to_income_type should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'payroll_employee_class_to_income_type'::name, ARRAY[
+    'ec_id'::name,
+    'it_id'::name
+]);
+
+RETURN NEXT has_column(       'public', 'payroll_employee_class_to_income_type', 'ec_id', 'Column public.payroll_employee_class_to_income_type.ec_id should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_employee_class_to_income_type', 'ec_id', 'integer', 'Column public.payroll_employee_class_to_income_type.ec_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'payroll_employee_class_to_income_type', 'ec_id', 'Column public.payroll_employee_class_to_income_type.ec_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_employee_class_to_income_type', 'ec_id', 'Column public.payroll_employee_class_to_income_type.ec_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'payroll_employee_class_to_income_type', 'it_id', 'Column public.payroll_employee_class_to_income_type.it_id should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_employee_class_to_income_type', 'it_id', 'integer', 'Column public.payroll_employee_class_to_income_type.it_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'payroll_employee_class_to_income_type', 'it_id', 'Column public.payroll_employee_class_to_income_type.it_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_employee_class_to_income_type', 'it_id', 'Column public.payroll_employee_class_to_income_type.it_id should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.payroll_income_category.sql.pg_include
+++ b/xt/pgtap/table_public.payroll_income_category.sql.pg_include
@@ -1,0 +1,33 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_payroll_income_category()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'payroll_income_category',
+    'Should have table public.payroll_income_category'
+);
+
+RETURN NEXT hasnt_pk(
+    'public', 'payroll_income_category',
+    'Table public.payroll_income_category should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'payroll_income_category'::name, ARRAY[
+    'id'::name,
+    'label'::name
+]);
+
+RETURN NEXT has_column(       'public', 'payroll_income_category', 'id', 'Column public.payroll_income_category.id should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_income_category', 'id', 'integer', 'Column public.payroll_income_category.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'payroll_income_category', 'id', 'Column public.payroll_income_category.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'payroll_income_category', 'id', 'Column public.payroll_income_category.id shouldhave a default');
+--SELECT col_default_is(   'public', 'payroll_income_category', 'id', 'nextval(''payroll_income_category_id_seq''::regclass)', 'Column public.payroll_income_category.id default is');RETURN NEXT col_default_is(   'public', 'payroll_income_category', 'id', 'nextval(''payroll_income_category_id_seq''::regclass)', 'Column public.payroll_income_category.id default is');
+
+RETURN NEXT has_column(       'public', 'payroll_income_category', 'label', 'Column public.payroll_income_category.label should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_income_category', 'label', 'text', 'Column public.payroll_income_category.label should be type text');
+RETURN NEXT col_is_null(      'public', 'payroll_income_category', 'label', 'Column public.payroll_income_category.label should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_income_category', 'label', 'Column public.payroll_income_category.label should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.payroll_income_class.sql.pg_include
+++ b/xt/pgtap/table_public.payroll_income_class.sql.pg_include
@@ -1,0 +1,38 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_payroll_income_class()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'payroll_income_class',
+    'Should have table public.payroll_income_class'
+);
+
+RETURN NEXT has_pk(
+    'public', 'payroll_income_class',
+    'Table public.payroll_income_class should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'payroll_income_class'::name, ARRAY[
+    'id'::name,
+    'country_id'::name,
+    'label'::name
+]);
+
+RETURN NEXT has_column(       'public', 'payroll_income_class', 'id', 'Column public.payroll_income_class.id should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_income_class', 'id', 'integer', 'Column public.payroll_income_class.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'payroll_income_class', 'id', 'Column public.payroll_income_class.id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_income_class', 'id', 'Column public.payroll_income_class.id should not have a default');
+
+RETURN NEXT has_column(       'public', 'payroll_income_class', 'country_id', 'Column public.payroll_income_class.country_id should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_income_class', 'country_id', 'integer', 'Column public.payroll_income_class.country_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'payroll_income_class', 'country_id', 'Column public.payroll_income_class.country_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_income_class', 'country_id', 'Column public.payroll_income_class.country_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'payroll_income_class', 'label', 'Column public.payroll_income_class.label should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_income_class', 'label', 'text', 'Column public.payroll_income_class.label should be type text');
+RETURN NEXT col_not_null(     'public', 'payroll_income_class', 'label', 'Column public.payroll_income_class.label should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_income_class', 'label', 'Column public.payroll_income_class.label should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.payroll_income_type.sql.pg_include
+++ b/xt/pgtap/table_public.payroll_income_type.sql.pg_include
@@ -1,0 +1,63 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_payroll_income_type()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'payroll_income_type',
+    'Should have table public.payroll_income_type'
+);
+
+RETURN NEXT hasnt_pk(
+    'public', 'payroll_income_type',
+    'Table public.payroll_income_type should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'payroll_income_type'::name, ARRAY[
+    'id'::name,
+    'account_id'::name,
+    'pic_id'::name,
+    'country_id'::name,
+    'label'::name,
+    'unit'::name,
+    'default_amount'::name
+]);
+
+RETURN NEXT has_column(       'public', 'payroll_income_type', 'id', 'Column public.payroll_income_type.id should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_income_type', 'id', 'integer', 'Column public.payroll_income_type.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'payroll_income_type', 'id', 'Column public.payroll_income_type.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'payroll_income_type', 'id', 'Column public.payroll_income_type.id shouldhave a default');
+--SELECT col_default_is(   'public', 'payroll_income_type', 'id', 'nextval(''payroll_income_type_id_seq''::regclass)', 'Column public.payroll_income_type.id default is');RETURN NEXT col_default_is(   'public', 'payroll_income_type', 'id', 'nextval(''payroll_income_type_id_seq''::regclass)', 'Column public.payroll_income_type.id default is');
+
+RETURN NEXT has_column(       'public', 'payroll_income_type', 'account_id', 'Column public.payroll_income_type.account_id should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_income_type', 'account_id', 'integer', 'Column public.payroll_income_type.account_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'payroll_income_type', 'account_id', 'Column public.payroll_income_type.account_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_income_type', 'account_id', 'Column public.payroll_income_type.account_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'payroll_income_type', 'pic_id', 'Column public.payroll_income_type.pic_id should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_income_type', 'pic_id', 'integer', 'Column public.payroll_income_type.pic_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'payroll_income_type', 'pic_id', 'Column public.payroll_income_type.pic_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_income_type', 'pic_id', 'Column public.payroll_income_type.pic_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'payroll_income_type', 'country_id', 'Column public.payroll_income_type.country_id should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_income_type', 'country_id', 'integer', 'Column public.payroll_income_type.country_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'payroll_income_type', 'country_id', 'Column public.payroll_income_type.country_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_income_type', 'country_id', 'Column public.payroll_income_type.country_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'payroll_income_type', 'label', 'Column public.payroll_income_type.label should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_income_type', 'label', 'text', 'Column public.payroll_income_type.label should be type text');
+RETURN NEXT col_not_null(     'public', 'payroll_income_type', 'label', 'Column public.payroll_income_type.label should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_income_type', 'label', 'Column public.payroll_income_type.label should not have a default');
+
+RETURN NEXT has_column(       'public', 'payroll_income_type', 'unit', 'Column public.payroll_income_type.unit should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_income_type', 'unit', 'text', 'Column public.payroll_income_type.unit should be type text');
+RETURN NEXT col_not_null(     'public', 'payroll_income_type', 'unit', 'Column public.payroll_income_type.unit should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_income_type', 'unit', 'Column public.payroll_income_type.unit should not have a default');
+
+RETURN NEXT has_column(       'public', 'payroll_income_type', 'default_amount', 'Column public.payroll_income_type.default_amount should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_income_type', 'default_amount', 'numeric', 'Column public.payroll_income_type.default_amount should be type numeric');
+RETURN NEXT col_is_null(      'public', 'payroll_income_type', 'default_amount', 'Column public.payroll_income_type.default_amount should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_income_type', 'default_amount', 'Column public.payroll_income_type.default_amount should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.payroll_paid_timeoff.sql.pg_include
+++ b/xt/pgtap/table_public.payroll_paid_timeoff.sql.pg_include
@@ -1,0 +1,44 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_payroll_paid_timeoff()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'payroll_paid_timeoff',
+    'Should have table public.payroll_paid_timeoff'
+);
+
+RETURN NEXT hasnt_pk(
+    'public', 'payroll_paid_timeoff',
+    'Table public.payroll_paid_timeoff should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'payroll_paid_timeoff'::name, ARRAY[
+    'employee_id'::name,
+    'pto_class_id'::name,
+    'report_id'::name,
+    'amount'::name
+]);
+
+RETURN NEXT has_column(       'public', 'payroll_paid_timeoff', 'employee_id', 'Column public.payroll_paid_timeoff.employee_id should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_paid_timeoff', 'employee_id', 'integer', 'Column public.payroll_paid_timeoff.employee_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'payroll_paid_timeoff', 'employee_id', 'Column public.payroll_paid_timeoff.employee_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_paid_timeoff', 'employee_id', 'Column public.payroll_paid_timeoff.employee_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'payroll_paid_timeoff', 'pto_class_id', 'Column public.payroll_paid_timeoff.pto_class_id should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_paid_timeoff', 'pto_class_id', 'integer', 'Column public.payroll_paid_timeoff.pto_class_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'payroll_paid_timeoff', 'pto_class_id', 'Column public.payroll_paid_timeoff.pto_class_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_paid_timeoff', 'pto_class_id', 'Column public.payroll_paid_timeoff.pto_class_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'payroll_paid_timeoff', 'report_id', 'Column public.payroll_paid_timeoff.report_id should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_paid_timeoff', 'report_id', 'integer', 'Column public.payroll_paid_timeoff.report_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'payroll_paid_timeoff', 'report_id', 'Column public.payroll_paid_timeoff.report_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_paid_timeoff', 'report_id', 'Column public.payroll_paid_timeoff.report_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'payroll_paid_timeoff', 'amount', 'Column public.payroll_paid_timeoff.amount should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_paid_timeoff', 'amount', 'numeric', 'Column public.payroll_paid_timeoff.amount should be type numeric');
+RETURN NEXT col_not_null(     'public', 'payroll_paid_timeoff', 'amount', 'Column public.payroll_paid_timeoff.amount should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_paid_timeoff', 'amount', 'Column public.payroll_paid_timeoff.amount should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.payroll_pto_class.sql.pg_include
+++ b/xt/pgtap/table_public.payroll_pto_class.sql.pg_include
@@ -1,0 +1,33 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_payroll_pto_class()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'payroll_pto_class',
+    'Should have table public.payroll_pto_class'
+);
+
+RETURN NEXT has_pk(
+    'public', 'payroll_pto_class',
+    'Table public.payroll_pto_class should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'payroll_pto_class'::name, ARRAY[
+    'id'::name,
+    'label'::name
+]);
+
+RETURN NEXT has_column(       'public', 'payroll_pto_class', 'id', 'Column public.payroll_pto_class.id should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_pto_class', 'id', 'integer', 'Column public.payroll_pto_class.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'payroll_pto_class', 'id', 'Column public.payroll_pto_class.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'payroll_pto_class', 'id', 'Column public.payroll_pto_class.id shouldhave a default');
+--SELECT col_default_is(   'public', 'payroll_pto_class', 'id', 'nextval(''payroll_pto_class_id_seq''::regclass)', 'Column public.payroll_pto_class.id default is');RETURN NEXT col_default_is(   'public', 'payroll_pto_class', 'id', 'nextval(''payroll_pto_class_id_seq''::regclass)', 'Column public.payroll_pto_class.id default is');
+
+RETURN NEXT has_column(       'public', 'payroll_pto_class', 'label', 'Column public.payroll_pto_class.label should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_pto_class', 'label', 'text', 'Column public.payroll_pto_class.label should be type text');
+RETURN NEXT col_not_null(     'public', 'payroll_pto_class', 'label', 'Column public.payroll_pto_class.label should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_pto_class', 'label', 'Column public.payroll_pto_class.label should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.payroll_report.sql.pg_include
+++ b/xt/pgtap/table_public.payroll_report.sql.pg_include
@@ -1,0 +1,51 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_payroll_report()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'payroll_report',
+    'Should have table public.payroll_report'
+);
+
+RETURN NEXT has_pk(
+    'public', 'payroll_report',
+    'Table public.payroll_report should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'payroll_report'::name, ARRAY[
+    'id'::name,
+    'ec_id'::name,
+    'payment_date'::name,
+    'created_by'::name,
+    'approved_by'::name
+]);
+
+RETURN NEXT has_column(       'public', 'payroll_report', 'id', 'Column public.payroll_report.id should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_report', 'id', 'integer', 'Column public.payroll_report.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'payroll_report', 'id', 'Column public.payroll_report.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'payroll_report', 'id', 'Column public.payroll_report.id shouldhave a default');
+--SELECT col_default_is(   'public', 'payroll_report', 'id', 'nextval(''payroll_report_id_seq''::regclass)', 'Column public.payroll_report.id default is');RETURN NEXT col_default_is(   'public', 'payroll_report', 'id', 'nextval(''payroll_report_id_seq''::regclass)', 'Column public.payroll_report.id default is');
+
+RETURN NEXT has_column(       'public', 'payroll_report', 'ec_id', 'Column public.payroll_report.ec_id should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_report', 'ec_id', 'integer', 'Column public.payroll_report.ec_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'payroll_report', 'ec_id', 'Column public.payroll_report.ec_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_report', 'ec_id', 'Column public.payroll_report.ec_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'payroll_report', 'payment_date', 'Column public.payroll_report.payment_date should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_report', 'payment_date', 'date', 'Column public.payroll_report.payment_date should be type date');
+RETURN NEXT col_not_null(     'public', 'payroll_report', 'payment_date', 'Column public.payroll_report.payment_date should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_report', 'payment_date', 'Column public.payroll_report.payment_date should not have a default');
+
+RETURN NEXT has_column(       'public', 'payroll_report', 'created_by', 'Column public.payroll_report.created_by should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_report', 'created_by', 'integer', 'Column public.payroll_report.created_by should be type integer');
+RETURN NEXT col_is_null(      'public', 'payroll_report', 'created_by', 'Column public.payroll_report.created_by should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_report', 'created_by', 'Column public.payroll_report.created_by should not have a default');
+
+RETURN NEXT has_column(       'public', 'payroll_report', 'approved_by', 'Column public.payroll_report.approved_by should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_report', 'approved_by', 'integer', 'Column public.payroll_report.approved_by should be type integer');
+RETURN NEXT col_is_null(      'public', 'payroll_report', 'approved_by', 'Column public.payroll_report.approved_by should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_report', 'approved_by', 'Column public.payroll_report.approved_by should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.payroll_report_line.sql.pg_include
+++ b/xt/pgtap/table_public.payroll_report_line.sql.pg_include
@@ -1,0 +1,63 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_payroll_report_line()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'payroll_report_line',
+    'Should have table public.payroll_report_line'
+);
+
+RETURN NEXT has_pk(
+    'public', 'payroll_report_line',
+    'Table public.payroll_report_line should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'payroll_report_line'::name, ARRAY[
+    'id'::name,
+    'report_id'::name,
+    'employee_id'::name,
+    'it_id'::name,
+    'qty'::name,
+    'rate'::name,
+    'description'::name
+]);
+
+RETURN NEXT has_column(       'public', 'payroll_report_line', 'id', 'Column public.payroll_report_line.id should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_report_line', 'id', 'integer', 'Column public.payroll_report_line.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'payroll_report_line', 'id', 'Column public.payroll_report_line.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'payroll_report_line', 'id', 'Column public.payroll_report_line.id shouldhave a default');
+--SELECT col_default_is(   'public', 'payroll_report_line', 'id', 'nextval(''payroll_report_line_id_seq''::regclass)', 'Column public.payroll_report_line.id default is');RETURN NEXT col_default_is(   'public', 'payroll_report_line', 'id', 'nextval(''payroll_report_line_id_seq''::regclass)', 'Column public.payroll_report_line.id default is');
+
+RETURN NEXT has_column(       'public', 'payroll_report_line', 'report_id', 'Column public.payroll_report_line.report_id should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_report_line', 'report_id', 'integer', 'Column public.payroll_report_line.report_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'payroll_report_line', 'report_id', 'Column public.payroll_report_line.report_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_report_line', 'report_id', 'Column public.payroll_report_line.report_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'payroll_report_line', 'employee_id', 'Column public.payroll_report_line.employee_id should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_report_line', 'employee_id', 'integer', 'Column public.payroll_report_line.employee_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'payroll_report_line', 'employee_id', 'Column public.payroll_report_line.employee_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_report_line', 'employee_id', 'Column public.payroll_report_line.employee_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'payroll_report_line', 'it_id', 'Column public.payroll_report_line.it_id should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_report_line', 'it_id', 'integer', 'Column public.payroll_report_line.it_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'payroll_report_line', 'it_id', 'Column public.payroll_report_line.it_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_report_line', 'it_id', 'Column public.payroll_report_line.it_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'payroll_report_line', 'qty', 'Column public.payroll_report_line.qty should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_report_line', 'qty', 'numeric', 'Column public.payroll_report_line.qty should be type numeric');
+RETURN NEXT col_not_null(     'public', 'payroll_report_line', 'qty', 'Column public.payroll_report_line.qty should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_report_line', 'qty', 'Column public.payroll_report_line.qty should not have a default');
+
+RETURN NEXT has_column(       'public', 'payroll_report_line', 'rate', 'Column public.payroll_report_line.rate should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_report_line', 'rate', 'numeric', 'Column public.payroll_report_line.rate should be type numeric');
+RETURN NEXT col_not_null(     'public', 'payroll_report_line', 'rate', 'Column public.payroll_report_line.rate should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_report_line', 'rate', 'Column public.payroll_report_line.rate should not have a default');
+
+RETURN NEXT has_column(       'public', 'payroll_report_line', 'description', 'Column public.payroll_report_line.description should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_report_line', 'description', 'text', 'Column public.payroll_report_line.description should be type text');
+RETURN NEXT col_is_null(      'public', 'payroll_report_line', 'description', 'Column public.payroll_report_line.description should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_report_line', 'description', 'Column public.payroll_report_line.description should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.payroll_wage.sql.pg_include
+++ b/xt/pgtap/table_public.payroll_wage.sql.pg_include
@@ -1,0 +1,45 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_payroll_wage()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'payroll_wage',
+    'Should have table public.payroll_wage'
+);
+
+RETURN NEXT has_pk(
+    'public', 'payroll_wage',
+    'Table public.payroll_wage should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'payroll_wage'::name, ARRAY[
+    'entry_id'::name,
+    'entity_id'::name,
+    'type_id'::name,
+    'rate'::name
+]);
+
+RETURN NEXT has_column(       'public', 'payroll_wage', 'entry_id', 'Column public.payroll_wage.entry_id should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_wage', 'entry_id', 'integer', 'Column public.payroll_wage.entry_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'payroll_wage', 'entry_id', 'Column public.payroll_wage.entry_id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'payroll_wage', 'entry_id', 'Column public.payroll_wage.entry_id shouldhave a default');
+--SELECT col_default_is(   'public', 'payroll_wage', 'entry_id', 'nextval(''payroll_wage_entry_id_seq''::regclass)', 'Column public.payroll_wage.entry_id default is');RETURN NEXT col_default_is(   'public', 'payroll_wage', 'entry_id', 'nextval(''payroll_wage_entry_id_seq''::regclass)', 'Column public.payroll_wage.entry_id default is');
+
+RETURN NEXT has_column(       'public', 'payroll_wage', 'entity_id', 'Column public.payroll_wage.entity_id should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_wage', 'entity_id', 'integer', 'Column public.payroll_wage.entity_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'payroll_wage', 'entity_id', 'Column public.payroll_wage.entity_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_wage', 'entity_id', 'Column public.payroll_wage.entity_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'payroll_wage', 'type_id', 'Column public.payroll_wage.type_id should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_wage', 'type_id', 'integer', 'Column public.payroll_wage.type_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'payroll_wage', 'type_id', 'Column public.payroll_wage.type_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_wage', 'type_id', 'Column public.payroll_wage.type_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'payroll_wage', 'rate', 'Column public.payroll_wage.rate should exist');
+RETURN NEXT col_type_is(      'public', 'payroll_wage', 'rate', 'numeric', 'Column public.payroll_wage.rate should be type numeric');
+RETURN NEXT col_not_null(     'public', 'payroll_wage', 'rate', 'Column public.payroll_wage.rate should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'payroll_wage', 'rate', 'Column public.payroll_wage.rate should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.person.sql.pg_include
+++ b/xt/pgtap/table_public.person.sql.pg_include
@@ -1,0 +1,76 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_person()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'person',
+    'Should have table public.person'
+);
+
+RETURN NEXT has_pk(
+    'public', 'person',
+    'Table public.person should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'person'::name, ARRAY[
+    'id'::name,
+    'entity_id'::name,
+    'salutation_id'::name,
+    'first_name'::name,
+    'middle_name'::name,
+    'last_name'::name,
+    'created'::name,
+    'birthdate'::name,
+    'personal_id'::name
+]);
+
+RETURN NEXT has_column(       'public', 'person', 'id', 'Column public.person.id should exist');
+RETURN NEXT col_type_is(      'public', 'person', 'id', 'integer', 'Column public.person.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'person', 'id', 'Column public.person.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'person', 'id', 'Column public.person.id shouldhave a default');
+--SELECT col_default_is(   'public', 'person', 'id', 'nextval(''person_id_seq''::regclass)', 'Column public.person.id default is');RETURN NEXT col_default_is(   'public', 'person', 'id', 'nextval(''person_id_seq''::regclass)', 'Column public.person.id default is');
+
+RETURN NEXT has_column(       'public', 'person', 'entity_id', 'Column public.person.entity_id should exist');
+RETURN NEXT col_type_is(      'public', 'person', 'entity_id', 'integer', 'Column public.person.entity_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'person', 'entity_id', 'Column public.person.entity_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'person', 'entity_id', 'Column public.person.entity_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'person', 'salutation_id', 'Column public.person.salutation_id should exist');
+RETURN NEXT col_type_is(      'public', 'person', 'salutation_id', 'integer', 'Column public.person.salutation_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'person', 'salutation_id', 'Column public.person.salutation_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'person', 'salutation_id', 'Column public.person.salutation_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'person', 'first_name', 'Column public.person.first_name should exist');
+RETURN NEXT col_type_is(      'public', 'person', 'first_name', 'text', 'Column public.person.first_name should be type text');
+RETURN NEXT col_not_null(     'public', 'person', 'first_name', 'Column public.person.first_name should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'person', 'first_name', 'Column public.person.first_name should not have a default');
+
+RETURN NEXT has_column(       'public', 'person', 'middle_name', 'Column public.person.middle_name should exist');
+RETURN NEXT col_type_is(      'public', 'person', 'middle_name', 'text', 'Column public.person.middle_name should be type text');
+RETURN NEXT col_is_null(      'public', 'person', 'middle_name', 'Column public.person.middle_name should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'person', 'middle_name', 'Column public.person.middle_name should not have a default');
+
+RETURN NEXT has_column(       'public', 'person', 'last_name', 'Column public.person.last_name should exist');
+RETURN NEXT col_type_is(      'public', 'person', 'last_name', 'text', 'Column public.person.last_name should be type text');
+RETURN NEXT col_not_null(     'public', 'person', 'last_name', 'Column public.person.last_name should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'person', 'last_name', 'Column public.person.last_name should not have a default');
+
+RETURN NEXT has_column(       'public', 'person', 'created', 'Column public.person.created should exist');
+RETURN NEXT col_type_is(      'public', 'person', 'created', 'date', 'Column public.person.created should be type date');
+RETURN NEXT col_not_null(     'public', 'person', 'created', 'Column public.person.created should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'person', 'created', 'Column public.person.created shouldhave a default');
+--SELECT col_default_is(   'public', 'person', 'created', '(''now''::text)::date', 'Column public.person.created default is');RETURN NEXT col_default_is(   'public', 'person', 'created', '(''now''::text)::date', 'Column public.person.created default is');
+
+RETURN NEXT has_column(       'public', 'person', 'birthdate', 'Column public.person.birthdate should exist');
+RETURN NEXT col_type_is(      'public', 'person', 'birthdate', 'date', 'Column public.person.birthdate should be type date');
+RETURN NEXT col_is_null(      'public', 'person', 'birthdate', 'Column public.person.birthdate should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'person', 'birthdate', 'Column public.person.birthdate should not have a default');
+
+RETURN NEXT has_column(       'public', 'person', 'personal_id', 'Column public.person.personal_id should exist');
+RETURN NEXT col_type_is(      'public', 'person', 'personal_id', 'text', 'Column public.person.personal_id should be type text');
+RETURN NEXT col_is_null(      'public', 'person', 'personal_id', 'Column public.person.personal_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'person', 'personal_id', 'Column public.person.personal_id should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.person_to_company.sql.pg_include
+++ b/xt/pgtap/table_public.person_to_company.sql.pg_include
@@ -1,0 +1,38 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_person_to_company()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'person_to_company',
+    'Should have table public.person_to_company'
+);
+
+RETURN NEXT has_pk(
+    'public', 'person_to_company',
+    'Table public.person_to_company should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'person_to_company'::name, ARRAY[
+    'location_id'::name,
+    'person_id'::name,
+    'company_id'::name
+]);
+
+RETURN NEXT has_column(       'public', 'person_to_company', 'location_id', 'Column public.person_to_company.location_id should exist');
+RETURN NEXT col_type_is(      'public', 'person_to_company', 'location_id', 'integer', 'Column public.person_to_company.location_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'person_to_company', 'location_id', 'Column public.person_to_company.location_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'person_to_company', 'location_id', 'Column public.person_to_company.location_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'person_to_company', 'person_id', 'Column public.person_to_company.person_id should exist');
+RETURN NEXT col_type_is(      'public', 'person_to_company', 'person_id', 'integer', 'Column public.person_to_company.person_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'person_to_company', 'person_id', 'Column public.person_to_company.person_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'person_to_company', 'person_id', 'Column public.person_to_company.person_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'person_to_company', 'company_id', 'Column public.person_to_company.company_id should exist');
+RETURN NEXT col_type_is(      'public', 'person_to_company', 'company_id', 'integer', 'Column public.person_to_company.company_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'person_to_company', 'company_id', 'Column public.person_to_company.company_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'person_to_company', 'company_id', 'Column public.person_to_company.company_id should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.pricegroup.sql.pg_include
+++ b/xt/pgtap/table_public.pricegroup.sql.pg_include
@@ -1,0 +1,33 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_pricegroup()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'pricegroup',
+    'Should have table public.pricegroup'
+);
+
+RETURN NEXT has_pk(
+    'public', 'pricegroup',
+    'Table public.pricegroup should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'pricegroup'::name, ARRAY[
+    'id'::name,
+    'pricegroup'::name
+]);
+
+RETURN NEXT has_column(       'public', 'pricegroup', 'id', 'Column public.pricegroup.id should exist');
+RETURN NEXT col_type_is(      'public', 'pricegroup', 'id', 'integer', 'Column public.pricegroup.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'pricegroup', 'id', 'Column public.pricegroup.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'pricegroup', 'id', 'Column public.pricegroup.id shouldhave a default');
+--SELECT col_default_is(   'public', 'pricegroup', 'id', 'nextval(''pricegroup_id_seq''::regclass)', 'Column public.pricegroup.id default is');RETURN NEXT col_default_is(   'public', 'pricegroup', 'id', 'nextval(''pricegroup_id_seq''::regclass)', 'Column public.pricegroup.id default is');
+
+RETURN NEXT has_column(       'public', 'pricegroup', 'pricegroup', 'Column public.pricegroup.pricegroup should exist');
+RETURN NEXT col_type_is(      'public', 'pricegroup', 'pricegroup', 'text', 'Column public.pricegroup.pricegroup should be type text');
+RETURN NEXT col_is_null(      'public', 'pricegroup', 'pricegroup', 'Column public.pricegroup.pricegroup should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'pricegroup', 'pricegroup', 'Column public.pricegroup.pricegroup should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.recurring.sql.pg_include
+++ b/xt/pgtap/table_public.recurring.sql.pg_include
@@ -1,0 +1,69 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_recurring()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'recurring',
+    'Should have table public.recurring'
+);
+
+RETURN NEXT hasnt_pk(
+    'public', 'recurring',
+    'Table public.recurring should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'recurring'::name, ARRAY[
+    'id'::name,
+    'reference'::name,
+    'startdate'::name,
+    'nextdate'::name,
+    'enddate'::name,
+    'recurring_interval'::name,
+    'howmany'::name,
+    'payment'::name
+]);
+
+RETURN NEXT has_column(       'public', 'recurring', 'id', 'Column public.recurring.id should exist');
+RETURN NEXT col_type_is(      'public', 'recurring', 'id', 'integer', 'Column public.recurring.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'recurring', 'id', 'Column public.recurring.id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'recurring', 'id', 'Column public.recurring.id should not have a default');
+
+RETURN NEXT has_column(       'public', 'recurring', 'reference', 'Column public.recurring.reference should exist');
+RETURN NEXT col_type_is(      'public', 'recurring', 'reference', 'text', 'Column public.recurring.reference should be type text');
+RETURN NEXT col_is_null(      'public', 'recurring', 'reference', 'Column public.recurring.reference should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'recurring', 'reference', 'Column public.recurring.reference should not have a default');
+
+RETURN NEXT has_column(       'public', 'recurring', 'startdate', 'Column public.recurring.startdate should exist');
+RETURN NEXT col_type_is(      'public', 'recurring', 'startdate', 'date', 'Column public.recurring.startdate should be type date');
+RETURN NEXT col_is_null(      'public', 'recurring', 'startdate', 'Column public.recurring.startdate should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'recurring', 'startdate', 'Column public.recurring.startdate should not have a default');
+
+RETURN NEXT has_column(       'public', 'recurring', 'nextdate', 'Column public.recurring.nextdate should exist');
+RETURN NEXT col_type_is(      'public', 'recurring', 'nextdate', 'date', 'Column public.recurring.nextdate should be type date');
+RETURN NEXT col_is_null(      'public', 'recurring', 'nextdate', 'Column public.recurring.nextdate should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'recurring', 'nextdate', 'Column public.recurring.nextdate should not have a default');
+
+RETURN NEXT has_column(       'public', 'recurring', 'enddate', 'Column public.recurring.enddate should exist');
+RETURN NEXT col_type_is(      'public', 'recurring', 'enddate', 'date', 'Column public.recurring.enddate should be type date');
+RETURN NEXT col_is_null(      'public', 'recurring', 'enddate', 'Column public.recurring.enddate should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'recurring', 'enddate', 'Column public.recurring.enddate should not have a default');
+
+RETURN NEXT has_column(       'public', 'recurring', 'recurring_interval', 'Column public.recurring.recurring_interval should exist');
+RETURN NEXT col_type_is(      'public', 'recurring', 'recurring_interval', 'interval', 'Column public.recurring.recurring_interval should be type interval');
+RETURN NEXT col_is_null(      'public', 'recurring', 'recurring_interval', 'Column public.recurring.recurring_interval should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'recurring', 'recurring_interval', 'Column public.recurring.recurring_interval should not have a default');
+
+RETURN NEXT has_column(       'public', 'recurring', 'howmany', 'Column public.recurring.howmany should exist');
+RETURN NEXT col_type_is(      'public', 'recurring', 'howmany', 'integer', 'Column public.recurring.howmany should be type integer');
+RETURN NEXT col_is_null(      'public', 'recurring', 'howmany', 'Column public.recurring.howmany should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'recurring', 'howmany', 'Column public.recurring.howmany should not have a default');
+
+RETURN NEXT has_column(       'public', 'recurring', 'payment', 'Column public.recurring.payment should exist');
+RETURN NEXT col_type_is(      'public', 'recurring', 'payment', 'boolean', 'Column public.recurring.payment should be type boolean');
+RETURN NEXT col_is_null(      'public', 'recurring', 'payment', 'Column public.recurring.payment should allow NULL');
+RETURN NEXT col_has_default(  'public', 'recurring', 'payment', 'Column public.recurring.payment shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'recurring', 'payment', 'false', 'Column public.recurring.payment default is');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.recurringemail.sql.pg_include
+++ b/xt/pgtap/table_public.recurringemail.sql.pg_include
@@ -1,0 +1,44 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_recurringemail()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'recurringemail',
+    'Should have table public.recurringemail'
+);
+
+RETURN NEXT has_pk(
+    'public', 'recurringemail',
+    'Table public.recurringemail should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'recurringemail'::name, ARRAY[
+    'id'::name,
+    'formname'::name,
+    'format'::name,
+    'message'::name
+]);
+
+RETURN NEXT has_column(       'public', 'recurringemail', 'id', 'Column public.recurringemail.id should exist');
+RETURN NEXT col_type_is(      'public', 'recurringemail', 'id', 'integer', 'Column public.recurringemail.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'recurringemail', 'id', 'Column public.recurringemail.id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'recurringemail', 'id', 'Column public.recurringemail.id should not have a default');
+
+RETURN NEXT has_column(       'public', 'recurringemail', 'formname', 'Column public.recurringemail.formname should exist');
+RETURN NEXT col_type_is(      'public', 'recurringemail', 'formname', 'text', 'Column public.recurringemail.formname should be type text');
+RETURN NEXT col_not_null(     'public', 'recurringemail', 'formname', 'Column public.recurringemail.formname should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'recurringemail', 'formname', 'Column public.recurringemail.formname should not have a default');
+
+RETURN NEXT has_column(       'public', 'recurringemail', 'format', 'Column public.recurringemail.format should exist');
+RETURN NEXT col_type_is(      'public', 'recurringemail', 'format', 'text', 'Column public.recurringemail.format should be type text');
+RETURN NEXT col_is_null(      'public', 'recurringemail', 'format', 'Column public.recurringemail.format should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'recurringemail', 'format', 'Column public.recurringemail.format should not have a default');
+
+RETURN NEXT has_column(       'public', 'recurringemail', 'message', 'Column public.recurringemail.message should exist');
+RETURN NEXT col_type_is(      'public', 'recurringemail', 'message', 'text', 'Column public.recurringemail.message should be type text');
+RETURN NEXT col_is_null(      'public', 'recurringemail', 'message', 'Column public.recurringemail.message should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'recurringemail', 'message', 'Column public.recurringemail.message should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.recurringprint.sql.pg_include
+++ b/xt/pgtap/table_public.recurringprint.sql.pg_include
@@ -1,0 +1,44 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_recurringprint()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'recurringprint',
+    'Should have table public.recurringprint'
+);
+
+RETURN NEXT has_pk(
+    'public', 'recurringprint',
+    'Table public.recurringprint should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'recurringprint'::name, ARRAY[
+    'id'::name,
+    'formname'::name,
+    'format'::name,
+    'printer'::name
+]);
+
+RETURN NEXT has_column(       'public', 'recurringprint', 'id', 'Column public.recurringprint.id should exist');
+RETURN NEXT col_type_is(      'public', 'recurringprint', 'id', 'integer', 'Column public.recurringprint.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'recurringprint', 'id', 'Column public.recurringprint.id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'recurringprint', 'id', 'Column public.recurringprint.id should not have a default');
+
+RETURN NEXT has_column(       'public', 'recurringprint', 'formname', 'Column public.recurringprint.formname should exist');
+RETURN NEXT col_type_is(      'public', 'recurringprint', 'formname', 'text', 'Column public.recurringprint.formname should be type text');
+RETURN NEXT col_not_null(     'public', 'recurringprint', 'formname', 'Column public.recurringprint.formname should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'recurringprint', 'formname', 'Column public.recurringprint.formname should not have a default');
+
+RETURN NEXT has_column(       'public', 'recurringprint', 'format', 'Column public.recurringprint.format should exist');
+RETURN NEXT col_type_is(      'public', 'recurringprint', 'format', 'text', 'Column public.recurringprint.format should be type text');
+RETURN NEXT col_is_null(      'public', 'recurringprint', 'format', 'Column public.recurringprint.format should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'recurringprint', 'format', 'Column public.recurringprint.format should not have a default');
+
+RETURN NEXT has_column(       'public', 'recurringprint', 'printer', 'Column public.recurringprint.printer should exist');
+RETURN NEXT col_type_is(      'public', 'recurringprint', 'printer', 'text', 'Column public.recurringprint.printer should be type text');
+RETURN NEXT col_is_null(      'public', 'recurringprint', 'printer', 'Column public.recurringprint.printer should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'recurringprint', 'printer', 'Column public.recurringprint.printer should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.robot.sql.pg_include
+++ b/xt/pgtap/table_public.robot.sql.pg_include
@@ -1,0 +1,58 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_robot()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'robot',
+    'Should have table public.robot'
+);
+
+RETURN NEXT has_pk(
+    'public', 'robot',
+    'Table public.robot should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'robot'::name, ARRAY[
+    'id'::name,
+    'entity_id'::name,
+    'first_name'::name,
+    'middle_name'::name,
+    'last_name'::name,
+    'created'::name
+]);
+
+RETURN NEXT has_column(       'public', 'robot', 'id', 'Column public.robot.id should exist');
+RETURN NEXT col_type_is(      'public', 'robot', 'id', 'integer', 'Column public.robot.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'robot', 'id', 'Column public.robot.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'robot', 'id', 'Column public.robot.id shouldhave a default');
+--SELECT col_default_is(   'public', 'robot', 'id', 'nextval(''robot_id_seq''::regclass)', 'Column public.robot.id default is');RETURN NEXT col_default_is(   'public', 'robot', 'id', 'nextval(''robot_id_seq''::regclass)', 'Column public.robot.id default is');
+
+RETURN NEXT has_column(       'public', 'robot', 'entity_id', 'Column public.robot.entity_id should exist');
+RETURN NEXT col_type_is(      'public', 'robot', 'entity_id', 'integer', 'Column public.robot.entity_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'robot', 'entity_id', 'Column public.robot.entity_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'robot', 'entity_id', 'Column public.robot.entity_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'robot', 'first_name', 'Column public.robot.first_name should exist');
+RETURN NEXT col_type_is(      'public', 'robot', 'first_name', 'text', 'Column public.robot.first_name should be type text');
+RETURN NEXT col_is_null(      'public', 'robot', 'first_name', 'Column public.robot.first_name should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'robot', 'first_name', 'Column public.robot.first_name should not have a default');
+
+RETURN NEXT has_column(       'public', 'robot', 'middle_name', 'Column public.robot.middle_name should exist');
+RETURN NEXT col_type_is(      'public', 'robot', 'middle_name', 'text', 'Column public.robot.middle_name should be type text');
+RETURN NEXT col_is_null(      'public', 'robot', 'middle_name', 'Column public.robot.middle_name should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'robot', 'middle_name', 'Column public.robot.middle_name should not have a default');
+
+RETURN NEXT has_column(       'public', 'robot', 'last_name', 'Column public.robot.last_name should exist');
+RETURN NEXT col_type_is(      'public', 'robot', 'last_name', 'text', 'Column public.robot.last_name should be type text');
+RETURN NEXT col_not_null(     'public', 'robot', 'last_name', 'Column public.robot.last_name should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'robot', 'last_name', 'Column public.robot.last_name should not have a default');
+
+RETURN NEXT has_column(       'public', 'robot', 'created', 'Column public.robot.created should exist');
+RETURN NEXT col_type_is(      'public', 'robot', 'created', 'date', 'Column public.robot.created should be type date');
+RETURN NEXT col_not_null(     'public', 'robot', 'created', 'Column public.robot.created should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'robot', 'created', 'Column public.robot.created shouldhave a default');
+--SELECT col_default_is(   'public', 'robot', 'created', '(''now''::text)::date', 'Column public.robot.created default is');RETURN NEXT col_default_is(   'public', 'robot', 'created', '(''now''::text)::date', 'Column public.robot.created default is');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.salutation.sql.pg_include
+++ b/xt/pgtap/table_public.salutation.sql.pg_include
@@ -1,0 +1,33 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_salutation()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'salutation',
+    'Should have table public.salutation'
+);
+
+RETURN NEXT has_pk(
+    'public', 'salutation',
+    'Table public.salutation should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'salutation'::name, ARRAY[
+    'id'::name,
+    'salutation'::name
+]);
+
+RETURN NEXT has_column(       'public', 'salutation', 'id', 'Column public.salutation.id should exist');
+RETURN NEXT col_type_is(      'public', 'salutation', 'id', 'integer', 'Column public.salutation.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'salutation', 'id', 'Column public.salutation.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'salutation', 'id', 'Column public.salutation.id shouldhave a default');
+--SELECT col_default_is(   'public', 'salutation', 'id', 'nextval(''salutation_id_seq''::regclass)', 'Column public.salutation.id default is');RETURN NEXT col_default_is(   'public', 'salutation', 'id', 'nextval(''salutation_id_seq''::regclass)', 'Column public.salutation.id default is');
+
+RETURN NEXT has_column(       'public', 'salutation', 'salutation', 'Column public.salutation.salutation should exist');
+RETURN NEXT col_type_is(      'public', 'salutation', 'salutation', 'text', 'Column public.salutation.salutation should be type text');
+RETURN NEXT col_not_null(     'public', 'salutation', 'salutation', 'Column public.salutation.salutation should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'salutation', 'salutation', 'Column public.salutation.salutation should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.session.sql.pg_include
+++ b/xt/pgtap/table_public.session.sql.pg_include
@@ -1,0 +1,60 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_session()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'session',
+    'Should have table public.session'
+);
+
+RETURN NEXT has_pk(
+    'public', 'session',
+    'Table public.session should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'session'::name, ARRAY[
+    'session_id'::name,
+    'token'::name,
+    'last_used'::name,
+    'ttl'::name,
+    'users_id'::name,
+    'notify_pasword'::name
+]);
+
+RETURN NEXT has_column(       'public', 'session', 'session_id', 'Column public.session.session_id should exist');
+RETURN NEXT col_type_is(      'public', 'session', 'session_id', 'integer', 'Column public.session.session_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'session', 'session_id', 'Column public.session.session_id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'session', 'session_id', 'Column public.session.session_id shouldhave a default');
+--SELECT col_default_is(   'public', 'session', 'session_id', 'nextval(''session_session_id_seq''::regclass)', 'Column public.session.session_id default is');RETURN NEXT col_default_is(   'public', 'session', 'session_id', 'nextval(''session_session_id_seq''::regclass)', 'Column public.session.session_id default is');
+
+RETURN NEXT has_column(       'public', 'session', 'token', 'Column public.session.token should exist');
+RETURN NEXT col_type_is(      'public', 'session', 'token', 'character varying(32)', 'Column public.session.token should be type character varying(32)');
+RETURN NEXT col_is_null(      'public', 'session', 'token', 'Column public.session.token should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'session', 'token', 'Column public.session.token should not have a default');
+
+RETURN NEXT has_column(       'public', 'session', 'last_used', 'Column public.session.last_used should exist');
+RETURN NEXT col_type_is(      'public', 'session', 'last_used', 'timestamp without time zone', 'Column public.session.last_used should be type timestamp without time zone');
+RETURN NEXT col_is_null(      'public', 'session', 'last_used', 'Column public.session.last_used should allow NULL');
+RETURN NEXT col_has_default(  'public', 'session', 'last_used', 'Column public.session.last_used shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'session', 'last_used', 'now()', 'Column public.session.last_used default is');
+
+RETURN NEXT has_column(       'public', 'session', 'ttl', 'Column public.session.ttl should exist');
+RETURN NEXT col_type_is(      'public', 'session', 'ttl', 'integer', 'Column public.session.ttl should be type integer');
+RETURN NEXT col_not_null(     'public', 'session', 'ttl', 'Column public.session.ttl should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'session', 'ttl', 'Column public.session.ttl shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'session', 'ttl', '3600', 'Column public.session.ttl default is');
+
+RETURN NEXT has_column(       'public', 'session', 'users_id', 'Column public.session.users_id should exist');
+RETURN NEXT col_type_is(      'public', 'session', 'users_id', 'integer', 'Column public.session.users_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'session', 'users_id', 'Column public.session.users_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'session', 'users_id', 'Column public.session.users_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'session', 'notify_pasword', 'Column public.session.notify_pasword should exist');
+RETURN NEXT col_type_is(      'public', 'session', 'notify_pasword', 'interval', 'Column public.session.notify_pasword should be type interval');
+RETURN NEXT col_not_null(     'public', 'session', 'notify_pasword', 'Column public.session.notify_pasword should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'session', 'notify_pasword', 'Column public.session.notify_pasword shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'session', 'notify_pasword', '7 days'::interval, 'Column public.session.notify_pasword default is');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.sic.sql.pg_include
+++ b/xt/pgtap/table_public.sic.sql.pg_include
@@ -1,0 +1,38 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_sic()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'sic',
+    'Should have table public.sic'
+);
+
+RETURN NEXT has_pk(
+    'public', 'sic',
+    'Table public.sic should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'sic'::name, ARRAY[
+    'code'::name,
+    'sictype'::name,
+    'description'::name
+]);
+
+RETURN NEXT has_column(       'public', 'sic', 'code', 'Column public.sic.code should exist');
+RETURN NEXT col_type_is(      'public', 'sic', 'code', 'character varying(6)', 'Column public.sic.code should be type character varying(6)');
+RETURN NEXT col_not_null(     'public', 'sic', 'code', 'Column public.sic.code should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'sic', 'code', 'Column public.sic.code should not have a default');
+
+RETURN NEXT has_column(       'public', 'sic', 'sictype', 'Column public.sic.sictype should exist');
+RETURN NEXT col_type_is(      'public', 'sic', 'sictype', 'character(1)', 'Column public.sic.sictype should be type character(1)');
+RETURN NEXT col_is_null(      'public', 'sic', 'sictype', 'Column public.sic.sictype should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'sic', 'sictype', 'Column public.sic.sictype should not have a default');
+
+RETURN NEXT has_column(       'public', 'sic', 'description', 'Column public.sic.description should exist');
+RETURN NEXT col_type_is(      'public', 'sic', 'description', 'text', 'Column public.sic.description should be type text');
+RETURN NEXT col_is_null(      'public', 'sic', 'description', 'Column public.sic.description should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'sic', 'description', 'Column public.sic.description should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.status.sql.pg_include
+++ b/xt/pgtap/table_public.status.sql.pg_include
@@ -1,0 +1,52 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_status()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'status',
+    'Should have table public.status'
+);
+
+RETURN NEXT has_pk(
+    'public', 'status',
+    'Table public.status should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'status'::name, ARRAY[
+    'trans_id'::name,
+    'formname'::name,
+    'printed'::name,
+    'emailed'::name,
+    'spoolfile'::name
+]);
+
+RETURN NEXT has_column(       'public', 'status', 'trans_id', 'Column public.status.trans_id should exist');
+RETURN NEXT col_type_is(      'public', 'status', 'trans_id', 'integer', 'Column public.status.trans_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'status', 'trans_id', 'Column public.status.trans_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'status', 'trans_id', 'Column public.status.trans_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'status', 'formname', 'Column public.status.formname should exist');
+RETURN NEXT col_type_is(      'public', 'status', 'formname', 'text', 'Column public.status.formname should be type text');
+RETURN NEXT col_not_null(     'public', 'status', 'formname', 'Column public.status.formname should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'status', 'formname', 'Column public.status.formname should not have a default');
+
+RETURN NEXT has_column(       'public', 'status', 'printed', 'Column public.status.printed should exist');
+RETURN NEXT col_type_is(      'public', 'status', 'printed', 'boolean', 'Column public.status.printed should be type boolean');
+RETURN NEXT col_is_null(      'public', 'status', 'printed', 'Column public.status.printed should allow NULL');
+RETURN NEXT col_has_default(  'public', 'status', 'printed', 'Column public.status.printed shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'status', 'printed', 'false', 'Column public.status.printed default is');
+
+RETURN NEXT has_column(       'public', 'status', 'emailed', 'Column public.status.emailed should exist');
+RETURN NEXT col_type_is(      'public', 'status', 'emailed', 'boolean', 'Column public.status.emailed should be type boolean');
+RETURN NEXT col_is_null(      'public', 'status', 'emailed', 'Column public.status.emailed should allow NULL');
+RETURN NEXT col_has_default(  'public', 'status', 'emailed', 'Column public.status.emailed shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'status', 'emailed', 'false', 'Column public.status.emailed default is');
+
+RETURN NEXT has_column(       'public', 'status', 'spoolfile', 'Column public.status.spoolfile should exist');
+RETURN NEXT col_type_is(      'public', 'status', 'spoolfile', 'text', 'Column public.status.spoolfile should be type text');
+RETURN NEXT col_is_null(      'public', 'status', 'spoolfile', 'Column public.status.spoolfile should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'status', 'spoolfile', 'Column public.status.spoolfile should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.tax.sql.pg_include
+++ b/xt/pgtap/table_public.tax.sql.pg_include
@@ -1,0 +1,71 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_tax()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'tax',
+    'Should have table public.tax'
+);
+
+RETURN NEXT has_pk(
+    'public', 'tax',
+    'Table public.tax should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'tax'::name, ARRAY[
+    'chart_id'::name,
+    'rate'::name,
+    'minvalue'::name,
+    'maxvalue'::name,
+    'taxnumber'::name,
+    'validto'::name,
+    'pass'::name,
+    'taxmodule_id'::name
+]);
+
+RETURN NEXT has_column(       'public', 'tax', 'chart_id', 'Column public.tax.chart_id should exist');
+RETURN NEXT col_type_is(      'public', 'tax', 'chart_id', 'integer', 'Column public.tax.chart_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'tax', 'chart_id', 'Column public.tax.chart_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'tax', 'chart_id', 'Column public.tax.chart_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'tax', 'rate', 'Column public.tax.rate should exist');
+RETURN NEXT col_type_is(      'public', 'tax', 'rate', 'numeric', 'Column public.tax.rate should be type numeric');
+RETURN NEXT col_is_null(      'public', 'tax', 'rate', 'Column public.tax.rate should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'tax', 'rate', 'Column public.tax.rate should not have a default');
+
+RETURN NEXT has_column(       'public', 'tax', 'minvalue', 'Column public.tax.minvalue should exist');
+RETURN NEXT col_type_is(      'public', 'tax', 'minvalue', 'numeric', 'Column public.tax.minvalue should be type numeric');
+RETURN NEXT col_is_null(      'public', 'tax', 'minvalue', 'Column public.tax.minvalue should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'tax', 'minvalue', 'Column public.tax.minvalue should not have a default');
+
+RETURN NEXT has_column(       'public', 'tax', 'maxvalue', 'Column public.tax.maxvalue should exist');
+RETURN NEXT col_type_is(      'public', 'tax', 'maxvalue', 'numeric', 'Column public.tax.maxvalue should be type numeric');
+RETURN NEXT col_is_null(      'public', 'tax', 'maxvalue', 'Column public.tax.maxvalue should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'tax', 'maxvalue', 'Column public.tax.maxvalue should not have a default');
+
+RETURN NEXT has_column(       'public', 'tax', 'taxnumber', 'Column public.tax.taxnumber should exist');
+RETURN NEXT col_type_is(      'public', 'tax', 'taxnumber', 'text', 'Column public.tax.taxnumber should be type text');
+RETURN NEXT col_is_null(      'public', 'tax', 'taxnumber', 'Column public.tax.taxnumber should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'tax', 'taxnumber', 'Column public.tax.taxnumber should not have a default');
+
+RETURN NEXT has_column(       'public', 'tax', 'validto', 'Column public.tax.validto should exist');
+RETURN NEXT col_type_is(      'public', 'tax', 'validto', 'timestamp without time zone', 'Column public.tax.validto should be type timestamp without time zone');
+RETURN NEXT col_not_null(     'public', 'tax', 'validto', 'Column public.tax.validto should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'tax', 'validto', 'Column public.tax.validto shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'tax', 'validto', 'infinity'::timestamp without time zone, 'Column public.tax.validto default is');
+
+RETURN NEXT has_column(       'public', 'tax', 'pass', 'Column public.tax.pass should exist');
+RETURN NEXT col_type_is(      'public', 'tax', 'pass', 'integer', 'Column public.tax.pass should be type integer');
+RETURN NEXT col_not_null(     'public', 'tax', 'pass', 'Column public.tax.pass should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'tax', 'pass', 'Column public.tax.pass shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'tax', 'pass', '0', 'Column public.tax.pass default is');
+
+RETURN NEXT has_column(       'public', 'tax', 'taxmodule_id', 'Column public.tax.taxmodule_id should exist');
+RETURN NEXT col_type_is(      'public', 'tax', 'taxmodule_id', 'integer', 'Column public.tax.taxmodule_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'tax', 'taxmodule_id', 'Column public.tax.taxmodule_id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'tax', 'taxmodule_id', 'Column public.tax.taxmodule_id shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'tax', 'taxmodule_id', '1', 'Column public.tax.taxmodule_id default is');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.tax_extended.sql.pg_include
+++ b/xt/pgtap/table_public.tax_extended.sql.pg_include
@@ -1,0 +1,38 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_tax_extended()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'tax_extended',
+    'Should have table public.tax_extended'
+);
+
+RETURN NEXT has_pk(
+    'public', 'tax_extended',
+    'Table public.tax_extended should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'tax_extended'::name, ARRAY[
+    'tax_basis'::name,
+    'rate'::name,
+    'entry_id'::name
+]);
+
+RETURN NEXT has_column(       'public', 'tax_extended', 'tax_basis', 'Column public.tax_extended.tax_basis should exist');
+RETURN NEXT col_type_is(      'public', 'tax_extended', 'tax_basis', 'numeric', 'Column public.tax_extended.tax_basis should be type numeric');
+RETURN NEXT col_is_null(      'public', 'tax_extended', 'tax_basis', 'Column public.tax_extended.tax_basis should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'tax_extended', 'tax_basis', 'Column public.tax_extended.tax_basis should not have a default');
+
+RETURN NEXT has_column(       'public', 'tax_extended', 'rate', 'Column public.tax_extended.rate should exist');
+RETURN NEXT col_type_is(      'public', 'tax_extended', 'rate', 'numeric', 'Column public.tax_extended.rate should be type numeric');
+RETURN NEXT col_is_null(      'public', 'tax_extended', 'rate', 'Column public.tax_extended.rate should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'tax_extended', 'rate', 'Column public.tax_extended.rate should not have a default');
+
+RETURN NEXT has_column(       'public', 'tax_extended', 'entry_id', 'Column public.tax_extended.entry_id should exist');
+RETURN NEXT col_type_is(      'public', 'tax_extended', 'entry_id', 'integer', 'Column public.tax_extended.entry_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'tax_extended', 'entry_id', 'Column public.tax_extended.entry_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'tax_extended', 'entry_id', 'Column public.tax_extended.entry_id should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.taxcategory.sql.pg_include
+++ b/xt/pgtap/table_public.taxcategory.sql.pg_include
@@ -1,0 +1,39 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_taxcategory()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'taxcategory',
+    'Should have table public.taxcategory'
+);
+
+RETURN NEXT has_pk(
+    'public', 'taxcategory',
+    'Table public.taxcategory should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'taxcategory'::name, ARRAY[
+    'taxcategory_id'::name,
+    'taxcategoryname'::name,
+    'taxmodule_id'::name
+]);
+
+RETURN NEXT has_column(       'public', 'taxcategory', 'taxcategory_id', 'Column public.taxcategory.taxcategory_id should exist');
+RETURN NEXT col_type_is(      'public', 'taxcategory', 'taxcategory_id', 'integer', 'Column public.taxcategory.taxcategory_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'taxcategory', 'taxcategory_id', 'Column public.taxcategory.taxcategory_id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'taxcategory', 'taxcategory_id', 'Column public.taxcategory.taxcategory_id shouldhave a default');
+--SELECT col_default_is(   'public', 'taxcategory', 'taxcategory_id', 'nextval(''taxcategory_taxcategory_id_seq''::regclass)', 'Column public.taxcategory.taxcategory_id default is');RETURN NEXT col_default_is(   'public', 'taxcategory', 'taxcategory_id', 'nextval(''taxcategory_taxcategory_id_seq''::regclass)', 'Column public.taxcategory.taxcategory_id default is');
+
+RETURN NEXT has_column(       'public', 'taxcategory', 'taxcategoryname', 'Column public.taxcategory.taxcategoryname should exist');
+RETURN NEXT col_type_is(      'public', 'taxcategory', 'taxcategoryname', 'text', 'Column public.taxcategory.taxcategoryname should be type text');
+RETURN NEXT col_not_null(     'public', 'taxcategory', 'taxcategoryname', 'Column public.taxcategory.taxcategoryname should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'taxcategory', 'taxcategoryname', 'Column public.taxcategory.taxcategoryname should not have a default');
+
+RETURN NEXT has_column(       'public', 'taxcategory', 'taxmodule_id', 'Column public.taxcategory.taxmodule_id should exist');
+RETURN NEXT col_type_is(      'public', 'taxcategory', 'taxmodule_id', 'integer', 'Column public.taxcategory.taxmodule_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'taxcategory', 'taxmodule_id', 'Column public.taxcategory.taxmodule_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'taxcategory', 'taxmodule_id', 'Column public.taxcategory.taxmodule_id should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.taxmodule.sql.pg_include
+++ b/xt/pgtap/table_public.taxmodule.sql.pg_include
@@ -1,0 +1,33 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_taxmodule()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'taxmodule',
+    'Should have table public.taxmodule'
+);
+
+RETURN NEXT has_pk(
+    'public', 'taxmodule',
+    'Table public.taxmodule should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'taxmodule'::name, ARRAY[
+    'taxmodule_id'::name,
+    'taxmodulename'::name
+]);
+
+RETURN NEXT has_column(       'public', 'taxmodule', 'taxmodule_id', 'Column public.taxmodule.taxmodule_id should exist');
+RETURN NEXT col_type_is(      'public', 'taxmodule', 'taxmodule_id', 'integer', 'Column public.taxmodule.taxmodule_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'taxmodule', 'taxmodule_id', 'Column public.taxmodule.taxmodule_id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'taxmodule', 'taxmodule_id', 'Column public.taxmodule.taxmodule_id shouldhave a default');
+--SELECT col_default_is(   'public', 'taxmodule', 'taxmodule_id', 'nextval(''taxmodule_taxmodule_id_seq''::regclass)', 'Column public.taxmodule.taxmodule_id default is');RETURN NEXT col_default_is(   'public', 'taxmodule', 'taxmodule_id', 'nextval(''taxmodule_taxmodule_id_seq''::regclass)', 'Column public.taxmodule.taxmodule_id default is');
+
+RETURN NEXT has_column(       'public', 'taxmodule', 'taxmodulename', 'Column public.taxmodule.taxmodulename should exist');
+RETURN NEXT col_type_is(      'public', 'taxmodule', 'taxmodulename', 'text', 'Column public.taxmodule.taxmodulename should be type text');
+RETURN NEXT col_not_null(     'public', 'taxmodule', 'taxmodulename', 'Column public.taxmodule.taxmodulename should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'taxmodule', 'taxmodulename', 'Column public.taxmodule.taxmodulename should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.template.sql.pg_include
+++ b/xt/pgtap/table_public.template.sql.pg_include
@@ -1,0 +1,58 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_template()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'template',
+    'Should have table public.template'
+);
+
+RETURN NEXT hasnt_pk(
+    'public', 'template',
+    'Table public.template should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'template'::name, ARRAY[
+    'id'::name,
+    'template_name'::name,
+    'language_code'::name,
+    'template'::name,
+    'format'::name,
+    'last_modified'::name
+]);
+
+RETURN NEXT has_column(       'public', 'template', 'id', 'Column public.template.id should exist');
+RETURN NEXT col_type_is(      'public', 'template', 'id', 'integer', 'Column public.template.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'template', 'id', 'Column public.template.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'template', 'id', 'Column public.template.id shouldhave a default');
+--SELECT col_default_is(   'public', 'template', 'id', 'nextval(''template_id_seq''::regclass)', 'Column public.template.id default is');RETURN NEXT col_default_is(   'public', 'template', 'id', 'nextval(''template_id_seq''::regclass)', 'Column public.template.id default is');
+
+RETURN NEXT has_column(       'public', 'template', 'template_name', 'Column public.template.template_name should exist');
+RETURN NEXT col_type_is(      'public', 'template', 'template_name', 'text', 'Column public.template.template_name should be type text');
+RETURN NEXT col_not_null(     'public', 'template', 'template_name', 'Column public.template.template_name should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'template', 'template_name', 'Column public.template.template_name should not have a default');
+
+RETURN NEXT has_column(       'public', 'template', 'language_code', 'Column public.template.language_code should exist');
+RETURN NEXT col_type_is(      'public', 'template', 'language_code', 'character varying(6)', 'Column public.template.language_code should be type character varying(6)');
+RETURN NEXT col_is_null(      'public', 'template', 'language_code', 'Column public.template.language_code should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'template', 'language_code', 'Column public.template.language_code should not have a default');
+
+RETURN NEXT has_column(       'public', 'template', 'template', 'Column public.template.template should exist');
+RETURN NEXT col_type_is(      'public', 'template', 'template', 'text', 'Column public.template.template should be type text');
+RETURN NEXT col_not_null(     'public', 'template', 'template', 'Column public.template.template should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'template', 'template', 'Column public.template.template should not have a default');
+
+RETURN NEXT has_column(       'public', 'template', 'format', 'Column public.template.format should exist');
+RETURN NEXT col_type_is(      'public', 'template', 'format', 'text', 'Column public.template.format should be type text');
+RETURN NEXT col_not_null(     'public', 'template', 'format', 'Column public.template.format should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'template', 'format', 'Column public.template.format should not have a default');
+
+RETURN NEXT has_column(       'public', 'template', 'last_modified', 'Column public.template.last_modified should exist');
+RETURN NEXT col_type_is(      'public', 'template', 'last_modified', 'timestamp with time zone', 'Column public.template.last_modified should be type timestamp with time zone');
+RETURN NEXT col_not_null(     'public', 'template', 'last_modified', 'Column public.template.last_modified should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'template', 'last_modified', 'Column public.template.last_modified shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'template', 'last_modified', 'now()', 'Column public.template.last_modified default is');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.trans_type.sql.pg_include
+++ b/xt/pgtap/table_public.trans_type.sql.pg_include
@@ -1,0 +1,32 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_trans_type()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'trans_type',
+    'Should have table public.trans_type'
+);
+
+RETURN NEXT has_pk(
+    'public', 'trans_type',
+    'Table public.trans_type should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'trans_type'::name, ARRAY[
+    'code'::name,
+    'description'::name
+]);
+
+RETURN NEXT has_column(       'public', 'trans_type', 'code', 'Column public.trans_type.code should exist');
+RETURN NEXT col_type_is(      'public', 'trans_type', 'code', 'character(2)', 'Column public.trans_type.code should be type character(2)');
+RETURN NEXT col_not_null(     'public', 'trans_type', 'code', 'Column public.trans_type.code should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'trans_type', 'code', 'Column public.trans_type.code should not have a default');
+
+RETURN NEXT has_column(       'public', 'trans_type', 'description', 'Column public.trans_type.description should exist');
+RETURN NEXT col_type_is(      'public', 'trans_type', 'description', 'character varying(1000)', 'Column public.trans_type.description should be type character varying(1000)');
+RETURN NEXT col_is_null(      'public', 'trans_type', 'description', 'Column public.trans_type.description should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'trans_type', 'description', 'Column public.trans_type.description should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.transactions.sql.pg_include
+++ b/xt/pgtap/table_public.transactions.sql.pg_include
@@ -1,0 +1,56 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_transactions()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'transactions',
+    'Should have table public.transactions'
+);
+
+RETURN NEXT has_pk(
+    'public', 'transactions',
+    'Table public.transactions should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'transactions'::name, ARRAY[
+    'id'::name,
+    'table_name'::name,
+    'locked_by'::name,
+    'approved'::name,
+    'approved_by'::name,
+    'approved_at'::name
+]);
+
+RETURN NEXT has_column(       'public', 'transactions', 'id', 'Column public.transactions.id should exist');
+RETURN NEXT col_type_is(      'public', 'transactions', 'id', 'integer', 'Column public.transactions.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'transactions', 'id', 'Column public.transactions.id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'transactions', 'id', 'Column public.transactions.id should not have a default');
+
+RETURN NEXT has_column(       'public', 'transactions', 'table_name', 'Column public.transactions.table_name should exist');
+RETURN NEXT col_type_is(      'public', 'transactions', 'table_name', 'text', 'Column public.transactions.table_name should be type text');
+RETURN NEXT col_is_null(      'public', 'transactions', 'table_name', 'Column public.transactions.table_name should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'transactions', 'table_name', 'Column public.transactions.table_name should not have a default');
+
+RETURN NEXT has_column(       'public', 'transactions', 'locked_by', 'Column public.transactions.locked_by should exist');
+RETURN NEXT col_type_is(      'public', 'transactions', 'locked_by', 'integer', 'Column public.transactions.locked_by should be type integer');
+RETURN NEXT col_is_null(      'public', 'transactions', 'locked_by', 'Column public.transactions.locked_by should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'transactions', 'locked_by', 'Column public.transactions.locked_by should not have a default');
+
+RETURN NEXT has_column(       'public', 'transactions', 'approved', 'Column public.transactions.approved should exist');
+RETURN NEXT col_type_is(      'public', 'transactions', 'approved', 'boolean', 'Column public.transactions.approved should be type boolean');
+RETURN NEXT col_is_null(      'public', 'transactions', 'approved', 'Column public.transactions.approved should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'transactions', 'approved', 'Column public.transactions.approved should not have a default');
+
+RETURN NEXT has_column(       'public', 'transactions', 'approved_by', 'Column public.transactions.approved_by should exist');
+RETURN NEXT col_type_is(      'public', 'transactions', 'approved_by', 'integer', 'Column public.transactions.approved_by should be type integer');
+RETURN NEXT col_is_null(      'public', 'transactions', 'approved_by', 'Column public.transactions.approved_by should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'transactions', 'approved_by', 'Column public.transactions.approved_by should not have a default');
+
+RETURN NEXT has_column(       'public', 'transactions', 'approved_at', 'Column public.transactions.approved_at should exist');
+RETURN NEXT col_type_is(      'public', 'transactions', 'approved_at', 'timestamp without time zone', 'Column public.transactions.approved_at should be type timestamp without time zone');
+RETURN NEXT col_is_null(      'public', 'transactions', 'approved_at', 'Column public.transactions.approved_at should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'transactions', 'approved_at', 'Column public.transactions.approved_at should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.translation.sql.pg_include
+++ b/xt/pgtap/table_public.translation.sql.pg_include
@@ -1,0 +1,38 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_translation()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'translation',
+    'Should have table public.translation'
+);
+
+RETURN NEXT has_pk(
+    'public', 'translation',
+    'Table public.translation should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'translation'::name, ARRAY[
+    'trans_id'::name,
+    'language_code'::name,
+    'description'::name
+]);
+
+RETURN NEXT has_column(       'public', 'translation', 'trans_id', 'Column public.translation.trans_id should exist');
+RETURN NEXT col_type_is(      'public', 'translation', 'trans_id', 'integer', 'Column public.translation.trans_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'translation', 'trans_id', 'Column public.translation.trans_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'translation', 'trans_id', 'Column public.translation.trans_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'translation', 'language_code', 'Column public.translation.language_code should exist');
+RETURN NEXT col_type_is(      'public', 'translation', 'language_code', 'character varying(6)', 'Column public.translation.language_code should be type character varying(6)');
+RETURN NEXT col_not_null(     'public', 'translation', 'language_code', 'Column public.translation.language_code should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'translation', 'language_code', 'Column public.translation.language_code should not have a default');
+
+RETURN NEXT has_column(       'public', 'translation', 'description', 'Column public.translation.description should exist');
+RETURN NEXT col_type_is(      'public', 'translation', 'description', 'text', 'Column public.translation.description should be type text');
+RETURN NEXT col_is_null(      'public', 'translation', 'description', 'Column public.translation.description should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'translation', 'description', 'Column public.translation.description should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.trial_balance__yearend_types.sql.pg_include
+++ b/xt/pgtap/table_public.trial_balance__yearend_types.sql.pg_include
@@ -1,0 +1,26 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_trial_balance__yearend_types()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'trial_balance__yearend_types',
+    'Should have table public.trial_balance__yearend_types'
+);
+
+RETURN NEXT has_pk(
+    'public', 'trial_balance__yearend_types',
+    'Table public.trial_balance__yearend_types should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'trial_balance__yearend_types'::name, ARRAY[
+    'type'::name
+]);
+
+RETURN NEXT has_column(       'public', 'trial_balance__yearend_types', 'type', 'Column public.trial_balance__yearend_types.type should exist');
+RETURN NEXT col_type_is(      'public', 'trial_balance__yearend_types', 'type', 'text', 'Column public.trial_balance__yearend_types.type should be type text');
+RETURN NEXT col_not_null(     'public', 'trial_balance__yearend_types', 'type', 'Column public.trial_balance__yearend_types.type should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'trial_balance__yearend_types', 'type', 'Column public.trial_balance__yearend_types.type should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.user_preference.sql.pg_include
+++ b/xt/pgtap/table_public.user_preference.sql.pg_include
@@ -1,0 +1,59 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_user_preference()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'user_preference',
+    'Should have table public.user_preference'
+);
+
+RETURN NEXT has_pk(
+    'public', 'user_preference',
+    'Table public.user_preference should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'user_preference'::name, ARRAY[
+    'id'::name,
+    'language'::name,
+    'stylesheet'::name,
+    'printer'::name,
+    'dateformat'::name,
+    'numberformat'::name
+]);
+
+RETURN NEXT has_column(       'public', 'user_preference', 'id', 'Column public.user_preference.id should exist');
+RETURN NEXT col_type_is(      'public', 'user_preference', 'id', 'integer', 'Column public.user_preference.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'user_preference', 'id', 'Column public.user_preference.id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'user_preference', 'id', 'Column public.user_preference.id should not have a default');
+
+RETURN NEXT has_column(       'public', 'user_preference', 'language', 'Column public.user_preference.language should exist');
+RETURN NEXT col_type_is(      'public', 'user_preference', 'language', 'character varying(6)', 'Column public.user_preference.language should be type character varying(6)');
+RETURN NEXT col_is_null(      'public', 'user_preference', 'language', 'Column public.user_preference.language should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'user_preference', 'language', 'Column public.user_preference.language should not have a default');
+
+RETURN NEXT has_column(       'public', 'user_preference', 'stylesheet', 'Column public.user_preference.stylesheet should exist');
+RETURN NEXT col_type_is(      'public', 'user_preference', 'stylesheet', 'text', 'Column public.user_preference.stylesheet should be type text');
+RETURN NEXT col_not_null(     'public', 'user_preference', 'stylesheet', 'Column public.user_preference.stylesheet should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'user_preference', 'stylesheet', 'Column public.user_preference.stylesheet shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'user_preference', 'stylesheet', 'ledgersmb.css'::text, 'Column public.user_preference.stylesheet default is');
+
+RETURN NEXT has_column(       'public', 'user_preference', 'printer', 'Column public.user_preference.printer should exist');
+RETURN NEXT col_type_is(      'public', 'user_preference', 'printer', 'text', 'Column public.user_preference.printer should be type text');
+RETURN NEXT col_is_null(      'public', 'user_preference', 'printer', 'Column public.user_preference.printer should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'user_preference', 'printer', 'Column public.user_preference.printer should not have a default');
+
+RETURN NEXT has_column(       'public', 'user_preference', 'dateformat', 'Column public.user_preference.dateformat should exist');
+RETURN NEXT col_type_is(      'public', 'user_preference', 'dateformat', 'text', 'Column public.user_preference.dateformat should be type text');
+RETURN NEXT col_not_null(     'public', 'user_preference', 'dateformat', 'Column public.user_preference.dateformat should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'user_preference', 'dateformat', 'Column public.user_preference.dateformat shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'user_preference', 'dateformat', 'yyyy-mm-dd'::text, 'Column public.user_preference.dateformat default is');
+
+RETURN NEXT has_column(       'public', 'user_preference', 'numberformat', 'Column public.user_preference.numberformat should exist');
+RETURN NEXT col_type_is(      'public', 'user_preference', 'numberformat', 'text', 'Column public.user_preference.numberformat should be type text');
+RETURN NEXT col_not_null(     'public', 'user_preference', 'numberformat', 'Column public.user_preference.numberformat should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'user_preference', 'numberformat', 'Column public.user_preference.numberformat shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'user_preference', 'numberformat', '1000.00'::text, 'Column public.user_preference.numberformat default is');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.users.sql.pg_include
+++ b/xt/pgtap/table_public.users.sql.pg_include
@@ -1,0 +1,46 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_users()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'users',
+    'Should have table public.users'
+);
+
+RETURN NEXT has_pk(
+    'public', 'users',
+    'Table public.users should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'users'::name, ARRAY[
+    'id'::name,
+    'username'::name,
+    'notify_password'::name,
+    'entity_id'::name
+]);
+
+RETURN NEXT has_column(       'public', 'users', 'id', 'Column public.users.id should exist');
+RETURN NEXT col_type_is(      'public', 'users', 'id', 'integer', 'Column public.users.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'users', 'id', 'Column public.users.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'users', 'id', 'Column public.users.id shouldhave a default');
+--SELECT col_default_is(   'public', 'users', 'id', 'nextval(''users_id_seq''::regclass)', 'Column public.users.id default is');RETURN NEXT col_default_is(   'public', 'users', 'id', 'nextval(''users_id_seq''::regclass)', 'Column public.users.id default is');
+
+RETURN NEXT has_column(       'public', 'users', 'username', 'Column public.users.username should exist');
+RETURN NEXT col_type_is(      'public', 'users', 'username', 'character varying(30)', 'Column public.users.username should be type character varying(30)');
+RETURN NEXT col_not_null(     'public', 'users', 'username', 'Column public.users.username should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'users', 'username', 'Column public.users.username should not have a default');
+
+RETURN NEXT has_column(       'public', 'users', 'notify_password', 'Column public.users.notify_password should exist');
+RETURN NEXT col_type_is(      'public', 'users', 'notify_password', 'interval', 'Column public.users.notify_password should be type interval');
+RETURN NEXT col_not_null(     'public', 'users', 'notify_password', 'Column public.users.notify_password should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'users', 'notify_password', 'Column public.users.notify_password shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'users', 'notify_password', '7 days'::interval, 'Column public.users.notify_password default is');
+
+RETURN NEXT has_column(       'public', 'users', 'entity_id', 'Column public.users.entity_id should exist');
+RETURN NEXT col_type_is(      'public', 'users', 'entity_id', 'integer', 'Column public.users.entity_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'users', 'entity_id', 'Column public.users.entity_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'users', 'entity_id', 'Column public.users.entity_id should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.voucher.sql.pg_include
+++ b/xt/pgtap/table_public.voucher.sql.pg_include
@@ -1,0 +1,45 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_voucher()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'voucher',
+    'Should have table public.voucher'
+);
+
+RETURN NEXT has_pk(
+    'public', 'voucher',
+    'Table public.voucher should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'voucher'::name, ARRAY[
+    'trans_id'::name,
+    'batch_id'::name,
+    'id'::name,
+    'batch_class'::name
+]);
+
+RETURN NEXT has_column(       'public', 'voucher', 'trans_id', 'Column public.voucher.trans_id should exist');
+RETURN NEXT col_type_is(      'public', 'voucher', 'trans_id', 'integer', 'Column public.voucher.trans_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'voucher', 'trans_id', 'Column public.voucher.trans_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'voucher', 'trans_id', 'Column public.voucher.trans_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'voucher', 'batch_id', 'Column public.voucher.batch_id should exist');
+RETURN NEXT col_type_is(      'public', 'voucher', 'batch_id', 'integer', 'Column public.voucher.batch_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'voucher', 'batch_id', 'Column public.voucher.batch_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'voucher', 'batch_id', 'Column public.voucher.batch_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'voucher', 'id', 'Column public.voucher.id should exist');
+RETURN NEXT col_type_is(      'public', 'voucher', 'id', 'integer', 'Column public.voucher.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'voucher', 'id', 'Column public.voucher.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'voucher', 'id', 'Column public.voucher.id shouldhave a default');
+--SELECT col_default_is(   'public', 'voucher', 'id', 'nextval(''voucher_id_seq''::regclass)', 'Column public.voucher.id default is');RETURN NEXT col_default_is(   'public', 'voucher', 'id', 'nextval(''voucher_id_seq''::regclass)', 'Column public.voucher.id default is');
+
+RETURN NEXT has_column(       'public', 'voucher', 'batch_class', 'Column public.voucher.batch_class should exist');
+RETURN NEXT col_type_is(      'public', 'voucher', 'batch_class', 'integer', 'Column public.voucher.batch_class should be type integer');
+RETURN NEXT col_not_null(     'public', 'voucher', 'batch_class', 'Column public.voucher.batch_class should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'voucher', 'batch_class', 'Column public.voucher.batch_class should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.warehouse.sql.pg_include
+++ b/xt/pgtap/table_public.warehouse.sql.pg_include
@@ -1,0 +1,33 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_warehouse()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'warehouse',
+    'Should have table public.warehouse'
+);
+
+RETURN NEXT has_pk(
+    'public', 'warehouse',
+    'Table public.warehouse should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'warehouse'::name, ARRAY[
+    'id'::name,
+    'description'::name
+]);
+
+RETURN NEXT has_column(       'public', 'warehouse', 'id', 'Column public.warehouse.id should exist');
+RETURN NEXT col_type_is(      'public', 'warehouse', 'id', 'integer', 'Column public.warehouse.id should be type integer');
+RETURN NEXT col_not_null(     'public', 'warehouse', 'id', 'Column public.warehouse.id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'warehouse', 'id', 'Column public.warehouse.id shouldhave a default');
+--SELECT col_default_is(   'public', 'warehouse', 'id', 'nextval(''warehouse_id_seq''::regclass)', 'Column public.warehouse.id default is');RETURN NEXT col_default_is(   'public', 'warehouse', 'id', 'nextval(''warehouse_id_seq''::regclass)', 'Column public.warehouse.id default is');
+
+RETURN NEXT has_column(       'public', 'warehouse', 'description', 'Column public.warehouse.description should exist');
+RETURN NEXT col_type_is(      'public', 'warehouse', 'description', 'text', 'Column public.warehouse.description should be type text');
+RETURN NEXT col_is_null(      'public', 'warehouse', 'description', 'Column public.warehouse.description should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'warehouse', 'description', 'Column public.warehouse.description should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.warehouse_inventory.sql.pg_include
+++ b/xt/pgtap/table_public.warehouse_inventory.sql.pg_include
@@ -1,0 +1,69 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_warehouse_inventory()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'warehouse_inventory',
+    'Should have table public.warehouse_inventory'
+);
+
+RETURN NEXT has_pk(
+    'public', 'warehouse_inventory',
+    'Table public.warehouse_inventory should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'warehouse_inventory'::name, ARRAY[
+    'entity_id'::name,
+    'warehouse_id'::name,
+    'parts_id'::name,
+    'trans_id'::name,
+    'orderitems_id'::name,
+    'qty'::name,
+    'shippingdate'::name,
+    'entry_id'::name
+]);
+
+RETURN NEXT has_column(       'public', 'warehouse_inventory', 'entity_id', 'Column public.warehouse_inventory.entity_id should exist');
+RETURN NEXT col_type_is(      'public', 'warehouse_inventory', 'entity_id', 'integer', 'Column public.warehouse_inventory.entity_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'warehouse_inventory', 'entity_id', 'Column public.warehouse_inventory.entity_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'warehouse_inventory', 'entity_id', 'Column public.warehouse_inventory.entity_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'warehouse_inventory', 'warehouse_id', 'Column public.warehouse_inventory.warehouse_id should exist');
+RETURN NEXT col_type_is(      'public', 'warehouse_inventory', 'warehouse_id', 'integer', 'Column public.warehouse_inventory.warehouse_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'warehouse_inventory', 'warehouse_id', 'Column public.warehouse_inventory.warehouse_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'warehouse_inventory', 'warehouse_id', 'Column public.warehouse_inventory.warehouse_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'warehouse_inventory', 'parts_id', 'Column public.warehouse_inventory.parts_id should exist');
+RETURN NEXT col_type_is(      'public', 'warehouse_inventory', 'parts_id', 'integer', 'Column public.warehouse_inventory.parts_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'warehouse_inventory', 'parts_id', 'Column public.warehouse_inventory.parts_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'warehouse_inventory', 'parts_id', 'Column public.warehouse_inventory.parts_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'warehouse_inventory', 'trans_id', 'Column public.warehouse_inventory.trans_id should exist');
+RETURN NEXT col_type_is(      'public', 'warehouse_inventory', 'trans_id', 'integer', 'Column public.warehouse_inventory.trans_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'warehouse_inventory', 'trans_id', 'Column public.warehouse_inventory.trans_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'warehouse_inventory', 'trans_id', 'Column public.warehouse_inventory.trans_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'warehouse_inventory', 'orderitems_id', 'Column public.warehouse_inventory.orderitems_id should exist');
+RETURN NEXT col_type_is(      'public', 'warehouse_inventory', 'orderitems_id', 'integer', 'Column public.warehouse_inventory.orderitems_id should be type integer');
+RETURN NEXT col_is_null(      'public', 'warehouse_inventory', 'orderitems_id', 'Column public.warehouse_inventory.orderitems_id should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'warehouse_inventory', 'orderitems_id', 'Column public.warehouse_inventory.orderitems_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'warehouse_inventory', 'qty', 'Column public.warehouse_inventory.qty should exist');
+RETURN NEXT col_type_is(      'public', 'warehouse_inventory', 'qty', 'numeric', 'Column public.warehouse_inventory.qty should be type numeric');
+RETURN NEXT col_is_null(      'public', 'warehouse_inventory', 'qty', 'Column public.warehouse_inventory.qty should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'warehouse_inventory', 'qty', 'Column public.warehouse_inventory.qty should not have a default');
+
+RETURN NEXT has_column(       'public', 'warehouse_inventory', 'shippingdate', 'Column public.warehouse_inventory.shippingdate should exist');
+RETURN NEXT col_type_is(      'public', 'warehouse_inventory', 'shippingdate', 'date', 'Column public.warehouse_inventory.shippingdate should be type date');
+RETURN NEXT col_is_null(      'public', 'warehouse_inventory', 'shippingdate', 'Column public.warehouse_inventory.shippingdate should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'warehouse_inventory', 'shippingdate', 'Column public.warehouse_inventory.shippingdate should not have a default');
+
+RETURN NEXT has_column(       'public', 'warehouse_inventory', 'entry_id', 'Column public.warehouse_inventory.entry_id should exist');
+RETURN NEXT col_type_is(      'public', 'warehouse_inventory', 'entry_id', 'integer', 'Column public.warehouse_inventory.entry_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'warehouse_inventory', 'entry_id', 'Column public.warehouse_inventory.entry_id should be NOT NULL');
+RETURN NEXT col_has_default(  'public', 'warehouse_inventory', 'entry_id', 'Column public.warehouse_inventory.entry_id shouldhave a default');
+--SELECT col_default_is(   'public', 'warehouse_inventory', 'entry_id', 'nextval(''warehouse_inventory_entry_id_seq''::regclass)', 'Column public.warehouse_inventory.entry_id default is');RETURN NEXT col_default_is(   'public', 'warehouse_inventory', 'entry_id', 'nextval(''warehouse_inventory_entry_id_seq''::regclass)', 'Column public.warehouse_inventory.entry_id default is');
+
+END;
+$$ LANGUAGE plpgsql;

--- a/xt/pgtap/table_public.yearend.sql.pg_include
+++ b/xt/pgtap/table_public.yearend.sql.pg_include
@@ -1,0 +1,39 @@
+CREATE OR REPLACE FUNCTION lsmb_pgtap._table_public_yearend()
+RETURNS SETOF TEXT AS $$
+BEGIN
+
+
+RETURN NEXT has_table(
+    'public', 'yearend',
+    'Should have table public.yearend'
+);
+
+RETURN NEXT has_pk(
+    'public', 'yearend',
+    'Table public.yearend should have a primary key'
+);
+
+RETURN NEXT columns_are('public'::name, 'yearend'::name, ARRAY[
+    'trans_id'::name,
+    'reversed'::name,
+    'transdate'::name
+]);
+
+RETURN NEXT has_column(       'public', 'yearend', 'trans_id', 'Column public.yearend.trans_id should exist');
+RETURN NEXT col_type_is(      'public', 'yearend', 'trans_id', 'integer', 'Column public.yearend.trans_id should be type integer');
+RETURN NEXT col_not_null(     'public', 'yearend', 'trans_id', 'Column public.yearend.trans_id should be NOT NULL');
+RETURN NEXT col_hasnt_default('public', 'yearend', 'trans_id', 'Column public.yearend.trans_id should not have a default');
+
+RETURN NEXT has_column(       'public', 'yearend', 'reversed', 'Column public.yearend.reversed should exist');
+RETURN NEXT col_type_is(      'public', 'yearend', 'reversed', 'boolean', 'Column public.yearend.reversed should be type boolean');
+RETURN NEXT col_is_null(      'public', 'yearend', 'reversed', 'Column public.yearend.reversed should allow NULL');
+RETURN NEXT col_has_default(  'public', 'yearend', 'reversed', 'Column public.yearend.reversed shouldhave a default');
+RETURN NEXT col_default_is(   'public', 'yearend', 'reversed', 'false', 'Column public.yearend.reversed default is');
+
+RETURN NEXT has_column(       'public', 'yearend', 'transdate', 'Column public.yearend.transdate should exist');
+RETURN NEXT col_type_is(      'public', 'yearend', 'transdate', 'date', 'Column public.yearend.transdate should be type date');
+RETURN NEXT col_is_null(      'public', 'yearend', 'transdate', 'Column public.yearend.transdate should allow NULL');
+RETURN NEXT col_hasnt_default('public', 'yearend', 'transdate', 'Column public.yearend.transdate should not have a default');
+
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
The following PR extracts pgTap schema validation files from the current schema in order to produce stricter validation tests.
- It allows using pg_tapgen to extract the current schema and compiles validation files for the schema and all tables into `xt/pgtap/*.pg_include`
- It allows using sub-tests to segment the validation
- It proposes an upgraded version of `42-reconciliation.pg` with the above modifications