### PR TITLE
Set mimimum TAP::Parser::SourceHandler::pgTAP version

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -96,7 +96,7 @@ on 'develop' => sub {
     requires 'Module::CPANfile'; # for 01.2-deps.t
     requires 'Perl::Critic';
     requires 'Pherkin::Extension::Weasel', '0.02';
-    requires 'TAP::Parser::SourceHandler::pgTAP';
+    requires 'TAP::Parser::SourceHandler::pgTAP', '3.33';
     requires 'Test::Exception';
     requires 'Test::Dependencies', '0.20';
     requires 'Test::BDD::Cucumber', '0.50';


### PR DESCRIPTION
This is a backport of commit 1db8f46de5ac2bad1f410d6ee732f60e069f0739

This PR fixes `unrecognized value "" for "pager"` errors when running
the xt/42-*.pg tests.

It sets 3.33 as the minimum version for TAP::Parser::SourceHandler::pgTAP

Unlike postgresql v9, postgresql v10 no longer allows an empty string
value for pager", which was provided for backwards compatibility with v8.

The latest TAP::Parser::SourceHandler::pgTAP 3.33 fixes this issue.

See: https://github.com/theory/pgtap/issues/135