### PR TITLE
Cleanup of LedgerSMB::Template and associated test

### DIFF
--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -281,7 +281,6 @@ use LedgerSMB::Template::DBProvider;
 
 use Template::Parser;
 use Log::Log4perl;
-use File::Copy 'cp';
 use File::Spec;
 use HTTP::Status qw( HTTP_OK);
 use Module::Runtime qw(use_module);

--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -113,10 +113,6 @@ and leaves auto-output enabled.
 Additionally, variables are added to the template processor as required
 by the HTML UI.
 
-=item preprocess ($rawvars, $escape)
-
-Preprocess for rendering.
-
 
 =item render($hashref)
 
@@ -132,6 +128,17 @@ extension as appropriate.
 
 Returns a hash with the default arguments for the Template and the
 desired file extention
+
+=back
+
+=head1 FUNCTIONS
+
+=over
+
+=item preprocess ($rawvars, $escape)
+
+Preprocess for rendering. This is not an object method, it is a standalone
+subroutine.
 
 =back
 

--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -4,17 +4,25 @@ LedgerSMB::Template - Template support module for LedgerSMB
 
 =head1 SYNOPSIS
 
-This module renders templates.
+This module renders templates to an in-memory property.
+
+Unlike legacy versions, this module does not handle the
+output/delivery of the rendered template (to browser, file,
+e-mail etc).
 
 =head1 METHODS
 
 =over
 
-=item new(user => \%myconfig, template => $string, format => $string, [locale => $locale], [language => $string], [include_path => $path], [no_escape => $bool], [debug => $bool] );
+=item new(user => \%myconfig, template => $string, format => $string, [locale => $locale], [language => $string], [path => $path], [no_escape => $bool], [debug => $bool] );
 
 Instantiates a new template. Accepts the following arguments:
 
 =over
+
+=item user (optional)
+
+A LedgerSMB::User object defining user preferences.
 
 =item template
 
@@ -26,7 +34,8 @@ to resolve to the correct template file.
 
 =item format
 
-The format to be used.  Currently HTML, PS, PDF, TXT and CSV are supported.
+The format to be used.  Currently HTML, PS, PDF, TXT, CSV, ODS, XLS, XLSX
+are supported, subject to their dependencies being available.
 
 =item format_options (optional)
 

--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -10,9 +10,9 @@ This module renders templates.
 
 =over
 
-=item new(user => \%myconfig, template => $string, format => $string, [locale => $locale], [language => $string], [include_path => $path], [method => $string], [no_escape => $bool], [debug => $bool] );
+=item new(user => \%myconfig, template => $string, format => $string, [locale => $locale], [language => $string], [path => $path], [method => $string], [no_escape => $bool], [debug => $bool] );
 
-This command instantiates a new template:
+Instantiates a new template. Accepts the following arguments:
 
 =over
 
@@ -49,7 +49,7 @@ gettext function.
 
 The language for template selection.
 
-=item include_path (optional)
+=item path (optional)
 
 Overrides the template directory.
 

--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -82,10 +82,6 @@ template to get debugging messages is to be surrounded by
 
 The output method to use, defaults to HTTP.  Media is a synonym for method
 
-=item output_file (optional)
-
-The base name of the file for output.
-
 =back
 
 =item available_formats()

--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -281,7 +281,6 @@ use LedgerSMB::Template::DBProvider;
 use Template::Parser;
 use Log::Log4perl;
 use File::Spec;
-use HTTP::Status qw( HTTP_OK);
 use Module::Runtime qw(use_module);
 use Scalar::Util qw(reftype);
 

--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -274,7 +274,6 @@ use Carp;
 use LedgerSMB::App_State;
 use LedgerSMB::Company_Config;
 use LedgerSMB::Locale;
-use LedgerSMB::Mailer;
 use LedgerSMB::Setting;
 use LedgerSMB::Sysconfig;
 use LedgerSMB::Template::DBProvider;

--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -127,10 +127,6 @@ Preprocess for rendering.
 Returns the LedgerSMB::Template object itself. Dies on error.
 
 
-=item output
-
-This function outputs the rendered file in an appropriate manner.
-
 =item get_template_source($extension)
 
 Returns the name of the Template source, incorporating the specified

--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -284,7 +284,6 @@ use File::Spec;
 use HTTP::Status qw( HTTP_OK);
 use Module::Runtime qw(use_module);
 use Scalar::Util qw(reftype);
-use Try::Tiny;
 
 use parent qw( Exporter );
 our @EXPORT_OK = qw( preprocess );

--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -563,9 +563,6 @@ sub _render {
         die "Template error: $err" if $err;
     }
 
-    if($self->{_no_postprocess}) {
-        return undef;
-    }
     $format->can('postprocess')->($self, $output, $config);
     return;
 }

--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -19,7 +19,7 @@ Instantiates a new template. Accepts the following arguments:
 =item template
 
 The template to be processed.  This is the file that is the template to be
-processed. When C<include_path> equals 'DB', the file is retrieved from
+processed. When 'path' equals 'DB', the file is retrieved from
 the database instead of from disk.
 Based on the specified format, an appropriate extension is appended
 to resolve to the correct template file.

--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -124,17 +124,19 @@ Preprocess for rendering.
 
 =item render($hashref)
 
-TODO
+Returns the LedgerSMB::Template object itself. Dies on error.
+
 
 =item output
 
 This function outputs the rendered file in an appropriate manner.
 
-=item my $source = get_template_source($get_template)
+=item get_template_source($extension)
 
-Returns the Template source when common or call a specialized getter if not
+Returns the name of the Template source, incorporating the specified
+extension as appropriate.
 
-=item my $arghash = get_template_args($extension)
+=item get_template_args($extension)
 
 Returns a hash with the default arguments for the Template and the
 desired file extention

--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -6,15 +6,16 @@ LedgerSMB::Template - Template support module for LedgerSMB
 
 This module renders templates to an in-memory property.
 
-Unlike legacy versions, this module does not handle the
-output/delivery of the rendered template (to browser, file,
-e-mail etc).
+This module does not handle the
+output/delivery of the rendered template to browser, file,
+e-mail etc.  For that, see modules such as LedgerSMB::PSGI::Util
+and LedgerSMB::Legacy_Util.
 
 =head1 METHODS
 
 =over
 
-=item new(user => \%myconfig, template => $string, format => $string, [locale => $locale], [language => $string], [path => $path], [no_escape => $bool], [debug => $bool] );
+=item new(user => \%myconfig, template => $string, format => $string, [format_options => $hashref], [locale => $locale], [language => $string], [path => $path], [no_escape => $bool], [debug => $bool] );
 
 Instantiates a new template. Accepts the following arguments:
 
