### PR TITLE
* Fix #3666: Undefined server error when printing check batch

### DIFF
--- a/lib/LedgerSMB/Scripts/payment.pm
+++ b/lib/LedgerSMB/Scripts/payment.pm
@@ -416,12 +416,12 @@ sub print {
             user => $payment->{_user},
             template => 'check_multiple',
             format => uc $payment->{'format'},
-            output_args => $payment,
+            path => 'DB',
+            output_options => {
+               filename => 'printed-checks',
+            },
         );
-        $template->render($payment);
-        $template->output(%$payment);
-        $request->{action} = 'update_payments';
-        return display_payments(@_);
+        return $template->render($payment);
     } else {
 
     }


### PR DESCRIPTION
The underlying error (file not found - check_base) is caused by the
fact that check_base is located in the database, but due to lack of
the path=>'DB' setting, the database isn't being searched.

Further more, the introduction of the 'filename' output option,
forces the Content-Disposition header to be sent and thereby a
download popup to be shown
