### PR TITLE
Fix Reconciliation Reports Summary links broken

### DIFF
--- a/UI/Reports/filters/reconciliation_search.html
+++ b/UI/Reports/filters/reconciliation_search.html
@@ -4,7 +4,7 @@
 <div class="title"><?lsmb text('Search Reconciliation Reports') ?></div>
 
 <div class="body">
-        <form data-dojo-type="lsmb/Form" name="reconciliation__search" method="post" action="recon.pl" id="reconciliation__search">
+        <form data-dojo-type="lsmb/Form" name="reconciliation__search" method="get" action="recon.pl" id="reconciliation__search">
             <div>
                 <?lsmb INCLUDE input element_data = {
                         label = text('Date From'), #'


### PR DESCRIPTION
This fixes #3568. Need backport to 1.6 and 1.5.

Fixes permalink and download links on "Reconciliation Reports" summary
report.