### PR TITLE
Refactor LedgerSMB.pm to_json method

### DIFF
--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -141,8 +141,7 @@ use LedgerSMB::Locale;
 use HTTP::Status qw( HTTP_OK) ;
 use LedgerSMB::User;
 use LedgerSMB::Company_Config;
-use LedgerSMB::Template::TXT;
-use LedgerSMB::Template qw( preprocess );
+use LedgerSMB::Template;
 use Log::Log4perl;
 use Carp;
 use JSON::MaybeXS;
@@ -436,13 +435,16 @@ sub merge {
 sub to_json {
     my ($self, $output) = @_;
 
-    return [ HTTP_OK,
-             [ 'Content-Type' => 'application/json; charset=UTF-8' ],
-             [ $json->encode(
-                   preprocess(
-                       $output,
-                       \&LedgerSMB::Template::TXT::escape )) ]
-        ];
+    my $response_data = LedgerSMB::Template::preprocess(
+        $output,
+        sub {return shift} # no escaping
+    );
+
+    return [
+        HTTP_OK,
+        [ 'Content-Type' => 'application/json; charset=UTF-8' ],
+        [ $json->encode($response_data) ],
+    ];
 }
 
 sub system_info {


### PR DESCRIPTION
Remove LedgerSMB.pm dependency on LedgerSMB::Template::TXT,
used only for null escape function.

The LedgerSMB::Template::XXX modules present a defined interface
intended to be used by the LedgerSMB::Template module. Using the
TXT format's escape function here, for JSON format output is unexpected.

Following the principle of least surprise, it's better to provide an explicit
escape function for the JSON output.

Refactored the to_json method for clarity. Functionality unchanged.