### PR TITLE
Remove unused variable from LedgerSMB::Scripts::menu

### DIFF
--- a/lib/LedgerSMB/Scripts/menu.pm
+++ b/lib/LedgerSMB/Scripts/menu.pm
@@ -88,8 +88,6 @@ Returns the menu items in JSON format
 sub menuitems_json {
     my ($request) = @_;
     my $locale = $request->{_locale};
-    # There must be a better way
-    my $method = $request->{_auth}->{env}->{REQUEST_METHOD};
     my $menu = LedgerSMB::DBObject::Menu->new({base => $request});
 
     $menu->generate;


### PR DESCRIPTION
Removed unused variable $method from menuitems_json().