### PR TITLE
Don't try to open the database if creds are undefined

### DIFF
--- a/lib/LedgerSMB/Middleware/AuthenticateSession.pm
+++ b/lib/LedgerSMB/Middleware/AuthenticateSession.pm
@@ -133,6 +133,8 @@ sub call {
         unless $env->{'lsmb.company'};
 
     my $creds = LedgerSMB::Auth::factory($env)->get_credentials;
+    return LedgerSMB::PSGI::Util::unauthorized()
+        unless $creds->{login} && $creds->{password};
     my $dbh = $env->{'lsmb.db'} =
         LedgerSMB::DBH->connect($env->{'lsmb.company'},
                                 $creds->{login},


### PR DESCRIPTION
We already know the database open is bound to fail later so we might as well say it now.