### PR TITLE
Add dojo form validation to Password Duration setting

### DIFF
--- a/UI/Configuration/settings.html
+++ b/UI/Configuration/settings.html
@@ -13,7 +13,16 @@
         <th align="right"><?lsmb ITEM.label ?></th>
         <td colspan="<?lsmb ITEM.info ? 1 : 2 ?>" style='white-space:nowrap'>
           <?lsmb
-             IF ITEM.type == 'YES_NO';
+             IF ITEM.name == 'password_duration';
+               PROCESS input element_data = {
+                       name = ITEM.name,
+                       type = 'text',
+                       value = form.${ITEM.name},
+                       size = 5,
+                       'data-dojo-type' = 'dijit/form/NumberTextBox',
+                       'data-dojo-props' = 'constraints:{min:0.00001,max:3653}',
+               };
+             ELSIF ITEM.type == 'YES_NO';
                IF form.${ITEM.name};
                  YES="CHECKED";
                  NO=undef;


### PR DESCRIPTION
Since 1.6, we have a database constraint for Password Duration. This commit
adds dojo form validation for this field so that a user error
is displayed if an invalid value is entered.

Previously a 'server error' box would be displayed on form
submission, which gave no clue as to what caused the issue.