### PR TITLE
Remove sysconfig tempdir option

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -14,6 +14,7 @@ Installation & Administration
 * No more warnings from database creation and upgrade (Erik H)
 * Improved logging: various logs correlated using unique request IDs (Erik H)
 * Functions 'warn()' and 'die()' logged to debug logs (Erik H)
+* Removed 'tempdir' configuration option (Nick P)
 
 Performance
 * PSGI responses no longer written to file but kept in memory (Erik H/Yves L)

--- a/conf/ledgersmb.conf.default
+++ b/conf/ledgersmb.conf.default
@@ -13,17 +13,6 @@
 # DB authentication module included.
 auth = DB
 
-# Be aware of tempdir setting. If client_browser and server_apache on same
-# machine, sharing tmp-dir , problems 'Permission denied' if server tries to
-# write temp-file which already exists as client-owned
-#
-# Note tempdir is used as the basename of the dir, the real dirname is
-# equivalent to....
-#    /tmp/ledgersmb-$EUID/
-# If you specify a different dir to /tmp/ledgersmb ensure it's parent is
-# writable by the running user.
-tempdir = /tmp/ledgersmb
-
 # This is the logical CSS directory.  I.e. it is what comes before the
 # ledgersmb.css in the url.  Example might be /my_css_dir/ or
 # http://localhost/other_css_dir/
@@ -91,7 +80,7 @@ localepath = locale/po
 
 # location where compiled templates are stored
 #
-# When relative, appended to the directory specified in the 'tempdir' variable
+# When relative, appended to the directory specified by	File::Spec->tmpdir()
 #
 #templates_cache = lsmb_templates
 

--- a/conf/ledgersmb.conf.default
+++ b/conf/ledgersmb.conf.default
@@ -80,7 +80,7 @@ localepath = locale/po
 
 # location where compiled templates are stored
 #
-# When relative, appended to the directory specified by	File::Spec->tmpdir()
+# When relative, appended to the directory specified by File::Spec->tmpdir()
 #
 #templates_cache = lsmb_templates
 

--- a/conf/ledgersmb.conf.travis-ci
+++ b/conf/ledgersmb.conf.travis-ci
@@ -1,14 +1,6 @@
 [main]
 auth = DB
 logging  = 0
-# Be aware of tempdir setting. If client_browser and server_apache on same 
-# machine, sharing tmp-dir , problems 'Permission denied' if server tries to 
-# write temp-file which already exists as client-owned
-#
-# Note tempdir is used as the basename of the dir, the real dirname is equivalent to....
-#    /tmp/ledgersmb-$EUID/
-#  If you specify a different dir to /tmp/ledgersmb ensure it's parent is writable by the running user.
-tempdir = /tmp/ledgersmb
 
 # This is the logical CSS directory.  I.e. it is what comes before the 
 # ledgersmb.css in the url.  Example might be /my_css_dir/ or 

--- a/conf/ledgersmb.conf.unbuilt-dojo
+++ b/conf/ledgersmb.conf.unbuilt-dojo
@@ -13,17 +13,6 @@
 # DB authentication module included.
 auth = DB
 
-# Be aware of tempdir setting. If client_browser and server_apache on same
-# machine, sharing tmp-dir , problems 'Permission denied' if server tries to
-# write temp-file which already exists as client-owned
-#
-# Note tempdir is used as the basename of the dir, the real dirname is
-# equivalent to....
-#    /tmp/ledgersmb-$EUID/
-# If you specify a different dir to /tmp/ledgersmb ensure it's parent is
-# writable by the running user.
-tempdir = /tmp/ledgersmb
-
 # This is the logical CSS directory.  I.e. it is what comes before the
 # ledgersmb.css in the url.  Example might be /my_css_dir/ or
 # http://localhost/other_css_dir/
@@ -91,7 +80,7 @@ localepath = locale/po
 
 # location where compiled templates are stored
 #
-# When relative, appended to the directory specified in the 'tempdir' variable
+# When relative, appended to the directory specified by	File::Spec->tmpdir()
 #
 #templates_cache = lsmb_templates
 

--- a/conf/ledgersmb.conf.unbuilt-dojo
+++ b/conf/ledgersmb.conf.unbuilt-dojo
@@ -80,7 +80,7 @@ localepath = locale/po
 
 # location where compiled templates are stored
 #
