### PR TITLE
Make sure PSGI returns a valid answer

### DIFF
--- a/lib/LedgerSMB/PSGI.pm
+++ b/lib/LedgerSMB/PSGI.pm
@@ -134,16 +134,17 @@ sub psgi_app {
     }
     catch {
         # The database setup middleware will roll back before disconnecting
-        if ($_ !~ /^Died at/) {
+        my $error = $_;
+        if ($error !~ /^Died at/) {
             $env->{'psgix.logger'}->({
                 level => 'error',
-                message => $_ });
+                message => $error });
             $res = LedgerSMB::PSGI::Util::internal_server_error(
-                $_, 'Error!',
+                $error, 'Error!',
                 $request->{dbversion}, $request->{company});
         }
         else {
-            $res = [ '500', [ 'Content-Type' => 'text/plain' ], [ $_ ]];
+            $res = [ '500', [ 'Content-Type' => 'text/plain' ], [ $error ]];
         }
     };
 

--- a/lib/LedgerSMB/PSGI.pm
+++ b/lib/LedgerSMB/PSGI.pm
@@ -134,14 +134,16 @@ sub psgi_app {
     }
     catch {
         # The database setup middleware will roll back before disconnecting
-        my $error = $_;
-        if ($error !~ /^Died at/) {
+        if ($_ !~ /^Died at/) {
             $env->{'psgix.logger'}->({
                 level => 'error',
                 message => $_ });
             $res = LedgerSMB::PSGI::Util::internal_server_error(
                 $_, 'Error!',
                 $request->{dbversion}, $request->{company});
+        }
+        else {
+            $res = [ '500', [ 'Content-Type' => 'text/plain' ], [ $_ ]];
         }
     };
 


### PR DESCRIPTION
PSGI protocol mandates every middleware to return a valid triplet as answer, so we need to return the error.
Failing to do so sends the user in a wild goose chase to find which middleware didn't when the PSGI Linter discovers the invalid, or undefined, triplet.