### PR TITLE
Don't strip filename path in LedgerSMB::Mailer->attach method

### DIFF
--- a/lib/LedgerSMB/Mailer.pm
+++ b/lib/LedgerSMB/Mailer.pm
@@ -165,13 +165,6 @@ sub attach {
         carp 'No attachement supplied' unless defined $args{data};
     }
 
-    # strip path from output name
-    my $filename;
-    if ($args{filename}) {
-        $filename = $args{filename};
-        $filename =~ s/(.*\/)//g;
-    }
-
     # handle both string and file types of input
     my @data;
     if (defined $args{data}) {
@@ -182,7 +175,7 @@ sub attach {
 
     return $self->{_message}->attach(
         'Type' => $args{mimetype},
-        'Filename' => $filename,
+        'Filename' => $args{filename},
         'Disposition' => 'attachment',
         @data,
         );


### PR DESCRIPTION
Prompted by @hasorli's  suggestion to replace a regex substitution
with File::Basename, I dug a little further...

We don't currently depend on path-stripping the filename argument
to this method. And conceptually, if the caller has explicitly
provided a filename to be sent, it is not our place to mangle it.

I have therefore remove the path stripping - we now use the provided
filename argument directly.