### PR TITLE
Fix PDF output - don't escape hash keys for template vars

### DIFF
--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -469,7 +469,7 @@ sub preprocess {
             # btw, some (internal) objects are XS objects, on which this trick
             # treating it as a hashref really doesn't work...
             next if /^_/;
-            $vars->{preprocess($_, $escape)} = preprocess( $rawvars->{$_}, $escape );
+            $vars->{$_} = preprocess( $rawvars->{$_}, $escape );
         }
     }
     # return undef for GLOB references (includes IO::File objects)


### PR DESCRIPTION
This fixes a regression between 1.5 and 1.6. Following refactoring
of the LedgerSMB::Template modules, both hash keys and values were
being escaped to create the `cleanvars` passed to the template.

This broke the PDF templates, causing their data rows to be empty.

I'd argue that applying a blanket escape to everything before the
template is flawed. We have no idea whether the template is going to
use the data for user display, or internal processing. We should
therefore leave escaping up to the template. As things stand, we
have individual templates trying to un-escape data to get at the
original raw values. That's for another time...