### PR TITLE
Fix application of password_duration constraint

### DIFF
--- a/sql/changes/1.6/constrain_default_password_duration.sql
+++ b/sql/changes/1.6/constrain_default_password_duration.sql
@@ -12,10 +12,16 @@
 UPDATE defaults
 SET value = NULL
 WHERE setting_key = 'password_duration' AND (
-  value ~ '^([0-9]+[.]?[0-9]*|[.][0-9]+)$' OR
+  value !~ '^([0-9]+[.]?[0-9]*|[.][0-9]+)$' OR
   value::numeric <= 0 OR
   value::numeric >= 3654
 );
+
+
+-- Drop existing constraint if this change has
+-- previously been applied.
+ALTER TABLE defaults
+DROP CONSTRAINT IF EXISTS defaults_password_duration_check;
 
 
 -- Add a constraint that enforces a valid


### PR DESCRIPTION
In 1.6 we are adding a constraint for the password_duration setting.

There is an error in the sql change script, meaning it wrongly clears
a valid password_duration and triggers an error when dealing with some
invalid password_duration values (such as those containing text).
This is the opposite to the desired behaviour.

The problem is caused by a missing negation operator.

Though we don't normally allow sql change scripts to be changed, this
PR is acceptable because:

1) The update script isn't yet part of a formal lsmb release
2) Not changing it risks loss of a valid configuration setting during
upgrade
3) It can safely be applied on development systems that have already
run the original version of this change.