### PR TITLE
* Fix #3457: remove 'format_string' invocations in printing code

### DIFF
--- a/bin/arapprn.pl
+++ b/bin/arapprn.pl
@@ -146,7 +146,6 @@ sub print_transaction {
       ( $form->{display_form} ) ? $form->{display_form} : "display_form";
 
     &{"$form->{vc}_details"};
-    @a = qw(name address1 address2 city state zipcode country);
 
     $form->{invtotal} = 0;
     foreach $i ( 1 .. $form->{rowcount} - 1 ) {
@@ -170,8 +169,6 @@ sub print_transaction {
     }
     foreach $accno ( split / /, $form->{taxaccounts} ) {
         if ( $form->{"tax_$accno"} ) {
-            $form->format_string("${accno}_description");
-
             $tax += $form->parse_amount( \%myconfig, $form->{"tax_$accno"} );
 
             $form->{"${accno}_tax"} = $form->{"tax_$accno"};
@@ -191,15 +188,10 @@ sub print_transaction {
     }
 
     $tax = 0 if $form->{taxincluded};
-
-    push @a, $form->{ARAP};
-    $form->format_string(@a);
-
     $form->{paid} = 0;
     for $i ( 1 .. $form->{paidaccounts} - 1 ) {
 
         if ( $form->{"paid_$i"} ) {
-            @a = ();
             $form->{paid} +=
               $form->parse_amount( \%myconfig, $form->{"paid_$i"} );
 
@@ -208,9 +200,6 @@ sub print_transaction {
                   $locale->date( \%myconfig, $form->{"datepaid_$i"},
                     $form->{longformat} );
             }
-
-            push @a, "$form->{ARAP}_paid_$i", "source_$i", "memo_$i";
-            $form->format_string(@a);
 
             ( $accno, $account ) = split /--/, $form->{"$form->{ARAP}_paid_$i"};
 
@@ -246,12 +235,6 @@ sub print_transaction {
     }
 
     $form->{notes} =~ s/^\s+//g;
-
-    @a = ( "invnumber", "transdate", "duedate", "crdate", "notes" );
-
-    push @a,
-      qw(company address tel fax businessnumber text_amount text_decimal);
-
     $form->{invdate} = $form->{transdate};
 
     $form->{templates} = "$myconfig{templates}";

--- a/bin/io.pl
+++ b/bin/io.pl
@@ -1301,24 +1301,12 @@ sub print_form {
 
     &{"$form->{vc}_details"};
 
-    my @vars = ();
-
     $form->{parts_id} = [];
     foreach $i ( 1 .. $form->{rowcount} ) {
-        push @vars,
-          (
-            "partnumber_$i",    "description_$i",
-            "projectnumber_$i", "partsgroup_$i",
-            "serialnumber_$i",  "bin_$i",
-            "unit_$i",          "notes_$i",
-            "image_$i",         "id_$i"
-          );
           push @{$form->{parts_id}}, $form->{"id_$i"};
     }
-    for ( split / /, $form->{taxaccounts} ) { push @vars, "${_}_description" }
 
     $ARAP = ( $form->{vc} eq 'customer' ) ? "AR" : "AP";
-    push @vars, $ARAP;
 
     # format payment dates
     for my $i ( 1 .. $form->{paidaccounts} - 1 ) {
@@ -1327,11 +1315,7 @@ sub print_form {
               $locale->date( \%myconfig, $form->{"datepaid_$i"},
                 $form->{longformat} );
         }
-
-        push @vars, "${ARAP}_paid_$i", "source_$i", "memo_$i";
     }
-
-    $form->format_string(@vars);
 
     ( $form->{employee} ) = split /--/, $form->{employee};
     ( $form->{warehouse}, $form->{warehouse_id} ) = split /--/,
@@ -1376,7 +1360,7 @@ sub print_form {
               $locale->date( \%myconfig, $form->{$_}, $form->{longformat} );
         }
     }
-    @vars =
+    my @vars =
       qw(name address1 address2 city state zipcode country contact phone fax email);
 
     $shipto = 1;
@@ -1403,12 +1387,6 @@ sub print_form {
             }
         }
     }
-
-    # some of the stuff could have umlauts so we translate them
-    push @vars,
-      qw(contact shiptoname shiptoaddress1 shiptoaddress2 shiptocity shiptostate shiptozipcode shiptocountry shiptocontact shiptoemail shippingpoint shipvia notes intnotes employee warehouse);
-
-    push @vars, ( "${inv}number", "${inv}date", "${due}date" );
 
     $form->{address} =~ s/\\n/\n/g;
 
@@ -1525,8 +1503,6 @@ sub print_form {
 
         $old_form->{queued} = $form->{queued};
     }
-
-    $form->format_string( "email", "cc", "bcc" );
 
     $form->{fileid} = $form->{"${inv}number"};
     $form->{fileid} =~ s/(\s|\W)+//g;

--- a/lib/LedgerSMB/IS.pm
+++ b/lib/LedgerSMB/IS.pm
@@ -197,9 +197,6 @@ sub invoice_details {
                   if $projectnumber_id;
                 $form->{projectnumber} .= $form->{partsgroup};
             }
-
-            $form->format_string($form->{projectnumber});
-
         }
 
         $sortby = qq|$projectnumber$form->{partsgroup}|;
@@ -669,8 +666,6 @@ sub invoice_details {
     $form->{text_decimal}   = $c->num2text( $form->{decimal} * 1 );
     $form->{text_amount}    = $c->num2text($whole);
     $form->{integer_amount} = $form->format_amount( $myconfig, $whole );
-
-    $form->format_string(qw(text_amount text_decimal));
 
     $form->{invtotal} ||= 0;
     $form->{paid} ||= 0;


### PR DESCRIPTION
Note that this commit removes the (related) use of
  the variables '@a' and '@vars' as far as can be
  established that the use was restricted to collecting
  field names for the 'format_string' call.

Also note that the deletion of the call to format the
  project number is in effect removing dead code:
  'format_string' expects the field name as its
  argument, not the value to be formatted.
