### PR TITLE
* Fix #3722: Voucher deletion throws error

### DIFF
--- a/lib/LedgerSMB/Scripts/vouchers.pm
+++ b/lib/LedgerSMB/Scripts/vouchers.pm
@@ -291,13 +291,13 @@ sub single_batch_unlock {
     }
 }
 
-=item batch_voucher_delete
+=item batch_vouchers_delete
 
 Deletes selected vouchers.
 
 =cut
 
-sub batch_voucher_delete {
+sub batch_vouchers_delete {
     my ($request) = @_;
     delete $request->{language}; # only applicable for printing of batches
     if ($request->close_form){


### PR DESCRIPTION
Align the UI element (batch_voucher*s*_delete) with the
name of the entrypoint (batch_vourcher_delete).
