### PR TITLE
* Fix #3440: Invoices printed with paid amount double-counted

### DIFF
--- a/lib/LedgerSMB/IR.pm
+++ b/lib/LedgerSMB/IR.pm
@@ -944,7 +944,7 @@ sub retrieve_invoice {
 
         $query = qq|
             SELECT a.invnumber, a.transdate, a.duedate,
-                   a.ordnumber, a.quonumber, a.paid, a.taxincluded,
+                   a.ordnumber, a.quonumber, 0 as paid, a.taxincluded,
                    a.notes, a.intnotes, a.curr AS currency,
                    a.entity_credit_account as vendor_id, a.language_code, a.ponumber, a.crdate,
                    a.on_hold, a.reverse, a.description

--- a/lib/LedgerSMB/IS.pm
+++ b/lib/LedgerSMB/IS.pm
@@ -1499,7 +1499,7 @@ sub retrieve_invoice {
         #HV TODO drop entity_id from ar
         $query = qq|
                SELECT a.invnumber, a.ordnumber, a.quonumber,
-                      a.transdate, a.paid,
+                      a.transdate, 0 as paid,
                       a.shippingpoint, a.shipvia, a.terms, a.notes,
                       a.intnotes,
                       a.duedate, a.taxincluded, a.curr AS currency,


### PR DESCRIPTION
Note: This fix works because the 'paid' column gets set to zero
  when going through the cash receipt/payment screen. Old code
  (and on older data, presumably) still sets the paid column to
  the payment value when entering payments directly in the
  invoice entry screen.
  Making sure we *read* the value as if it were zero mimics
  the situation as if payment records were entered through
  cash receipt/payment.
