### PR TITLE
Use Travis variable test-jobs instead of a fixed 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -164,7 +164,7 @@ script:
      LSMB_BASE_URL="http://127.0.0.1:5000"
      PSGI_BASE_URL="http://127.0.0.1:5001"
      HARNESS_RULESFILE="t/testrules.yml"
-    prove -j$(test-jobs) -r
+    prove --jobs $(test-jobs) --recurse
           --pgtap-option dbname=lsmbinstalltest
           --pgtap-option username=postgres
           --feature-option tags=~@wip

--- a/.travis.yml
+++ b/.travis.yml
@@ -164,7 +164,7 @@ script:
      LSMB_BASE_URL="http://127.0.0.1:5000"
      PSGI_BASE_URL="http://127.0.0.1:5001"
      HARNESS_RULESFILE="t/testrules.yml"
-    prove -j9 -r
+    prove -j$(test-jobs) -r
           --pgtap-option dbname=lsmbinstalltest
           --pgtap-option username=postgres
           --feature-option tags=~@wip

--- a/t/.proverc
+++ b/t/.proverc
@@ -1,5 +1,5 @@
 # default arguments for the 'prove' command
--l
+--lib
 -Iold/lib/
 # arguments for Perl source runner
 --source Perl


### PR DESCRIPTION
Make sure we start CORES+1 tests instead of a fixed amount of 9.