### PR TITLE
Round variance for reconciliation - ignore fractional difference

### DIFF
--- a/lib/LedgerSMB/Scripts/recon.pm
+++ b/lib/LedgerSMB/Scripts/recon.pm
@@ -283,7 +283,10 @@ sub _display_report {
                                     + $recon->{outstanding_total}
                                     + $recon->{mismatch_our_total});
     $recon->{out_of_balance} = $recon->{their_total} - $recon->{our_total};
-    $recon->{submit_enabled} = ($recon->{their_total} == $recon->{our_total});
+    $recon->{out_of_balance}->bfround(
+        LedgerSMB::Setting->get('decimal_places') * -1
+    );
+    $recon->{submit_enabled} = ($recon->{out_of_balance} == 0);
 
     # Check if only one entry could explain the difference
     if ( !$recon->{submit_enabled}) {


### PR DESCRIPTION
This reinstates 1.5 behaviour on master.

Variance amount in reconciliation is now rounded to the number of
decimal places specified in settings.

Without this, fractional penny differences between GL and bank
statement balance prevent submission of reconciliation.

Such fractional differences can result from foreign exchange
transactions.