### PR TITLE
Remove unused sysconfig elements

### DIFF
--- a/conf/ledgersmb.conf.default
+++ b/conf/ledgersmb.conf.default
@@ -18,10 +18,6 @@ auth = DB
 # http://localhost/other_css_dir/
 cssdir = css/
 
-# This is the location on the file system where the css files are, for editing
-# and selection.  An example might be /var/www/ledgersmb_css/
-fs_cssdir = css/
-
 # If set to a true value this caches templates.  Typically it will be set to 0
 # to disable or 1 to enable.
 cache_templates = 0

--- a/conf/ledgersmb.conf.default
+++ b/conf/ledgersmb.conf.default
@@ -70,16 +70,6 @@ localepath = locale/po
 #templates_cache = lsmb_templates
 
 [programs]
-# For latex and pdflatex, specify  full path.  These will be used to configure
-# Template::Latex so it can find them.  This can be used to specify programs
-# other than vanilla latex and pdflatex, such as the xe varieties of either one,
-# if unicode is required.
-#
-# If these are not set, the package defaults (set when you installed
-# Template::Latex) will be used
-#
-# pdflatex = /usr/bin/pdflatex
-# latex    = /usr/bin/latex
 
 [mail]
 # The sendmail command is used to send mail unless smtphost is set.

--- a/conf/ledgersmb.conf.default
+++ b/conf/ledgersmb.conf.default
@@ -43,13 +43,6 @@ max_post_size = 4194304
 # logged in at the same time
 cookie_name = LedgerSMB-1.5
 
-# This is the string we look for in the failed connection error to determine
-# if the database was not found.  For English-language locales, this can be
-# left in place.  If the database server is running a different locale, it may
-# need to be changed.  Any partial match on the connection error assumes that
-# the failure to connect was caused by an invalid database request.
-no_db_str = database
-
 # This is the Dojo theme to be used by default -- e.g. when no other theme
 # has been selected.
 #dojo_theme = claro

--- a/conf/ledgersmb.conf.default
+++ b/conf/ledgersmb.conf.default
@@ -72,10 +72,6 @@ templates  = templates
 # images base directory
 images  = UI/images
 
-# location we write backup files to on the server
-backupdir = /tmp/ledgersmb-backups
-
-
 localepath = locale/po
 
 # location where compiled templates are stored

--- a/conf/ledgersmb.conf.default
+++ b/conf/ledgersmb.conf.default
@@ -80,8 +80,6 @@ localepath = locale/po
 #
 # pdflatex = /usr/bin/pdflatex
 # latex    = /usr/bin/latex
-# dvips    = /usr/bin/dvips
-#
 
 [mail]
 # The sendmail command is used to send mail unless smtphost is set.

--- a/conf/ledgersmb.conf.default
+++ b/conf/ledgersmb.conf.default
@@ -70,9 +70,6 @@ localepath = locale/po
 #templates_cache = lsmb_templates
 
 [programs]
-# program to use for file compression
-gzip       = gzip -S .gz
-
 # For latex and pdflatex, specify  full path.  These will be used to configure
 # Template::Latex so it can find them.  This can be used to specify programs
 # other than vanilla latex and pdflatex, such as the xe varieties of either one,

--- a/conf/ledgersmb.conf.travis-ci
+++ b/conf/ledgersmb.conf.travis-ci
@@ -52,8 +52,6 @@ localepath = locale/po
 #
 # pdflatex = /usr/bin/pdflatex
 # latex    = /usr/bin/latex
-# dvips    = /usr/bin/dvips
-#
 
 [mail]
 ### How to send mail.  The sendmail command is used unless smtphost is set.

--- a/conf/ledgersmb.conf.travis-ci
+++ b/conf/ledgersmb.conf.travis-ci
@@ -42,9 +42,6 @@ images  = UI/images
 localepath = locale/po
 
 [programs]
-# program to use for file compression
-gzip       = gzip -S .gz
-
 # For latex and pdflatex, specify  full path.  These will be used to configure
 # Template::Latex so it can find them.  This can be used to specify programs
 # other than vanilla latex and pdflatex, such as the xe varieties of either one,

--- a/conf/ledgersmb.conf.travis-ci
+++ b/conf/ledgersmb.conf.travis-ci
@@ -7,10 +7,6 @@ logging  = 0
 # http://localhost/other_css_dir/
 cssdir = css/
 
-# THis is the location on the file system where the css files are, for editing 
-# and selection.  An example might be /var/www/ledgersmb_css/
-fs_cssdir = UI/css/
-
 # If set to a true value this caches templates.  Typically it will be set to 0 
 # to disable or 1 to enable.
 

