### PR TITLE
Remove unnecessary methods from LedgerSMB::PGOld

### DIFF
--- a/lib/LedgerSMB/Scripts/payment.pm
+++ b/lib/LedgerSMB/Scripts/payment.pm
@@ -1296,20 +1296,16 @@ sub post_payment {
         }
     }
     # Finally we store all the data inside the LedgerSMB::DBObject::Payment object.
-    $Payment->{cash_account_id}    =
-        $Payment->_db_array_scalars(@cash_account_id);
-    $Payment->{amount}             =  $Payment->_db_array_scalars(@amount);
-    $Payment->{source}             =  $Payment->_db_array_scalars(@source);
-    $Payment->{memo}               =  $Payment->_db_array_scalars(@memo);
-    $Payment->{transaction_id}     =
-        $Payment->_db_array_scalars(@transaction_id);
-    $Payment->{op_amount}          =  $Payment->_db_array_scalars(@op_amount);
-    $Payment->{op_cash_account_id} =
-        $Payment->_db_array_scalars(@op_cash_account_id);
-    $Payment->{op_source}          =  $Payment->_db_array_scalars(@op_source);
-    $Payment->{op_memo}            =  $Payment->_db_array_scalars(@op_memo);
-    $Payment->{op_account_id}      =
-        $Payment->_db_array_scalars(@op_account_id);
+    $Payment->{cash_account_id}    = \@cash_account_id;
+    $Payment->{amount}             = \@amount;
+    $Payment->{source}             = \@source;
+    $Payment->{memo}               = \@memo;
+    $Payment->{transaction_id}     = \@transaction_id;
+    $Payment->{op_amount}          = \@op_amount;
+    $Payment->{op_cash_account_id} = \@op_cash_account_id;
+    $Payment->{op_source}          = \@op_source;
+    $Payment->{op_memo}            = \@op_memo;
+    $Payment->{op_account_id}      = \@op_account_id;
     # Ok, passing the control to postgresql and hoping for the best...
 
     $Payment->post_payment();
@@ -1964,7 +1960,7 @@ sub post_overpayment {
         for my $field (qw(amount cash_account_id source memo transaction_id
                           ovp_payment_id)) {
             $list_key->{$key} =
-                $list_key->_db_array_scalars(@{$list_key->{"array_$field"}});
+                $list_key->{"array_$field"};
         }
 
         $entity_list{$key}->post_payment();

--- a/old/lib/LedgerSMB/DBObject/Account.pm
+++ b/old/lib/LedgerSMB/DBObject/Account.pm
@@ -261,7 +261,7 @@ sub generate_links {
         }
      }
 
-     return $self->{link} = $self->_db_array_scalars(@links);
+     return $self->{link} = \@links;
 }
 
 =item list_headings

