### PR TITLE
Don't set HOME environment variable in LedgerSMB::Sysconfig

### DIFF
--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -614,9 +614,6 @@ if(!(-d LedgerSMB::Sysconfig::tempdir())){
 
 sub check_permissions {
     my $tempdir = LedgerSMB::Sysconfig::tempdir();
-    # commit 6978b88 added this line to resolve issues if HOME isn't set
-    $ENV{HOME} = $tempdir;    ## no critic   # sniff
-
 
     if(!(-d "$tempdir")){
         die_pretty( "$tempdir wasn't created.",


### PR DESCRIPTION
This setting is believed to be unnecessary, following discussion:
https://matrix.to/#/!qyoLumPqusaXqFJNyK:matrix.org/$15225277541391956avFuF:matrix.org

In any case, we would rather set localised environment variables only
where necessary, so that their purpose is explicitly documented.