### PR TITLE
Fix broken report Permalink regression

### DIFF
--- a/UI/Reports/display_report.html
+++ b/UI/Reports/display_report.html
@@ -8,14 +8,15 @@ PROCESS "elements.html";
 PROCESS "dynatable.html";
 
 FORMATS = LIST_FORMATS();
-QSTRING = ENVARS.QUERY_STRING;
+QSTRING = request.query_string;
 
-IF NOT QSTRING.match('&amp;company=');
-   QSTRING = QSTRING _ '&amp;company=' _ DBNAME;
+IF NOT QSTRING.match('company=');
+   ESCAPED_COMPANY = request.company FILTER uri;
+   QSTRING = QSTRING _ '&amp;company=' _ ESCAPED_COMPANY;
 END;
 
 LINK = request.script _ '?' _ QSTRING;
-LINK = LINK.replace('\&amp;\&amp;', '&amp;');
+
 
 ?>
 <body class="lsmb <?lsmb dojo_theme ?>">


### PR DESCRIPTION
This fixes a regression that broke Permalinks, caused by the
QUERY_STRING environment variable not being available since 1.6.

Note that Permalink is still broken from Cash->Reports->Reconciliation,
but that is a separate problem and is not a regression - that particular
permalink is broken in 1.5 also.