### PR TITLE
Separate template `method` parameter

### DIFF
--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -10,7 +10,7 @@ This module renders templates.
 
 =over
 
-=item new(user => \%myconfig, template => $string, format => $string, [locale => $locale], [language => $string], [include_path => $path], [method => $string], [no_escape => $bool], [debug => $bool] );
+=item new(user => \%myconfig, template => $string, format => $string, [locale => $locale], [language => $string], [include_path => $path], [no_escape => $bool], [debug => $bool] );
 
 This command instantiates a new template:
 
@@ -77,10 +77,6 @@ template to get debugging messages is to be surrounded by
   <?lsmb DEBUG format '' ?>
   <?lsmb END ?>
     </tr>
-
-=item method/media (optional)
-
-The output method to use, defaults to HTTP.  Media is a synonym for method
 
 =item output_file (optional)
 
@@ -329,11 +325,10 @@ sub new {
     $logger->trace('output_options, keys: ' . join '|', keys %{$args{output_options}});
 
     $self->{$_} = $args{$_}
-        for (qw( template format language no_escape debug locale method
+        for (qw( template format language no_escape debug locale
                  format_options output_options additional_vars ));
     $self->{user} = $args{user};
     $self->{include_path} = $args{path};
-    $self->{method} ||= $args{media};
     if ($self->{language}){ # Language takes precedence over locale
         $self->{locale} = LedgerSMB::Locale->get_handle($self->{language});
     }

--- a/old/bin/io.pl
+++ b/old/bin/io.pl
@@ -1506,11 +1506,10 @@ sub print_form {
         path => 'DB',
         language => $form->{language_code},
         format => uc $form->{format},
-        method => $form->{media},
         output_options => \%output_options,
         filename => $form->{formname} . "-" . $form->{"${inv}number"},
         );
-    LedgerSMB::Legacy_Util::render_template($template, $form);
+    LedgerSMB::Legacy_Util::render_template($template, $form, $form->{media});
 
     # if we got back here restore the previous form
     if ( %$old_form ) {

--- a/old/lib/LedgerSMB/Legacy_Util.pm
+++ b/old/lib/LedgerSMB/Legacy_Util.pm
@@ -3,12 +3,12 @@ package LedgerSMB::Legacy_Util;
 
 =head1 NAME
 
-LedgerSMB::PSGI::Util - LedgerSMB Utility functions
+LedgerSMB::Legacy_Util - LedgerSMB Utility functions
 
 =head1 DESCRIPTION
 
-
-
+Functions for rendering templates and delivering the result via the
+specified output method.
 
 =cut
 
@@ -21,17 +21,36 @@ use Log::Log4perl;
 
 =head1 FUNCTIONS
 
-=head2 render_template($template, $variables)
+=head2 render_template($template, $variables, [$method])
+
+=over
+
+=item template
+
+A LedgerSMB::Template object.
+
+=item variables
+
+A hashref of variables which is passed to the template.
+
+=item method (optional)
+
+Determines where to send the output. Allowed values:
+
+email|print|screen|<printer name>
+
+=back
 
 =cut
 
 sub render_template {
-    my $self = shift @_;
-    my $vars = shift @_;
+    my $self = shift;
+    my $vars = shift;
+    my $method = shift;
 
     my $post = $self->_render($vars);
 
-    output_template($self);
+    output_template($self, (method => $method));
 }
 
 
@@ -46,10 +65,6 @@ supported keys in C<%args>:
 Determines where to send the output. Allowed values:
 
 email|print|screen|<printer name>
-
-=item media
-
-Synonym for method
 
 =item printmode + OUT
 
@@ -68,8 +83,7 @@ sub output_template {
 
     for ( keys %args ) { $template->{output_options}->{$_} = $args{$_}; };
 
-    my $method = $template->{method} || $args{method} || $args{media};
-    $method = '' if !defined $method;
+    my $method = $args{method} // '';
 
     if ('email' eq lc $method) {
         _output_template_email($template);


### PR DESCRIPTION
LedgerSMB::Template should be self-contained. It's object creator   
and properties were, for legacy reasons, being used to pass a 
`method` argument to functions in LedgerSMB::Legacy_Util.

`method` and `media` parameters now removed from LedgerSMB::Template
module and passed directly to LedgerSMB::Legacy_Util::render_template().

All calls to `LedgerSMB::Legacy_Util::render_template()` have been 
checked against this change. `media` parameter was not in use.