### PR TITLE
Stop relying only on exceptions for DOM element presence

### DIFF
--- a/xt/lib/PageObject.pm
+++ b/xt/lib/PageObject.pm
@@ -57,8 +57,7 @@ sub wait_for_page {
                 # if there's a reference element,
                 # wait for it to go stale (raise an exception)
                 eval {
-                    $ref->tag_name;
-                    1;
+                    defined $ref->tag_name;
                 };
                 $ref = undef if !defined $@;
                 return 0;

--- a/xt/lib/PageObject/App/Main.pm
+++ b/xt/lib/PageObject/App/Main.pm
@@ -36,10 +36,10 @@ sub content {
 
     my $gone = 1;
     try {
-        $self->_get_content->tag_name
+        my $tagname = $self->_get_content->tag_name
             if $self->has_content;
         # we're still here?
-        $gone = 0;
+        $gone = 0 if defined $tagname;
     };
     $self->clear_content if $gone; # force builder
 
@@ -73,10 +73,10 @@ sub wait_for_content {
             if ($old_content) {
                 my $gone = 1;
                 try {
-                    $old_content->tag_name;
+                    my $tagname = $old_content->tag_name;
                     # When successfully accessing the tag
                     #  it's not out of scope yet...
-                    $gone = 0;
+                    $gone = 0 if defined $tagname;
                 };
                 $old_content = undef if $gone;
                 return 0;

--- a/xt/lib/PageObject/App/Menu.pm
+++ b/xt/lib/PageObject/App/Menu.pm
@@ -20,6 +20,7 @@ __PACKAGE__->self_register(
               tag_name => 'div',
               attributes => {
                   id => 'menudiv',
+#                role => 'presentation'
               });
 
 
@@ -107,7 +108,7 @@ sub click_menu {
         ok(use_module($tgt_class),
            "$tgt_class can be 'use'-d dynamically");
 
-        my $root = $self->find("//*[\@id='top_menu']");
+        my $root = $self->find("//*[\@id='top_menu']"); # and \@role='presentation'
         ok($root, "Menu tree loaded");
 
         my $item = $root;

--- a/xt/lib/PageObject/Root.pm
+++ b/xt/lib/PageObject/Root.pm
@@ -34,10 +34,10 @@ sub wait_for_body {
             if ($old_body) {
                 my $gone = 1;
                 try {
-                    $old_body->tag_name;
+                    my $tagname = $old_body->tag_name;
                     # When successfully accessing the tag
                     #  it's not out of scope yet...
-                    $gone = 0;
+                    $gone = 0 if defined $tagname;
                 };
                 $old_body = undef if $gone;
                 return 0; # Not done yet


### PR DESCRIPTION
For months, we've been having DOM errors and timeouts on tests.
This tries to fix that by making sure we work when Selenium triggers exceptions or returns undefined for DOM elements.