### PR TITLE
Remove Travis sudo requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # run on GCE build as per suggested:
 # https://github.com/travis-ci/travis-ci/issues/3251#issuecomment-219675294
-sudo: required
+sudo: false
 dist: trusty
 language: perl
 env:
@@ -105,7 +105,7 @@ cache:
 
 before_install:
   # list all the running services before we start. Perhaps we can stop some of them to save resources.
-  - sudo service --status-all
+  - service --status-all
   # display the available resources
   - utils/diagnostics/t/01-system-resources.t
   - source /opt/jdk_switcher/jdk_switcher.sh
@@ -191,10 +191,6 @@ after_failure:
   # display the available resources
   - utils/diagnostics/t/01-system-resources.t
   # display the dmesg log. may give some hints about system related failures. eg: has the OOM killer triggered
-  - echo ===============================
-  - echo === dmesg                   ===
-  - echo ===============================
-  - sudo dmesg
   - echo ===============================
   - echo === /tmp/plackup-access.log ===
   - echo ===============================

--- a/t/testrules.yml
+++ b/t/testrules.yml
@@ -10,10 +10,14 @@ seq:
     - par:
       - t/*
       - xt/{0,1,2,3}*
-  - seq: xt/40-dbsetup.t
+  - seq:
+    - xt/40-dbsetup.t
+    - par:
+      - xt/40-database.t
+      - xt/41-coaload.t
   - seq:
     - par:
-      - xt/{4,5,7}*.t
+      - xt/{43,44,5,7}*.t
       - xt/6{1,2,3,7,8,9}*.t
       - seq:
         - xt/60-startlsmb.t


### PR DESCRIPTION
Except for the access to `dmesg`, which was use for VM exploration, our builds do not, and should not, require `sudo`. Moreover, Travis advertise as moving toward a container-based infrastructure and that this should provides more performance.
`sudo` decides on the choice between a VM and a container based setup for Travis tests.