### PR TITLE
Remove unused logging parameters in calls to DBAdmin->run_file

### DIFF
--- a/lib/LedgerSMB/Database.pm
+++ b/lib/LedgerSMB/Database.pm
@@ -387,13 +387,9 @@ tag in the LOADORDER file will be applied (the main use-case being migrations).
 
 sub load_base_schema {
     my ($self, %args) = @_;
-    my $log = loader_log_filename();
 
     $self->run_file(
-
         file       => "$self->{source_dir}/Pg-database.sql",
-        log_stdout => ($args{log} || "${log}_stdout"),
-        log_stderr => ($args{errlog} || "${log}_stderr")
     );
     my $dbh = $self->connect({ AutoCommit => 1 });
     my $sth = $dbh->prepare(
@@ -415,8 +411,6 @@ sub load_base_schema {
         while (my $fname = readdir(LOADDIR)) {
             $self->run_file(
                 file       => "$self->{source_dir}/on_load/$fname",
-                log_stdout => ($args{log} || "${log}_stdout"),
-                log_stderr => ($args{errlog} || "${log}_stderr")
                 ) if -f "$self->{source_dir}/on_load/$fname";
         }
         closedir(LOADDIR);
@@ -434,7 +428,6 @@ Loads or reloads sql modules from $loadorder
 
 sub load_modules {
     my ($self, $loadorder, $args) = @_;
-    my $log = loader_log_filename();
 
     my $filename = "$self->{source_dir}/modules/$loadorder";
     open my $fh, '<', $filename
@@ -454,8 +447,6 @@ sub load_modules {
 
         $self->run_file(
             file       => "$self->{source_dir}/modules/$mod",
-            log_stdout => $args->{log}    || "${log}_stdout",
-            log_stderr => $args->{errlog} || "${log}_stderr"
         );
 
         my $sth = $dbh->prepare(q{select value from defaults
@@ -482,12 +473,9 @@ the chart of accounts file name given for the given 2-char (iso) country code.
 
 sub load_coa {
     my ($self, $args) = @_;
-    my $log = loader_log_filename();
 
     $self->run_file (
         file         => "$self->{source_dir}/coa/$args->{country}/chart/$args->{chart}",
-        log_stdout   => $log,
-        log_stderr   => $log,
         );
 
     $args->{gifi} //= $args->{chart};
@@ -495,16 +483,12 @@ sub load_coa {
         && -f "$self->{source_dir}/coa/$args->{country}/gifi/$args->{gifi}"){
         $self->run_file(
             file        => "$self->{source_dir}/coa/$args->{country}/gifi/$args->{gifi}",
-            log_stdout  => $log,
-            log_stderr  => $log,
             );
     }
     if (defined $args->{sic}
         && -f "$self->{source_dir}/coa/$args->{country}/sic/$args->{sic}"){
         $self->run_file(
             file        => "$self->{source_dir}/coa/$args->{country}/sic/$args->{sic}",
-            log_stdout  => $log,
-            log_stderr  => $log,
             );
     }
     return;


### PR DESCRIPTION
Calls to `PGObject::Util::DBAdmin->run_file` included parameters
`log_stdout` and `log_stderr` which are not implemented (and have
never been implemented) by the DBAdmin class. They therefore
serve no purpose, so I have removed them.