### PR TITLE
* Detect charset of imported CSV; or detect BOM

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -13,6 +13,7 @@ requires 'DateTime';
 requires 'DateTime::Format::Strptime';
 requires 'HTML::Entities';
 requires 'HTML::Escape';
+requires 'HTTP::Headers::Fast'; # dependency of Plack too; don't need '::Fast'
 requires 'HTTP::Status';
 requires 'IO::Scalar';
 requires 'JSON::MaybeXS';


### PR DESCRIPTION
Note that we want to recognise UTF-8 when a valid
file is being imported; 'jonan' on the chat channel
uploaded valid UTF-8 (with BOM, even) but the upload
was completely garbled. This commit fixes that.
