### PR TITLE
Fix SL migration - error running migration sql commands

### DIFF
--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -1262,7 +1262,7 @@ sub process_and_run_upgrade_script {
        or warn 'Failed to close temporary file';
 
     $database->run_file(
-        file => $tempfile,
+        file => $tempfile->filename,
         stdout_log => $temp . '_stdout',
         errlog => $temp . '_stderr'
         );


### PR DESCRIPTION
This fix responds to a bug filed against PGObject::Util::DBAdmin
https://github.com/ledgersmb/PGObject-Util-DBAdmin/issues/38

> Migration fails with -e on closed filehandle

The DBAdmin run_file method was being called with a File::Temp object
reference instead of a file path. Now that more stringent checks are
enforced by DBAdmin, this causes an error when DBAdmin checks that the
file exists using perl's `-e` operator.

Previously this bug went unnoticed, because in string context, a
File::Temp object evaluates to the temporary file's path. But in other
contexts, such as when passed to `-e`, it evaluates to a filehandle.

I don't have any SL files to test this fix (we need one as part
of the test suite), so have requested review.