### PR TITLE
* Fix #3457: remove 'format_string' invocations in printing code

### DIFF
--- a/old/bin/arapprn.pl
+++ b/old/bin/arapprn.pl
@@ -146,7 +146,6 @@ sub print_transaction {
       ( $form->{display_form} ) ? $form->{display_form} : "display_form";
 
     &{"$form->{vc}_details"};
-    @a = qw(name address1 address2 city state zipcode country);
 
     $form->{invtotal} = 0;
     foreach my $i ( 1 .. $form->{rowcount} - 1 ) {
@@ -170,8 +169,6 @@ sub print_transaction {
     }
     foreach my $accno ( split / /, $form->{taxaccounts} ) {
         if ( $form->{"tax_$accno"} ) {
-            $form->format_string("${accno}_description");
-
             $tax += $form->parse_amount( \%myconfig, $form->{"tax_$accno"} );
 
             $form->{"${accno}_tax"} = $form->{"tax_$accno"};
@@ -191,15 +188,10 @@ sub print_transaction {
     }
 
     $tax = 0 if $form->{taxincluded};
-
-    push @a, $form->{ARAP};
-    $form->format_string(@a);
-
     $form->{paid} = 0;
     foreach my $i ( 1 .. $form->{paidaccounts} - 1 ) {
 
         if ( $form->{"paid_$i"} ) {
-            @a = ();
             $form->{paid} +=
               $form->parse_amount( \%myconfig, $form->{"paid_$i"} );
 
@@ -208,9 +200,6 @@ sub print_transaction {
                   $locale->date( \%myconfig, $form->{"datepaid_$i"},
                     $form->{longformat} );
             }
-
-            push @a, "$form->{ARAP}_paid_$i", "source_$i", "memo_$i";
-            $form->format_string(@a);
 
             ( $accno, $account ) = split /--/, $form->{"$form->{ARAP}_paid_$i"};
 
@@ -246,12 +235,6 @@ sub print_transaction {
     }
 
     $form->{notes} =~ s/^\s+//g;
-
-    @a = ( "invnumber", "transdate", "duedate", "crdate", "notes" );
-
-    push @a,
-      qw(company address tel fax businessnumber text_amount text_decimal);
-
     $form->{invdate} = $form->{transdate};
 
     if ($form->{formname} eq 'transaction' ){

--- a/old/bin/io.pl
+++ b/old/bin/io.pl
@@ -1293,24 +1293,12 @@ sub print_form {
 
     &{"$form->{vc}_details"};
 
-    my @vars = ();
-
     $form->{parts_id} = [];
     foreach my $i ( 1 .. $form->{rowcount} ) {
-        push @vars,
-          (
-            "partnumber_$i",    "description_$i",
-            "projectnumber_$i", "partsgroup_$i",
-            "serialnumber_$i",  "bin_$i",
-            "unit_$i",          "notes_$i",
-            "image_$i",         "id_$i"
-          );
-          push @{$form->{parts_id}}, $form->{"id_$i"};
+        push @{$form->{parts_id}}, $form->{"id_$i"};
     }
-    for ( split / /, $form->{taxaccounts} ) { push @vars, "${_}_description" }
 
     $ARAP = ( $form->{vc} eq 'customer' ) ? "AR" : "AP";
-    push @vars, $ARAP;
 
     # format payment dates
     foreach my $i ( 1 .. $form->{paidaccounts} - 1 ) {
@@ -1319,11 +1307,7 @@ sub print_form {
               $locale->date( \%myconfig, $form->{"datepaid_$i"},
                 $form->{longformat} );
         }
-
-        push @vars, "${ARAP}_paid_$i", "source_$i", "memo_$i";
     }
-
-    $form->format_string(@vars);
 
     ( $form->{employee} ) = split /--/, $form->{employee};
     ( $form->{warehouse}, $form->{warehouse_id} ) = split /--/,
@@ -1368,7 +1352,7 @@ sub print_form {
               $locale->date( \%myconfig, $form->{$_}, $form->{longformat} );
         }
     }
-    @vars =
+    my @vars =
       qw(name address1 address2 city state zipcode country contact phone fax email);
 
     $shipto = 1;
@@ -1395,12 +1379,6 @@ sub print_form {
             }
         }
     }
-
-    # some of the stuff could have umlauts so we translate them
-    push @vars,
-      qw(contact shiptoname shiptoaddress1 shiptoaddress2 shiptocity shiptostate shiptozipcode shiptocountry shiptocontact shiptoemail shippingpoint shipvia notes intnotes employee warehouse);
-
-    push @vars, ( "${inv}number", "${inv}date", "${due}date" );
 
     $form->{address} =~ s/\\n/\n/g;
 
@@ -1517,8 +1495,6 @@ sub print_form {
 
         $old_form->{queued} = $form->{queued};
     }
-
-    $form->format_string( "email", "cc", "bcc" );
 
     $form->{fileid} = $form->{"${inv}number"};
     $form->{fileid} =~ s/(\s|\W)+//g;

--- a/old/lib/LedgerSMB/IS.pm
+++ b/old/lib/LedgerSMB/IS.pm
@@ -196,9 +196,6 @@ sub invoice_details {
                   if $projectnumber_id;
                 $form->{projectnumber} .= $form->{partsgroup};
             }
-
-            $form->format_string($form->{projectnumber});
-
         }
 
         $sortby = qq|$projectnumber$form->{partsgroup}|;
@@ -668,8 +665,6 @@ sub invoice_details {
     $form->{text_decimal}   = $c->num2text( $form->{decimal} * 1 );
     $form->{text_amount}    = $c->num2text($whole);
     $form->{integer_amount} = $form->format_amount( $myconfig, $whole );
-
-    $form->format_string(qw(text_amount text_decimal));
 
     $form->{invtotal} ||= 0;
     $form->{paid} ||= 0;

--- a/templates/demo/ap_transaction.html
+++ b/templates/demo/ap_transaction.html
@@ -115,7 +115,7 @@
 	  <td width=10> </td>
 	  <td align=right><?lsmb amount.${loop_count} ?></td>
 	  <td width=10> </td>
-	  <td><?lsmb description.${loop_count} ?></td>
+	  <td><?lsmb description.${loop_count}.replace("\n","<br />") ?></td>
 	  <td width=10> </td>
 	  <td><?lsmb projectnumber.${loop_count} ?></td>
 	</tr>
@@ -136,7 +136,7 @@
 	<?lsmb FOREACH tax ?>
 	<?lsmb loop_count = loop.count - 1 ?>
 	<tr>
-	  <th colspan=2 align=right><?lsmb taxdescription.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
+	  <th colspan=2 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
 	  <td width=10> </td>
 	  <td align=right><?lsmb tax.${loop_count} ?></td>
 	</tr>

--- a/templates/demo/ar_transaction.html
+++ b/templates/demo/ar_transaction.html
@@ -114,7 +114,7 @@
 	  <td width=10>&nbsp;</td>
 	  <td align=right><?lsmb amount.${loop_count} ?></td>
 	  <td width=10>&nbsp;</td>
-	  <td><?lsmb description.${loop_count} ?></td>
+	  <td><?lsmb description.${loop_count}.replace("\n","<br />") ?></td>
 	  <td width=10>&nbsp;</td>
 	  <td><?lsmb projectnumber.${loop_count} ?></td>
 	</tr>
@@ -135,7 +135,7 @@
 	<?lsmb FOREACH tax ?>
 	<?lsmb loop_count = loop.count - 1 ?>
 	<tr>
-	  <th colspan=2 align=right><?lsmb taxdescription.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
+	  <th colspan=2 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
 	  <td width=10>&nbsp;</td>
 	  <td align=right><?lsmb tax.${loop_count} ?></td>
 	</tr>
@@ -221,7 +221,7 @@
   <tr>
     <td>&nbsp;</td>
 
-    <th colspan=9 align=left><font size=-2><?lsmb taxdescription.${loop_count} ?> <?lsmb text('Registration') _ ' ' _  taxnumber.${loop_count} ?></th>
+    <th colspan=9 align=left><font size=-2><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> <?lsmb text('Registration') _ ' ' _  taxnumber.${loop_count} ?></th>
   </tr>
   <?lsmb END ?>
 

--- a/templates/demo/bin_list.html
+++ b/templates/demo/bin_list.html
@@ -159,7 +159,7 @@
 	<tr valign=top>
 	  <td><?lsmb runningnumber.${loop_count} ?></td>
 	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count} ?></td>
+	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
 	  <td><?lsmb serialnumber.${loop_count} ?></td>
 	  <td><?lsmb deliverydate.${loop_count} ?></td>
 	  <td align=right><?lsmb qty.${loop_count} ?></td>

--- a/templates/demo/invoice.html
+++ b/templates/demo/invoice.html
@@ -152,7 +152,7 @@
         <tr valign=top>
           <td align=right><?lsmb runningnumber.${loop_count} ?>.</td>
           <td><?lsmb number.${loop_count} ?></td>
-          <td><?lsmb item_description.${loop_count} ?></td>
+          <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
           <td><?lsmb deliverydate.${loop_count} ?></td>
           <td align=right><?lsmb qty.${loop_count} ?></td>
           <td><?lsmb unit.${loop_count} ?></td>
@@ -176,7 +176,7 @@
         <?lsmb FOREACH tax ?>
         <?lsmb loop_count = loop.count - 1 ?>
         <tr>
-          <th colspan=7 align=right><?lsmb taxdescription.${loop_count} ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
+          <th colspan=7 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
           <td colspan=2 align=right><?lsmb tax.${loop_count} ?></td>
         </tr>
         <?lsmb END ?>
@@ -304,7 +304,7 @@
   <tr>
     <td>&nbsp;</td>
 
-    <th colspan=9 align=left><font size=-2><?lsmb taxdescription.${loop_count} ?> <?lsmb text('Registration [_1]', taxnumber.${loop_count}) ?></th>
+    <th colspan=9 align=left><font size=-2><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> <?lsmb text('Registration [_1]', taxnumber.${loop_count}) ?></th>
   </tr>
   <?lsmb END ?>
 

--- a/templates/demo/packing_list.html
+++ b/templates/demo/packing_list.html
@@ -130,7 +130,7 @@
 	<tr valign=top>
 	  <td><?lsmb runningnumber.${loop_count} ?></td>
 	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count} ?></td>
+	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
 	  <td><?lsmb serialnumber.${loop_count} ?></td>
 	  <td><?lsmb deliverydate.${loop_count} ?></td>
 	  <td align=right><?lsmb qty.${loop_count} ?></td>

--- a/templates/demo/pick_list.html
+++ b/templates/demo/pick_list.html
@@ -121,7 +121,7 @@
 	<tr valign=top>
 	  <td><?lsmb runningnumber.${loop_count} ?></td>
 	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count} ?></td>
+	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
 	  <td align=right><?lsmb qty.${loop_count} ?></td>
 	  <td align=right>[&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]</td>
 	  <td><?lsmb unit.${loop_count} ?></td>

--- a/templates/demo/product_receipt.html
+++ b/templates/demo/product_receipt.html
@@ -138,7 +138,7 @@
         <tr valign=top>
           <td align=right><?lsmb runningnumber.${loop_count} ?>.</td>
           <td><?lsmb number.${loop_count} ?></td>
-          <td><?lsmb item_description.${loop_count} ?></td>
+          <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
           <td align=right><?lsmb qty.${loop_count} ?></td>
           <td><?lsmb unit.${loop_count} ?></td>
           <td align=right><?lsmb sellprice.${loop_count} ?></td>
@@ -164,7 +164,7 @@
         <?lsmb FOREACH tax ?>
         <?lsmb loop_count = loop.count - 1 ?>
         <tr>
-          <th colspan=7 align=right><?lsmb taxdescription.${loop_count} ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
+          <th colspan=7 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
           <td colspan=1 align=right><?lsmb tax.${loop_count} ?></td>
         </tr>
         <?lsmb END ?>

--- a/templates/demo/purchase_order.html
+++ b/templates/demo/purchase_order.html
@@ -138,7 +138,7 @@
 	<tr valign=top>
 	  <td align=right><?lsmb runningnumber.${loop_count} ?>.</td>
 	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count} ?></td>
+	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
 	  <td align=right><?lsmb qty.${loop_count} ?></td>
 	  <td><?lsmb unit.${loop_count} ?></td>
 	  <td align=right><?lsmb sellprice.${loop_count} ?></td>
@@ -164,7 +164,7 @@
         <?lsmb FOREACH tax ?>
 	<?lsmb loop_count = loop.count - 1 ?>
 	<tr>
-	  <th colspan=7 align=right><?lsmb taxdescription.${loop_count} ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
+	  <th colspan=7 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
 	  <td colspan=1 align=right><?lsmb tax.${loop_count} ?></td>
 	</tr>
         <?lsmb END ?>

--- a/templates/demo/request_quotation.html
+++ b/templates/demo/request_quotation.html
@@ -151,7 +151,7 @@
         <tr valign=top>
           <td align=right><?lsmb runningnumber.${loop_count} ?>.</td>
 	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count} ?></td>
