### PR TITLE
Remove unused modules and variables from Format modules

### DIFF
--- a/lib/LedgerSMB/Template/CSV.pm
+++ b/lib/LedgerSMB/Template/CSV.pm
@@ -14,8 +14,6 @@ package LedgerSMB::Template::CSV;
 use warnings;
 use strict;
 
-use Template;
-
 my $binmode = ':utf8';
 my $extension = 'csv';
 

--- a/lib/LedgerSMB/Template/HTML.pm
+++ b/lib/LedgerSMB/Template/HTML.pm
@@ -14,7 +14,6 @@ package LedgerSMB::Template::HTML;
 use strict;
 use warnings;
 
-use Template;
 use HTML::Entities;
 use HTML::Escape;
 use LedgerSMB::Sysconfig;

--- a/lib/LedgerSMB/Template/ODS.pm
+++ b/lib/LedgerSMB/Template/ODS.pm
@@ -18,9 +18,6 @@ package LedgerSMB::Template::ODS;
 use strict;
 use warnings;
 
-use IO::Scalar;
-use Template;
-use LedgerSMB::Sysconfig;
 use Data::Dumper;  ## no critic
 use XML::Twig;
 use Digest::MD5 qw(md5_hex);
@@ -29,8 +26,6 @@ use HTML::Escape;
 use OpenOffice::OODoc;
 use OpenOffice::OODoc::Styles;
 
-my $binmode = undef;
-my $extension = 'ods';
 
 # SC: The ODS handlers need these vars in common
 my $ods;

--- a/lib/LedgerSMB/Template/TXT.pm
+++ b/lib/LedgerSMB/Template/TXT.pm
@@ -14,7 +14,6 @@ package LedgerSMB::Template::TXT;
 use strict;
 use warnings;
 
-use Template;
 use DateTime;
 
 # The following are for EDI only

--- a/lib/LedgerSMB/Template/XLSX.pm
+++ b/lib/LedgerSMB/Template/XLSX.pm
@@ -19,7 +19,6 @@ use strict;
 use warnings;
 
 use IO::Scalar;
-use Template;
 use Excel::Writer::XLSX;
 use Spreadsheet::WriteExcel;
 


### PR DESCRIPTION
No need for the LedgerSMB::Template::XXX format modules to
`use Template` themselves - only the LedgerSMB::Template module
which calls them needs that.

Removed some more unused variables and other unused imports from
LedgerSMB::Template::ODS.