### PR TITLE
Fix e-mail attachment data appended to message body text

### DIFF
--- a/old/bin/io.pl
+++ b/old/bin/io.pl
@@ -1446,6 +1446,7 @@ sub print_form {
         $output_options{message} = $form->{message};
         $output_options{filename} = $form->{formname} . '-'. $form->{"${inv}number"};
         $output_options{filename} .= '.'. $form->{format}; # assuming pdf or html
+        $output_options{attach} = 1 if $form->{sendmode} eq 'attachment';
 
         if ( %$old_form ) {
             $old_form->{intnotes} = qq|$old_form->{intnotes}\n\n|


### PR DESCRIPTION
Fixes bug reported on the mailing list by @freelock.

When e-mailing invoices as attachments, the attachment data was
erroneously appended to the body text, in addition to being sent
as a separate attachment.