+	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
 	  <td align=right><?lsmb qty.${loop_count} ?></td>
 	  <td><?lsmb unit.${loop_count} ?></td>
 	</tr>

--- a/templates/demo/sales_order.html
+++ b/templates/demo/sales_order.html
@@ -140,7 +140,7 @@
 	<tr valign=top>
           <td align=right><?lsmb runningnumber.${loop_count} ?>.</td>
 	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count} ?></td>
+	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
 	  <td align=right><?lsmb qty.${loop_count} ?></td>
 	  <td><?lsmb unit.${loop_count} ?></td>
 	  <td align=right><?lsmb sellprice.${loop_count} ?></td>
@@ -166,7 +166,7 @@
 	<?lsmb FOREACH tax ?>
 	<?lsmb loop_count = loop.count - 1 ?>
 	<tr>
-	  <th colspan=6 align=right><?lsmb taxdescription.${loop_count} ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
+	  <th colspan=6 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
 	  <td colspan=2 align=right><?lsmb tax.${loop_count} ?></td>
 	</tr>
 	<?lsmb END ?>

--- a/templates/demo/sales_quotation.html
+++ b/templates/demo/sales_quotation.html
@@ -109,7 +109,7 @@
 	<tr valign=top>
 	  <td align=right><?lsmb runningnumber.${loop_count} ?></td>
 	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count} ?></td>
