### PR TITLE
Remove unused/undocumented/untested commit arg from LedgerSMB->open_form()

### DIFF
--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -192,15 +192,11 @@ sub new {
 }
 
 sub open_form {
-    my ($self, $args) = @_;
-    my $i = 1;
+    my ($self) = @_;
     my @vars = $self->call_procedure(procname => 'form_open',
                               args => [$self->{_session_id}],
                               continue_on_error => 1
     );
-    if ($args->{commit}){
-       $self->{dbh}->commit;
-    }
     return $self->{form_id} = $vars[0]->{form_open};
 }
 


### PR DESCRIPTION
LedgerSMB->open_form() method accepted a `commit` argument, but this
was neither used, nor documented, nor tested. It has been removed.