### PR TITLE
Master separate ui template (close #3649)

### DIFF
--- a/UI/Contact/divs/address.html
+++ b/UI/Contact/divs/address.html
@@ -183,7 +183,7 @@
         </div>
         <div>
                 <?lsmb IF !country_id; country_id = default_country; END -?>
-                <?lsmb INCLUDE select element_data = {
+                <?lsmb INCLUDE select_country element_data = {
                         id = "address-country-select"
                         text_attr = "name"
                         value_attr = "id"

--- a/UI/Contact/divs/company.html
+++ b/UI/Contact/divs/company.html
@@ -96,7 +96,7 @@
                 IF !company_country_id;
                           company_country_id = default_country;
                 END;
-                INCLUDE select element_data = {
+                INCLUDE select_country element_data = {
                         id = 'company-country-id'
                         text_attr = "name"
                         value_attr = "id"

--- a/UI/Contact/divs/credit.html
+++ b/UI/Contact/divs/credit.html
@@ -270,7 +270,7 @@ PROCESS dynatable
            IF NOT credit_act.language_code;
                 credit_act.language_code = default_language;
            END;
-           INCLUDE select element_data = {
+           INCLUDE select_language element_data = {
                 title = text("Language")
                 label = text("Language")
                 name = "language_code"

--- a/UI/Contact/divs/employee.html
+++ b/UI/Contact/divs/employee.html
@@ -115,7 +115,7 @@ IF employee.is_manager; checked = "CHECKED"; ELSE; checked = undef; END;
 <div class="input_line" id="person-country-div">
 <div class="input_group solo">
        <?lsmb country_list.unshift({}) ?>
-                <?lsmb INCLUDE select element_data = {
+                <?lsmb INCLUDE select_country element_data = {
                         text_attr = "name"
                         value_attr = "id"
                         default_values = [employee.country_id]

--- a/UI/Contact/divs/person.html
+++ b/UI/Contact/divs/person.html
@@ -132,7 +132,7 @@
                 IF !person_country_id;
                           person_country_id = default_country;
                 END;
-                INCLUDE select element_data = {
+                INCLUDE select_country element_data = {
                         id = 'person-country-id'
                         text_attr = "name"
                         value_attr = "id"

--- a/UI/Reports/filters/balance_sheet.html
+++ b/UI/Reports/filters/balance_sheet.html
@@ -234,7 +234,7 @@
         </div>
         <div class="input_row">
           <?lsmb
-             PROCESS select element_data = {
+             PROCESS select_language element_data = {
              label = text('Language')
              name = 'language'
              options = languages

--- a/UI/Reports/filters/income_statement.html
+++ b/UI/Reports/filters/income_statement.html
@@ -281,7 +281,7 @@
         </div>
         <div class="input_row">
           <?lsmb
-             PROCESS select element_data = {
+             PROCESS select_language element_data = {
              label = text('Language')
              name = 'language'
              options = languages

--- a/UI/Reports/filters/purchase_history.html
+++ b/UI/Reports/filters/purchase_history.html
@@ -98,7 +98,7 @@
               <tr>
                 <th align=right nowrap><?lsmb text('Country') ?></th>
                 <td><?lsmb country_list.unshift({});
-                     INCLUDE select element_data = {
+                     INCLUDE select_country element_data = {
                          name = "country_id",
                          text_attr = 'name',
                          value_attr = 'id',

--- a/UI/lib/elements.html
+++ b/UI/lib/elements.html
@@ -464,3 +464,19 @@ END ?>
     </div>
   <?lsmb END;
 END ?>
+
+<?lsmb BLOCK select_language;
+    IF ! element_data.default_values || element_data.default_values.size == 0 ;
+       element_data.default_values = [ SETTINGS.default_language ] ;
+    END ;
+    INCLUDE select element_data=element_data ;
+  END ;
+   ?>
+
+<?lsmb BLOCK select_country;
+    IF ! element_data.default_values || element_data.default_values.size == 0 ;
+       element_data.default_values = [ SETTINGS.default_country ] ;
+    END ;
+    PROCESS select element_data=element_data ;
+  END ;
+   ?>

--- a/UI/lib/utilities.html
+++ b/UI/lib/utilities.html
@@ -18,7 +18,7 @@ END;
 
 IF languages.defined;
 languages.push({});
-PROCESS select element_data = {
+PROCESS select_language element_data = {
            name = "language"
         options = languages
  default_values = [language]

--- a/UI/orders/order.html
+++ b/UI/orders/order.html
@@ -286,7 +286,7 @@
   <?lsmb
     PROCESS select element_data=form_elements.formname;
     IF selectlanguage.defined;
-        PROCESS select element_data=form_elements.language;
+        PROCESS select_language element_data=form_elements.language;
     END;
     PROCESS select element_data=form_elements.format;
     PROCESS select element_data=form_elements.media ?>

--- a/UI/payroll/deduction.html
+++ b/UI/payroll/deduction.html
@@ -6,7 +6,7 @@
 
 countries.push({});
 
-PROCESS select element_data = {
+PROCESS select_country element_data = {
            default_values = [country_id]
                   options = countries
                      name = 'country_id',

--- a/UI/payroll/income.html
+++ b/UI/payroll/income.html
@@ -7,7 +7,7 @@
 
 countries.push({});
 
-PROCESS select element_data = {
+PROCESS select_country element_data = {
            default_values = [country_id]
                   options = countries
                      name = 'country_id',

--- a/UI/taxform/add_taxform.html
+++ b/UI/taxform/add_taxform.html
@@ -21,7 +21,7 @@
 
     <?lsmb IF countries ?>
         <?lsmb IF !country_id; country_id = default_country; END ?>
-        <?lsmb PROCESS select element_data = {
+        <?lsmb PROCESS select_country element_data = {
                         name = "country_id"
                         default_values = [country_id]
                         options = countries

--- a/UI/users/preferences.html
+++ b/UI/users/preferences.html
@@ -69,7 +69,7 @@ password_strings = 'title:"' _ text("Change Password") _
               <tr>
                 <th align="right"><?lsmb text('Language') ?></th>
                 <td><?lsmb country_codes.unshift({}) ?>
-                    <?lsmb PROCESS select element_data={
+                    <?lsmb PROCESS select_language element_data={
                      name = 'language',
                      options = user.country_codes,
                      default_values = [ user.prefs.language ],

--- a/lib/LedgerSMB/Company_Config.pm
+++ b/lib/LedgerSMB/Company_Config.pm
@@ -39,6 +39,7 @@ use LedgerSMB::App_State;
 my @company_settings = qw(templates businessnumber weightunit curr
                           default_email_from default_email_to
                           default_email_bcc  default_email_cc
+                          default_language default_country
                           separate_duties company_name company_email
                           company_phone company_fax businessnumber
                           company_address dojo_theme decimal_places min_empty);
@@ -52,6 +53,7 @@ sub initialize{
    my ($self) = @_;
    $settings = { map {$_ => LedgerSMB::Setting->get($_) } @company_settings };
    $settings->{curr} = [ split (/:/, $settings->{curr}) ];
+   $settings->{default_currency} = $settings->{curr}->[0];
 
    return $LedgerSMB::App_State::Company_Config = $settings;
 }

--- a/lib/LedgerSMB/Company_Config.pm
+++ b/lib/LedgerSMB/Company_Config.pm
@@ -49,9 +49,8 @@ our $settings = {};
 sub initialize{
    my ($self) = @_;
    $settings= {map {$_ => LedgerSMB::Setting->get($_) } @company_settings};
-   { no strict 'refs';  ## no critic  # sniff
-   @{$settings->{curr}} = split (/:/, $settings->{curr});
-   }
+   $settings->{curr} = [ split (/:/, $settings->{curr}) ];
+
    return $LedgerSMB::App_State::Company_Config = $settings;
 }
 

--- a/lib/LedgerSMB/Company_Config.pm
+++ b/lib/LedgerSMB/Company_Config.pm
@@ -44,11 +44,13 @@ my @company_settings = qw(templates businessnumber weightunit curr
                           company_address dojo_theme decimal_places min_empty);
 
 our $VERSION = 1.0;
+
+# Used in old/bin/*.pl
 our $settings = {};
 
 sub initialize{
    my ($self) = @_;
-   $settings= {map {$_ => LedgerSMB::Setting->get($_) } @company_settings};
+   $settings = { map {$_ => LedgerSMB::Setting->get($_) } @company_settings };
    $settings->{curr} = [ split (/:/, $settings->{curr}) ];
 
    return $LedgerSMB::App_State::Company_Config = $settings;

--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -326,6 +326,7 @@ package LedgerSMB::Template;
 use strict;
 use warnings;
 use Carp;
+
 use LedgerSMB::App_State;
 use LedgerSMB::Locale;
 use LedgerSMB::Setting;
@@ -555,13 +556,12 @@ sub _maketext {
 sub _render {
     my $self = shift;
     my $vars = shift;
-    my $cvars = shift;
+    my $cvars = shift // {};
     $vars->{ENVARS} = \%ENV;
     $vars->{USER} = $self->{user};
     $vars->{DBNAME} = $LedgerSMB::App_State::DBName;
     $vars->{SETTINGS} = {
-        default_currency =>
-            (LedgerSMB::Setting->new(%$self)->get_currencies)[0],
+        %$LedgerSMB::App_State::Company_Config,
     } if $vars->{DBNAME} && LedgerSMB::App_State::DBH;
 
     my $format = "LedgerSMB::Template::$self->{format}";
@@ -574,7 +574,7 @@ sub _render {
           escape => sub { return $escape->(@_); },
           text => sub { return $self->_maketext($escape, @_); },
           tt_url => \&_tt_url,
-          %{$self->{additional_vars}},
+          %{$self->{additional_vars} // {}},
           %$cvars )
     };
 

--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -327,7 +327,6 @@ use strict;
 use warnings;
 use Carp;
 use LedgerSMB::App_State;
-use LedgerSMB::Company_Config;
 use LedgerSMB::Locale;
 use LedgerSMB::Setting;
 use LedgerSMB::Sysconfig;
@@ -563,7 +562,6 @@ sub _render {
     $vars->{SETTINGS} = {
         default_currency =>
             (LedgerSMB::Setting->new(%$self)->get_currencies)[0],
-        decimal_places => $LedgerSMB::Company_Config::decimal_places,
     } if $vars->{DBNAME} && LedgerSMB::App_State::DBH;
 
     my $format = "LedgerSMB::Template::$self->{format}";

--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -568,7 +568,7 @@ sub _render {
     my $escape = $format->can('escape');
     my $unescape = $format->can('unescape');
     my $cleanvars = {
-        ( preprocess($vars, $escape),
+        ( %{preprocess($vars, $escape)},
           UNESCAPE => ($unescape ? sub { return $unescape->(@_); }
                        : sub { return @_; }),
           escape => sub { return $escape->(@_); },

--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -421,7 +421,7 @@ sub new_UI {
         additional_vars => {
             dojo_theme =>
                 ($LedgerSMB::App_State::Company_Config->{dojo_theme}
-                 // $LedgerSMB::Sysconfig::dojo_theme),
+                 || LedgerSMB::Sysconfig::dojo_theme()),
             PRINTERS => [
                ( map { { text => $_, value => $_ } }
                  keys %LedgerSMB::Sysconfig::printers,
@@ -432,7 +432,7 @@ sub new_UI {
                     value => 'screen'
                  } )
             ],
-            LIST_FORMATS => sub { return $self->available_formats; },
+            LIST_FORMATS => sub { return available_formats(); },
         },
     );
 }

--- a/t/04-template-handling.t
+++ b/t/04-template-handling.t
@@ -7,6 +7,7 @@ use Test::More 'no_plan';
 use Test::Exception;
 
 use File::Temp;
+use LedgerSMB;
 use LedgerSMB::Sysconfig;
 use LedgerSMB::Locale;
 use LedgerSMB::Legacy_Util;


### PR DESCRIPTION
Separate setting of UI related variables into `LedgerSMB::Template::new_UI` (from `::render()`);
Additionally, close #3649 by creating two new template helpers `select_language` and `select_country` which help to set default values.