### PR TITLE
Fix spelling in LedgerSMB::PSGI running-as-root message

### DIFF
--- a/lib/LedgerSMB/PSGI.pm
+++ b/lib/LedgerSMB/PSGI.pm
@@ -40,14 +40,13 @@ use Plack::Util;
 use English qw(-no_match_vars);
 if ($EUID == 0) {
     die join("\n",
-        'Running a Web Service as root is a security problem',
-        'If you are starting LedgerSMB as a system service',
-        'please make sure that you drop privlidges as per README.md',
-        'and the example files in conf/',
-        'This makes it difficult to run on a privlidged port (<1024)',
-        'In theory you can pass the --user argument to starman,',
-        'However starman drops privlidges too late, starting us as root.'
-        );
+        'Running a Web Service as root is a security problem.',
+        'If you are starting LedgerSMB as a system service,',
+        'please make sure that you drop privileges as per README.md',
+        'and the example files in conf/.',
+        'The method of passing a --user argument to starman cannot',
+        'be used as starman drops privileges too late, starting us as root.'
+    );
 }
 
 


### PR DESCRIPTION
"privilege" misspelt in running-as-root warning. Refactored words
to make clear that the starman `--user` option cannot be used. Added
punctuation.