### PR TITLE
Add minimal option to NYTProf

### DIFF
--- a/utils/devel/starman-development.psgi
+++ b/utils/devel/starman-development.psgi
@@ -90,7 +90,8 @@ builder {
             if check_config_option('DBITrace','Plack::Middleware::Debug::DBITrace');
         enable 'Debug::TraceENV', method => $LedgerSMB::Sysconfig::TraceENV_method
             if check_config_option('TraceENV','Plack::Middleware::Debug::TraceENV');
-        enable 'Debug::Profiler::NYTProf', exclude => [$LedgerSMB::Sysconfig::NYTProf_exclude]
+        enable 'Debug::Profiler::NYTProf', exclude => [$LedgerSMB::Sysconfig::NYTProf_exclude],
+                                           minimal  => $LedgerSMB::Sysconfig::NYTProf_minimal
             if check_config_option('NYTProf','Plack::Middleware::Debug::Profiler::NYTProf');
     }
 #   qw/Dancer::Settings Dancer::Logger Dancer::Version/


### PR DESCRIPTION
By default, NYTProf will generate graphviz .dot files and block/sub-level reports. Setting minimal will disable this behaviour and make it considerably faster.

Uses the option declared in Sysconfig to control minimal behaviour. Fixes #3521.