### PR TITLE
Use File::Temp for temporary files in 04-template-handling.t

### DIFF
--- a/t/04-template-handling.t
+++ b/t/04-template-handling.t
@@ -7,6 +7,7 @@ use Test::More 'no_plan';
 use Test::Trap qw(trap $trap);
 use Test::Exception;
 
+use File::Temp;
 use LedgerSMB::AM;
 use LedgerSMB::Form;
 use LedgerSMB::Sysconfig;
@@ -20,8 +21,7 @@ use LedgerSMB::App_State;
 use Log::Log4perl;
 Log::Log4perl::init(\$LedgerSMB::Sysconfig::log4perl_config);
 
-
-my $temp = $LedgerSMB::Sysconfig::tempdir;
+my $temp;
 my $form;
 my $myconfig;
 my $template;
@@ -114,6 +114,7 @@ SKIP: {
     $template = undef;
     $template = LedgerSMB::Template->new('user' => $myconfig, 'format' => 'PDF',
         path => 't/data', 'template' => '04-template');
+    $temp = File::Temp->new();
     ok(defined $template,
         'Template, new (PDF): Object creation with format and template');
     isa_ok($template, 'LedgerSMB::Template',
@@ -121,18 +122,19 @@ SKIP: {
     is($template->{include_path}, 't/data',
         'Template, new (PDF): Object creation with format and template');
     is($template->render({'login' => 'foo&bar'}),
-        "$temp/04-template-output-$$.pdf",
+        $temp->filename,
         'Template, render (PDF): Simple PDF template, default filename');
-    ok(-e "$temp/04-template-output-$$.pdf",
+    ok(-e $temp->filename,
         'Template, render (PDF): File created');
-    is(unlink("$temp/04-template-output-$$.pdf"), 1,
+    is(unlink($temp->filename), 1,
         'Template, render (PDF): removing testfile');
-    ok(!-e "$temp/04-template-output-$$.pdf",
+    ok(!-e $temp->filename,
         'Template, render (PDF): testfile removed');
 
     $template = undef;
     $template = LedgerSMB::Template->new('user' => $myconfig, 'format' => 'PS',
         path => 't/data', 'template' => '04-template');
+    $temp = File::Temp->new();
     ok(defined $template,
         'Template, new (PS): Object creation with format and template');
     isa_ok($template, 'LedgerSMB::Template',
@@ -140,17 +142,18 @@ SKIP: {
     is($template->{include_path}, 't/data',
         'Template, new (PS): Object creation with format and template');
     is($template->render({'login' => 'foo\&bar'}),
-        "$temp/04-template-output-$$.ps",
+        $temp->filename,
         'Template, render (PS): Simple Postscript template, default filename');
-    ok(-e "$temp/04-template-output-$$.ps", 'Template, render (PS): File created');
-    is(unlink("$temp/04-template-output-$$.ps"), 1,
+    ok(-e $temp->filename, 'Template, render (PS): File created');
+    is(unlink($temp->filename), 1,
         'Template, render (PS): removing testfile');
-    ok(!-e "$temp/04-template-output-$$.ps",
+    ok(!-e $temp->filename,
         'Template, render (PS): testfile removed');
 
     $template = undef;
     $template = LedgerSMB::Template->new('user' => $myconfig, 'format' => 'XLS',
         path => 't/data', 'template' => '04-template');
+    $temp = File::Temp->new();
     ok(defined $template,
         'Template, new (XLS): Object creation with format and template');
     isa_ok($template, 'LedgerSMB::Template',
@@ -158,17 +161,18 @@ SKIP: {
     is($template->{include_path}, 't/data',
         'Template, new (XLS): Object creation with format and template');
     is($template->render({'login' => 'foo\&bar'}),
-        "$temp/04-template-output-$$.xls",
+        $temp->filename,
         'Template, render (XLS): Simple Postscript template, default filename');
-    ok(-e "$temp/04-template-output-$$.xls", 'Template, render (XLS): File created');
-    is(unlink("$temp/04-template-output-$$.xls"), 1,
+    ok(-e $temp->filename, 'Template, render (XLS): File created');
+    is(unlink($temp->filename), 1,
         'Template, render (XLS): removing testfile');
-    ok(!-e "$temp/04-template-output-$$.xls",
+    ok(!-e $temp->filename,
         'Template, render (XLS): testfile removed');
 
     $template = undef;
     $template = LedgerSMB::Template->new('user' => $myconfig, 'format' => 'XLSX',
         path => 't/data', 'template' => '04-template');
+    $temp = File::Temp->new();
     ok(defined $template,
         'Template, new (XLSX): Object creation with format and template');
     isa_ok($template, 'LedgerSMB::Template',
@@ -176,12 +180,12 @@ SKIP: {
     is($template->{include_path}, 't/data',
         'Template, new (XLSX): Object creation with format and template');
     is($template->render({'login' => 'foo\&bar'}),
-        "$temp/04-template-output-$$.xlsx",
+        $temp->filename,
         'Template, render (XLSX): Simple Postscript template, default filename');
-    ok(-e "$temp/04-template-output-$$.xlsx", 'Template, render (XLSX): File created');
-    is(unlink("$temp/04-template-output-$$.xlsx"), 1,
+    ok(-e $temp->filename, 'Template, render (XLSX): File created');
+    is(unlink($temp->filename), 1,
         'Template, render (XLSX): removing testfile');
-    ok(!-e "$temp/04-template-output-$$.xlsx",
+    ok(!-e $temp->filename,
         'Template, render (XLSX): testfile removed');
 
 }

--- a/t/04-template-handling.t
+++ b/t/04-template-handling.t
@@ -126,8 +126,7 @@ SKIP: {
         'Template, render (PDF): Simple PDF template, default filename');
     ok(-e $temp->filename,
         'Template, render (PDF): File created');
-    is(unlink($temp->filename), 1,
-        'Template, render (PDF): removing testfile');
+    undef $temp;
     ok(!-e $temp->filename,
         'Template, render (PDF): testfile removed');
 
@@ -145,8 +144,7 @@ SKIP: {
         $temp->filename,
         'Template, render (PS): Simple Postscript template, default filename');
     ok(-e $temp->filename, 'Template, render (PS): File created');
-    is(unlink($temp->filename), 1,
-        'Template, render (PS): removing testfile');
+    undef $temp;
     ok(!-e $temp->filename,
         'Template, render (PS): testfile removed');
 
@@ -164,8 +162,7 @@ SKIP: {
         $temp->filename,
         'Template, render (XLS): Simple Postscript template, default filename');
     ok(-e $temp->filename, 'Template, render (XLS): File created');
-    is(unlink($temp->filename), 1,
-        'Template, render (XLS): removing testfile');
+    undef $temp;
     ok(!-e $temp->filename,
         'Template, render (XLS): testfile removed');
 
@@ -183,8 +180,7 @@ SKIP: {
         $temp->filename,
         'Template, render (XLSX): Simple Postscript template, default filename');
     ok(-e $temp->filename, 'Template, render (XLSX): File created');
-    is(unlink($temp->filename), 1,
-        'Template, render (XLSX): removing testfile');
+    undef $temp;
     ok(!-e $temp->filename,
         'Template, render (XLSX): testfile removed');
 


### PR DESCRIPTION
This removes dependency on $LedgerSMB::Sysconfig::tempdir and delegates
temporary file handling to core module File::Temp.

Now that we use File::Temp to handle temporary files, it takes care of their
removal. We therefore no longer need to test `unlink` but we do still confirm
that File::Temp actually removed the temp files.