### PR TITLE
Add smtpport configuration option

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -18,6 +18,7 @@ Installation & Administration
 * Removed numerous unused configuration options (Nick P)
 * Specific output formats can be disabled in configuration (Yves L)
 * Respect smtpuser and smtppass configuration options (Nick P)
+* Add smtpport configuration option (Nick P)
 
 Performance
 * PSGI responses no longer written to file but kept in memory (Erik H/Yves L)

--- a/conf/ledgersmb.conf.default
+++ b/conf/ledgersmb.conf.default
@@ -78,6 +78,7 @@ localepath = locale/po
 # If smtp host is defined, messages will be sent via this smtp server,
 # instead of the default sendmail method.
 # smtphost = localhost
+# smtpport = 25
 # smtpuser = username
 # smtppass = password
 # smtptimeout = 60

--- a/conf/ledgersmb.conf.unbuilt-dojo
+++ b/conf/ledgersmb.conf.unbuilt-dojo
@@ -78,6 +78,7 @@ localepath = locale/po
 # If smtp host is defined, messages will be sent via this smtp server,
 # instead of the default sendmail method.
 # smtphost = localhost
+# smtpport = 25
 # smtpuser = username
 # smtppass = password
 # smtptimeout = 60

--- a/lib/LedgerSMB/Mailer.pm
+++ b/lib/LedgerSMB/Mailer.pm
@@ -204,6 +204,7 @@ sub send {
                 'smtp',
                 $LedgerSMB::Sysconfig::smtphost,
                 Timeout => $LedgerSMB::Sysconfig::smtptimeout,
+                Port => $LedgerSMB::Sysconfig::smtpport,
             );
 
             if (defined $LedgerSMB::Sysconfig::smtpuser) {

--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -403,6 +403,11 @@ def 'smtphost',
     default => undef,
     doc => 'Connect to this SMTP host to send e-mails. If defined, used instead of sendmail.';
 
+def 'smtpport',
+    section => 'mail',
+    default => 25,
+    doc => 'Connect to the smtp host using this port.';
+
 def 'smtptimeout',
     section => 'mail',
     default => 60,


### PR DESCRIPTION
Allows smtp port to be set explicitly, in an obvious and clearly
documented manner. Defaults to standard port 25.