### PR TITLE
Add stdout/stderr capture after database run_file error

### DIFF
--- a/lib/LedgerSMB/Database.pm
+++ b/lib/LedgerSMB/Database.pm
@@ -445,9 +445,10 @@ sub load_modules {
                     values ('module_load_ok', 'no') })
             or die $dbh->errstr;
 
-        $self->run_file(
-            file       => "$self->{source_dir}/modules/$mod",
+        my ($success, $stdout, $stderr) = $self->run_file_with_logs(
+            file => "$self->{source_dir}/modules/$mod",
         );
+        $success or die $stderr;
 
         my $sth = $dbh->prepare(q{select value from defaults
                                    where setting_key = 'module_load_ok'});
@@ -618,6 +619,47 @@ sub stats {
 
     return $results;
 }
+
+=head2 run_file_with_logs(file => $file) 
+
+Wrapper around run_file() method, which does not die on error and returns
+the captured stdout and stderr output.
+
+Returns an array of three elements comprising:
+
+   * success, false if an error occurred, true otherwise
+   * stdout output log
+   * stderr output log
+
+=cut
+
+sub run_file_with_logs {
+
+    my $self = shift;
+    my @args = @_;
+    my $stdout_fh = File::Temp->new;
+    my $stderr_fh = File::Temp->new;
+
+    # ->run_file croaks on error, but we trap that condition
+    # so that we can carry on and do something useful with
+    # its output logs.
+    local ($!, $@) = (undef, undef);
+    my $success = eval {
+        $self->run_file(
+            @args,
+            stdout_log => $stdout_fh->filename,
+            errlog => $stderr_fh->filename,
+        ) and return 1;
+    };
+
+    # Slurp contents of log files
+    local $/ = undef;
+    my $stdout = <$stdout_fh>;
+    my $stderr = <$stderr_fh>;
+
+    return ($success, $stdout, $stderr);
+}
+
 
 =head1 COPYRIGHT
 


### PR DESCRIPTION
By design, PGObject::Util::DBAdmin croaks on error, which
prevents access to the captured log output. This commit adds a
run_file_with_logs() method, which wraps the run_file() method in
an eval to trap the error, then slurps and returns the log files.

This new method is applied inside the load_modules() method to
display a meaningful error message on failure.