### PR TITLE
Make sure a hash is passed as raw vars to the PSGI renderer

### DIFF
--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -1253,7 +1253,7 @@ sub process_and_run_upgrade_script {
         format_options => {extension => 'sql'},
         format => 'TXT' );
 
-    $dbtemplate->render($request, VERSION_COMPARE => \&Version::Compare::version_compare);
+    $dbtemplate->render($request, {VERSION_COMPARE => \&Version::Compare::version_compare});
 
     my $tempfile = File::Temp->new();
     print $tempfile $dbtemplate->{output}


### PR DESCRIPTION
Fixes "Can't use string ("VERSION_COMPARE") as a HASH ref while "strict refs""