### PR TITLE
* Calculate subtotals in Perl code instead of in the template

### DIFF
--- a/UI/payments/payment2.html
+++ b/UI/payments/payment2.html
@@ -182,7 +182,7 @@ onLoad="maximize_minimize_on_load(event, 'div_topay_state', 'payments/img/down.g
         <?lsmb END ?>
       </tr>
       <?lsmb # We have to clear i for later usage :)  ?>
-      <?lsmb i = '0'; topay_subtotal = 0  -?>
+      <?lsmb i = '0';  -?>
       <?lsmb FOREACH row IN rows ?>
       <?lsmb i = i + 1; j = i % 2; alterning_style = "listrow$j" ?>
       <tr class="<?lsmb alterning_style ?>">
@@ -226,7 +226,6 @@ onLoad="maximize_minimize_on_load(event, 'div_topay_state', 'payments/img/down.g
         </td>
         <?lsmb END ?>
         <?lsmb #This should be computed and updated to the div using  ?>
-        <?lsmb topay_subtotal=topay_subtotal + row.topay_fx.value; -?>
         <td align="center"><?lsmb row.topay_fx.id=row.topay_fx.name;
                                   PROCESS input element_data = {
                                       type = "text"
@@ -316,7 +315,7 @@ onLoad="maximize_minimize_on_load(event, 'div_topay_state', 'payments/img/down.g
         <th class="listheading">X</th>
       </tr>
       <?lsmb # We have to insert the overpayment data  -?>
-      <?lsmb overpayment_item = 0; overpayment_subtotal = 0 -?>
+      <?lsmb overpayment_item = 0; -?>
       <?lsmb FOREACH item IN overpayment -?>
       <?lsmb overpayment_item = overpayment_item + 1  -?>
       <?lsmb j = overpayment_item % 2; alterning_style = "listrow$j" ?>
@@ -366,7 +365,6 @@ onLoad="maximize_minimize_on_load(event, 'div_topay_state', 'payments/img/down.g
                    id="overpayment_topay_" _ overpayment_item
                    name="overpayment_topay_" _ overpayment_item
                    value=item.amount } ?>
-            <?lsmb overpayment_subtotal = overpayment_subtotal + item.amount -?>
         </td>
         <td align="center">
           <?lsmb
@@ -459,7 +457,6 @@ onLoad="maximize_minimize_on_load(event, 'div_topay_state', 'payments/img/down.g
    <th colspan="2"><?lsmb overpayment_subtotal -?>&nbsp;<?lsmb curr.value -?></th>
    </tr>
    <tr class="listtotal">
-   <?lsmb payment_total = overpayment_subtotal + topay_subtotal -?>
    <th colspan="5" align="right"><?lsmb text('Total') -?></th>
    <th colspan="2"><?lsmb payment_total -?>&nbsp;<?lsmb curr.value -?></th>
    </tr>

--- a/lib/LedgerSMB/Scripts/payment.pm
+++ b/lib/LedgerSMB/Scripts/payment.pm
@@ -55,6 +55,7 @@ use LedgerSMB::Scripts::reports;
 use LedgerSMB::Report::Invoices::Payments;
 use strict;
 use warnings;
+use List::Util qw/sum/;
 
 # CT:  A few notes for future refactoring of this code:
 # 1:  I don't think it is a good idea to make the UI too dependant on internal
@@ -977,7 +978,7 @@ sub payment2 {
                 my ($cashid, $cashaccno, $cashdescription  ) = split(/--/, $request->{"overpayment_cash_account_$i"});
 
                 push @overpayment, {
-                    amount  => $request->{"overpayment_topay_$i"},
+                    amount  => LedgerSMB::PGNumber->from_input($request->{"overpayment_topay_$i"}),
                     source1 => $request->{"overpayment_source1_$i"},
                     source2 => $request->{"overpayment_source2_$i"},
                     memo    => $request->{"overpayment_memo_$i"},
@@ -1051,6 +1052,7 @@ sub payment2 {
         },
         column_headers => \@column_headers,
         rows        =>  \@invoice_data,
+        topay_subtotal => (sum map { $_->{topay} } @invoice_data) // 0,
         topay_state   => \@topay_state,
         vendorcustomer => {
             name => 'vendor-customer',
@@ -1083,6 +1085,9 @@ sub payment2 {
         notes => $request->{notes},
         overpayment         => \@overpayment,
         overpayment_account => \@overpayment_account,
+        overpayment_subtotal => (sum map { $_->{amount} } @overpayment) // 0,
+        payment_total => (sum map { $_->{amount} } @overpayment)
+            + (sum map { $_->{topay} } @invoice_data),
     };
 
     $select->{selected_account} = $vc_options[0]->{cash_account_id}


### PR DESCRIPTION
Note that in the Perl code, there are mechanisms to accomodate
locale specific number formatting while in the template such
mechanisms are missing (leading to the issue reported in #3282).