### PR TITLE
* Fix #3705: Print button doesn't work more than once

### DIFF
--- a/lib/LedgerSMB/Middleware/AuthenticateSession.pm
+++ b/lib/LedgerSMB/Middleware/AuthenticateSession.pm
@@ -201,7 +201,7 @@ sub call {
             my $res = shift;
 
             # Set the new cookie (with the extended life-time on response
-            Plack::Util::header_set(
+            Plack::Util::header_push(
                 $res->[1], 'Set-Cookie',
                 qq|$cookie_name=$extended_cookie; path=$path$secure|)
                 if $extended_cookie;

--- a/lib/LedgerSMB/Middleware/ClearDownloadCookie.pm
+++ b/lib/LedgerSMB/Middleware/ClearDownloadCookie.pm
@@ -56,7 +56,7 @@ sub call {
             my $res = shift;
 
                 # Set the requested cookie's value
-                Plack::Util::header_set(
+                Plack::Util::header_push(
                     $res->[1], 'Set-Cookie',
                     qq|$cookie=downloaded; path=$path$secure|)
                     if $cookie;


### PR DESCRIPTION
Note that the print button needs a specific cookie
to be reset (=contain the value 'downloaded').
However, due to using 'header_set', the session
setting AuthenticateSession middleware overwrites
the download-cookie-resetting Set-Cookie header.
Switching both to 'header_push' makes setting
cookies an additive action.
