### PR TITLE
* Fix #3686: Failure to change groups of user in HR screen

### DIFF
--- a/UI/Contact/divs/user.html
+++ b/UI/Contact/divs/user.html
@@ -153,7 +153,6 @@
                         value = form_id
                 };
            ?>
-        <input type="hidden" name="entity_id" value="<?lsmb entity_id ?>"/>
 
             <table>
                 <!-- Groups section -->


### PR DESCRIPTION
Note that the error was caused by a duplicate 'entity_id' field
which this commit removes.
