### PR TITLE
Bank Reconciliation - don't present editable fields after submit

### DIFF
--- a/UI/reconciliation/report.html
+++ b/UI/reconciliation/report.html
@@ -41,15 +41,19 @@ END ?>
   <td><?lsmb beginning_balance ?></td>
 </tr>
 <tr>
- <th><?lsmb text('Ending Statement Balance:') ?></th>
- <td><?lsmb INCLUDE input element_data = {
+  <th><?lsmb text('Ending Statement Balance:') ?></th>
+<?lsmb IF submitted ?>
+  <td><?lsmb their_total ?></td>
+<?lsmb ELSE ?>
+  <td><?lsmb INCLUDE input element_data = {
     name = "their_total",
     type = "text",
     class = "money",
     size = "15",
     value = their_total
     } ?>
- </td>
+  </td>
+<?lsmb END ?>
 <?lsmb IF ! approved ?>
   <?lsmb IF !submit_enabled ?>
     <th><?lsmb text('Variance:') ?></th>


### PR DESCRIPTION
After a bank reconciliation report has been submitted, it is no longer
valid to edit the ending statement balance.

This PR makes this field simple text, rather than an input, when viewing
a submitted reconciliation report.