--- a/old/lib/LedgerSMB/DBObject/Asset_Report.pm
+++ b/old/lib/LedgerSMB/DBObject/Asset_Report.pm
@@ -97,7 +97,6 @@ sub save {
     if ($self->{depreciation}){
         my ($ref) = $self->call_dbmethod(funcname => 'asset_report__save');
         $self->{report_id} = $ref->{id};
-        $self->{asset_ids} = $self->_db_array_scalars(@{$self->{asset_ids}});
         my ($dep) = $self->call_dbmethod(funcname => 'asset_class__get_dep_method');
         $self->call_dbmethod(funcname => $dep->{sproc});
     } else {

--- a/old/lib/LedgerSMB/DBObject/Payment.pm
+++ b/old/lib/LedgerSMB/DBObject/Payment.pm
@@ -584,9 +584,8 @@ sub get_payment_detail_data {
         $inv->{source} = "";
         $self->{"source_$inv->{contact_id}"} = "";
         }
-    my $tmp_invoices = $inv->{invoices};
-        $inv->{invoices} = [];
-        @{$inv->{invoices}} = $self->_parse_array($tmp_invoices);
+
+        $inv->{invoices} //= [];
         @{$inv->{invoices}} = sort { $a->[2] cmp $b->[2] } @{ $inv->{invoices} };
         for my $invoice (@{$inv->{invoices}}){
             $invoice->[6] = LedgerSMB::PGNumber->new($invoice->[6]);  ## no critic (ProhibitMagicNumbers) sniff

--- a/old/lib/LedgerSMB/PGOld.pm
+++ b/old/lib/LedgerSMB/PGOld.pm
@@ -52,8 +52,11 @@ sub new {
         $args->{dbh} = $args->{_DBH};
         delete $args->{_DBH};
     };
-    my $mergelist = $args->{mergelist} || [keys %{$args->{base}}];
-    my $self = { map { $_ => $args->{base}->{$_} } @$mergelist };
+
+    # key/value pairs from the `base` argument become
+    # properties of the new object.
+    my $self = { map { $_ => $args->{base}->{$_} } keys %{$args->{base}} };
+
     $self =  PGObject::Simple::new($pkg, %$self);
     $self->__validate__  if $self->can('__validate__');
     return $self;

--- a/old/lib/LedgerSMB/PGOld.pm
+++ b/old/lib/LedgerSMB/PGOld.pm
@@ -87,13 +87,6 @@ sub dbh {
     return LedgerSMB::App_State::DBH();
 }
 
-sub _parse_array {
-    my ($self, $value) = @_;
-    return @$value if ref $value eq 'ARRAY';
-    return if !defined $value;
-    # No longer needed since we require DBD::Pg 2.x
-}
-
 =item $self->merge(\%base, %args)
 
 Sets the values from hash 'base' in $self, optionally limited by the

--- a/old/lib/LedgerSMB/PGOld.pm
+++ b/old/lib/LedgerSMB/PGOld.pm
@@ -101,13 +101,6 @@ sub _db_array_scalars {
     # No longer needed since we require DBD::Pg 2.x
 }
 
-sub _db_array_literal {
-    my $self = shift @_;
-    my @args = @_;
-    return \@args;
-    # No longer needed since we require DBD::Pg 2.x
-}
-
 =item $self->merge(\%base, %args)
 
 Sets the values from hash 'base' in $self, optionally limited by the

--- a/old/lib/LedgerSMB/PGOld.pm
+++ b/old/lib/LedgerSMB/PGOld.pm
@@ -94,13 +94,6 @@ sub _parse_array {
     # No longer needed since we require DBD::Pg 2.x
 }
 
-sub _db_array_scalars {
-    my $self = shift @_;
-    my @args = @_;
-    return \@args;
-    # No longer needed since we require DBD::Pg 2.x
-}
-
 =item $self->merge(\%base, %args)
 
 Sets the values from hash 'base' in $self, optionally limited by the

--- a/old/lib/LedgerSMB/PGOld.pm
+++ b/old/lib/LedgerSMB/PGOld.pm
@@ -133,10 +133,6 @@ sub is_allowed_role {
     return $access->{lsmb__is_allowed_role};
 }
 
-sub _get_schema {
-    return 'public';
-}
-
 =back
 
 =cut

--- a/old/lib/LedgerSMB/PGOld.pm
+++ b/old/lib/LedgerSMB/PGOld.pm
@@ -6,10 +6,6 @@ LedgerSMB::PGOld - Old DBObject replacement for 1.3-era LedgerSMB code
 
 This is like DBObject but uses the PGObject::Simple for base functionality.
 
-=head1 METHODS
-
-See PGObject::Simple
-
 =cut
 
 # This is temporary until we can get rid of it.  Basically the following
@@ -29,12 +25,23 @@ use LedgerSMB::App_State;
 
 =head1 METHODS
 
+See PGObject::Simple
+
 =over
 
 =item new(%args)
-=item rew(\%args)
 
 Constructor.
+
+Recognized arguments are:
+
+=over
+
+=item base
+
+A hashref which is imported as properties of the new object.
+
+=back
 
 =cut
 

--- a/old/lib/LedgerSMB/Setting.pm
+++ b/old/lib/LedgerSMB/Setting.pm
@@ -189,7 +189,7 @@ sub increment_process{
 sub get_currencies {
     my $self = shift;
     my @data = $self->call_dbmethod(funcname => 'setting__get_currencies');
-    @{$self->{currencies}} = $self->_parse_array($data[0]->{setting__get_currencies});
+    $self->{currencies} = $data[0]->{setting__get_currencies};
     return @{$self->{currencies}};
 }
 


### PR DESCRIPTION
This PR removes unnecessary methods from LedgerSMB::PGOld. Gradually disposing of old code...

Method _db_array_scalars was still being called, but it's functionality had been reduced to returning an array reference of its arguments - so it is removed completely in this PR.