### PR TITLE
Fix XLSX mimetype, add tests, untangle LedgerSMB::Template properties

### DIFF
--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -304,6 +304,10 @@ configuration hash C<$config>.
 This function does not have a defined return value, but should return
 C<undef> for forward compatibility.
 
+=item mimetype()
+
+Returns the MIME content-type for the rendered template.
+
 =back
 
 =head1 Copyright 2007-2017, The LedgerSMB Core Team
@@ -599,6 +603,7 @@ sub _render {
     }
 
     $format->can('postprocess')->($self, $output, $config);
+    $self->{mimetype} = $format->can('mimetype')->($config);
     return;
 }
 

--- a/lib/LedgerSMB/Template/CSV.pm
+++ b/lib/LedgerSMB/Template/CSV.pm
@@ -50,8 +50,18 @@ Implements the template's post-processing protocol.
 
 sub postprocess {
     my ($parent, $output, $config) = @_;
-    $parent->{mimetype} = 'text/' . $extension;
     return undef;
+}
+
+=item mimetype()
+
+Returns the rendered template's mimetype.
+
+=cut
+
+sub mimetype {
+    my $config = shift;
+    return 'text/' . $extension;
 }
 
 =back

--- a/lib/LedgerSMB/Template/HTML.pm
+++ b/lib/LedgerSMB/Template/HTML.pm
@@ -68,8 +68,18 @@ Implements the template's post-processing protocol.
 
 sub postprocess {
     my ($parent, $output, $config) = @_;
-    $parent->{mimetype} = 'text/' . $extension;
     return undef;
+}
+
+=item mimetype()
+
+Returns the rendered template's mimetype.
+
+=cut
+
+sub mimetype {
+    my $config = shift;
+    return 'text/' . $extension;
 }
 
 =back

--- a/lib/LedgerSMB/Template/LaTeX.pm
+++ b/lib/LedgerSMB/Template/LaTeX.pm
@@ -135,13 +135,26 @@ Implements the template's post-processing protocol.
 
 sub postprocess {
     my ($parent, $output, $config) = @_;
+    return undef;
+}
+
+=item mimetype()
+
+Returns the rendered template's mimetype.
+
+=cut
+
+sub mimetype {
+    my $config = shift;
+    my $mimetype;
 
     if (lc $config->{_format} eq 'pdf') {
-        $parent->{mimetype} = 'application/pdf';
+        $mimetype = 'application/pdf';
     } else {
-        $parent->{mimetype} = 'application/postscript';
+        $mimetype = 'application/postscript';
     }
-    return undef;
+
+    return $mimetype;
 }
 
 =back

--- a/lib/LedgerSMB/Template/ODS.pm
+++ b/lib/LedgerSMB/Template/ODS.pm
@@ -835,9 +835,18 @@ sub postprocess {
     my ($parent, $output, $config) = @_;
 
     &_ods_process($config->{_output}, $$output);
-    $parent->{mimetype} = 'application/vnd.oasis.opendocument.spreadsheet';
-
     return undef;
+}
+
+=item mimetype()
+
+Returns the rendered template's mimetype.
+
+=cut
+
+sub mimetype {
+    my $config = shift;
+    return 'application/vnd.oasis.opendocument.spreadsheet';
 }
 
 =back

--- a/lib/LedgerSMB/Template/TXT.pm
+++ b/lib/LedgerSMB/Template/TXT.pm
@@ -69,8 +69,18 @@ Implements the template's post-processing protocol.
 
 sub postprocess {
     my ($parent, $output, $config) = @_;
-    $parent->{mimetype} = 'text/plain';
     return undef;
+}
+
+=item mimetype()
+
+Returns the rendered template's mimetype.
+
+=cut
+
+sub mimetype {
+    my $config = shift;
+    return 'text/plain';
 }
 
 =back

