### PR TITLE
Fix #3520 Respect smtp config options

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -17,6 +17,7 @@ Installation & Administration
 * Removed need for 'tempdir' and associated configuration option (Nick P)
 * Removed numerous unused configuration options (Nick P)
 * Specific output formats can be disabled in configuration (Yves L)
+* Respect smtpuser and smtppass configuration options (Nick P)
 
 Performance
 * PSGI responses no longer written to file but kept in memory (Erik H/Yves L)

--- a/conf/ledgersmb.conf.default
+++ b/conf/ledgersmb.conf.default
@@ -73,11 +73,16 @@ localepath = locale/po
 
 [mail]
 # The sendmail command is used to send mail unless smtphost is set.
-sendmail   = /usr/bin/sendmail
+# sendmail   = /usr/bin/sendmail
 
-#
-# smtphost = 127.0.0.1
+# If smtp host is defined, messages will be sent via this smtp server,
+# instead of the default sendmail method.
+# smtphost = localhost
+# smtpuser = username
+# smtppass = password
 # smtptimeout = 60
+
+# This must be set to enable e-mail delivery of backups
 # backup_email_from = backups@lsmb_hosting.com
 
 [printers]

--- a/conf/ledgersmb.conf.unbuilt-dojo
+++ b/conf/ledgersmb.conf.unbuilt-dojo
@@ -73,11 +73,16 @@ localepath = locale/po
 
 [mail]
 # The sendmail command is used to send mail unless smtphost is set.
-sendmail   = /usr/bin/sendmail
+# sendmail   = /usr/bin/sendmail
 
-#
-# smtphost = 127.0.0.1
+# If smtp host is defined, messages will be sent via this smtp server,
+# instead of the default sendmail method.
+# smtphost = localhost
+# smtpuser = username
+# smtppass = password
 # smtptimeout = 60
+
+# This must be set to enable e-mail delivery of backups
 # backup_email_from = backups@lsmb_hosting.com
 
 [printers]

--- a/lib/LedgerSMB/Mailer.pm
+++ b/lib/LedgerSMB/Mailer.pm
@@ -197,19 +197,31 @@ sub send {
     $self->{_message}->replace( 'X-Mailer' => "LedgerSMB::Mailer $VERSION" );
     local $@ = undef;
     eval {
-        if ( $LedgerSMB::Sysconfig::smtphost ) {
-            $self->{_message}->send(
+        my @send_options;
+
+        if (defined $LedgerSMB::Sysconfig::smtphost) {
+            @send_options = (
                 'smtp',
                 $LedgerSMB::Sysconfig::smtphost,
-                Timeout => $LedgerSMB::Sysconfig::smtptimeout
-                 ) || return "$!";
+                Timeout => $LedgerSMB::Sysconfig::smtptimeout,
+            );
+
+            if (defined $LedgerSMB::Sysconfig::smtpuser) {
+                push(@send_options, AuthUser => $LedgerSMB::Sysconfig::smtpuser);
+            }
+
+            if (defined $LedgerSMB::Sysconfig::smtppass) {
+                push(@send_options, AuthPass => $LedgerSMB::Sysconfig::smtpass);
+            }
         } else {
-            $self->{_message}->send(
+            @send_options = (
                 'sendmail',
                 SendMail => $LedgerSMB::Sysconfig::sendmail,
-                     SetSender => 1
-                ) || return "$!";
+                SetSender => 1
+            );
         }
+
+        $self->{_message}->send(@send_options) or return "$!";
     };
     die "Could not send email: $@.  Please check your configuration." if $@;
     return;

--- a/lib/LedgerSMB/Mailer.pm
+++ b/lib/LedgerSMB/Mailer.pm
@@ -211,7 +211,7 @@ sub send {
             }
 
             if (defined $LedgerSMB::Sysconfig::smtppass) {
-                push(@send_options, AuthPass => $LedgerSMB::Sysconfig::smtpass);
+                push(@send_options, AuthPass => $LedgerSMB::Sysconfig::smtppass);
             }
         } else {
             @send_options = (

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -37,6 +37,7 @@ use LedgerSMB::Database;
 use LedgerSMB::DBObject::Admin;
 use LedgerSMB::DBObject::User;
 use LedgerSMB::Magic qw( EC_EMPLOYEE HTTP_454 PERL_TIME_EPOCH );
+use LedgerSMB::Mailer;
 use LedgerSMB::PSGI::Util;
 use LedgerSMB::Upgrade_Preparation;
 use LedgerSMB::Upgrade_Tests;

--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -396,28 +396,27 @@ def 'template_ods',
 def 'sendmail',
     section => 'mail',
     default => '/usr/sbin/sendmail -t',
-    doc => q{location of sendmail};
-
+    doc => q{The sendmail command used for sending e-mail. Applies only when smtphost is not defined.};
 
 def 'smtphost',
     section => 'mail',
-    default => '',
-    doc => '';
+    default => undef,
+    doc => 'Connect to this SMTP host to send e-mails. If defined, used instead of sendmail.';
 
 def 'smtptimeout',
     section => 'mail',
     default => 60,
-    doc => '';
+    doc => 'Timeout in seconds for smtp connections.';
 
 def 'smtpuser',
     section => 'mail',
-    default => '',
-    doc => '';
+    default => undef,
+    doc => 'Optional username used when connecting to smtp server.';
 
 def 'smtppass',
     section => 'mail',
-    default => '',
-    doc => '';
+    default => undef,
+    doc => 'Optional password used when connecting to smtp server.';
 
 def 'smtpauthmethod',
     section => 'mail',
@@ -426,8 +425,8 @@ def 'smtpauthmethod',
 
 def 'backup_email_from',
     section => 'mail',
-    default => '',
-    doc => '';
+    default => undef,
+    doc => 'The e-mail address from which backups are sent.';
 
 
 ### SECTION  ---   database

--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -418,11 +418,6 @@ def 'smtppass',
     default => undef,
     doc => 'Optional password used when connecting to smtp server.';
 
-def 'smtpauthmethod',
-    section => 'mail',
-    default => '',
-    doc => '';
-
 def 'backup_email_from',
     section => 'mail',
     default => undef,


### PR DESCRIPTION
With this PR, optional configuration parameters `smtpuser` and `smtppass` are respected when sending e-mail. Unsupported parameter `smtpauthmethod` is removed.

Adds documentation for these options within LedgerSMB::Sysconfig.