+	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
 	  <td align=right><?lsmb qty.${loop_count} ?></td>
 	  <td><?lsmb unit.${loop_count} ?></td>
 	  <td align=right><?lsmb sellprice.${loop_count} ?></td>
@@ -135,7 +135,7 @@
 	<?lsmb FOREACH tax ?>
 	<?lsmb loop_count = loop.count - 1 ?>
 	<tr>
-	  <th colspan=6 align=right><?lsmb taxdescription.${loop_count} ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
+	  <th colspan=6 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
 	  <td colspan=2 align=right><?lsmb tax.${loop_count} ?></td>
 	</tr>
 	<?lsmb END ?>

--- a/templates/demo/work_order.html
+++ b/templates/demo/work_order.html
@@ -139,7 +139,7 @@
 	<tr valign=top>
           <td align=right><?lsmb runningnumber.${loop_count} ?>.</td>
 	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count} ?></td>
+	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
 	  <td align=right><?lsmb qty.${loop_count} ?></td>
 	  <td><?lsmb unit.${loop_count} ?></td>
            <td><?lsmb bin.${loop_count} ?></td>

--- a/templates/demo_with_images/ap_transaction.html
+++ b/templates/demo_with_images/ap_transaction.html
@@ -115,7 +115,7 @@
 	  <td width=10> </td>
 	  <td align=right><?lsmb amount.${loop_count} ?></td>
 	  <td width=10> </td>