--- a/lib/LedgerSMB/Template/XLSX.pm
+++ b/lib/LedgerSMB/Template/XLSX.pm
@@ -211,7 +211,14 @@ Returns the rendered template's mimetype.
 
 sub mimetype {
     my $config = shift;
-    return 'application/vnd.ms-excel';
+    my $mimetype;
+
+    if ($config->{_output_extension} eq 'xlsx') {
+        $mimetype = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+    }
+    else {
+        $mimetype = 'application/vnd.ms-excel';
+    }
 }
 
 =back

--- a/lib/LedgerSMB/Template/XLSX.pm
+++ b/lib/LedgerSMB/Template/XLSX.pm
@@ -219,6 +219,8 @@ sub mimetype {
     else {
         $mimetype = 'application/vnd.ms-excel';
     }
+
+    return $mimetype;
 }
 
 =back

--- a/lib/LedgerSMB/Template/XLSX.pm
+++ b/lib/LedgerSMB/Template/XLSX.pm
@@ -183,8 +183,6 @@ Implements the template's post-processing protocol.
 sub postprocess {
     my ($parent, $temp_output, $config) = @_;
 
-    $parent->{mimetype} = 'application/vnd.ms-excel';
-
     # Implement Template Toolkit's protocol: if the variable
     # '$output' contains a string, it's a filename. If it's a
     # reference, the variable referred to is the output memory area
@@ -203,6 +201,17 @@ sub postprocess {
     &_xlsx_process($workbook, $$temp_output);
 
     return undef;
+}
+
+=item mimetype()
+
+Returns the rendered template's mimetype.
+
+=cut
+
+sub mimetype {
+    my $config = shift;
+    return 'application/vnd.ms-excel';
 }
 
 =back

--- a/t/04-template-handling.t
+++ b/t/04-template-handling.t
@@ -249,6 +249,21 @@ is($template->{mimetype}, 'text/plain', 'Template, new (HTML): correct mimetype'
 
 $template = undef;
 $template = LedgerSMB::Template->new(
+    'format'   => 'CSV',
+    'path'     => 't/data',
+    'template' => '04-template'
+);
+ok(defined $template,
+        'Template, new (CSV): Object creation with format and template');
+isa_ok($template, 'LedgerSMB::Template',
+       'Template, new (CSV): Object creation with format and template');
+$template->render({'login' => 'foo&bar'});
+is($template->{output}, "account,amount,description,project",
+        'Template, render (CSV): Simple TXT template, correct output');
+is($template->{mimetype}, 'text/csv', 'Template, new (CSV): correct mimetype');
+
+$template = undef;
+$template = LedgerSMB::Template->new(
     'format'   => 'HTML',
     'path'     => 't/data',
     'template' => '04-template'

--- a/t/04-template-handling.t
+++ b/t/04-template-handling.t
@@ -102,9 +102,9 @@ throws_ok{$template->render({'login' => 'foo'})} qr/not found/,
 
 SKIP: {
     eval {require Template::Plugin::Latex} ||
-        skip 'Template::Plugin::Latex not installed', 10;
+        skip 'Template::Plugin::Latex not installed', 12;
     eval {require Template::Latex} ||
-        skip 'Template::Latex not installed', 10;
+        skip 'Template::Latex not installed', 12;
 
     $template = undef;
     $template = LedgerSMB::Template->new(
@@ -122,6 +122,11 @@ SKIP: {
         'LedgerSMB::Template',
         'Template, render (PDF): Simple PDF template, default filename');
     like($template->{output}, qr/^%PDF/, 'Template, render (PDF): output is PDF');
+    is(
+        $template->{mimetype},
+        'application/pdf',
+        'Template, render (PDF): correct mimetype'
+    );
 
     $template = undef;
     $template = LedgerSMB::Template->new(
@@ -139,14 +144,15 @@ SKIP: {
         'LedgerSMB::Template',
         'Template, render (PS): Simple Postscript template, default filename');
     like($template->{output}, qr/^%!PS/, 'Template, render (PS): output is Postscript');
+    is($template->{mimetype}, 'application/postscript', 'Template, render (PS): correct mimetype');
 }
 
 
 SKIP: {
     eval {require Excel::Writer::XLSX} ||
-        skip 'Excel::Writer::XLSX not installed', 10;
+        skip 'Excel::Writer::XLSX not installed', 12;
     eval {require Spreadsheet::WriteExcel} ||
-        skip 'Spreadsheet::WriteExcel not installed', 10;
+        skip 'Spreadsheet::WriteExcel not installed', 12;
 
     $template = undef;
     $template = LedgerSMB::Template->new(
@@ -166,6 +172,11 @@ SKIP: {
     # xls is a Microsoft BIFF format file.
     # make sure it looks like one by checking the first few header bytes.
     like($template->{output}, qr/^\xD0\xCF\x11\xE0/, 'Template, render (XLS): output is XLS');
+    is(
+        $template->{mimetype},
+        'application/vnd.ms-excel',
+        'Template, render (XLS): correct mimetype'
+    );
 
     $template = undef;
     $template = LedgerSMB::Template->new(
@@ -184,6 +195,11 @@ SKIP: {
         'Template, render (XLSX): Simple Postscript template, default filename');
     # xlsx is actualy a zip file.
     like($template->{output}, qr/^PK/, 'Template, render (XLSX): output is XLSX');
+    is(
+        $template->{mimetype},
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        'Template, render (XLSX): correct mimetype'
+    );
 }
 
 SKIP: {
@@ -209,6 +225,11 @@ SKIP: {
         'Template, render (ODS): Simple Postscript template, default filename');
     # ods is actualy a zip file.
     like($template->{output}, qr/^PK/, 'Template, render (ODS): output is ODS');
+    is(
+        $template->{mimetype},
+        'application/vnd.oasis.opendocument.spreadsheet',
+        'Template, render (ODS): correct mimetype'
+    );
 }
 
 $template = undef;
@@ -224,6 +245,7 @@ isa_ok($template, 'LedgerSMB::Template',
 $template->render({'login' => 'foo&bar'});
 is($template->{output}, "I am a template.\nLook at me foo&bar.",
         'Template, render (TXT): Simple TXT template, correct output');
+is($template->{mimetype}, 'text/plain', 'Template, new (HTML): correct mimetype');
 
 $template = undef;
 $template = LedgerSMB::Template->new(
@@ -238,6 +260,7 @@ isa_ok($template, 'LedgerSMB::Template',
 $template->render({'login' => 'foo&bar'});
 is($template->{output}, "I am a template.\nLook at me foo&amp;bar.",
         'Template, render (HTML): Simple HTML template, correct output');
+is($template->{mimetype}, 'text/html', 'Template, new (HTML): correct mimetype');
 
 #########################################
 ## LedgerSMB::Template private methods ##

--- a/t/data/04-template.csv
+++ b/t/data/04-template.csv
@@ -1,0 +1,5 @@
+account,amount,description,project
+<?lsmb FOREACH amount ?><?lsmb lc = loop.count - 1 ?><?lsmb accno.${lc} ?>,<?lsmb account.${lc} ?>,<?lsmb amount.${lc} ?>,<?lsmb description.${lc} ?>,<?lsmb projectnumber.${lc} ?>
+<?lsmb END ?><?lsmb FOREACH t IN taxaccounts.split(' ') ?><?lsmb loop_count = loop.count - 1 -?>
+<?lsmb t.remove('"') ?>,<?lsmb tax.${loop_count} ?>,<?lsmb taxdescription.${loop_count} ?>,
+<?lsmb END ?>


### PR DESCRIPTION
* Fix mimetype for XLSX output
* Add tests for CSV template format
* Add mimetype tests for template handling
* Added new function `mimetype()` to all LedgerSMB::Template::XXX format modules
* Separation of internal LedgerSMB::Template object properties

The format modules were directly setting the LedgerSMB::Template
object's internal `mimetype` property during their `postprocess()` function.
    
They should not be manipulating the parent LedgerSMB::Template
object's internal state as this breaks good separation of concerns
and causes opaque action-at-a-distance.