--- a/conf/ledgersmb.conf.travis-ci
+++ b/conf/ledgersmb.conf.travis-ci
@@ -27,14 +27,6 @@ max_post_size = 4194304
 # logged in at the same time
 cookie_name = LedgerSMB-1.5
 
-# This is the string we look for in the failed connection error to determine
-# if the database was not found.  For English-language locales, this can be
-# left in place.  If the database server is running a different locale, it may
-# need to be changed.  Any partial match on the connection error assumes that
-# the failure to connect was caused by an invalid database request.
-
-no_db_str = database
-
 [environment]
 # If the server can't find applications, append to the path
 PATH=/bin:/usr/bin:/usr/local/bin:/usr/local/pgsql/bin

--- a/conf/ledgersmb.conf.travis-ci
+++ b/conf/ledgersmb.conf.travis-ci
@@ -55,9 +55,6 @@ templates  = templates
 images  = UI/images
 localepath = locale/po
 
-# location we write backup files to on the server
-backupdir = /tmp/ledgersmb-backups
-
 [programs]
 # program to use for file compression
 gzip       = gzip -S .gz

--- a/conf/ledgersmb.conf.travis-ci
+++ b/conf/ledgersmb.conf.travis-ci
@@ -42,16 +42,6 @@ images  = UI/images
 localepath = locale/po
 
 [programs]
-# For latex and pdflatex, specify  full path.  These will be used to configure
-# Template::Latex so it can find them.  This can be used to specify programs
-# other than vanilla latex and pdflatex, such as the xe varieties of either one,
-# if unicode is required.
-#
-# If these are not set, the package defaults (set when you installed 
-# Template::Latex) will be used
-#
-# pdflatex = /usr/bin/pdflatex
-# latex    = /usr/bin/latex
 
 [mail]
 ### How to send mail.  The sendmail command is used unless smtphost is set.

--- a/conf/ledgersmb.conf.travis-ci
+++ b/conf/ledgersmb.conf.travis-ci
@@ -18,8 +18,6 @@ language =
 log_level = ERROR
 #DBI_TRACE = 1=/tmp/dbi.trace
 DBI_TRACE = 0
-# For Windows, uncomment the pathsep line=
-# pathsep = ;
 
 # Maximum POST size to prevent DoS (4MB default)
 max_post_size = 4194304

--- a/conf/ledgersmb.conf.unbuilt-dojo
+++ b/conf/ledgersmb.conf.unbuilt-dojo
@@ -18,10 +18,6 @@ auth = DB
 # http://localhost/other_css_dir/
 cssdir = css/
 
-# This is the location on the file system where the css files are, for editing
-# and selection.  An example might be /var/www/ledgersmb_css/
-fs_cssdir = css/
-
 # If set to a true value this caches templates.  Typically it will be set to 0
 # to disable or 1 to enable.
 cache_templates = 0

--- a/conf/ledgersmb.conf.unbuilt-dojo
+++ b/conf/ledgersmb.conf.unbuilt-dojo
@@ -70,16 +70,6 @@ localepath = locale/po
 #templates_cache = lsmb_templates
 
 [programs]
-# For latex and pdflatex, specify  full path.  These will be used to configure
-# Template::Latex so it can find them.  This can be used to specify programs
-# other than vanilla latex and pdflatex, such as the xe varieties of either one,
-# if unicode is required.
-#
-# If these are not set, the package defaults (set when you installed
-# Template::Latex) will be used
-#
-# pdflatex = /usr/bin/pdflatex
-# latex    = /usr/bin/latex
 
 [mail]
 # The sendmail command is used to send mail unless smtphost is set.

--- a/conf/ledgersmb.conf.unbuilt-dojo
+++ b/conf/ledgersmb.conf.unbuilt-dojo
@@ -43,13 +43,6 @@ max_post_size = 4194304
 # logged in at the same time
 cookie_name = LedgerSMB-1.5
 
-# This is the string we look for in the failed connection error to determine
-# if the database was not found.  For English-language locales, this can be
-# left in place.  If the database server is running a different locale, it may
-# need to be changed.  Any partial match on the connection error assumes that
-# the failure to connect was caused by an invalid database request.
-no_db_str = database
-
 # This is the Dojo theme to be used by default -- e.g. when no other theme
 # has been selected.
 #dojo_theme = claro

--- a/conf/ledgersmb.conf.unbuilt-dojo
+++ b/conf/ledgersmb.conf.unbuilt-dojo
@@ -72,10 +72,6 @@ templates  = templates
 # images base directory
 images  = UI/images
 