-	  <td><?lsmb description.${loop_count} ?></td>
+	  <td><?lsmb description.${loop_count}.replace("\n","<br />") ?></td>
 	  <td width=10> </td>
 	  <td><?lsmb projectnumber.${loop_count} ?></td>
 	</tr>
@@ -136,7 +136,7 @@
 	<?lsmb FOREACH tax ?>
 	<?lsmb loop_count = loop.count - 1 ?>
 	<tr>
-	  <th colspan=2 align=right><?lsmb taxdescription.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
+	  <th colspan=2 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
 	  <td width=10> </td>
 	  <td align=right><?lsmb tax.${loop_count} ?></td>
 	</tr>

--- a/templates/demo_with_images/ar_transaction.html
+++ b/templates/demo_with_images/ar_transaction.html
@@ -114,7 +114,7 @@
 	  <td width=10>&nbsp;</td>
 	  <td align=right><?lsmb amount.${loop_count} ?></td>
 	  <td width=10>&nbsp;</td>
-	  <td><?lsmb description.${loop_count} ?></td>
+	  <td><?lsmb description.${loop_count}.replace("\n","<br />") ?></td>
 	  <td width=10>&nbsp;</td>
 	  <td><?lsmb projectnumber.${loop_count} ?></td>
 	</tr>
@@ -135,7 +135,7 @@
 	<?lsmb FOREACH tax ?>
 	<?lsmb loop_count = loop.count - 1 ?>
 	<tr>
-	  <th colspan=2 align=right><?lsmb taxdescription.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
+	  <th colspan=2 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
 	  <td width=10>&nbsp;</td>
 	  <td align=right><?lsmb tax.${loop_count} ?></td>
 	</tr>
@@ -221,7 +221,7 @@
   <tr>
     <td>&nbsp;</td>
 
-    <th colspan=9 align=left><font size=-2><?lsmb taxdescription.${loop_count} ?> <?lsmb text('Registration') _ ' ' _  taxnumber.${loop_count} ?></th>
+    <th colspan=9 align=left><font size=-2><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> <?lsmb text('Registration') _ ' ' _  taxnumber.${loop_count} ?></th>
   </tr>
   <?lsmb END ?>
 

