### PR TITLE
* Solve the running balance being incorrectly calculated

### DIFF
--- a/sql/modules/Report.sql
+++ b/sql/modules/Report.sql
@@ -265,7 +265,9 @@ FOR retval IN
               ac.source, ac.amount, c.accno, c.gifi_accno,
               g.till, ac.cleared, ac.memo, c.description AS accname,
               ac.chart_id, ac.entry_id,
-              sum(ac.amount) over (rows unbounded preceding) + t_balance
+              sum(ac.amount) over (order by ac.transdate, ac.trans_id,
+                                            c.accno, ac.entry_id)
+                + t_balance
                 as running_balance,
               compound_array(ARRAY[ARRAY[bac.class_id, bac.bu_id]])
          FROM (select id, 'gl' as type, false as invoice, reference,
@@ -312,7 +314,7 @@ FOR retval IN
               ac.chart_id, ac.entry_id, ac.trans_id
        HAVING in_business_units is null or in_business_units
                 <@ compound_array(string_to_array(bu_tree.path, ',')::int[])
-     ORDER BY ac.transdate, ac.trans_id, c.accno
+     ORDER BY ac.transdate, ac.trans_id, c.accno, ac.entry_id
 LOOP
    RETURN NEXT retval;
 END LOOP;


### PR DESCRIPTION
Note how PostgreSQL documents running window functions over the
virtual table being the result of WHERE, GROUP BY and HAVING processing
and note that that list excludes ORDER BY processing.  In order
to make sure we run the balance function over the same order
as is the result of the final query, we must include the same
ORDER BY condition in the window function.

Also note that a window function runs over the _current row *and* its
equivalents as considered under ORDER BY_ which is why we include
'ac.entry_id' in the order function: it's guaranteed to be unique.
