### PR TITLE
Fix 3551

### DIFF
--- a/sql/changes/1.6/no-inv-entity-tables.sql.checks.pl
+++ b/sql/changes/1.6/no-inv-entity-tables.sql.checks.pl
@@ -6,8 +6,8 @@ use LedgerSMB::Database::ChangeChecks;
 
 check q|Assert "inventory_report" table's columns can be upgraded|,
     query => q|SELECT ir.transdate,
-                      ap.invnum as ap_invoice_number,
-                      ar.invnum as ar_invoice_number  FROM inventory_report ir
+                      ap.invnumber as ap_invoice_number,
+                      ar.invnumber as ar_invoice_number  FROM inventory_report ir
                LEFT JOIN ap ON ap.id = ir.ap_trans_id
                LEFT JOIN ar ON ar.id = ir.ar_trans_id
                 WHERE NOT EXISTS
@@ -81,8 +81,9 @@ gap.
            $dbh->do("INSERT INTO defaults VALUES ('inv-entity-retain', 'y')")
               or die "Failed to set migration strategy: " . $dbh->errstr;
         }
-        else
+        else {
           die "Unexpected confirmation value found: $confirm";
+        }
     }
 ;
 

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -57,11 +57,11 @@
 #1.6 changes
 1.6/drop_chart.sql
 1.6/drop_arap_cols.sql
+1.6/gl-trans-type.sql
 1.6/no-inv-entity-cleanup.sql
 1.6/no-inv-entity-tables.sql
 1.6/no-inv-entity-end-entity.sql
 !1.6/no-inv-entity-remove-entity.sql
-1.6/gl-trans-type.sql
 1.6/drop-entity-duplicate_constraint.sql
 1.6/fix-entity-primary-key.sql
 1.6/add-eca-business-foreign-key.sql


### PR DESCRIPTION
Fix 2 typos in 1.6/no-inv-entity-tables.sql.checks
- MIssing braces around a die statement
- invalid column in inventory_report

Fix load order of 1.6 changes