--- a/templates/demo_with_images/bin_list.html
+++ b/templates/demo_with_images/bin_list.html
@@ -159,7 +159,7 @@
 	<tr valign=top>
 	  <td><?lsmb runningnumber.${loop_count} ?></td>
 	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count} ?></td>
+	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
 	  <td><?lsmb serialnumber.${loop_count} ?></td>
 	  <td><?lsmb deliverydate.${loop_count} ?></td>
 	  <td align=right><?lsmb qty.${loop_count} ?></td>

--- a/templates/demo_with_images/invoice.html
+++ b/templates/demo_with_images/invoice.html
@@ -154,7 +154,7 @@
         <tr valign=top>
           <td align=right><?lsmb runningnumber.${loop_count} ?>.</td>
           <td><?lsmb number.${loop_count} ?></td>
-          <td><?lsmb item_description.${loop_count} ?></td>
+          <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
           <td><?lsmb deliverydate.${loop_count} ?></td>
           <td align=right><?lsmb qty.${loop_count} ?></td>
           <td><?lsmb unit.${loop_count} ?></td>
@@ -177,7 +177,7 @@
         <?lsmb FOREACH tax ?>
         <?lsmb loop_count = loop.count - 1 ?>
         <tr>
-          <th colspan=7 align=right><?lsmb taxdescription.${loop_count} ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
+          <th colspan=7 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
           <td colspan=2 align=right><?lsmb tax.${loop_count} ?></td>
         </tr>
         <?lsmb END ?>
@@ -307,7 +307,7 @@
   <tr>
     <td>&nbsp;</td>
 
-    <th colspan=9 align=left><font size=-2><?lsmb taxdescription.${loop_count} ?> <?lsmb text('Registration [_1]', taxnumber.${loop_count}) ?></th>
+    <th colspan=9 align=left><font size=-2><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> <?lsmb text('Registration [_1]', taxnumber.${loop_count}) ?></th>
   </tr>
   <?lsmb END ?>
 

--- a/templates/demo_with_images/packing_list.html
+++ b/templates/demo_with_images/packing_list.html
@@ -130,7 +130,7 @@
 	<tr valign=top>
 	  <td><?lsmb runningnumber.${loop_count} ?></td>
 	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count} ?></td>
+	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
 	  <td><?lsmb serialnumber.${loop_count} ?></td>
 	  <td><?lsmb deliverydate.${loop_count} ?></td>
 	  <td align=right><?lsmb qty.${loop_count} ?></td>

--- a/templates/demo_with_images/pick_list.html
+++ b/templates/demo_with_images/pick_list.html
@@ -121,7 +121,7 @@
 	<tr valign=top>
 	  <td><?lsmb runningnumber.${loop_count} ?></td>
 	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count} ?></td>
+	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
 	  <td align=right><?lsmb qty.${loop_count} ?></td>
 	  <td align=right>[&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]</td>
 	  <td><?lsmb unit.${loop_count} ?></td>

--- a/templates/demo_with_images/product_receipt.html
+++ b/templates/demo_with_images/product_receipt.html
@@ -138,7 +138,7 @@
         <tr valign=top>
           <td align=right><?lsmb runningnumber.${loop_count} ?>.</td>
           <td><?lsmb number.${loop_count} ?></td>
-          <td><?lsmb item_description.${loop_count} ?></td>
+          <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
           <td align=right><?lsmb qty.${loop_count} ?></td>
           <td><?lsmb unit.${loop_count} ?></td>
           <td align=right><?lsmb sellprice.${loop_count} ?></td>
@@ -164,7 +164,7 @@
         <?lsmb FOREACH tax ?>
         <?lsmb loop_count = loop.count - 1 ?>
         <tr>
-          <th colspan=7 align=right><?lsmb taxdescription.${loop_count} ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
+          <th colspan=7 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
           <td colspan=1 align=right><?lsmb tax.${loop_count} ?></td>
         </tr>
         <?lsmb END ?>

--- a/templates/demo_with_images/purchase_order.html
+++ b/templates/demo_with_images/purchase_order.html
@@ -138,7 +138,7 @@
 	<tr valign=top>
 	  <td align=right><?lsmb runningnumber.${loop_count} ?>.</td>
 	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count} ?></td>
+	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
 	  <td align=right><?lsmb qty.${loop_count} ?></td>
 	  <td><?lsmb unit.${loop_count} ?></td>
 	  <td align=right><?lsmb sellprice.${loop_count} ?></td>
@@ -164,7 +164,7 @@
         <?lsmb FOREACH tax ?>
 	<?lsmb loop_count = loop.count - 1 ?>
 	<tr>
