### PR TITLE
Move @io_lineitem_columns from Sysconfig

### DIFF
--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -461,12 +461,6 @@ def 'db_sslmode',
     envvar => 'PGSSLMODE',
     doc => '';
 
-### WHAT DOES THIS DO???
-our @io_lineitem_columns = qw(unit onhand sellprice discount linetotal);
-
-
-
-
 
 # available printers
 our %printer;

--- a/old/bin/io.pl
+++ b/old/bin/io.pl
@@ -203,7 +203,7 @@ qq|<option value="$ref->{partsgroup}--$ref->{id}">$ref->{partsgroup}\n|;
         $form->{oldlanguage_code} = $form->{language_code};
     }
 
-    push @column_index, @{LedgerSMB::Sysconfig::io_lineitem_columns};
+    push @column_index, qw(unit onhand sellprice discount linetotal);
     for my $cls(@{$form->{bu_class}}){
         if (scalar @{$form->{b_units}->{"$cls->{id}"}}){
              push @column_index, "b_unit_$cls->{id}";


### PR DESCRIPTION
Removes unclear definition @io_lineitem_columns from
LedgerSMB::Sysconfig and puts it directly in the single
piece of old code which uses it.

One less piece of magic and an improvement in clarity.
Improves separation between old code and new code.