### PR TITLE
1.5: Clarify error message changing password via Preferences

### DIFF
--- a/UI/js-src/lsmb/users/ChangePassword.js
+++ b/UI/js-src/lsmb/users/ChangePassword.js
@@ -120,7 +120,7 @@ define(["lsmb/TabularForm",
                             if (err.response.status != "500"){
                                  I.setFeedback(0, I.text("Bad username/Password"));
                             } else {
-                                 I.setFeedback(0,I.text("Company does not exist."));
+                                 I.setFeedback(0,I.text("Error changing password."));
                             }
                           }
                       });


### PR DESCRIPTION
Fix for #3231 - corrects misleading error message.

Currently, when a user changes their password, any error is reported as
`Company does not exist`. This makes no sense, as we are logged in to
a company, so there must be another reason for the failure.

Message changed to more generic - and accurate - `Error changing password`.

This ensures that if an invalid password_duration is set in defaults, a reasonable
error message is given when that causes a failure in changing passwords. lsmb 1.6
introduces a database constraint to prevent that root cause.