-	  <th colspan=7 align=right><?lsmb taxdescription.${loop_count} ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
+	  <th colspan=7 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
 	  <td colspan=1 align=right><?lsmb tax.${loop_count} ?></td>
 	</tr>
         <?lsmb END ?>

--- a/templates/demo_with_images/request_quotation.html
+++ b/templates/demo_with_images/request_quotation.html
@@ -151,7 +151,7 @@
         <tr valign=top>
           <td align=right><?lsmb runningnumber.${loop_count} ?>.</td>
 	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count} ?></td>
+	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
 	  <td align=right><?lsmb qty.${loop_count} ?></td>
 	  <td><?lsmb unit.${loop_count} ?></td>
 	</tr>

--- a/templates/demo_with_images/sales_order.html
+++ b/templates/demo_with_images/sales_order.html
@@ -140,7 +140,7 @@
 	<tr valign=top>
           <td align=right><?lsmb runningnumber.${loop_count} ?>.</td>
 	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count} ?></td>
+	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
 	  <td align=right><?lsmb qty.${loop_count} ?></td>
 	  <td><?lsmb unit.${loop_count} ?></td>
 	  <td align=right><?lsmb sellprice.${loop_count} ?></td>
@@ -166,7 +166,7 @@
 	<?lsmb FOREACH tax ?>
 	<?lsmb loop_count = loop.count - 1 ?>
 	<tr>
-	  <th colspan=6 align=right><?lsmb taxdescription.${loop_count} ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
+	  <th colspan=6 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
 	  <td colspan=2 align=right><?lsmb tax.${loop_count} ?></td>
 	</tr>
 	<?lsmb END ?>

--- a/templates/demo_with_images/sales_quotation.html
+++ b/templates/demo_with_images/sales_quotation.html
@@ -109,7 +109,7 @@
 	<tr valign=top>
 	  <td align=right><?lsmb runningnumber.${loop_count} ?></td>
 	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count} ?></td>
+	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
 	  <td align=right><?lsmb qty.${loop_count} ?></td>
 	  <td><?lsmb unit.${loop_count} ?></td>
 	  <td align=right><?lsmb sellprice.${loop_count} ?></td>
@@ -135,7 +135,7 @@
 	<?lsmb FOREACH tax ?>
 	<?lsmb loop_count = loop.count - 1 ?>
 	<tr>
-	  <th colspan=6 align=right><?lsmb taxdescription.${loop_count} ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
+	  <th colspan=6 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
 	  <td colspan=2 align=right><?lsmb tax.${loop_count} ?></td>
 	</tr>
 	<?lsmb END ?>

--- a/templates/demo_with_images/work_order.html
+++ b/templates/demo_with_images/work_order.html
@@ -139,7 +139,7 @@
 	<tr valign=top>
           <td align=right><?lsmb runningnumber.${loop_count} ?>.</td>
 	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count} ?></td>
+	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
 	  <td align=right><?lsmb qty.${loop_count} ?></td>
 	  <td><?lsmb unit.${loop_count} ?></td>
            <td><?lsmb bin.${loop_count} ?></td>

--- a/templates/xedemo/ap_transaction.html
+++ b/templates/xedemo/ap_transaction.html
@@ -115,7 +115,7 @@
 	  <td width=10> </td>
 	  <td align=right><?lsmb amount.${loop_count} ?></td>
 	  <td width=10> </td>
-	  <td><?lsmb description.${loop_count} ?></td>
+	  <td><?lsmb description.${loop_count}.replace("\n","<br />") ?></td>
 	  <td width=10> </td>
 	  <td><?lsmb projectnumber.${loop_count} ?></td>
 	</tr>
@@ -136,7 +136,7 @@
 	<?lsmb FOREACH tax ?>
 	<?lsmb loop_count = loop.count - 1 ?>
 	<tr>
-	  <th colspan=2 align=right><?lsmb taxdescription.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
+	  <th colspan=2 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
 	  <td width=10> </td>
 	  <td align=right><?lsmb tax.${loop_count} ?></td>
 	</tr>

--- a/templates/xedemo/ar_transaction.html
+++ b/templates/xedemo/ar_transaction.html
@@ -114,7 +114,7 @@
 	  <td width=10>&nbsp;</td>
 	  <td align=right><?lsmb amount.${loop_count} ?></td>
 	  <td width=10>&nbsp;</td>
-	  <td><?lsmb description.${loop_count} ?></td>
+	  <td><?lsmb description.${loop_count}.replace("\n","<br />") ?></td>
 	  <td width=10>&nbsp;</td>
 	  <td><?lsmb projectnumber.${loop_count} ?></td>
 	</tr>