@@ -44,9 +45,13 @@ details.
 
 =item output_options (optional)
 
-A hash of output-specific options.  If the output is sent as an HTTP
-response, the output option C<filename> causes C<Content-Disposition>
-headers to be generated of the type C<attachment> (forcing file download).
+A hash of output-specific options, not used internally by LedgerSMB::Template.
+These options may be used by output/delivery code.
+
+For example, if the output is sent as an HTTP response using
+LedgerSMB::PSGI::Util::template_to_psgi(),  the output option C<filename>
+causes C<Content-Disposition> headers to be generated of the type
+C<attachment> (forcing file download).
 
 =item locale (optional)
 
@@ -68,7 +73,7 @@ current database.  Resolving the template takes the 'language' and
 
 =item no_escape (optional)
 
-Disables escaping on the template variables.
+Disables escaping on the template variables when true.
 
 =item debug (optional)
 
@@ -87,17 +92,8 @@ template to get debugging messages is to be surrounded by
   <?lsmb END ?>
     </tr>
 
-<<<<<<< HEAD
-=item method/media (optional)
-
-The output method to use, defaults to HTTP.  Media is a synonym for method
-=======
-=item output_file (optional)
-
-The base name of the file for output.
->>>>>>> master
-
 =back
+
 
 =item available_formats()
 
@@ -115,9 +111,12 @@ Returns a list of format names, any of the following (in order) as applicable:
 
 =item XLS
 
+=item XLSX
+
 =item ODS
 
 =back
+
 
 =item new_UI($request, template => $file, ...)
 
@@ -133,11 +132,15 @@ by the HTML UI.
 
 Returns the LedgerSMB::Template object itself. Dies on error.
 
+The rendered template result is available from the LedgerSMB::Template
+object's C<output> property.
+
 
 =item get_template_source($extension)
 
 Returns the name of the Template source, incorporating the specified
 extension as appropriate.
+
 
 =item get_template_args($extension)
 
@@ -145,6 +148,7 @@ Returns a hash with the default arguments for the Template and the
 desired file extention
 
 =back
+
 
 =head1 FUNCTIONS
 
@@ -156,6 +160,28 @@ Preprocess for rendering. This is not an object method, it is a standalone
 subroutine.
 
 =back
+
+
+=head1 PROPERTIES
+
+=over 
+
+=item output
+
+The result of rendering the template.
+
+=item mimetype
+
+The mimetype of the rendered template.
+
+=item output_options
+
+Not used internally by LedgerSMB::Template, but used as a way of passing
+options to output/delivery code, such as
+LedgerSMB::PSGI::Util::template_to_psgi().
+
+=back
+
 
 =head1 TEMPLATE FUNCTIONS
 