-# When relative, appended to the directory specified by	File::Spec->tmpdir()
+# When relative, appended to the directory specified by File::Spec->tmpdir()
 #
 #templates_cache = lsmb_templates
 

--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -370,13 +370,6 @@ def 'fs_cssdir',
     default => 'css/',
     doc => q{};
 
-# Temporary files stored at"
-def 'tempdir',
-    section => 'main', # SHOULD BE 'paths' ????
-    default => sub { $ENV{TEMP} && "$ENV{TEMP}/ledgersmb" || '/tmp/ledgersmb' }, # We can't specify envvar=>'TEMP' as that would overwrite TEMP with anything set in ledgersmb.conf. Conversely we need to use TEMP as the prefix for the default
-    suffix => "-$EUID",
-    doc => q{};
-
 # Backup files stored at"
 def 'backupdir',
     section => 'paths',
@@ -603,44 +596,6 @@ our $log4perl_config = qq(
 #log4perl.logger.LedgerSMB.ScriptLib.Company=TRACE
 
 
-if(!(-d LedgerSMB::Sysconfig::tempdir())){
-     my $rc;
-     if ($Config{path_sep} eq ';'){ # We need an actual platform configuration variable
-         $rc = system('mkdir ' . LedgerSMB::Sysconfig::tempdir());
-     } else {
-         $rc=system('mkdir -p ' . LedgerSMB::Sysconfig::tempdir());
-     }
-}
-
-sub check_permissions {
-    my $tempdir = LedgerSMB::Sysconfig::tempdir();
-
-    if(!(-d "$tempdir")){
-        die_pretty( "$tempdir wasn't created.",
-                    "Does UID $EUID have access to $tempdir\'s parent?"
-        );
-    }
-
-    if(!(-r "$tempdir")){
-        die_pretty(" $tempdir can't be read from.",
-                    "Does UID $EUID have read permission?"
-        );
-    }
-
-    if(!(-w "$tempdir")){
-        die_pretty( "$tempdir can't be written to.",
-                    "Does UID $EUID have write permission?"
-        );
-    }
-
-    if(!(-x "$tempdir")){
-        die_pretty( "$tempdir can't be listed.",
-                    "Does UID $EUID have execute permission?"
-        );
-    }
-    return;
-}
-
 # if you have latex installed set to 1
 ###TODO-LOCALIZE-DOLLAR-AT
 our $latex = 0;
@@ -667,6 +622,5 @@ sub override_defaults {
 }
 
 override_defaults;
-check_permissions;
 
 1;

--- a/t/12-sysconfig.t
+++ b/t/12-sysconfig.t
@@ -10,11 +10,10 @@ chdir 't/data';
 require LedgerSMB::Sysconfig;
 
 
-plan tests => (11+scalar(@LedgerSMB::Sysconfig::scripts)
+plan tests => (10+scalar(@LedgerSMB::Sysconfig::scripts)
                +scalar(@LedgerSMB::Sysconfig::newscripts));
 
 is $LedgerSMB::Sysconfig::auth, 'DB2', 'Auth set correctly';
-is $LedgerSMB::Sysconfig::tempdir, "test-$EUID", 'tempdir set correctly';
 is $LedgerSMB::Sysconfig::cssdir, 'css3/', 'css dir set correctly';
 is $LedgerSMB::Sysconfig::fs_cssdir, 'css4', 'css fs dir set correctly';
 is $LedgerSMB::Sysconfig::cache_templates, 5, 'template caching working';

--- a/t/data/ledgersmb.conf
+++ b/t/data/ledgersmb.conf
@@ -1,10 +1,6 @@
 [main]
 auth = DB2
 logging  = 1
-# Be aware of tempdir setting. If client_browser and server_apache on same 
-# machine, sharing tmp-dir , problems 'Permission denied' if server tries to 
-# write temp-file which already exists as client-owned
-tempdir = test
 
 # This is the logical CSS directory.  I.e. it is what comes before the 
 # ledgersmb.css in the url.  Example might be /my_css_dir/ or 


### PR DESCRIPTION
The LedgerSMB::Sysconfig::tempdir option is no longer used by
lsmb, so removing this configuration option entirely.