### PR TITLE
* Fix #3642: Taxform report missing action 'generate_report'

### DIFF
--- a/UI/Reports/filters/taxforms.html
+++ b/UI/Reports/filters/taxforms.html
@@ -9,7 +9,7 @@
 ?>
 <body class="lsmb <?lsmb dojo_theme ?>">
 
-<form data-dojo-type="lsmb/Form" method="post" action="<?lsmb request.script ?>">
+<form data-dojo-type="lsmb/Form" method="post" action="taxform.pl">
 <?lsmb PROCESS input element_data = {
     type = "hidden"
     name = "sort"


### PR DESCRIPTION
Note that the template parameter 'request.script' evaluates
to the empty string, which causes the form to be posted
against 'login.pl' instead of against 'taxform.pl'.
