### PR TITLE
Remove unused have_latex property from LedgerSMB.pm

### DIFF
--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -174,7 +174,6 @@ sub new {
     $self->{version} = $VERSION;
     $self->{dbversion} = $VERSION;
     $self->{VERSION} = $VERSION;
-    $self->{have_latex} = $LedgerSMB::Sysconfig::latex;
     $self->{_uploads} = $uploads  if defined $uploads;
     $self->{_cookies} = $cookies  if defined $cookies;
     $self->{query_string} = $query_string if defined $query_string;


### PR DESCRIPTION
The LedgerSMB.pm module was defining a `have_latex` property, but
this property is not in used. Removed.