### PR TITLE
* Fix #3676: Regression UTF-8 characters garbled

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -47,6 +47,7 @@ requires 'Plack::Builder::Conditionals';
 requires 'Plack::Middleware::ConditionalGET';
 requires 'Plack::Middleware::ReverseProxy';
 requires 'Plack::Request';
+requires 'Plack::Request::WithEncoding';
 requires 'Plack::Util';
 requires 'Template', '2.14';
 requires 'Template::Parser';

--- a/lib/LedgerSMB/PSGI.pm
+++ b/lib/LedgerSMB/PSGI.pm
@@ -29,7 +29,7 @@ use Scalar::Util qw{ reftype };
 # To build the URL space
 use Plack;
 use Plack::Builder;
-use Plack::Request;
+use Plack::Request::WithEncoding;
 use Plack::App::File;
 use Plack::Middleware::ConditionalGET;
 use Plack::Middleware::ReverseProxy;
@@ -89,7 +89,7 @@ sub psgi_app {
 
     my $auth = LedgerSMB::Auth::factory($env);
 
-    my $psgi_req = Plack::Request->new($env);
+    my $psgi_req = Plack::Request::WithEncoding->new($env);
     my $request = LedgerSMB->new(
         $psgi_req->parameters, $env->{'lsmb.script'}, $env->{QUERY_STRING},
         $psgi_req->uploads, $psgi_req->cookies, $auth, $env->{'lsmb.db'},


### PR DESCRIPTION
Note that all data submitted to the PSGI server is UTF-8 encoded
because the HTML5 standard requires data to be submitted in the
same encoding as the encoding of the form-containing document.

PSGI however, doesn't interpret encoding and simply interprets the
bytes in the input stream. Before, our code would instruct the CGI
parser to interpret input as UTF-8, which due to switching to PSGI
has been removed.

Add back the interpretation of the submitted values as UTF-8.