-# location we write backup files to on the server
-backupdir = /tmp/ledgersmb-backups
-
-
 localepath = locale/po
 
 # location where compiled templates are stored

--- a/conf/ledgersmb.conf.unbuilt-dojo
+++ b/conf/ledgersmb.conf.unbuilt-dojo
@@ -80,8 +80,6 @@ localepath = locale/po
 #
 # pdflatex = /usr/bin/pdflatex
 # latex    = /usr/bin/latex
-# dvips    = /usr/bin/dvips
-#
 
 [mail]
 # The sendmail command is used to send mail unless smtphost is set.

--- a/conf/ledgersmb.conf.unbuilt-dojo
+++ b/conf/ledgersmb.conf.unbuilt-dojo
@@ -70,9 +70,6 @@ localepath = locale/po
 #templates_cache = lsmb_templates
 
 [programs]
-# program to use for file compression
-gzip       = gzip -S .gz
-
 # For latex and pdflatex, specify  full path.  These will be used to configure
 # Template::Latex so it can find them.  This can be used to specify programs
 # other than vanilla latex and pdflatex, such as the xe varieties of either one,

--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -478,8 +478,6 @@ for ($cfg->Parameters('printers')){
 
 # Programs
 our $zip = $cfg->val('programs', 'zip', 'zip -r %dir %dir');
-our $gzip = $cfg->val('programs', 'gzip', 'gzip -S .gz');
-
 
 
 # Whitelist for redirect destination / this isn't really configuration.

--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -365,11 +365,6 @@ def 'cssdir',
     default => 'css/',
     doc => q{};
 
-def 'fs_cssdir',
-    section => 'main', # SHOULD BE 'paths' ????
-    default => 'css/',
-    doc => q{};
-
 # Path to the translation files
 def 'localepath',
     section => 'paths',

--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -198,11 +198,6 @@ def 'Log4perl',
     default => 1,
     doc => q{};
 
-def 'Log4perl_category',
-    section => 'debug',
-    default => 'plack',
-    doc => q{};
-
 def 'Memory',
     section => 'debug',
     default => 0,

--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -342,11 +342,6 @@ def 'no_db_str',
     default => 'database',
     doc => q{};
 
-def 'db_autoupdate',
-    section => 'main',
-    default => undef,
-    doc => q{};
-
 def 'cache_templates',
     section => 'main',
     default => 0,

--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -354,12 +354,6 @@ def 'cache_templates',
 
 ### SECTION  ---   paths
 
-def 'pathsep',
-    section => 'main', # SHOULD BE 'paths' ????
-    default => ':',
-    doc => q{
-The documentation for the 'main.pathsep' key};
-
 def 'cssdir',
     section => 'main', # SHOULD BE 'paths' ????
     default => 'css/',

--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -370,12 +370,6 @@ def 'fs_cssdir',
     default => 'css/',
     doc => q{};
 
-# Backup files stored at"
-def 'backupdir',
-    section => 'paths',
-    default => sub { $ENV{BACKUP} || '/tmp/ledgersmb-backups' },
-    doc => q{};
-
 # Path to the translation files
 def 'localepath',
     section => 'paths',

--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -337,11 +337,6 @@ def 'DBI_TRACE',
     default => 0,
     doc => q{};
 
-def 'no_db_str',
-    section => 'main',
-    default => 'database',
-    doc => q{};
-
 def 'cache_templates',
     section => 'main',
     default => 0,

--- a/t/12-sysconfig.t
+++ b/t/12-sysconfig.t
@@ -10,12 +10,11 @@ chdir 't/data';
 require LedgerSMB::Sysconfig;
 
 
-plan tests => (10+scalar(@LedgerSMB::Sysconfig::scripts)
+plan tests => (9+scalar(@LedgerSMB::Sysconfig::scripts)
                +scalar(@LedgerSMB::Sysconfig::newscripts));
 
 is $LedgerSMB::Sysconfig::auth, 'DB2', 'Auth set correctly';
 is $LedgerSMB::Sysconfig::cssdir, 'css3/', 'css dir set correctly';
-is $LedgerSMB::Sysconfig::fs_cssdir, 'css4', 'css fs dir set correctly';
 is $LedgerSMB::Sysconfig::cache_templates, 5, 'template caching working';
 is $LedgerSMB::Sysconfig::language, 'en2', 'language set correctly';
 is $LedgerSMB::Sysconfig::check_max_invoices, '52',

--- a/t/12-sysconfig.t
+++ b/t/12-sysconfig.t
@@ -10,7 +10,7 @@ chdir 't/data';
 require LedgerSMB::Sysconfig;
 
 
-plan tests => (9+scalar(@LedgerSMB::Sysconfig::scripts)
+plan tests => (8+scalar(@LedgerSMB::Sysconfig::scripts)
                +scalar(@LedgerSMB::Sysconfig::newscripts));
 
 is $LedgerSMB::Sysconfig::auth, 'DB2', 'Auth set correctly';
@@ -22,8 +22,6 @@ is $LedgerSMB::Sysconfig::check_max_invoices, '52',
 is $LedgerSMB::Sysconfig::max_post_size, 4194304333,
    'max post size set correctly';
 is $LedgerSMB::Sysconfig::cookie_name, 'LedgerSMB-1.32', 'cookie set correctly';
-is $LedgerSMB::Sysconfig::no_db_str, 'database2',
-   'missing db string set correctly';
 
 like $ENV{PATH}, '/foo$/', 'appends config path correctly';
 

--- a/t/data/ledgersmb.conf
+++ b/t/data/ledgersmb.conf
@@ -50,16 +50,6 @@ memberfile = users/members
 localepath = locale/po
 
 [programs]
-# For latex and pdflatex, specify  full path.  These will be used to configure
-# Template::Latex so it can find them.  This can be used to specify programs
-# other than vanilla latex and pdflatex, such as the xe varieties of either one,
-# if unicode is required.
-#
-# If these are not set, the package defaults (set when you installed 
-# Template::Latex) will be used
-#
-# pdflatex = /usr/bin/pdflatex
-# latex    = /usr/bin/latex
 
 [mail]
 ### How to send mail.  The sendmail command is used unless smtphost is set.

--- a/t/data/ledgersmb.conf
+++ b/t/data/ledgersmb.conf
@@ -60,8 +60,6 @@ localepath = locale/po
 #
 # pdflatex = /usr/bin/pdflatex
 # latex    = /usr/bin/latex
-# dvips    = /usr/bin/dvips
-#
 
 [mail]
 ### How to send mail.  The sendmail command is used unless smtphost is set.

--- a/t/data/ledgersmb.conf
+++ b/t/data/ledgersmb.conf
@@ -29,14 +29,6 @@ decimal_places = 22
 # logged in at the same time
 cookie_name = LedgerSMB-1.32
 
-# This is the string we look for in the failed connection error to determine
-# if the database was not found.  For English-language locales, this can be
-# left in place.  If the database server is running a different locale, it may
-# need to be changed.  Any partial match on the connection error assumes that
-# the failure to connect was caused by an invalid database request.
-
-no_db_str = database2
-
 [environment]
 # If the server can't find applications, append to the path
 PATH=/bin:/usr/bin:/usr/local/bin:/usr/local/pgsql/bin:/usr/foo

--- a/t/data/ledgersmb.conf
+++ b/t/data/ledgersmb.conf
@@ -50,9 +50,6 @@ memberfile = users/members
 localepath = locale/po
 
 [programs]
-# program to use for file compression
-gzip       = gzip -S .gz
-
 # For latex and pdflatex, specify  full path.  These will be used to configure
 # Template::Latex so it can find them.  This can be used to specify programs
 # other than vanilla latex and pdflatex, such as the xe varieties of either one,

--- a/t/data/ledgersmb.conf
+++ b/t/data/ledgersmb.conf
@@ -18,8 +18,6 @@ language = en2
 log_level = ERROR
 #DBI_TRACE = 1=/tmp/dbi.trace
 DBI_TRACE = 0
-# For Windows, uncomment the pathsep line=
-# pathsep = ;
 
 # Maximum POST size to prevent DoS (4MB default)
 max_post_size = 4194304333

--- a/t/data/ledgersmb.conf
+++ b/t/data/ledgersmb.conf
@@ -7,13 +7,8 @@ logging  = 1
 # http://localhost/other_css_dir/
 cssdir = css3/
 
-# THis is the location on the file system where the css files are, for editing 
-# and selection.  An example might be /var/www/ledgersmb_css/
-fs_cssdir = css4
-
 # If set to a true value this caches templates.  Typically it will be set to 0 
 # to disable or 1 to enable.
-
 cache_templates = 5
 
 check_max_invoices = 52


### PR DESCRIPTION
Remove the following unused configuration elements from LedgerSMB::Sysconfig:

* Log4perl_category
* no_db_str
* db_autoupdate
* pathsep
* fs_cssdir
* backupdir

Removes clutter, confusion and false hope :)