@@ -135,7 +135,7 @@
 	<?lsmb FOREACH tax ?>
 	<?lsmb loop_count = loop.count - 1 ?>
 	<tr>
-	  <th colspan=2 align=right><?lsmb taxdescription.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
+	  <th colspan=2 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
 	  <td width=10>&nbsp;</td>
 	  <td align=right><?lsmb tax.${loop_count} ?></td>
 	</tr>
@@ -221,7 +221,7 @@
   <tr>
     <td>&nbsp;</td>
 
-    <th colspan=9 align=left><font size=-2><?lsmb taxdescription.${loop_count} ?> <?lsmb text('Registration') _ ' ' _  taxnumber.${loop_count} ?></th>
+    <th colspan=9 align=left><font size=-2><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> <?lsmb text('Registration') _ ' ' _  taxnumber.${loop_count} ?></th>
   </tr>
   <?lsmb END ?>
 

--- a/templates/xedemo/bin_list.html
+++ b/templates/xedemo/bin_list.html
@@ -159,7 +159,7 @@
 	<tr valign=top>
 	  <td><?lsmb runningnumber.${loop_count} ?></td>
 	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count} ?></td>
+	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
 	  <td><?lsmb serialnumber.${loop_count} ?></td>
 	  <td><?lsmb deliverydate.${loop_count} ?></td>
 	  <td align=right><?lsmb qty.${loop_count} ?></td>

--- a/templates/xedemo/invoice.html
+++ b/templates/xedemo/invoice.html
@@ -153,7 +153,7 @@
         <tr valign=top>
           <td align=right><?lsmb runningnumber.${loop_count} ?>.</td>
           <td><?lsmb number.${loop_count} ?></td>
-          <td><?lsmb item_description.${loop_count} ?></td>
+          <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
           <td><?lsmb deliverydate.${loop_count} ?></td>
           <td align=right><?lsmb qty.${loop_count} ?></td>
           <td><?lsmb unit.${loop_count} ?></td>
@@ -176,7 +176,7 @@
         <?lsmb FOREACH tax ?>
         <?lsmb loop_count = loop.count - 1 ?>
         <tr>
-          <th colspan=7 align=right><?lsmb taxdescription.${loop_count} ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
+          <th colspan=7 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
           <td colspan=2 align=right><?lsmb tax.${loop_count} ?></td>
         </tr>
         <?lsmb END ?>
@@ -306,7 +306,7 @@
   <tr>
     <td>&nbsp;</td>
 
-    <th colspan=9 align=left><font size=-2><?lsmb taxdescription.${loop_count} ?> <?lsmb text('Registration [_1]', taxnumber.${loop_count}) ?></th>
+    <th colspan=9 align=left><font size=-2><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> <?lsmb text('Registration [_1]', taxnumber.${loop_count}) ?></th>
   </tr>
   <?lsmb END ?>
 

--- a/templates/xedemo/packing_list.html
+++ b/templates/xedemo/packing_list.html
@@ -130,7 +130,7 @@
 	<tr valign=top>
 	  <td><?lsmb runningnumber.${loop_count} ?></td>
 	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count} ?></td>
+	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
 	  <td><?lsmb serialnumber.${loop_count} ?></td>
 	  <td><?lsmb deliverydate.${loop_count} ?></td>
 	  <td align=right><?lsmb qty.${loop_count} ?></td>

--- a/templates/xedemo/pick_list.html
+++ b/templates/xedemo/pick_list.html
@@ -121,7 +121,7 @@
 	<tr valign=top>
 	  <td><?lsmb runningnumber.${loop_count} ?></td>
 	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count} ?></td>
+	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
 	  <td align=right><?lsmb qty.${loop_count} ?></td>
 	  <td align=right>[&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;]</td>
 	  <td><?lsmb unit.${loop_count} ?></td>

--- a/templates/xedemo/product_receipt.html
+++ b/templates/xedemo/product_receipt.html
@@ -140,7 +140,7 @@
         <tr valign=top>
           <td align=right><?lsmb runningnumber.${loop_count} ?>.</td>
           <td><?lsmb number.${loop_count} ?></td>
-          <td><?lsmb item_description.${loop_count} ?></td>
+          <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
           <td align=right><?lsmb qty.${loop_count} ?></td>
           <td><?lsmb unit.${loop_count} ?></td>
           <td align=right><?lsmb sellprice.${loop_count} ?></td>
@@ -166,7 +166,7 @@
         <?lsmb FOREACH tax ?>
         <?lsmb loop_count = loop.count - 1 ?>
         <tr>
