### PR TITLE
LedgerSMB::Sysconfig - use File::Path to make temporary directory

### DIFF
--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -11,6 +11,7 @@ use Config;
 use Config::IniFiles;
 use DBI qw(:sql_types);
 use English qw(-no_match_vars);
+use File::Path qw(make_path);
 
 binmode STDOUT, ':utf8';
 binmode STDERR, ':utf8';
@@ -434,13 +435,10 @@ our $log4perl_config = qq(
 
 
 if(!(-d LedgerSMB::Sysconfig::tempdir())){
-     my $rc;
-     if ($Config{path_sep} eq ';'){ # We need an actual platform configuration variable
-         $rc = system("mkdir " . LedgerSMB::Sysconfig::tempdir());
-     } else {
-         $rc=system("mkdir -p " . LedgerSMB::Sysconfig::tempdir());
-     #$logger->info("created tempdir \$tempdir rc=\$rc"); log4perl not initialised yet!
-     }
+    make_path(
+        LedgerSMB::Sysconfig::tempdir(),
+        {mode => oct('0700')},
+    ) or die 'failed to create temporary directory ' . LedgerSMB::Sysconfig::tempdir() . " $!";
 }
 
 sub check_permissions {

--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -435,10 +435,8 @@ our $log4perl_config = qq(
 
 
 if(!(-d LedgerSMB::Sysconfig::tempdir())){
-    make_path(
-        LedgerSMB::Sysconfig::tempdir(),
-        {mode => oct('0700')},
-    ) or die 'failed to create temporary directory ' . LedgerSMB::Sysconfig::tempdir() . " $!";
+    make_path(LedgerSMB::Sysconfig::tempdir())
+        or die 'failed to create temporary directory ' . LedgerSMB::Sysconfig::tempdir() . " $!";
 }
 
 sub check_permissions {


### PR DESCRIPTION
LedgerSMB::Sysconfig was previously using a shell and `mkdir` to create the temporary
directory, which is less portable and fails if the tempdir configuration file option contains characters which are not shell-safe.