### PR TITLE
backport separate stderr and stdout logs during upgrade

### DIFF
--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -1129,7 +1129,7 @@ sub process_and_run_upgrade_script {
     $dbtemplate->render($request);
     $database->run_file(
         file =>  $LedgerSMB::Sysconfig::tempdir . "/upgrade.sql",
-        log => $temp . "_stdout",
+        stdout_log => $temp . "_stdout",
         errlog => $temp . "_stderr"
         );
 


### PR DESCRIPTION
This backports to 1.5 a change committed by @ylavoie to master as
commit f733c76b47545fe9250d7ceccf29be65d9d9fcca.

Prior to this patch, run_files() was called with an invalid
combination of arguments - it is not valid to specify both
log and errlog parameters.

This was a bug... the intention was always to have separate
logs for stderr and stdout - and messages direct the user
to look for separate log files. After this patch, behaviour
matches expectation :)