### PR TITLE
Conditionally enable/disable e-mail backup UI elements

### DIFF
--- a/UI/setup/begin_backup.html
+++ b/UI/setup/begin_backup.html
@@ -20,18 +20,37 @@ include_stylesheet=["setup/stylesheet.css"] ?>
    value = backup
 } ?>
 <div class="inputrow" id="emailopt">
+<?lsmb IF can_email ?>
 <?lsmb INCLUDE input element_data = {
-    type = 'radio'
-    name = 'backup_type'
-   label = text('To email') #'
-   value = 'email'
-}, label_pos = 1 ?>
+        type = 'radio'
+        name = 'backup_type'
+       label = text('To email') #'
+       value = 'email'
+    }, label_pos = 1
+?>
 <?lsmb INCLUDE input element_data = {
     type = "text"
     name = "email"
    value = email
    class = "email"
 } ?>
+<?lsmb ELSE ?>
+<?lsmb INCLUDE input element_data = {
+        type = 'radio'
+        name = 'backup_type'
+       label = text('To email') #'
+       value = 'email'
+    disabled = 'disabled'
+    }, label_pos = 1
+?>
+<?lsmb INCLUDE input element_data = {
+    type = "text"
+    name = "email"
+   value = email
+   class = "email"
+disabled = "disabled"
+} ?>
+<?lsmb END ?>
 </div>
 <div class="inputrow" id="browseropt">
 <?lsmb INCLUDE input element_data = {
@@ -39,6 +58,7 @@ include_stylesheet=["setup/stylesheet.css"] ?>
     name = 'backup_type'
    label = text('To my browser') #'
    value = 'browser'
+ checked = "checked"
 }, label_pos = 1 ?>
 </div>
 <div class="inputrow">

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -389,6 +389,7 @@ sub backup_roles {
 # Private method, basically just passes the inputs on to the next screen.
 sub _begin_backup {
     my $request = shift @_;
+    $request->{can_email} = defined $LedgerSMB::Sysconfig::backup_email_from;
     my $template = LedgerSMB::Template->new_UI(
         $request,
         template => 'setup/begin_backup',


### PR DESCRIPTION
If the `backup_email_from` configuration element is not defined,
attempting to e-mail a backup will fail with a user-unfriendly
error message.

This PR disables the e-mail backup UI elements unless the
`backup_email_from` configuration is set.

The facility to return backups to the browser remains enabled under
all circumstances and is made the default selection.