### PR TITLE
Fix errors in XLS/XLSX report template title page

### DIFF
--- a/UI/Reports/display_report.xlst
+++ b/UI/Reports/display_report.xlst
@@ -16,11 +16,11 @@ END;
      <cell text="<?lsmb name ?>" />
 </row>
 <row><cell text="<?lsmb text('Company') ?>:" />
-     <cell test="<?lsmb request.company ?>" />
+     <cell text="<?lsmb request.company ?>" />
 </row>
 <?lsmb FOREACH HLINE IN hlines -?>
 <row><cell text="<?lsmb HLINE.text ?>:" />
-     <cell text="<?lsmb request.${LINE.name} ?>" />
+     <cell text="<?lsmb request.${HLINE.name} ?>" />
 </row>
 <?lsmb END -?>
 </worksheet>


### PR DESCRIPTION
* Company database name not displayed
* Dynamic field values not displayed

Both issues caused by minor typos in the template.