--- a/lib/LedgerSMB/Template/LaTeX.pm
+++ b/lib/LedgerSMB/Template/LaTeX.pm
@@ -121,7 +121,7 @@ Latex plugin.
 sub initialize_template {
     my ($parent, $config, $template) = @_;
 
-    my %options = ( FORMAT => $config->{_format} );
+    my %options = ( format => $config->{_format} );
     Template::Plugin::Latex->new($template->context, \%options);
 
     return undef;

--- a/old/lib/LedgerSMB/Legacy_Util.pm
+++ b/old/lib/LedgerSMB/Legacy_Util.pm
@@ -208,7 +208,7 @@ sub _output_template_lpr {
     if ($self->{format} ne 'LaTeX') {
         die 'Invalid Format';
     }
-    my $lpr = $LedgerSMB::Sysconfig::printer{$args->{media}};
+    my $lpr = $LedgerSMB::Sysconfig::printer{$args->{method}};
 
     open my $pipe, '|-', $lpr
         or die "Failed to open lpr pipe $lpr : $!";

--- a/t/04-template-handling.t
+++ b/t/04-template-handling.t
@@ -322,8 +322,5 @@ SKIP: {
 
     my $LPR_TEST;
     ok(open ($LPR_TEST, '<', "t/var/04-lpr-test"), 'LedgerSMB::Template::_output_lpr output file opened successfully');
-
-    my $line1 = <$LPR_TEST>;
-
-    like($line1, qr/^%PDF/, 'output file is pdf');
+    like(<$LPR_TEST>, qr/^%PDF/, 'output file is pdf');
 }

--- a/t/04-template-handling.t
+++ b/t/04-template-handling.t
@@ -257,23 +257,6 @@ isa_ok($template, 'LedgerSMB::Template',
 ## LedgerSMB::Template::Elements ##
 ###################################
 
-$template = undef;
-
-my $lsmb = LedgerSMB->new();
-$locale = LedgerSMB::Locale->get_handle( LedgerSMB::Sysconfig::language() )
-  or $lsmb->error( __FILE__ . ':' . __LINE__ . ": Locale not loaded: $!\n" );
-
-
-$template = LedgerSMB::Template->new(
-    'user'     => {numberformat => '1.000,00'},
-    'format'   => 'HTML',
-    'path'     => 't/data',
-    'locale'   => $locale,
-    'template' => '04-complex_template'
-);
-
-$template->render({});
-
 my $contact_request = {
         entity_id    => 1,
         control_code => 'test1',

--- a/t/04-template-handling.t
+++ b/t/04-template-handling.t
@@ -190,6 +190,24 @@ SKIP: {
         'Template, render (XLSX): Simple Postscript template, default filename');
     # xlsx is actualy a zip file.
     like($template->{output}, qr/^PK/, 'Template, render (XLSX): output is XLSX');
+
+    $template = undef;
+    $template = LedgerSMB::Template->new(
+        'format'   => 'ODS',
+        'path'     => 't/data',
+        'template' => '04-template'
+    );
+    ok(defined $template,
+        'Template, new (ODS): Object creation with format and template');
+    isa_ok($template, 'LedgerSMB::Template',
+        'Template, new (ODS): Object creation with format and template');
+    is($template->{include_path}, 't/data',
+        'Template, new (ODS): Object creation with format and template');
+    isa_ok($template->render({'login' => 'foo\&bar'}),
+        'LedgerSMB::Template',
+        'Template, render (ODS): Simple Postscript template, default filename');
+    # xlsx is actualy a zip file.
+    like($template->{output}, qr/^PK/, 'Template, render (ODS): output is ODS');
 }
 
 $template = undef;

--- a/t/04-template-handling.t
+++ b/t/04-template-handling.t
@@ -7,7 +7,6 @@ use Test::More 'no_plan';
 use Test::Trap qw(trap $trap);
 use Test::Exception;
 
-use File::Temp;
 use LedgerSMB::AM;
 use LedgerSMB::Form;
 use LedgerSMB::Sysconfig;
@@ -21,7 +20,8 @@ use LedgerSMB::App_State;
 use Log::Log4perl;
 Log::Log4perl::init(\$LedgerSMB::Sysconfig::log4perl_config);
 
-my $temp;
+
+my $temp = $LedgerSMB::Sysconfig::tempdir;
 my $form;
 my $myconfig;
 my $template;
@@ -114,7 +114,6 @@ SKIP: {
     $template = undef;
     $template = LedgerSMB::Template->new('user' => $myconfig, 'format' => 'PDF',
         path => 't/data', 'template' => '04-template');
-    $temp = File::Temp->new();
     ok(defined $template,
         'Template, new (PDF): Object creation with format and template');
     isa_ok($template, 'LedgerSMB::Template',
@@ -122,19 +121,18 @@ SKIP: {
     is($template->{include_path}, 't/data',
         'Template, new (PDF): Object creation with format and template');
     is($template->render({'login' => 'foo&bar'}),
-        $temp->filename,
+        "$temp/04-template-output-$$.pdf",
         'Template, render (PDF): Simple PDF template, default filename');
-    ok(-e $temp->filename,
+    ok(-e "$temp/04-template-output-$$.pdf",
         'Template, render (PDF): File created');
-    is(unlink($temp->filename), 1,
+    is(unlink("$temp/04-template-output-$$.pdf"), 1,
         'Template, render (PDF): removing testfile');
-    ok(!-e $temp->filename,
+    ok(!-e "$temp/04-template-output-$$.pdf",
         'Template, render (PDF): testfile removed');
 
     $template = undef;
     $template = LedgerSMB::Template->new('user' => $myconfig, 'format' => 'PS',
         path => 't/data', 'template' => '04-template');
-    $temp = File::Temp->new();
     ok(defined $template,
         'Template, new (PS): Object creation with format and template');
     isa_ok($template, 'LedgerSMB::Template',
@@ -142,18 +140,17 @@ SKIP: {
     is($template->{include_path}, 't/data',
         'Template, new (PS): Object creation with format and template');
     is($template->render({'login' => 'foo\&bar'}),
-        $temp->filename,
+        "$temp/04-template-output-$$.ps",
         'Template, render (PS): Simple Postscript template, default filename');
-    ok(-e $temp->filename, 'Template, render (PS): File created');
-    is(unlink($temp->filename), 1,
+    ok(-e "$temp/04-template-output-$$.ps", 'Template, render (PS): File created');
+    is(unlink("$temp/04-template-output-$$.ps"), 1,
         'Template, render (PS): removing testfile');
-    ok(!-e $temp->filename,
+    ok(!-e "$temp/04-template-output-$$.ps",
         'Template, render (PS): testfile removed');
 
     $template = undef;
     $template = LedgerSMB::Template->new('user' => $myconfig, 'format' => 'XLS',
         path => 't/data', 'template' => '04-template');
-    $temp = File::Temp->new();
     ok(defined $template,
         'Template, new (XLS): Object creation with format and template');
     isa_ok($template, 'LedgerSMB::Template',
@@ -161,18 +158,17 @@ SKIP: {
     is($template->{include_path}, 't/data',
         'Template, new (XLS): Object creation with format and template');
     is($template->render({'login' => 'foo\&bar'}),
-        $temp->filename,
+        "$temp/04-template-output-$$.xls",
         'Template, render (XLS): Simple Postscript template, default filename');
-    ok(-e $temp->filename, 'Template, render (XLS): File created');
-    is(unlink($temp->filename), 1,
+    ok(-e "$temp/04-template-output-$$.xls", 'Template, render (XLS): File created');
+    is(unlink("$temp/04-template-output-$$.xls"), 1,
         'Template, render (XLS): removing testfile');
-    ok(!-e $temp->filename,
+    ok(!-e "$temp/04-template-output-$$.xls",
         'Template, render (XLS): testfile removed');
 
     $template = undef;
     $template = LedgerSMB::Template->new('user' => $myconfig, 'format' => 'XLSX',
         path => 't/data', 'template' => '04-template');
-    $temp = File::Temp->new();
     ok(defined $template,
         'Template, new (XLSX): Object creation with format and template');
     isa_ok($template, 'LedgerSMB::Template',
@@ -180,12 +176,12 @@ SKIP: {
     is($template->{include_path}, 't/data',
         'Template, new (XLSX): Object creation with format and template');
     is($template->render({'login' => 'foo\&bar'}),
-        $temp->filename,
+        "$temp/04-template-output-$$.xlsx",
         'Template, render (XLSX): Simple Postscript template, default filename');
-    ok(-e $temp->filename, 'Template, render (XLSX): File created');
-    is(unlink($temp->filename), 1,
+    ok(-e "$temp/04-template-output-$$.xlsx", 'Template, render (XLSX): File created');
+    is(unlink("$temp/04-template-output-$$.xlsx"), 1,
         'Template, render (XLSX): removing testfile');
-    ok(!-e $temp->filename,
+    ok(!-e "$temp/04-template-output-$$.xlsx",
         'Template, render (XLSX): testfile removed');
 
 }

--- a/t/04-template-handling.t
+++ b/t/04-template-handling.t
@@ -4,7 +4,6 @@ use strict;
 use warnings;
 
 use Test::More 'no_plan';
-use Test::Trap qw(trap $trap);
 use Test::Exception;
 
 use File::Temp;

--- a/t/04-template-handling.t
+++ b/t/04-template-handling.t
@@ -22,8 +22,6 @@ Log::Log4perl::init(\$LedgerSMB::Sysconfig::log4perl_config);
 
 
 my $temp = $LedgerSMB::Sysconfig::tempdir;
-my $form;
-my $myconfig;
 my $template;
 my $locale;
 
@@ -259,7 +257,6 @@ isa_ok($template, 'LedgerSMB::Template',
 ###################################
 
 $template = undef;
-$form = undef;
 
 my $lsmb = LedgerSMB->new();
 $locale = LedgerSMB::Locale->get_handle( LedgerSMB::Sysconfig::language() )
@@ -312,7 +309,6 @@ my $payment_template =  LedgerSMB::Template->new(
     path            => 'UI/payments',
     template        => 'payments_detail',
     format          => 'HTML',
-    no_auto_output  => 1,
 );
 
 $payment_template->render({ request => { script => '' },
@@ -329,11 +325,9 @@ SKIP: {
     %LedgerSMB::Sysconfig::printer = ('test' => 'cat > t/var/04-lpr-test');
 
     $template = LedgerSMB::Template->new(
-        'user'           => $myconfig,
         'format'         => 'PDF',
         'template'       => '04-template',
         'locale'         => $locale,
-        'no_auto_output' => 1
     );
     $template->render({media => 'test'});
     $template->output(media => 'test');

--- a/t/04-template-handling.t
+++ b/t/04-template-handling.t
@@ -307,9 +307,9 @@ is(grep(/Locked by/, @output), 1, 'Invoice locked label shown');
 # LPR Printing Tests
 SKIP: {
     eval {require Template::Plugin::Latex} ||
-        skip 'Template::Plugin::Latex not installed', 10;
+        skip 'Template::Plugin::Latex not installed', 2;
     eval {require Template::Latex} ||
-        skip 'Template::Latex not installed', 10;
+        skip 'Template::Latex not installed', 2;
 
     my $temp = File::Temp->new();
     %LedgerSMB::Sysconfig::printer = ('test' => "cat > $temp");

--- a/t/04-template-handling.t
+++ b/t/04-template-handling.t
@@ -7,17 +7,11 @@ use Test::More 'no_plan';
 use Test::Trap qw(trap $trap);
 use Test::Exception;
 
-use LedgerSMB::AM;
-use LedgerSMB::Form;
 use LedgerSMB::Sysconfig;
 use LedgerSMB::Locale;
 use LedgerSMB::Legacy_Util;
 use LedgerSMB::Template;
-use LedgerSMB::Template::Elements;
-use LedgerSMB::Template::CSV;
 use LedgerSMB::Template::HTML;
-use LedgerSMB::Template::TXT;
-use LedgerSMB::App_State;
 use Log::Log4perl;
 Log::Log4perl::init(\$LedgerSMB::Sysconfig::log4perl_config);
 

--- a/t/04-template-handling.t
+++ b/t/04-template-handling.t
@@ -137,8 +137,8 @@ SKIP: {
         'Template, new (PDF): Object creation with format and template');
     is($template->{include_path}, 't/data',
         'Template, new (PDF): Object creation with format and template');
-    is($template->render({'login' => 'foo&bar'}),
-        "$temp/04-template-output-$$.pdf",
+    isa_ok($template->render({'login' => 'foo&bar'}),
+        'LedgerSMB::Template',
         'Template, render (PDF): Simple PDF template, default filename');
     ok(-e "$temp/04-template-output-$$.pdf",
         'Template, render (PDF): File created');
@@ -160,8 +160,8 @@ SKIP: {
         'Template, new (PS): Object creation with format and template');
     is($template->{include_path}, 't/data',
         'Template, new (PS): Object creation with format and template');
-    is($template->render({'login' => 'foo\&bar'}),
-        "$temp/04-template-output-$$.ps",
+    isa_ok($template->render({'login' => 'foo\&bar'}),
+        'LedgerSMB::Template',
         'Template, render (PS): Simple Postscript template, default filename');
     ok(-e "$temp/04-template-output-$$.ps", 'Template, render (PS): File created');
     is(unlink("$temp/04-template-output-$$.ps"), 1,
@@ -182,8 +182,8 @@ SKIP: {
         'Template, new (XLS): Object creation with format and template');
     is($template->{include_path}, 't/data',
         'Template, new (XLS): Object creation with format and template');
-    is($template->render({'login' => 'foo\&bar'}),
-        "$temp/04-template-output-$$.xls",
+    isa_ok($template->render({'login' => 'foo\&bar'}),
+        'LedgerSMB::Template',
         'Template, render (XLS): Simple Postscript template, default filename');
     ok(-e "$temp/04-template-output-$$.xls", 'Template, render (XLS): File created');
     is(unlink("$temp/04-template-output-$$.xls"), 1,
@@ -204,8 +204,8 @@ SKIP: {
         'Template, new (XLSX): Object creation with format and template');
     is($template->{include_path}, 't/data',
         'Template, new (XLSX): Object creation with format and template');
-    is($template->render({'login' => 'foo\&bar'}),
-        "$temp/04-template-output-$$.xlsx",
+    isa_ok($template->render({'login' => 'foo\&bar'}),
+        'LedgerSMB::Template',
         'Template, render (XLSX): Simple Postscript template, default filename');
     ok(-e "$temp/04-template-output-$$.xlsx", 'Template, render (XLSX): File created');
     is(unlink("$temp/04-template-output-$$.xlsx"), 1,
@@ -347,7 +347,7 @@ is(grep(/Locked by/, @output), 1, 'Invoice locked label shown');
 
 # LPR PRinting Tests
 SKIP: {
-    skip 'LATEX_TESTING is not set', 2 unless $ENV{LATEX_TESTING};
+#    skip 'LATEX_TESTING is not set', 2 unless $ENV{LATEX_TESTING};
     use LedgerSMB::Sysconfig;
     %LedgerSMB::Sysconfig::printer = ('test' => 'cat > t/var/04-lpr-test');
 

--- a/t/04-template-handling.t
+++ b/t/04-template-handling.t
@@ -101,7 +101,11 @@ throws_ok{$template->render({'login' => 'foo'})} qr/not found/,
 #####################
 
 SKIP: {
-    #skip "LATEX_TESTING not set", 7 unless $ENV{LATEX_TESTING};
+    eval {require Template::Plugin::Latex} ||
+        skip 'Template::Plugin::Latex not installed', 10;
+    eval {require Template::Latex} ||
+        skip 'Template::Latex not installed', 10;
+
     $template = undef;
     $template = LedgerSMB::Template->new(
         'format'   => 'PDF',
@@ -135,6 +139,14 @@ SKIP: {
         'LedgerSMB::Template',
         'Template, render (PS): Simple Postscript template, default filename');
     like($template->{output}, qr/^%!PS/, 'Template, render (PS): output is Postscript');
+}
+
+
+SKIP: {
+    eval {require Excel::Writer::XLSX} ||
+        skip 'Excel::Writer::XLSX not installed', 10;
+    eval {require Spreadsheet::WriteExcel} ||
+        skip 'Spreadsheet::WriteExcel not installed', 10;
 
     $template = undef;
     $template = LedgerSMB::Template->new(
@@ -172,6 +184,13 @@ SKIP: {
         'Template, render (XLSX): Simple Postscript template, default filename');
     # xlsx is actualy a zip file.
     like($template->{output}, qr/^PK/, 'Template, render (XLSX): output is XLSX');
+}
+
+SKIP: {
+    eval {require XML::Twig } ||
+        skip 'XML::Twig not installed', 5;
+    eval {require OpenOffice::OODoc} ||
+        skip 'OpenOffice::OODoc not installed', 5;
 
     $template = undef;
     $template = LedgerSMB::Template->new(
@@ -188,7 +207,7 @@ SKIP: {
     isa_ok($template->render({'login' => 'foo\&bar'}),
         'LedgerSMB::Template',
         'Template, render (ODS): Simple Postscript template, default filename');
-    # xlsx is actualy a zip file.
+    # ods is actualy a zip file.
     like($template->{output}, qr/^PK/, 'Template, render (ODS): output is ODS');
 }
 
@@ -285,9 +304,13 @@ is(grep(/name="payment_101"/, @output), 0, 'Invoice locked');
 is(grep(/Locked by/, @output), 1, 'Invoice locked label shown');
 
 
-# LPR PRinting Tests
+# LPR Printing Tests
 SKIP: {
-    #skip 'LATEX_TESTING is not set', 2 unless $ENV{LATEX_TESTING};
+    eval {require Template::Plugin::Latex} ||
+        skip 'Template::Plugin::Latex not installed', 10;
+    eval {require Template::Latex} ||
+        skip 'Template::Latex not installed', 10;
+
     my $temp = File::Temp->new();
     %LedgerSMB::Sysconfig::printer = ('test' => "cat > $temp");
 

--- a/t/04-template-handling.t
+++ b/t/04-template-handling.t
@@ -78,7 +78,7 @@ is_deeply(LedgerSMB::Template::preprocess({'fruit' => '&veggies',
 ####################
 
 # Template->new
-$myconfig = {'templates' => 't/data'};
+$myconfig = {};
 $template = undef;
 $template = LedgerSMB::Template->new('user' => $myconfig, 'language' => 'de',
         'path' => 't/data', 'format' => 'HTML');

--- a/t/04-template-handling.t
+++ b/t/04-template-handling.t
@@ -78,10 +78,8 @@ is_deeply(LedgerSMB::Template::preprocess({'fruit' => '&veggies',
 ####################
 
 # Template->new
-$myconfig = {};
 $template = undef;
 $template = LedgerSMB::Template->new(
-    'user'     => $myconfig,
     'language' => 'de',
     'path'     => 't/data',
     'format'   => 'HTML'
@@ -95,7 +93,6 @@ is($template->{include_path}, 't/data',
 
 $template = undef;
 $template = LedgerSMB::Template->new(
-    'user'     => $myconfig,
     'format'   => 'HTML',
     'path'     => 't/data',
     'template' => '04-template',
@@ -108,7 +105,6 @@ isa_ok($template, 'LedgerSMB::Template',
 
 $template = undef;
 $template = LedgerSMB::Template->new(
-    'user'     => $myconfig,
     'format'   => 'HTML',
     'path'     => 't/data',
     'template' => '04-template-2'
@@ -123,6 +119,7 @@ throws_ok{$template->render({'login' => 'foo'})} qr/not found/,
 #####################
 
 SKIP: {
+    $myconfig = {};
     skip "LATEX_TESTING not set", 7 unless $ENV{LATEX_TESTING};
     $template = undef;
     $template = LedgerSMB::Template->new(
@@ -217,7 +214,6 @@ SKIP: {
 
 $template = undef;
 $template = LedgerSMB::Template->new(
-    'user'     => $myconfig,
     'format'   => 'TXT',
     'path'     => 't/data',
     'template' => '04-template'
@@ -232,7 +228,6 @@ is($template->{output}, "I am a template.\nLook at me foo&bar.",
 
 $template = undef;
 $template = LedgerSMB::Template->new(
-    'user'     => $myconfig,
     'format'   => 'HTML',
     'path'     => 't/data',
     'template' => '04-template'
@@ -260,22 +255,6 @@ ok(defined $template,
         'Template, private (preprocess): Object creation with format and template');
 isa_ok($template, 'LedgerSMB::Template',
         'Template, private (preprocess): Object creation with format and template');
-my $number = Math::BigFloat->new(17.5);
-isa_ok($number, 'Math::BigFloat',
-        'Template, private (preprocess): number');
-## Commending out the one below because it is not valid when Math::BigInt::GMP is loaded
-# $template->_preprocess($number);
-## Commenting out these tests since currently the functionality is known broken
-## and unused
-#cmp_ok($number, 'eq', '17,50',
-#       'Template, private (_preprocess): Math::BigFloat conversion');
-#$number = [Math::BigFloat->new(1008.51), 'hello'];
-#$template->_preprocess($number);
-#
-#cmp_ok($number->[0], 'eq', '1.008,51',
-#       'Template, private (_preprocess): Math::BigFloat conversion (array)');
-#cmp_ok($number->[1], 'eq', 'hello',
-#       'Template, private (_preprocess): no conversion (array)');
 
 ###################################
 ## LedgerSMB::Template::Elements ##
@@ -347,7 +326,7 @@ is(grep(/Locked by/, @output), 1, 'Invoice locked label shown');
 
 # LPR PRinting Tests
 SKIP: {
-#    skip 'LATEX_TESTING is not set', 2 unless $ENV{LATEX_TESTING};
+    skip 'LATEX_TESTING is not set', 2 unless $ENV{LATEX_TESTING};
     use LedgerSMB::Sysconfig;
     %LedgerSMB::Sysconfig::printer = ('test' => 'cat > t/var/04-lpr-test');
 

--- a/t/04-template-handling.t
+++ b/t/04-template-handling.t
@@ -11,6 +11,7 @@ use LedgerSMB::AM;
 use LedgerSMB::Form;
 use LedgerSMB::Sysconfig;
 use LedgerSMB::Locale;
+use LedgerSMB::Legacy_Util;
 use LedgerSMB::Template;
 use LedgerSMB::Template::Elements;
 use LedgerSMB::Template::CSV;
@@ -320,19 +321,24 @@ is(grep(/Locked by/, @output), 1, 'Invoice locked label shown');
 
 # LPR PRinting Tests
 SKIP: {
-    skip 'LATEX_TESTING is not set', 2 unless $ENV{LATEX_TESTING};
+    #skip 'LATEX_TESTING is not set', 2 unless $ENV{LATEX_TESTING};
     use LedgerSMB::Sysconfig;
     %LedgerSMB::Sysconfig::printer = ('test' => 'cat > t/var/04-lpr-test');
 
     $template = LedgerSMB::Template->new(
-        'format'         => 'PDF',
-        'template'       => '04-template',
-        'locale'         => $locale,
+        'format'   => 'PDF',
+        'template' => '04-template',
+        'locale'   => $locale,
+        'path'     => 't/data',
     );
-    $template->render({media => 'test'});
-    $template->output(media => 'test');
+    LedgerSMB::Legacy_Util::render_template(
+        $template,
+        {},
+        'test',
+    );
+
     my $LPR_TEST;
-    ok(open ($LPR_TEST, '<', "$temp/04-lpr-test"), 'LedgerSMB::Template::_output_lpr output file opened successfully');
+    ok(open ($LPR_TEST, '<', "t/var/04-lpr-test"), 'LedgerSMB::Template::_output_lpr output file opened successfully');
 
     my $line1 = <$LPR_TEST>;
 

--- a/t/04-template-handling.t
+++ b/t/04-template-handling.t
@@ -126,7 +126,8 @@ SKIP: {
         'Template, render (PDF): Simple PDF template, default filename');
     ok(-e $temp->filename,
         'Template, render (PDF): File created');
-    undef $temp;
+    is(unlink($temp->filename), 1,
+        'Template, render (PDF): removing testfile');
     ok(!-e $temp->filename,
         'Template, render (PDF): testfile removed');
 
@@ -144,7 +145,8 @@ SKIP: {
         $temp->filename,
         'Template, render (PS): Simple Postscript template, default filename');
     ok(-e $temp->filename, 'Template, render (PS): File created');
-    undef $temp;
+    is(unlink($temp->filename), 1,
+        'Template, render (PS): removing testfile');
     ok(!-e $temp->filename,
         'Template, render (PS): testfile removed');
 
@@ -162,7 +164,8 @@ SKIP: {
         $temp->filename,
         'Template, render (XLS): Simple Postscript template, default filename');
     ok(-e $temp->filename, 'Template, render (XLS): File created');
-    undef $temp;
+    is(unlink($temp->filename), 1,
+        'Template, render (XLS): removing testfile');
     ok(!-e $temp->filename,
         'Template, render (XLS): testfile removed');
 
@@ -180,7 +183,8 @@ SKIP: {
         $temp->filename,
         'Template, render (XLSX): Simple Postscript template, default filename');
     ok(-e $temp->filename, 'Template, render (XLSX): File created');
-    undef $temp;
+    is(unlink($temp->filename), 1,
+        'Template, render (XLSX): removing testfile');
     ok(!-e $temp->filename,
         'Template, render (XLSX): testfile removed');
 

--- a/t/04-template-handling.t
+++ b/t/04-template-handling.t
@@ -119,11 +119,9 @@ throws_ok{$template->render({'login' => 'foo'})} qr/not found/,
 #####################
 
 SKIP: {
-    $myconfig = {};
-    skip "LATEX_TESTING not set", 7 unless $ENV{LATEX_TESTING};
+    #skip "LATEX_TESTING not set", 7 unless $ENV{LATEX_TESTING};
     $template = undef;
     $template = LedgerSMB::Template->new(
-        'user'     => $myconfig,
         'format'   => 'PDF',
         'path'     => 't/data',
         'template' => '04-template'
@@ -137,17 +135,11 @@ SKIP: {
     isa_ok($template->render({'login' => 'foo&bar'}),
         'LedgerSMB::Template',
         'Template, render (PDF): Simple PDF template, default filename');
-    ok(-e "$temp/04-template-output-$$.pdf",
-        'Template, render (PDF): File created');
-    is(unlink("$temp/04-template-output-$$.pdf"), 1,
-        'Template, render (PDF): removing testfile');
-    ok(!-e "$temp/04-template-output-$$.pdf",
-        'Template, render (PDF): testfile removed');
+    like($template->{output}, qr/^%PDF/, 'Template, render (PDF): output is PDF');
 
     $template = undef;
     $template = LedgerSMB::Template->new(
-        'user'     => $myconfig,
-        'format'   => 'PS',
+        'format'   => 'postscript',
         'path'     => 't/data',
         'template' => '04-template'
     );
@@ -160,15 +152,10 @@ SKIP: {
     isa_ok($template->render({'login' => 'foo\&bar'}),
         'LedgerSMB::Template',
         'Template, render (PS): Simple Postscript template, default filename');
-    ok(-e "$temp/04-template-output-$$.ps", 'Template, render (PS): File created');
-    is(unlink("$temp/04-template-output-$$.ps"), 1,
-        'Template, render (PS): removing testfile');
-    ok(!-e "$temp/04-template-output-$$.ps",
-        'Template, render (PS): testfile removed');
+    like($template->{output}, qr/^%!PS/, 'Template, render (PS): output is Postscript');
 
     $template = undef;
     $template = LedgerSMB::Template->new(
-        'user'     => $myconfig,
         'format'   => 'XLS',
         'path'     => 't/data',
         'template' => '04-template'
@@ -182,15 +169,12 @@ SKIP: {
     isa_ok($template->render({'login' => 'foo\&bar'}),
         'LedgerSMB::Template',
         'Template, render (XLS): Simple Postscript template, default filename');
-    ok(-e "$temp/04-template-output-$$.xls", 'Template, render (XLS): File created');
-    is(unlink("$temp/04-template-output-$$.xls"), 1,
-        'Template, render (XLS): removing testfile');
-    ok(!-e "$temp/04-template-output-$$.xls",
-        'Template, render (XLS): testfile removed');
+    # xls is a Microsoft BIFF format file.
+    # make sure it looks like one by checking the first few header bytes.
+    like($template->{output}, qr/^\xD0\xCF\x11\xE0/, 'Template, render (XLS): output is XLS');
 
     $template = undef;
     $template = LedgerSMB::Template->new(
-        'user'     => $myconfig,
         'format'   => 'XLSX',
         'path'     => 't/data',
         'template' => '04-template'
@@ -204,12 +188,8 @@ SKIP: {
     isa_ok($template->render({'login' => 'foo\&bar'}),
         'LedgerSMB::Template',
         'Template, render (XLSX): Simple Postscript template, default filename');
-    ok(-e "$temp/04-template-output-$$.xlsx", 'Template, render (XLSX): File created');
-    is(unlink("$temp/04-template-output-$$.xlsx"), 1,
-        'Template, render (XLSX): removing testfile');
-    ok(!-e "$temp/04-template-output-$$.xlsx",
-        'Template, render (XLSX): testfile removed');
-
+    # xlsx is actualy a zip file.
+    like($template->{output}, qr/^PK/, 'Template, render (XLSX): output is XLSX');
 }
 
 $template = undef;

--- a/t/04-template-handling.t
+++ b/t/04-template-handling.t
@@ -28,16 +28,6 @@ my $locale;
 
 $locale = LedgerSMB::Locale->get_handle('fr');
 
-##############
-## AM tests ##
-##############
-my $expStackTrace = 0;
-if ( defined $ENV{PERL5OPT}
-     && ($ENV{PERL5OPT}=~/.*?Devel::SimpleTrace.*/ ||
-         $ENV{PERL5OPT}=~/.*?Carp::Always.*/ ))
-{
-   $expStackTrace = 1;
-}
 
 ###############################################
 ## LedgerSMB::Template::preprocess checks ##

--- a/t/04-template-handling.t
+++ b/t/04-template-handling.t
@@ -80,8 +80,12 @@ is_deeply(LedgerSMB::Template::preprocess({'fruit' => '&veggies',
 # Template->new
 $myconfig = {};
 $template = undef;
-$template = LedgerSMB::Template->new('user' => $myconfig, 'language' => 'de',
-        'path' => 't/data', 'format' => 'HTML');
+$template = LedgerSMB::Template->new(
+    'user'     => $myconfig,
+    'language' => 'de',
+    'path'     => 't/data',
+    'format'   => 'HTML'
+);
 ok(defined $template,
         'Template, new: Object creation with valid language and path');
 isa_ok($template, 'LedgerSMB::Template',
@@ -90,16 +94,25 @@ is($template->{include_path}, 't/data',
         'Template, new: Object creation with valid path overrides language');
 
 $template = undef;
-$template = LedgerSMB::Template->new('user' => $myconfig, 'format' => 'HTML',
-        path => 't/data', 'template' => '04-template', 'locale' => $locale);
+$template = LedgerSMB::Template->new(
+    'user'     => $myconfig,
+    'format'   => 'HTML',
+    'path'     => 't/data',
+    'template' => '04-template',
+    'locale' => $locale
+);
 ok(defined $template,
         'Template, new: Object creation with locale');
 isa_ok($template, 'LedgerSMB::Template',
         'Template, new: Object creation with locale');
 
 $template = undef;
-$template = LedgerSMB::Template->new('user' => $myconfig, 'format' => 'HTML',
-        path => 't/data', 'template' => '04-template-2');
+$template = LedgerSMB::Template->new(
+    'user'     => $myconfig,
+    'format'   => 'HTML',
+    'path'     => 't/data',
+    'template' => '04-template-2'
+);
 ok(defined $template,
         'Template, new: Object creation with non-existent template');
 throws_ok{$template->render({'login' => 'foo'})} qr/not found/,
@@ -112,8 +125,12 @@ throws_ok{$template->render({'login' => 'foo'})} qr/not found/,
 SKIP: {
     skip "LATEX_TESTING not set", 7 unless $ENV{LATEX_TESTING};
     $template = undef;
-    $template = LedgerSMB::Template->new('user' => $myconfig, 'format' => 'PDF',
-        path => 't/data', 'template' => '04-template');
+    $template = LedgerSMB::Template->new(
+        'user'     => $myconfig,
+        'format'   => 'PDF',
+        'path'     => 't/data',
+        'template' => '04-template'
+    );
     ok(defined $template,
         'Template, new (PDF): Object creation with format and template');
     isa_ok($template, 'LedgerSMB::Template',
@@ -131,8 +148,12 @@ SKIP: {
         'Template, render (PDF): testfile removed');
 
     $template = undef;
-    $template = LedgerSMB::Template->new('user' => $myconfig, 'format' => 'PS',
-        path => 't/data', 'template' => '04-template');
+    $template = LedgerSMB::Template->new(
+        'user'     => $myconfig,
+        'format'   => 'PS',
+        'path'     => 't/data',
+        'template' => '04-template'
+    );
     ok(defined $template,
         'Template, new (PS): Object creation with format and template');
     isa_ok($template, 'LedgerSMB::Template',
@@ -149,8 +170,12 @@ SKIP: {
         'Template, render (PS): testfile removed');
 
     $template = undef;
-    $template = LedgerSMB::Template->new('user' => $myconfig, 'format' => 'XLS',
-        path => 't/data', 'template' => '04-template');
+    $template = LedgerSMB::Template->new(
+        'user'     => $myconfig,
+        'format'   => 'XLS',
+        'path'     => 't/data',
+        'template' => '04-template'
+    );
     ok(defined $template,
         'Template, new (XLS): Object creation with format and template');
     isa_ok($template, 'LedgerSMB::Template',
@@ -167,8 +192,12 @@ SKIP: {
         'Template, render (XLS): testfile removed');
 
     $template = undef;
-    $template = LedgerSMB::Template->new('user' => $myconfig, 'format' => 'XLSX',
-        path => 't/data', 'template' => '04-template');
+    $template = LedgerSMB::Template->new(
+        'user'     => $myconfig,
+        'format'   => 'XLSX',
+        'path'     => 't/data',
+        'template' => '04-template'
+    );
     ok(defined $template,
         'Template, new (XLSX): Object creation with format and template');
     isa_ok($template, 'LedgerSMB::Template',
@@ -187,8 +216,12 @@ SKIP: {
 }
 
 $template = undef;
-$template = LedgerSMB::Template->new('user' => $myconfig, 'format' => 'TXT',
-        path => 't/data', 'template' => '04-template');
+$template = LedgerSMB::Template->new(
+    'user'     => $myconfig,
+    'format'   => 'TXT',
+    'path'     => 't/data',
+    'template' => '04-template'
+);
 ok(defined $template,
         'Template, new (TXT): Object creation with format and template');
 isa_ok($template, 'LedgerSMB::Template',
@@ -198,8 +231,12 @@ is($template->{output}, "I am a template.\nLook at me foo&bar.",
         'Template, render (TXT): Simple TXT template, correct output');
 
 $template = undef;
-$template = LedgerSMB::Template->new('user' => $myconfig, 'format' => 'HTML',
-        path => 't/data', 'template' => '04-template');
+$template = LedgerSMB::Template->new(
+    'user'     => $myconfig,
+    'format'   => 'HTML',
+    'path'     => 't/data',
+    'template' => '04-template'
+);
 ok(defined $template,
         'Template, new (HTML): Object creation with format and template');
 isa_ok($template, 'LedgerSMB::Template',
@@ -214,8 +251,11 @@ is($template->{output}, "I am a template.\nLook at me foo&amp;bar.",
 
 use Math::BigFloat;
 $template = undef;
-$template = LedgerSMB::Template->new('user' => {numberformat => '1.000,00'},
-        'format' => 'HTML', 'template' => '04-template');
+$template = LedgerSMB::Template->new(
+    'user'     => {numberformat => '1.000,00'},
+    'format'   => 'HTML',
+    'template' => '04-template'
+);
 ok(defined $template,
         'Template, private (preprocess): Object creation with format and template');
 isa_ok($template, 'LedgerSMB::Template',
@@ -249,8 +289,13 @@ $locale = LedgerSMB::Locale->get_handle( LedgerSMB::Sysconfig::language() )
   or $lsmb->error( __FILE__ . ':' . __LINE__ . ": Locale not loaded: $!\n" );
 
 
-$template = LedgerSMB::Template->new('user' => {numberformat => '1.000,00'},
-        'format' => 'HTML', path => 't/data', locale => $locale, 'template' => '04-complex_template');
+$template = LedgerSMB::Template->new(
+    'user'     => {numberformat => '1.000,00'},
+    'format'   => 'HTML',
+    'path'     => 't/data',
+    'locale'   => $locale,
+    'template' => '04-complex_template'
+);
 
 $template->render({});
 
@@ -287,10 +332,10 @@ $payment->merge({
                                 'test']]}]});
 
 my $payment_template =  LedgerSMB::Template->new(
-        path            => 'UI/payments',
-        template        => 'payments_detail',
-        format          => 'HTML',
-        no_auto_output  => 1,
+    path            => 'UI/payments',
+    template        => 'payments_detail',
+    format          => 'HTML',
+    no_auto_output  => 1,
 );
 
 $payment_template->render({ request => { script => '' },
@@ -306,8 +351,13 @@ SKIP: {
     use LedgerSMB::Sysconfig;
     %LedgerSMB::Sysconfig::printer = ('test' => 'cat > t/var/04-lpr-test');
 
-    $template = LedgerSMB::Template->new('user' => $myconfig, 'format' => 'PDF',
-        'template' => '04-template', 'locale' => $locale, no_auto_output => 1);
+    $template = LedgerSMB::Template->new(
+        'user'           => $myconfig,
+        'format'         => 'PDF',
+        'template'       => '04-template',
+        'locale'         => $locale,
+        'no_auto_output' => 1
+    );
     $template->render({media => 'test'});
     $template->output(media => 'test');
     my $LPR_TEST;

--- a/t/04-template-handling.t
+++ b/t/04-template-handling.t
@@ -7,6 +7,7 @@ use Test::More 'no_plan';
 use Test::Trap qw(trap $trap);
 use Test::Exception;
 
+use File::Temp;
 use LedgerSMB::Sysconfig;
 use LedgerSMB::Locale;
 use LedgerSMB::Legacy_Util;
@@ -16,7 +17,6 @@ use Log::Log4perl;
 Log::Log4perl::init(\$LedgerSMB::Sysconfig::log4perl_config);
 
 
-my $temp = $LedgerSMB::Sysconfig::tempdir;
 my $template;
 my $locale;
 
@@ -289,8 +289,8 @@ is(grep(/Locked by/, @output), 1, 'Invoice locked label shown');
 # LPR PRinting Tests
 SKIP: {
     #skip 'LATEX_TESTING is not set', 2 unless $ENV{LATEX_TESTING};
-    use LedgerSMB::Sysconfig;
-    %LedgerSMB::Sysconfig::printer = ('test' => 'cat > t/var/04-lpr-test');
+    my $temp = File::Temp->new();
+    %LedgerSMB::Sysconfig::printer = ('test' => "cat > $temp");
 
     $template = LedgerSMB::Template->new(
         'format'   => 'PDF',
@@ -305,6 +305,6 @@ SKIP: {
     );
 
     my $LPR_TEST;
-    ok(open ($LPR_TEST, '<', "t/var/04-lpr-test"), 'LedgerSMB::Template::_output_lpr output file opened successfully');
+    ok(open ($LPR_TEST, '<', $temp), 'LedgerSMB::Template::_output_lpr output file opened successfully');
     like(<$LPR_TEST>, qr/^%PDF/, 'output file is pdf');
 }

--- a/t/data/04-template.odst
+++ b/t/data/04-template.odst
@@ -1,0 +1,16 @@
+<workbook>
+<worksheet name="<?lsmb text('Title Page') ?>" rows="<?lsmb HEADS ?>" 
+           columns="2">
+<row><cell text="<?lsmb text('Report Name') ?>:" />
+     <cell text="<?lsmb name ?>" />
+</row>
+<row><cell text="<?lsmb text('Company') ?>:" />
+     <cell test="<?lsmb request.company ?>" />
+</row>
+<?lsmb FOREACH HLINE IN hlines -?>
+<row><cell text="<?lsmb HLINE.text ?>:" />
+     <cell text="<?lsmb request.${LINE.name} ?>" />
+</row>
+<?lsmb END -?>
+</worksheet>
+</workbook>

--- a/t/data/04-template.xlst
+++ b/t/data/04-template.xlst
@@ -1,0 +1,30 @@
+<?lsmb PROCESS "dynatable.xlst" 
+
+HEADS 2;
+
+IF hlines.size;
+
+  HEADS = HEADS + hlines.size;
+
+END;
+
+?>
+<workbook>
+<worksheet name="<?lsmb text('Title Page') ?>" rows="<?lsmb HEADS ?>" 
+           columns="2">
+<row><cell text="<?lsmb text('Report Name') ?>:" />
+     <cell text="<?lsmb name ?>" />
+</row>
+<row><cell text="<?lsmb text('Company') ?>:" />
+     <cell test="<?lsmb request.company ?>" />
+</row>
+<?lsmb FOREACH HLINE IN hlines -?>
+<row><cell text="<?lsmb HLINE.text ?>:" />
+     <cell text="<?lsmb request.${LINE.name} ?>" />
+</row>
+<?lsmb END -?>
+</worksheet>
+<?lsmb PROCESS dynatable
+       attributes = {id = name }
+       tbody = {rows = rows } ?>
+</workbook>


### PR DESCRIPTION
* Corrections to POD
* Removal of unused imports
* Reinstate explicit test file names, prior to further refactoring

LATEX_TESTING tests are broken and have been for some time. This is a step towards fixing and enabling them as part of CI testing.