-          <th colspan=7 align=right><?lsmb taxdescription.${loop_count} ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
+          <th colspan=7 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
           <td colspan=1 align=right><?lsmb tax.${loop_count} ?></td>
         </tr>
         <?lsmb END ?>

--- a/templates/xedemo/purchase_order.html
+++ b/templates/xedemo/purchase_order.html
@@ -138,7 +138,7 @@
 	<tr valign=top>
 	  <td align=right><?lsmb runningnumber.${loop_count} ?>.</td>
 	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count} ?></td>
+	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
 	  <td align=right><?lsmb qty.${loop_count} ?></td>
 	  <td><?lsmb unit.${loop_count} ?></td>
 	  <td align=right><?lsmb sellprice.${loop_count} ?></td>
@@ -164,7 +164,7 @@
         <?lsmb FOREACH tax ?>
 	<?lsmb loop_count = loop.count - 1 ?>
 	<tr>
-	  <th colspan=7 align=right><?lsmb taxdescription.${loop_count} ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
+	  <th colspan=7 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
 	  <td colspan=1 align=right><?lsmb tax.${loop_count} ?></td>
 	</tr>
         <?lsmb END ?>

--- a/templates/xedemo/request_quotation.html
+++ b/templates/xedemo/request_quotation.html
@@ -151,7 +151,7 @@
         <tr valign=top>
           <td align=right><?lsmb runningnumber.${loop_count} ?>.</td>
 	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count} ?></td>
+	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
 	  <td align=right><?lsmb qty.${loop_count} ?></td>
 	  <td><?lsmb unit.${loop_count} ?></td>
 	</tr>

--- a/templates/xedemo/sales_order.html
+++ b/templates/xedemo/sales_order.html
@@ -140,7 +140,7 @@
 	<tr valign=top>
           <td align=right><?lsmb runningnumber.${loop_count} ?>.</td>
 	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count} ?></td>
+	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
 	  <td align=right><?lsmb qty.${loop_count} ?></td>
 	  <td><?lsmb unit.${loop_count} ?></td>
 	  <td align=right><?lsmb sellprice.${loop_count} ?></td>
@@ -166,7 +166,7 @@
 	<?lsmb FOREACH tax ?>
 	<?lsmb loop_count = loop.count - 1 ?>
 	<tr>
-	  <th colspan=6 align=right><?lsmb taxdescription.${loop_count} ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
+	  <th colspan=6 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
 	  <td colspan=2 align=right><?lsmb tax.${loop_count} ?></td>
 	</tr>
 	<?lsmb END ?>

--- a/templates/xedemo/sales_quotation.html
+++ b/templates/xedemo/sales_quotation.html
@@ -109,7 +109,7 @@
 	<tr valign=top>
 	  <td align=right><?lsmb runningnumber.${loop_count} ?></td>
 	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count} ?></td>
+	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
 	  <td align=right><?lsmb qty.${loop_count} ?></td>
 	  <td><?lsmb unit.${loop_count} ?></td>
 	  <td align=right><?lsmb sellprice.${loop_count} ?></td>
@@ -135,7 +135,7 @@
 	<?lsmb FOREACH tax ?>
 	<?lsmb loop_count = loop.count - 1 ?>
 	<tr>
-	  <th colspan=6 align=right><?lsmb taxdescription.${loop_count} ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
+	  <th colspan=6 align=right><?lsmb taxdescription.${loop_count}.replace("\n","<br />") ?> on <?lsmb taxbase.${loop_count} ?> @ <?lsmb taxrate.${loop_count} ?> %</th>
 	  <td colspan=2 align=right><?lsmb tax.${loop_count} ?></td>
 	</tr>
 	<?lsmb END ?>

--- a/templates/xedemo/work_order.html
+++ b/templates/xedemo/work_order.html
@@ -139,7 +139,7 @@
 	<tr valign=top>
           <td align=right><?lsmb runningnumber.${loop_count} ?>.</td>
 	  <td><?lsmb number.${loop_count} ?></td>
-	  <td><?lsmb item_description.${loop_count} ?></td>
+	  <td><?lsmb item_description.${loop_count}.replace("\n","<br />") ?></td>
 	  <td align=right><?lsmb qty.${loop_count} ?></td>
 	  <td><?lsmb unit.${loop_count} ?></td>
            <td><?lsmb bin.${loop_count} ?></td>


### PR DESCRIPTION
Note that this commit removes the (related) use of
  the variables '@a' and '@vars' as far as can be
  established that the use was restricted to collecting
  field names for the 'format_string' call.

Also note that the deletion of the call to format the
  project number is in effect removing dead code:
  'format_string' expects the field name as its
  argument, not the value to be formatted.