### PR TITLE
Fix template_format configuration options broken

### DIFF
--- a/conf/ledgersmb.conf.default
+++ b/conf/ledgersmb.conf.default
@@ -111,7 +111,7 @@ sslmode = prefer
 [template_format]
 # These define the file format options allowed for report exports
 # Set to 'disabled' to prevent the option being made available
-# Otherwise options will be made available subhect to a load-time
+# Otherwise options will be made available subject to a load-time
 # check against module availability.
 #template_latex = disabled
 #template_xls = disabled

--- a/conf/ledgersmb.conf.default
+++ b/conf/ledgersmb.conf.default
@@ -109,14 +109,14 @@ sslmode = prefer
 #dojo_built = 1
 
 [template_format]
-# This is the file format allowed to export reports
-# Allowed values are 1, 0 or disabled. The values will be checked at
-# load time against module availability and loadability if not disabled.
-template_latex = 0
-template_xls = 0
-template_xlsx = 0
-template_ods = 0
-
+# These define the file format options allowed for report exports
+# Set to 'disabled' to prevent the option being made available
+# Otherwise options will be made available subhect to a load-time
+# check against module availability.
+#template_latex = disabled
+#template_xls = disabled
+#template_xlsx = disabled
+#template_ods = disabled
 
 [log4perl_config_modules_loglevel]
 LedgerSMB = INFO

--- a/conf/ledgersmb.conf.unbuilt-dojo
+++ b/conf/ledgersmb.conf.unbuilt-dojo
@@ -111,7 +111,7 @@ dojo_built = 0
 [template_format]
 # These define the file format options allowed for report exports
 # Set to 'disabled' to prevent the option being made available
-# Otherwise options will be made available subhect to a load-time
+# Otherwise options will be made available subject to a load-time
 # check against module availability.
 #template_latex = disabled
 #template_xls = disabled

--- a/conf/ledgersmb.conf.unbuilt-dojo
+++ b/conf/ledgersmb.conf.unbuilt-dojo
@@ -109,14 +109,14 @@ sslmode = prefer
 dojo_built = 0
 
 [template_format]
-# This is the file format allowed to export reports
-# Allowed values are 1, 0 or disabled. The values will be checked at
-# load time against module availability and loadability if not disabled.
-template_latex = 0
-template_xls = 0
-template_xlsx = 0
-template_ods = 0
-
+# These define the file format options allowed for report exports
+# Set to 'disabled' to prevent the option being made available
+# Otherwise options will be made available subhect to a load-time
+# check against module availability.
+#template_latex = disabled
+#template_xls = disabled
+#template_xlsx = disabled
+#template_ods = disabled
 
 [log4perl_config_modules_loglevel]
 LedgerSMB = INFO

