### PR TITLE
Make sure undefined in warning messages do not trigger useless warnings

### DIFF
--- a/lib/LedgerSMB/PSGI/Util.pm
+++ b/lib/LedgerSMB/PSGI/Util.pm
@@ -47,7 +47,8 @@ sub internal_server_error {
     my @body_lines = ( '<html><body>',
                        q{<h2 class="error">Error!</h2>},
                        "<p><b>$msg</b></p>" );
-    push @body_lines, "<p>dbversion: $dbversion, company: $company</p>"
+    push @body_lines, '<p>dbversion: ' . ($dbversion // 'undef') .
+         ', company: ' . ($company//'undef') . '</p>'
         if $company || $dbversion;
 
     push @body_lines, '</body></html>';

--- a/lib/LedgerSMB/PSGI/Util.pm
+++ b/lib/LedgerSMB/PSGI/Util.pm
@@ -47,8 +47,8 @@ sub internal_server_error {
     my @body_lines = ( '<html><body>',
                        q{<h2 class="error">Error!</h2>},
                        "<p><b>$msg</b></p>" );
-    push @body_lines, '<p>dbversion: ' . ($dbversion // 'undef') .
-         ', company: ' . ($company//'undef') . '</p>'
+    push @body_lines, '<p>dbversion: ' . ($dbversion // '') .
+         ', company: ' . ($company // '') . '</p>'
         if $company || $dbversion;
 
     push @body_lines, '</body></html>';


### PR DESCRIPTION
Remove useless warnings when database version or company is missing.