### PR TITLE
1.6 Backports - fix uploads

### DIFF
--- a/lib/LedgerSMB/File.pm
+++ b/lib/LedgerSMB/File.pm
@@ -194,7 +194,9 @@ sets it.
 sub get_mime_type {
     my ($self) = @_;
     if (!($self->mime_type_id || $self->mime_type_text)){
-       $self->mime_type_text(MIME::Type->new->mimeTypeOf($self->file_name));
+       $self->mime_type_text(
+            MIME::Types->new->mimeTypeOf($self->file_name)->type
+       );
     }
     if (!($self->mime_type_id && $self->mime_type_text)){
        my ($ref) = $self->call_dbmethod(funcname => 'file__get_mime_type');
@@ -310,7 +312,7 @@ sub list_links{
 
 =head1 COPYRIGHT
 
-Copyright (C) 2011 The LedgerSMB Core Team
+Copyright (C) 2011-2018 The LedgerSMB Core Team
 
 This file is licensed under the Gnu General Public License version 2, or at your
 option any later version.  A copy of the license should have been included with

--- a/lib/LedgerSMB/File.pm
+++ b/lib/LedgerSMB/File.pm
@@ -204,21 +204,6 @@ sub get_mime_type {
     return $self->mime_type_text;
 }
 
-=item set_mime_type
-
-Sets the mipe_type_id from the mime_type_text
-
-=cut
-
-sub set_mime_type {
-    my ($self, $mime_type) = @_;
-    $self->mime_type_text($mime_type);
-    my ($ref) = $self->call_procedure(funcname => 'file__mime_type_text',
-         args => [undef, $self->mime_type_text]);
-    return $self->mime_type_id($ref->{id});
-
-}
-
 =item detect_type
 
 Auto-detects the type of the file.  Not yet implemented

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -1257,7 +1257,7 @@ sub process_and_run_upgrade_script {
        or warn 'Failed to close temporary file';
 
     $database->run_file(
-        file => $tempfile,
+        file => $tempfile->filename,
         stdout_log => $temp . '_stdout',
         errlog => $temp . '_stderr'
         );

--- a/lib/LedgerSMB/Scripts/template.pm
+++ b/lib/LedgerSMB/Scripts/template.pm
@@ -121,25 +121,33 @@ will be accepted.
 
 sub upload {
     my ($request) = @_;
-    my @fnames =  $request->upload;
-    my $name = $fnames[0];
-    my $fh = $request->upload($name);
-    my $fdata = join ('', <$fh>);
+
+    my $upload = $request->{_uploads}->{template_file}
+        or die 'No template file uploaded';
+
+    # Slurp uploaded file
+    open my $fh, '<', $upload->path or die "Error opening uploaded file $!";
+    local $/ = undef;
+    my $fdata = <$fh>;
+
+    # Sanity check that browser-provided local name of uploaded file matches
+    # the template name and extension. Is this appropriate/necessary?
     die 'No content' unless $fdata;
     my $testname = $request->{template_name} . '.' . $request->{format};
     die LedgerSMB::App_State::Locale->text(
                 'Unexpected file name, expected [_1], got [_2]',
-                 $testname, $name)
-          unless $name eq $testname;
+                 $testname, $upload->basename)
+          unless $upload->basename eq $testname;
     $request->{template} = $fdata;
     my $dbtemp = LedgerSMB::Template::DB->new(%$request);
     $dbtemp->save();
+
     return display($request);
 }
 
 =head1 COPYRIGHT
 
-Copyright (C) 2014-2016 The LedgerSMB Core Team.
+Copyright (C) 2014-2018 The LedgerSMB Core Team.
 
 This file may be re-used under the terms of the GNU General Public License
 version 2 or at your option any later version.  Please see the included

--- a/xt/43-ledgersmb-file.t
+++ b/xt/43-ledgersmb-file.t
@@ -1,0 +1,52 @@
+#!/usr/bin/perl
+
+=head1 UNIT TESTS FOR LedgerSMB::File
+
+Partial tests for the LedgerSMB::File module, currently testing
+just the mime type functionality.
+
+=cut
+
+
+use strict;
+use warnings;
+
+use DBI;
+use Test::More;
+use LedgerSMB::File;
+
+
+# Create test run conditions
+my $file;
+my $dbh = DBI->connect(
+    "dbi:Pg:dbname=$ENV{LSMB_NEW_DB}",
+    undef,
+    undef,
+    { AutoCommit => 1, PrintError => 0 }
+) or BAIL_OUT "Can't connect to template database: " . DBI->errstr;
+
+
+plan tests => (8);
+
+
+# Test detection of mime type from file extension
+$file = LedgerSMB::File->new(
+    _dbh => $dbh,
+);
+ok($file, 'LedgerSMB::File object created');
+$file->file_name('index.html');
+is($file->get_mime_type, 'text/html', q{automatically set mime type 'text/html' for filename 'index.html'});
+is($file->mime_type_text, 'text/html', q{correct mime_type_text property after for filename 'index.html'});
+like($file->mime_type_id, qr/^[1-9]\d*$/, q{valid mime_type_id property for filename 'index.html'});
+
+
+# Test setting explicit mime type
+$file = LedgerSMB::File->new(
+    _dbh => $dbh,
+);
+ok($file, 'LedgerSMB::File object created');
+$file->mime_type_text('image/png');
+is($file->get_mime_type, 'image/png', q{returned 'image/png' after explicitly setting mime type});
+is($file->mime_type_text, 'image/png', q{correct mime_type_text property after explicitly setting 'image/png' mime type});
+like($file->mime_type_id, qr/^[1-9]\d*$/, q{valid mime_type_id property after explicitly setting 'image/png' mime type});
+


### PR DESCRIPTION
Backport fixes from 1.6 to master:

* Fix file uploads fail
* Fix template upload broken
* Fix LedgerSMB::File get_mime_type() method
* Fix error running SL migration sql commands
* Remove broken and unused method LedgerSMB::File->set_mime_type()
* Add tests for LedgerSMB::File module