--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -563,7 +563,6 @@ our $log4perl_config = qq(
 
 
 # if you have latex installed set to 1
-###TODO-LOCALIZE-DOLLAR-AT
 our $latex = 0;
 
 

--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -373,22 +373,22 @@ def 'templates_cache',
 def 'template_latex',
     section => 'template_format',
     default => 0,
-    doc => q{};
+    doc => q{Set to 'disabled' to prevent LaTeX output formats (Postscript and PDF) being made available};
 
 def 'template_xls',
     section => 'template_format',
     default => 0,
-    doc => q{};
+    doc => q{Set to 'disabled' to prevent XLS output formats being made available};
 
 def 'template_xlsx',
     section => 'template_format',
     default => 0,
-    doc => q{};
+    doc => q{Set to 'disabled' to prevent XLSX output formats being made available};
 
 def 'template_ods',
     section => 'template_format',
     default => 0,
-    doc => q{};
+    doc => q{Set to 'disabled' to prevent ODS output formats being made available};
 
 
 ### SECTION  ---   mail
@@ -575,14 +575,22 @@ sub override_defaults {
     $latex = eval {require Template::Plugin::Latex; 1;};
 
     # Check availability and loadability
-    $LedgerSMB::Sysconfig::template_latex = eval {require LedgerSMB::Template::LaTeX; 1}
-        if $LedgerSMB::Sysconfig::template_latex ne 'disabled';
-    $LedgerSMB::Sysconfig::template_xls   = eval {require LedgerSMB::Template::XLS; 1}
-        if $LedgerSMB::Sysconfig::template_xls ne 'disabled';
-    $LedgerSMB::Sysconfig::template_xlsx  = eval {require LedgerSMB::Template::XLSX; 1}
-        if $LedgerSMB::Sysconfig::template_xlsx ne 'disabled';
-    $LedgerSMB::Sysconfig::template_ods   = eval {require LedgerSMB::Template::ODS; 1}
-        if $LedgerSMB::Sysconfig::template_ods ne 'disabled';
+    $LedgerSMB::Sysconfig::template_latex = (
+        $LedgerSMB::Sysconfig::template_latex ne 'disabled' &&
+        eval {require LedgerSMB::Template::LaTeX}
+    );
+    $LedgerSMB::Sysconfig::template_xls = (
+        $LedgerSMB::Sysconfig::template_xls ne 'disabled' &&
+        eval {require LedgerSMB::Template::XLS}
+    );
+    $LedgerSMB::Sysconfig::template_xlsx = (
+        $LedgerSMB::Sysconfig::template_xlsx ne 'disabled' &&
+        eval {require LedgerSMB::Template::XLSX}
+    );
+    $LedgerSMB::Sysconfig::template_ods = (
+        $LedgerSMB::Sysconfig::template_ods ne 'disabled' &&
+        eval {require LedgerSMB::Template::ODS}
+    );
 
     return;
 }

--- a/t/12-sysconfig.t
+++ b/t/12-sysconfig.t
@@ -10,7 +10,7 @@ chdir 't/data';
 require LedgerSMB::Sysconfig;
 
 
-plan tests => (8+scalar(@LedgerSMB::Sysconfig::scripts)
+plan tests => (12+scalar(@LedgerSMB::Sysconfig::scripts)
                +scalar(@LedgerSMB::Sysconfig::newscripts));
 
 is $LedgerSMB::Sysconfig::auth, 'DB2', 'Auth set correctly';
@@ -22,6 +22,25 @@ is $LedgerSMB::Sysconfig::check_max_invoices, '52',
 is $LedgerSMB::Sysconfig::max_post_size, 4194304333,
    'max post size set correctly';
 is $LedgerSMB::Sysconfig::cookie_name, 'LedgerSMB-1.32', 'cookie set correctly';
+ok(!$LedgerSMB::Sysconfig::template_xls, 'template_xls is false');
+
+SKIP: {
+    eval {require LedgerSMB::Template::XLSX} ||
+        skip 'LedgerSMB::Template::XLSX not available', 1;
+    ok($LedgerSMB::Sysconfig::template_xlsx, 'template_xlsx is true');
+}
+
+SKIP: {
+    eval {require LedgerSMB::Template::ODS} ||
+        skip 'LedgerSMB::Template::ODS not available', 1;
+    ok($LedgerSMB::Sysconfig::template_ods, 'template_ods is true');
+}
+
+SKIP: {
+    eval {require LedgerSMB::Template::LaTeX} ||
+        skip 'LedgerSMB::Template::LaTeX not available', 1;
+    ok($LedgerSMB::Sysconfig::template_latex, 'template_latex is true');
+}
 
 like $ENV{PATH}, '/foo$/', 'appends config path correctly';
 

--- a/t/data/ledgersmb.conf
+++ b/t/data/ledgersmb.conf
@@ -76,7 +76,7 @@ sslmode = prefer
 [template_format]
 # These define the file format options allowed for report exports
 # Set to 'disabled' to prevent the option being made available
-# Otherwise options will be made available subhect to a load-time
+# Otherwise options will be made available subject to a load-time
 # check against module availability.
 #template_latex = disabled
 template_xls = disabled

--- a/t/data/ledgersmb.conf
+++ b/t/data/ledgersmb.conf
@@ -73,6 +73,16 @@ db_namespace = public
 # sslmode can be require, allow, prefer, or disable.  Defaults to prefer.
 sslmode = prefer
 
+[template_format]
+# These define the file format options allowed for report exports
+# Set to 'disabled' to prevent the option being made available
+# Otherwise options will be made available subhect to a load-time
+# check against module availability.
+#template_latex = disabled
+template_xls = disabled
+#template_xlsx = disabled
+#template_ods = disabled
+
 [log4perl_config_modules_loglevel]
 LedgerSMB = INFO
 LedgerSMB.DBObject = INFO


### PR DESCRIPTION
* Fix broken logic for template_format config options
* Document template_format config options in LedgerSMB::Sysconfig
* Add tests for template_format config options

This fixes broken logic in processing the template_format
configuration options `template_latex`, `template_xls`,
`template_xlsx` and `template_ods`.

Output format options were always being displayed, regardless
of dependencies, when the respective configuration
option was set to "disabled".

In that instance, the dependency logic was not executed and the
raw "disabled" value was used as the configuration setting instead
of a processed true/false value. As "disabled" evaluates to true,
the format options were incorrectly displayed.

Default configuration files now comment out the `template_XXX` lines,
meaning that all formats are enabled by default, providing their
dependencies are satisfied. This was the effect (despite appearances)
of the previous default configuration, which set `template_XXX = 0`