### PR TITLE
Enable Perl::Critic RequireExplicitInclusion

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -76,6 +76,7 @@ feature 'edi', "X12 EDI support" =>
 feature 'latex-pdf-ps', "PDF and PostScript output" =>
     sub {
         requires 'LaTeX::Driver', '0.300.2';
+        requires 'Template::Latex', '3.08';
         requires 'Template::Plugin::Latex', '3.08';
         requires 'TeX::Encode';
 };

--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -140,6 +140,7 @@ use HTTP::Status qw( HTTP_OK ) ;
 use JSON::MaybeXS;
 use Log::Log4perl;
 use PGObject;
+use Plack;
 
 use LedgerSMB::Sysconfig;
 use LedgerSMB::App_State;

--- a/lib/LedgerSMB/Database.pm
+++ b/lib/LedgerSMB/Database.pm
@@ -32,14 +32,17 @@ use strict;
 use warnings;
 
 use DateTime;
+use DBD::Pg;
 use DBI;
 use File::Spec;
+use File::Temp;
 use Log::Log4perl;
 use Moose;
 use namespace::autoclean;
 
 extends 'PGObject::Util::DBAdmin';
 
+use LedgerSMB;
 use LedgerSMB::Sysconfig;
 use LedgerSMB::Database::Loadorder;
 

--- a/lib/LedgerSMB/File/Order.pm
+++ b/lib/LedgerSMB/File/Order.pm
@@ -27,7 +27,8 @@ methods only
 
 =cut
 
-use strict;
+use LedgerSMB::File::Transaction;
+
 use Moose;
 use namespace::autoclean;
 extends 'LedgerSMB::File';

--- a/lib/LedgerSMB/Middleware/DynamicLoadWorkflow.pm
+++ b/lib/LedgerSMB/Middleware/DynamicLoadWorkflow.pm
@@ -25,8 +25,9 @@ use strict;
 use warnings;
 use parent qw ( Plack::Middleware );
 
-use Module::Runtime qw/ use_module /;
 use List::Util qw{ none any };
+use Module::Runtime qw/ use_module /;
+use Plack::Request;
 
 use LedgerSMB::PSGI::Util;
 

--- a/lib/LedgerSMB/PGDate.pm
+++ b/lib/LedgerSMB/PGDate.pm
@@ -14,14 +14,19 @@ The type behaves internally as a Datetime module.
 
 =cut
 
-use DateTime::Format::Strptime;
-use LedgerSMB::App_State;
-use LedgerSMB::Magic qw( MONTHS_PER_QUARTER YEARS_PER_CENTURY FUTURE_YEARS_LIMIT );
-use Carp;
-use PGObject;
-use base qw(PGObject::Type::DateTime);
 use strict;
 use warnings;
+use base qw(PGObject::Type::DateTime);
+
+use Carp;
+use DateTime;
+use DateTime::Format::Strptime;
+use PGObject;
+
+use LedgerSMB::App_State;
+use LedgerSMB::Magic
+    qw( MONTHS_PER_QUARTER YEARS_PER_CENTURY FUTURE_YEARS_LIMIT );
+
 
 __PACKAGE__->register(registry => 'default', types => ['date']);
 

--- a/lib/LedgerSMB/PGNumber.pm
+++ b/lib/LedgerSMB/PGNumber.pm
@@ -15,12 +15,16 @@ Math::BigFloat and can be used in this way.
 
 =cut
 
-# try using the GMP library for Math::BigFloat for speed
-use Math::BigFloat try => 'GMP';
-use base qw(PGObject::Type::BigFloat);
 use strict;
 use warnings;
+use base qw(PGObject::Type::BigFloat);
+
+# try using the GMP library for Math::BigFloat for speed
+use Math::BigFloat try => 'GMP';
 use Number::Format;
+use PGObject::Type::BigFloat;
+
+use LedgerSMB::App_State;
 use LedgerSMB::Setting;
 use LedgerSMB::Magic qw( DEFAULT_NUM_PREC );
 
@@ -29,11 +33,11 @@ __PACKAGE__->register(registry => 'default',
 
 our ($accuracy, $precision, $round_mode, $div_scale);
 
-# Globals
-$accuracy = PGObject::Type::BigFloat->accuracy();
-$precision = PGObject::Type::BigFloat->precision();
-$round_mode = PGObject::Type::BigFloat->round_mode();
-$div_scale = PGObject::Type::BigFloat->div_scale();
+# Same initialization as PGObject::Type::BigFloat
+# which works around Math::BigFloat's weird idea of OO
+$accuracy = $precision = undef;
+$round_mode = 'even';
+$div_scale = 40;
 
 =head1 INHERITS
 

--- a/lib/LedgerSMB/PSGI/Util.pm
+++ b/lib/LedgerSMB/PSGI/Util.pm
@@ -143,8 +143,7 @@ sub template_to_psgi {
     }
 
     my $body = $self->{output};
-    utf8::encode($body)
-        if utf8::is_utf8($body);
+    utf8::encode($body) if utf8::is_utf8($body); ## no critic
 
     return [ HTTP_OK, $headers, [ $body ] ];
 }

--- a/lib/LedgerSMB/Report.pm
+++ b/lib/LedgerSMB/Report.pm
@@ -40,13 +40,17 @@ UI/reports/display_report template will be used.
 
 =cut
 
+
+use List::Util qw{ any };
+
+use LedgerSMB::App_State;
+use LedgerSMB::PGNumber;
+use LedgerSMB::Template;
+use LedgerSMB::Setting;
+
 use Moose;
 use namespace::autoclean;
 with 'LedgerSMB::PGObject', 'LedgerSMB::I18N';
-use LedgerSMB::Setting;
-use List::Util qw{ any };
-use LedgerSMB::Template;
-use LedgerSMB::App_State;
 
 =head1 PROPERTIES
 

--- a/lib/LedgerSMB/Report/Assets/Net_Book_Value.pm
+++ b/lib/LedgerSMB/Report/Assets/Net_Book_Value.pm
@@ -62,56 +62,57 @@ none
 =cut
 
 sub columns {
+    my ($self) = @_;
     return
     [
           {type => 'text',
          col_id => 'id',
-           name =>  LedgerSMB::Report::text('ID'), },
+           name =>  $self->Text('ID'), },
 
           {type => 'href',
          col_id => 'tag',
       href_base => 'asset.pl?action=asset_edit&id=',
-           name =>  LedgerSMB::Report::text('Tag'),},
+           name =>  $self->Text('Tag'),},
 
           {type => 'text',
          col_id => 'description',
-           name =>  LedgerSMB::Report::text('Description'), },
+           name =>  $self->Text('Description'), },
 
           {type => 'text',
          col_id => 'begin_depreciation',
-           name =>  LedgerSMB::Report::text('In Svc'), },
+           name =>  $self->Text('In Svc'), },
 
           {type => 'text',
          col_id => 'method',
-           name =>  LedgerSMB::Report::text('Method'),},
+           name =>  $self->Text('Method'),},
 
           {type => 'text',
          col_id => 'remaining_life',
-           name =>  LedgerSMB::Report::text('Rem. Life'),},
+           name =>  $self->Text('Rem. Life'),},
 
           {type => 'text',
          col_id => 'basis',
-           name =>  LedgerSMB::Report::text('Basis'),},
+           name =>  $self->Text('Basis'),},
 
           {type => 'text',
          col_id => 'salvage_value',
-           name =>  LedgerSMB::Report::text('(+) Salvage Value'),},
+           name =>  $self->Text('(+) Salvage Value'),},
 
           {type => 'text',
          col_id => 'through_date',
-           name =>  LedgerSMB::Report::text('Dep. Through'),},
+           name =>  $self->Text('Dep. Through'),},
 
           {type => 'text',
          col_id => 'accum_depreciation',
-           name =>  LedgerSMB::Report::text('(-) Accum. Dep.'),},
+           name =>  $self->Text('(-) Accum. Dep.'),},
 
           {type => 'text',
          col_id => 'net_book_value',
-           name =>  LedgerSMB::Report::text('(=) NBV'),},
+           name =>  $self->Text('(=) NBV'),},
 
           {type => 'text',
          col_id => 'percent_depreciated',
-           name =>  LedgerSMB::Report::text('% Dep.'),},
+           name =>  $self->Text('% Dep.'),},
   ];
 };
 
@@ -133,7 +134,8 @@ Net Book Value
 =cut
 
 sub name {
-    return LedgerSMB::Report::text('Net Book Value');
+    my ($self) = @_;
+    return $self->Text('Net Book Value');
 }
 
 =head1 METHODS

--- a/lib/LedgerSMB/Report/Budget/Search.pm
+++ b/lib/LedgerSMB/Report/Budget/Search.pm
@@ -66,37 +66,38 @@ Who marked the budget obsolete
 =cut
 
 sub columns {
-   return [ {col_id => 'start_date',
+    my ($self) = @_;
+    return [ {col_id => 'start_date',
                type => 'href',
           href_base => 'budget_reports.pl?action=variance_report&id=',
-               name => LedgerSMB::Report::text('Start Date') },
+               name => $self->Text('Start Date') },
 
             {col_id => 'end_date',
                type => 'href',
           href_base => 'budget_reports.pl?action=variance_report&id=',
-               name => LedgerSMB::Report::text('End Date') },
+               name => $self->Text('End Date') },
 
             {col_id => 'reference',
                type => 'href',
           href_base => 'budgets.pl?action=view_budget&id=',
-               name => LedgerSMB::Report::text('Reference') },
+               name => $self->Text('Reference') },
 
             {col_id => 'description',
                type => 'href',
           href_base => 'budgets.pl?action=view_budget&id=',
-               name => LedgerSMB::Report::text('Description') },
+               name => $self->Text('Description') },
 
             {col_id => 'entered_by_name',
                type => 'text',
-               name => LedgerSMB::Report::text('Entered By') },
+               name => $self->Text('Entered By') },
 
             {col_id => 'approved_by_name',
                type => 'text',
-               name => LedgerSMB::Report::text('Approved By') },
+               name => $self->Text('Approved By') },
 
             {col_id => 'obsolete_by_name',
                type => 'text',
-               name => LedgerSMB::Report::text('Obsolete By') },
+               name => $self->Text('Obsolete By') },
    ];
 }
 
@@ -108,7 +109,8 @@ Returns the localized name of the template
 =cut
 
 sub name {
-   return LedgerSMB::Report::text('Budget Search Results');
+    my ($self) = @_;
+    return $self->Text('Budget Search Results');
 }
 
 =item header_lines
@@ -118,16 +120,17 @@ Returns the inputs to display on header.
 =cut
 
 sub header_lines {
+    my ($self) = @_;
     return [{name => 'date_from',
-             text => LedgerSMB::Report::text('Start Date')},
+             text => $self->Text('Start Date')},
             {name => 'date_to',
-             text => LedgerSMB::Report::text('End Date')},
+             text => $self->Text('End Date')},
             {name => 'accno',
-             text => LedgerSMB::Report::text('Account Number')},
+             text => $self->Text('Account Number')},
             {name => 'reference',
-             text => LedgerSMB::Report::text('Reference')},
+             text => $self->Text('Reference')},
             {name => 'source',
-             text => LedgerSMB::Report::text('Source')}];
+             text => $self->Text('Source')}];
 }
 
 =back

--- a/lib/LedgerSMB/Report/Budget/Variance.pm
+++ b/lib/LedgerSMB/Report/Budget/Variance.pm
@@ -65,33 +65,34 @@ Difference between budgetted and used.
 =cut
 
 sub columns {
-   return [
+    my ($self) = @_;
+    return [
       {col_id => 'budget_description',
          type => 'text',
-         name => LedgerSMB::Report::text('Description')},
+         name => $self->Text('Description')},
 
       {col_id => 'accno',
          type => 'text',
-         name => LedgerSMB::Report::text('Account Number')},
+         name => $self->Text('Account Number')},
 
       {col_id => 'account_label',
          type => 'text',
-         name => LedgerSMB::Report::text('Account Label')},
+         name => $self->Text('Account Label')},
 
       {col_id => 'budget_amount',
          type => 'text',
          money => 1,
-         name => LedgerSMB::Report::text('Amount Budgetted')},
+         name => $self->Text('Amount Budgetted')},
 
       {col_id => 'used_amount',
          type => 'text',
          money => 1,
-         name => '- ' . LedgerSMB::Report::text('Used')},
+         name => '- ' . $self->Text('Used')},
 
       {col_id => 'variance',
          type => 'text',
          money => 1,
-         name => '= ' . LedgerSMB::Report::text('Variance')},
+         name => '= ' . $self->Text('Variance')},
    ];
 }
 
@@ -102,7 +103,8 @@ Returns name of report
 =cut
 
 sub name {
-    return LedgerSMB::Report::text('Budget Variance Report');
+    my ($self) = @_;
+    return $self->Text('Budget Variance Report');
 }
 
 =item header_lines
@@ -112,14 +114,15 @@ Returns the inputs to display on header.
 =cut
 
 sub header_lines {
+    my ($self) = @_;
     return [{name => 'reference',
-             text => LedgerSMB::Report::text('Budget Number')},
+             text => $self->Text('Budget Number')},
             {name => 'description',
-             text => LedgerSMB::Report::text('Description')},
+             text => $self->Text('Description')},
             {name => 'start_date',
-             text => LedgerSMB::Report::text('Start Date')},
+             text => $self->Text('Start Date')},
             {name => 'end_date',
-             text => LedgerSMB::Report::text('End Date')},];
+             text => $self->Text('End Date')},];
 }
 
 =back

--- a/lib/LedgerSMB/Report/Contact/History.pm
+++ b/lib/LedgerSMB/Report/Contact/History.pm
@@ -55,11 +55,11 @@ sub columns {
     my $cols = [
          {col_id => 'name',
             type => 'text',
-            name => LedgerSMB::Report::text('Name') },
+            name => $self->Text('Name') },
 
          {col_id => 'meta_number',
             type => 'text',
-            name => LedgerSMB::Report::text('Account Number') }];
+            name => $self->Text('Account Number') }];
 
     if (!$self->is_summary){
 
@@ -67,59 +67,59 @@ sub columns {
          {col_id => 'invnumber',
             type => 'href',
        #href_base => 'is.pl?action=edit&id=',
-            name => LedgerSMB::Report::text('Invoice Number') },
+            name => $self->Text('Invoice Number') },
 
          {col_id => 'curr',
             type => 'text',
-            name => LedgerSMB::Report::text('Currency') };
+            name => $self->Text('Currency') };
     }
 
       push @$cols,
 
          {col_id => 'partnumber',
             type => 'text',
-            name => LedgerSMB::Report::text('Part Number') },
+            name => $self->Text('Part Number') },
 
          {col_id => 'description',
             type => 'text',
-            name => LedgerSMB::Report::text('Description') },
+            name => $self->Text('Description') },
 
          {col_id => 'qty',
             type => 'text',
-            name => LedgerSMB::Report::text('Qty') },
+            name => $self->Text('Qty') },
 
          {col_id => 'unit',
             type => 'text',
-            name => LedgerSMB::Report::text('Unit') };
+            name => $self->Text('Unit') };
 
    push @$cols,
          {col_id => 'sellprice',
             type => 'text',
            money => 1,
-            name => LedgerSMB::Report::text('Sell Price') };
+            name => $self->Text('Sell Price') };
 
    push @$cols,
          {col_id => 'discount',
             type => 'text',
-            name => LedgerSMB::Report::text('Disc') },
+            name => $self->Text('Disc') },
 
          {col_id => 'delivery_date',
             type => 'text',
-            name => LedgerSMB::Report::text('Delivery Date') },
+            name => $self->Text('Delivery Date') },
 
          {col_id => 'serialnumber',
             type => 'text',
-            name => LedgerSMB::Report::text('Serial Number') }
+            name => $self->Text('Serial Number') }
           unless $self->is_summary;
 
     push @$cols,
          {col_id => 'exchangerate',
             type => 'text',
-            name => LedgerSMB::Report::text('Exchange Rate') },
+            name => $self->Text('Exchange Rate') },
 
          {col_id => 'salesperson_name',
             type => 'text',
-            name => LedgerSMB::Report::text('Salesperson') };
+            name => $self->Text('Salesperson') };
 
     return $cols;
 }
@@ -128,24 +128,28 @@ sub columns {
 
 =cut
 
-sub name { return LedgerSMB::Report::text('Purchase History') }
+sub name {
+    my ($self) = @_;
+    return $self->Text('Purchase History');
+}
 
 =item header_lines
 
 =cut
 
 sub header_lines {
+    my ($self) = @_;
      return [
             {name => 'name',
-             text => LedgerSMB::Report::text('Name')},
+             text => $self->Text('Name')},
 
             {name => 'meta_number',
-             text => LedgerSMB::Report::text('Account Number')},
+             text => $self->Text('Account Number')},
             {name => 'from_date',
-             text => LedgerSMB::Report::text('Start Date')},
+             text => $self->Text('Start Date')},
 
             {name => 'to_date',
-             text => LedgerSMB::Report::text('End Date')},
+             text => $self->Text('End Date')},
 
 
       ];

--- a/lib/LedgerSMB/Report/Contact/Purchase.pm
+++ b/lib/LedgerSMB/Report/Contact/Purchase.pm
@@ -49,6 +49,7 @@ Read-only accessor, returns a list of columns.
 =cut
 
 sub columns {
+    my ($self) = @_;
     return [
          {col_id => 'running_number',
             type => 'text',
@@ -56,67 +57,67 @@ sub columns {
 
          {col_id => 'id',
             type => 'text',
-            name => LedgerSMB::Report::text('ID') },
+            name => $self->Text('ID') },
          {col_id => 'entity_name',
             type => 'text',
-            name => LedgerSMB::Report::text('Name') },
+            name => $self->Text('Name') },
 
          {col_id => 'invnumber',
             type => 'href',
        href_base => '',
-            name => LedgerSMB::Report::text('Invoice Number') },
+            name => $self->Text('Invoice Number') },
 
          {col_id => 'ordnumber',
             type => 'text',
-            name => LedgerSMB::Report::text('Order Number') },
+            name => $self->Text('Order Number') },
 
          {col_id => 'ponumber',
             type => 'text',
-            name => LedgerSMB::Report::text('PO Number') },
+            name => $self->Text('PO Number') },
 
          {col_id => 'curr',
             type => 'text',
-            name => LedgerSMB::Report::text('Currency') },
+            name => $self->Text('Currency') },
 
          {col_id => 'amount',
             type => 'text',
            money => 1,
-            name => LedgerSMB::Report::text('Amount') },
+            name => $self->Text('Amount') },
 
          {col_id => 'tax',
             type => 'text',
            money => 1,
-            name => LedgerSMB::Report::text('Tax') },
+            name => $self->Text('Tax') },
 
          {col_id => 'paid',
             type => 'text',
            money => 1,
-            name => LedgerSMB::Report::text('Paid') },
+            name => $self->Text('Paid') },
 
          {col_id => 'due',
             type => 'text',
            money => 1,
-            name => LedgerSMB::Report::text('Due') },
+            name => $self->Text('Due') },
 
          {col_id => 'date_paid',
             type => 'text',
-            name => LedgerSMB::Report::text('Date Paid') },
+            name => $self->Text('Date Paid') },
 
          {col_id => 'due_date',
             type => 'text',
-            name => LedgerSMB::Report::text('Due Date') },
+            name => $self->Text('Due Date') },
 
          {col_id => 'notes',
             type => 'text',
-            name => LedgerSMB::Report::text('Notes') },
+            name => $self->Text('Notes') },
 
          {col_id => 'shipping_point',
             type => 'text',
-            name => LedgerSMB::Report::text('Shipping Point') },
+            name => $self->Text('Shipping Point') },
 
          {col_id => 'ship_via',
             type => 'text',
-            name => LedgerSMB::Report::text('Ship Via') },
+            name => $self->Text('Ship Via') },
     ];
 }
 
@@ -127,9 +128,9 @@ sub columns {
 sub name {
    my ($self) = @_;
    if ($self->entity_class == 1){
-       return LedgerSMB::Report::text('AP Transactions');
+       return $self->Text('AP Transactions');
    } elsif ($self->entity_class == 2){
-       return LedgerSMB::Report::text('AR Transactions');
+       return $self->Text('AR Transactions');
    }
 }
 
@@ -138,11 +139,12 @@ sub name {
 =cut
 
 sub header_lines {
+    my ($self) = @_;
      return [
             {name => 'name_part',
-             text => LedgerSMB::Report::text('Name')},
+             text => $self->Text('Name')},
             {name => 'meta_number',
-             text => LedgerSMB::Report::text('Account Number')}
+             text => $self->Text('Account Number')}
        ];
 }
 

--- a/lib/LedgerSMB/Report/Contact/Search.pm
+++ b/lib/LedgerSMB/Report/Contact/Search.pm
@@ -59,29 +59,29 @@ sub columns {
        {col_id => 'name',
             type => 'href',
        href_base => "contact.pl?action=get$entity_class_param",
-            name => LedgerSMB::Report::text('Name') },
+            name => $self->Text('Name') },
 
        {col_id => 'entity_control_code',
             type => 'href',
        href_base => "contact.pl?action=get$entity_class_param",
-            name => LedgerSMB::Report::text('Control Code') },
+            name => $self->Text('Control Code') },
 
        {col_id => 'meta_number',
             type => 'href',
        href_base => "contact.pl?action=get$entity_class_param",
-            name => LedgerSMB::Report::text('Credit Account Number') },
+            name => $self->Text('Credit Account Number') },
 
        {col_id => 'credit_description',
             type => 'text',
-            name => LedgerSMB::Report::text('Description') },
+            name => $self->Text('Description') },
 
        {col_id => 'business_type',
             type => 'text',
-            name => LedgerSMB::Report::text('Business Type') },
+            name => $self->Text('Business Type') },
 
        {col_id => 'curr',
             type => 'text',
-            name => LedgerSMB::Report::text('Currency') },
+            name => $self->Text('Currency') },
     ];
 }
 
@@ -89,18 +89,22 @@ sub columns {
 
 =cut
 
-sub name { return LedgerSMB::Report::text('Contact Search') }
+sub name {
+    my ($self) = @_;
+    return $self->Text('Contact Search');
+}
 
 =item header_lines
 
 =cut
 
 sub header_lines {
+    my ($self) = @_;
      return [
             {name => 'name_part',
-             text => LedgerSMB::Report::text('Name')},
+             text => $self->Text('Name')},
             {name => 'meta_number',
-             text => LedgerSMB::Report::text('Account Number')}
+             text => $self->Text('Account Number')}
        ];
 }
 

--- a/lib/LedgerSMB/Report/Dates.pm
+++ b/lib/LedgerSMB/Report/Dates.pm
@@ -11,10 +11,13 @@ LedgerSMB::Report::Dates - Date properties for reports in LedgerSMB
 
 =cut
 
-use Moose::Role;
-use namespace::autoclean;
 use LedgerSMB::MooseTypes;
 use LedgerSMB::Magic qw( MONTHS_PER_QUARTER );
+use LedgerSMB::PGDate;
+
+use Moose::Role;
+use namespace::autoclean;
+
 =head1 DESCRIPTION
 
 This handles standard date controls in reports.  It just adds properties to

--- a/lib/LedgerSMB/Report/GL.pm
+++ b/lib/LedgerSMB/Report/GL.pm
@@ -26,14 +26,15 @@ searching for and reporting financial transactions.
 
 =cut
 
+use LedgerSMB::App_State;
+use LedgerSMB::Business_Unit_Class;
+use LedgerSMB::Business_Unit;
+use LedgerSMB::Report;
+
 use Moose;
 use namespace::autoclean;
 extends 'LedgerSMB::Report';
 with 'LedgerSMB::Report::Dates', 'LedgerSMB::Report::Approval_Option';
-
-use LedgerSMB::Business_Unit_Class;
-use LedgerSMB::Business_Unit;
-use LedgerSMB::App_State;
 
 =head1 PROPERTIES
 

--- a/lib/LedgerSMB/Report/Inventory/Activity.pm
+++ b/lib/LedgerSMB/Report/Inventory/Activity.pm
@@ -90,15 +90,15 @@ sub columns {
     return [
      {col_id => 'partnumber',
         type => 'text',
-        name => LedgerSMB::Report::text('Partnumber'), },
+        name => $self->Text('Partnumber'), },
 
      {col_id => 'description',
         type => 'text',
-        name => LedgerSMB::Report::text('Description'), },
+        name => $self->Text('Description'), },
 
      {col_id => 'sold',
         type => 'href',
-        name => LedgerSMB::Report::text('Sold'),
+        name => $self->Text('Sold'),
    href_base => "invoice.pl?&from_date=$from_date&to_date=$to_date"
                 . '&open=1&closed=1&action=invoice_search&'
                 . 'col_invnumber=1&col_transdate=1&col_entity_name=1&'
@@ -108,11 +108,11 @@ sub columns {
      {col_id => 'revenue',
         type => 'text',
        money => 1,
-        name => LedgerSMB::Report::text('Revenue'), },
+        name => $self->Text('Revenue'), },
 
      {col_id => 'purchased',
         type => 'href',
-        name => LedgerSMB::Report::text('Purchased'),
+        name => $self->Text('Purchased'),
    href_base => "invoice.pl?&date_from=$self->date_from&date_to=$self->date_to"
                 . '&open=1&closed=1&action=invoice_search&'
                 . 'col_invnumber=1&col_transdate=1&col_entity_name=1&'
@@ -122,22 +122,22 @@ sub columns {
      {col_id => 'cost',
         type => 'text',
        money => 1,
-        name => LedgerSMB::Report::text('Cost'), },
+        name => $self->Text('Cost'), },
 
      {col_id => 'used',
         type => 'text',
        money => 1,
-        name => LedgerSMB::Report::text('Used'), },
+        name => $self->Text('Used'), },
 
      {col_id => 'assembled',
         type => 'text',
        money => 1,
-      name => LedgerSMB::Report::text('Assembled'), },
+      name => $self->Text('Assembled'), },
 
      {col_id => 'adjusted',
         type => 'text',
        money => 1,
-      name => LedgerSMB::Report::text('Adjusted'), }
+      name => $self->Text('Adjusted'), }
     ];
 }
 
@@ -158,11 +158,12 @@ sub columns {
 =cut
 
 sub header_lines {
+    my ($self) = @_;
     return [
-      { name => 'partnumber',  text => LedgerSMB::Report::text('Partnumber') },
-      { name => 'description', text => LedgerSMB::Report::text('Description') },
-      { name => 'date_from',   text => LedgerSMB::Report::text('From Date') },
-      { name => 'date_to',     text => LedgerSMB::Report::text('To Date') },
+      { name => 'partnumber',  text => $self->Text('Partnumber') },
+      { name => 'description', text => $self->Text('Description') },
+      { name => 'date_from',   text => $self->Text('From Date') },
+      { name => 'date_to',     text => $self->Text('To Date') },
     ];
 }
 
@@ -174,7 +175,8 @@ Inventory Activity Report
 =cut
 
 sub name {
-    return LedgerSMB::Report::text('Inventory Activity Report');
+    my ($self) = @_;
+    return $self->Text('Inventory Activity Report');
 }
 
 =head1 METHODS

--- a/lib/LedgerSMB/Report/Inventory/Adj_Details.pm
+++ b/lib/LedgerSMB/Report/Inventory/Adj_Details.pm
@@ -63,14 +63,18 @@ has source => (is => 'rw', isa => 'Maybe[Str]');
 
 =cut
 
-sub name { return LedgerSMB::Report::text('Inventory Adjustment Details') }
+sub name {
+    my ($self) = @_;
+    return $self->Text('Inventory Adjustment Details');
+}
 
 =item header_lines
 
 =cut
 
 sub header_lines {
-    return [{name => 'source', text => LedgerSMB::Report::text('Source') }];
+    my ($self) = @_;
+    return [{name => 'source', text => $self->Text('Source') }];
 }
 
 =item columns
@@ -78,23 +82,24 @@ sub header_lines {
 =cut
 
 sub columns {
+    my ($self) = @_;
     return [
       {col_id => 'partnumber',
          type => 'href',
     href_base => 'ic.pl?action=edit&id=',
-         name => LedgerSMB::Report::text('Part Number') },
+         name => $self->Text('Part Number') },
       {col_id => 'description',
          type => 'text',
-         name => LedgerSMB::Report::text('Description') },
+         name => $self->Text('Description') },
       {col_id => 'counted',
          type => 'text',
-         name => LedgerSMB::Report::text('Counted') },
+         name => $self->Text('Counted') },
       {col_id => 'expected',
          type => 'text',
-         name => LedgerSMB::Report::text('Expected') },
+         name => $self->Text('Expected') },
       {col_id => 'variance',
          type => 'text',
-         name => LedgerSMB::Report::text('Variance') },
+         name => $self->Text('Variance') },
     ];
 }
 
@@ -107,17 +112,18 @@ This sets buttons relevant to approving the adjustments.
 =cut
 
 sub set_buttons {
+    my ($self) = @_;
     return [{
        name => 'action',
        type => 'submit',
       value => 'approve',
-       text => LedgerSMB::Report::text('Approve'),
+       text => $self->Text('Approve'),
       class => 'submit',
     },{
        name => 'action',
        type => 'submit',
       value => 'delete',
-       text => LedgerSMB::Report::text('Delete'),
+       text => $self->Text('Delete'),
       class => 'submit',
     }];
 }

--- a/lib/LedgerSMB/Report/Inventory/History.pm
+++ b/lib/LedgerSMB/Report/Inventory/History.pm
@@ -108,62 +108,63 @@ has inc_rfq => (is => 'ro', isa => 'Bool', required => 0);
 =cut
 
 sub columns {
+    my ($self) = @_;
    return [
     {col_id => 'id',
        type => 'href',
   href_base => 'ic.pl?action=edit&id=',
-       name => LedgerSMB::Report::text('ID'),},
+       name => $self->Text('ID'),},
 
     {col_id => 'partnumber',
        type => 'href',
   href_base => 'ic.pl?action=edit&id=',
-       name => LedgerSMB::Report::text('Part Number'),},
+       name => $self->Text('Part Number'),},
 
     {col_id => 'description',
        type => 'text',
-       name => LedgerSMB::Report::text('Description'),},
+       name => $self->Text('Description'),},
 
     {col_id => 'onhand',
        type => 'text',
-       name => LedgerSMB::Report::text('On Hand'),},
+       name => $self->Text('On Hand'),},
 
     {col_id => 'unit',
        type => 'text',
-       name => LedgerSMB::Report::text('Unit'),},
+       name => $self->Text('Unit'),},
 
     {col_id => 'bin',
        type => 'text',
-       name => LedgerSMB::Report::text('Bin'),},
+       name => $self->Text('Bin'),},
 
     {col_id => 'ordnumber',
        type => 'href',
-       name => LedgerSMB::Report::text('Order/Invoice'),},
+       name => $self->Text('Order/Invoice'),},
 
     {col_id => 'transdate',
        type => 'href',
-       name => LedgerSMB::Report::text('Date'),},
+       name => $self->Text('Date'),},
 
     {col_id => 'oe_class',
        type => 'href',
-       name => LedgerSMB::Report::text('Type'),},
+       name => $self->Text('Type'),},
 
     {col_id => 'sellprice',
        type => 'text',
       money => 1,
-       name => LedgerSMB::Report::text('Sell Price'),},
+       name => $self->Text('Sell Price'),},
 
     {col_id => 'qty',
        type => 'text',
-       name => LedgerSMB::Report::text('Qty'),},
+       name => $self->Text('Qty'),},
 
     {col_id => 'linetotal',
        type => 'text',
       money => 1,
-       name => LedgerSMB::Report::text('Total'),},
+       name => $self->Text('Total'),},
 
     {col_id => 'serialnumber',
        type => 'text',
-       name => LedgerSMB::Report::text('Serial Number'),},
+       name => $self->Text('Serial Number'),},
 
     ];
 }
@@ -185,7 +186,8 @@ Goods and Services
 =cut
 
 sub name {
-    return LedgerSMB::Report::text('Goods and Services History');
+    my ($self) = @_;
+    return $self->Text('Goods and Services History');
 }
 
 =head1 METHODS

--- a/lib/LedgerSMB/Report/Inventory/Partsgroups.pm
+++ b/lib/LedgerSMB/Report/Inventory/Partsgroups.pm
@@ -48,10 +48,11 @@ has partsgroup => (is => 'ro', isa => 'Str', required => '0');
 =cut
 
 sub columns {
+    my ($self) = @_;
     return [{col_id => 'partsgroup',
                type => 'href',
           href_base => 'pe.pl?action=edit&type=partsgroup&id=',
-               name => LedgerSMB::Report::text('Group') }];
+               name => $self->Text('Group') }];
 }
 
 =head2 header_lines
@@ -65,8 +66,9 @@ sub columns {
 =cut
 
 sub header_lines {
+    my ($self) = @_;
     return [{name => 'partsgroup',
-             text => LedgerSMB::Report::text('Partsgroup') }];
+             text => $self->Text('Partsgroup') }];
 }
 
 =head2 name
@@ -76,7 +78,8 @@ Partsgroups
 =cut
 
 sub name {
-    return LedgerSMB::Report::text('Partsgroups');
+    my ($self) = @_;
+    return $self->Text('Partsgroups');
 }
 
 =head1 METHODS

--- a/lib/LedgerSMB/Report/Inventory/Pricegroups.pm
+++ b/lib/LedgerSMB/Report/Inventory/Pricegroups.pm
@@ -48,10 +48,11 @@ has pricegroup => (is => 'ro', isa => 'Str', required => '0');
 =cut
 
 sub columns {
+    my ($self) = @_;
     return [{col_id => 'pricegroup',
                type => 'href',
           href_base => 'pe.pl?action=edit&type=pricegroup&id=',
-               name => LedgerSMB::Report::text('Price Group') }];
+               name => $self->Text('Price Group') }];
 }
 
 =head2 header_lines
@@ -65,8 +66,9 @@ sub columns {
 =cut
 
 sub header_lines {
+    my ($self) = @_;
     return [{name => 'partsgroup',
-             text => LedgerSMB::Report::text('Price Group') }];
+             text => $self->Text('Price Group') }];
 }
 
 =head2 name
@@ -76,7 +78,8 @@ Price Groups
 =cut
 
 sub name {
-    return LedgerSMB::Report::text('Price Groups');
+    my ($self) = @_;
+    return $self->Text('Price Groups');
 }
 
 =head1 METHODS

--- a/lib/LedgerSMB/Report/Inventory/Search.pm
+++ b/lib/LedgerSMB/Report/Inventory/Search.pm
@@ -184,125 +184,126 @@ has rfqs => (is => 'ro', isa => 'Bool', required => 0);
 =cut
 
 sub columns {
+    my ($self) = @_;
    return [
     {col_id => 'id',
        type => 'href',
   href_base => 'ic.pl?action=edit&id=',
-       name => LedgerSMB::Report::text('ID'),},
+       name => $self->Text('ID'),},
 
     {col_id => 'partnumber',
        type => 'href',
   href_base => 'ic.pl?action=edit&id=',
-       name => LedgerSMB::Report::text('Part Number'),},
+       name => $self->Text('Part Number'),},
 
     {col_id => 'description',
        type => 'text',
-       name => LedgerSMB::Report::text('Description'),},
+       name => $self->Text('Description'),},
 
     {col_id => 'onhand',
        type => 'text',
-       name => LedgerSMB::Report::text('On Hand'),},
+       name => $self->Text('On Hand'),},
 
     {col_id => 'unit',
        type => 'text',
-       name => LedgerSMB::Report::text('Unit'),},
+       name => $self->Text('Unit'),},
 
     {col_id => 'rop',
        type => 'text',
-       name => LedgerSMB::Report::text('ROP'),},
+       name => $self->Text('ROP'),},
 
     {col_id => 'bin',
        type => 'text',
-       name => LedgerSMB::Report::text('Bin'),},
+       name => $self->Text('Bin'),},
 
     {col_id => 'weight',
        type => 'text',
-       name => LedgerSMB::Report::text('Weight'),},
+       name => $self->Text('Weight'),},
 
     {col_id => 'listprice',
        type => 'text',
       money => 1,
-       name => LedgerSMB::Report::text('List Price'),},
+       name => $self->Text('List Price'),},
 
     {col_id => 'sellprice',
        type => 'text',
       money => 1,
-       name => LedgerSMB::Report::text('Sell Price'),},
+       name => $self->Text('Sell Price'),},
 
     {col_id => 'lastcost',
        type => 'text',
       money => 1,
-       name => LedgerSMB::Report::text('Last Cost'),},
+       name => $self->Text('Last Cost'),},
 
     {col_id => 'avgcost',
        type => 'text',
       money => 1,
-       name => LedgerSMB::Report::text('Avg. Cost'),},
+       name => $self->Text('Avg. Cost'),},
 
     {col_id => 'markup',
        type => 'text',
-       name => LedgerSMB::Report::text('Markup'),},
+       name => $self->Text('Markup'),},
 
     {col_id => 'priceupdate',
        type => 'text',
-       name => LedgerSMB::Report::text('Price Updated'),},
+       name => $self->Text('Price Updated'),},
 
     {col_id => 'make',
        type => 'text',
-       name => LedgerSMB::Report::text('Make'),},
+       name => $self->Text('Make'),},
 
     {col_id => 'model',
        type => 'text',
-       name => LedgerSMB::Report::text('Model'),},
+       name => $self->Text('Model'),},
 
     {col_id => 'image',
        type => 'href',
-       name => LedgerSMB::Report::text('Image'),},
+       name => $self->Text('Image'),},
 
     {col_id => 'drawing',
        type => 'href',
-       name => LedgerSMB::Report::text('Drawing'),},
+       name => $self->Text('Drawing'),},
 
     {col_id => 'microfiche',
        type => 'text',
-       name => LedgerSMB::Report::text('Microfiche'),},
+       name => $self->Text('Microfiche'),},
 
     {col_id => 'notes',
        type => 'text',
-       name => LedgerSMB::Report::text('Notes'),},
+       name => $self->Text('Notes'),},
 
     {col_id => 'partsgroup',
        type => 'text',
-       name => LedgerSMB::Report::text('Partsgroup'),},
+       name => $self->Text('Partsgroup'),},
 
     {col_id => 'invnumber',
        type => 'href',
-       name => LedgerSMB::Report::text('Invoice'),},
+       name => $self->Text('Invoice'),},
 
     {col_id => 'ordnumber',
        type => 'href',
-       name => LedgerSMB::Report::text('Order'),},
+       name => $self->Text('Order'),},
 
     {col_id => 'quonumber',
        type => 'href',
-       name => LedgerSMB::Report::text('Quotation'),},
+       name => $self->Text('Quotation'),},
 
     {col_id => 'curr',
        type => 'text',
-       name => LedgerSMB::Report::text('Currency'),},
+       name => $self->Text('Currency'),},
 
     {col_id => 'qty',
        type => 'text',
-       name => LedgerSMB::Report::text('Qty'),},
+       name => $self->Text('Qty'),},
 
     {col_id => 'linetotal',
        type => 'text',
       money => 1,
-       name => LedgerSMB::Report::text('Total'),},
+       name => $self->Text('Total'),},
 
     {col_id => 'serialnumber',
        type => 'text',
-       name => LedgerSMB::Report::text('Serial Number'),},
+       name => $self->Text('Serial Number'),},
 
     ];
 }
@@ -324,7 +325,8 @@ Goods and Services
 =cut
 
 sub name {
-    return LedgerSMB::Report::text('Goods and Services');
+    my ($self) = @_;
+    return $self->Text('Goods and Services');
 }
 
 =head1 METHODS

--- a/lib/LedgerSMB/Report/Inventory/Search_Adj.pm
+++ b/lib/LedgerSMB/Report/Inventory/Search_Adj.pm
@@ -68,21 +68,25 @@ has source => (is => 'ro', isa => 'Maybe[Str]');
 
 =cut
 
-sub name { return LedgerSMB::Report::text('Inventory Adjustments') };
+sub name {
+    my ($self) = @_;
+    return $self->Text('Inventory Adjustments');
+};
 
 =item header_lines
 
 =cut
 
 sub header_lines {
+    my ($self) = @_;
     return [{name => 'from_date',
-             text => LedgerSMB::Report::text('Start Date') },
+             text => $self->Text('Start Date') },
             {name => 'to_date',
-             text => LedgerSMB::Report::text('End Date') },
+             text => $self->Text('End Date') },
             {name => 'partnumber',
-             text => LedgerSMB::Report::text('Including partnumber') },
+             text => $self->Text('Including partnumber') },
             {name => 'source',
-             text => LedgerSMB::Report::text('Source starting with') },
+             text => $self->Text('Source starting with') },
            ];
 }
 
@@ -91,21 +95,22 @@ sub header_lines {
 =cut
 
 sub columns {
+    my ($self) = @_;
     return [{col_id => 'transdate',
                type => 'href',
           href_base => 'inv_reports.pl?action=adj_detail&id=',
-               name => LedgerSMB::Report::text('Date')},
+               name => $self->Text('Date')},
             {col_id => 'source',
                type => 'href',
           href_base => 'inv_reports.pl?action=adj_detail&id=',
-               name => LedgerSMB::Report::text('Reference')},
+               name => $self->Text('Reference')},
             {col_id => 'ar_invnumber',
                type => 'href',
-               name => LedgerSMB::Report::text('AR Invoice'),
+               name => $self->Text('AR Invoice'),
           href_base => 'is.pl?action=edit&id='},
             {col_id => 'ap_invnumber',
                type => 'href',
-               name => LedgerSMB::Report::text('AP Invoice'),
+               name => $self->Text('AP Invoice'),
           href_base => 'ir.pl?action=edit&id='},
       ];
 }

--- a/lib/LedgerSMB/Report/Invoices/COGS.pm
+++ b/lib/LedgerSMB/Report/Invoices/COGS.pm
@@ -82,53 +82,54 @@ This report supports the following columns:
 =cut
 
 sub columns {
+    my ($self) = @_;
     return [
       { col_id => 'invnumber',
           type => 'href',
         pwidth => 1,
-          name => LedgerSMB::Report::text('Invoice Number'),
+          name => $self->Text('Invoice Number'),
      href_base => 'ir.pl?action=edit&id=', },
 
       { col_id => 'transdate',
           type => 'text',
         pwidth => 1,
-          name => LedgerSMB::Report::text('Invoice Date'), },
+          name => $self->Text('Invoice Date'), },
 
       { col_id => 'partnumber',
           type => 'href',
         pwidth => 1,
-          name => LedgerSMB::Report::text('Part Number'),
+          name => $self->Text('Part Number'),
      href_base => 'ic.pl?action=edit&id=', },
 
       { col_id => 'description',
           type => 'text',
         pwidth => 3,
-          name => LedgerSMB::Report::text('Part'), },
+          name => $self->Text('Part'), },
 
       { col_id => 'onhand',
           type => 'text',
         pwidth => 1,
-          name => LedgerSMB::Report::text('On Hand'), },
+          name => $self->Text('On Hand'), },
 
       { col_id => 'qty',
           type => 'text',
         pwidth => 1,
-          name => LedgerSMB::Report::text('Quantity'), },
+          name => $self->Text('Quantity'), },
 
       { col_id => 'total_value',
           type => 'text',
         pwidth => 1,
-          name => LedgerSMB::Report::text('Total'), },
+          name => $self->Text('Total'), },
 
       { col_id => 'allocated',
           type => 'text',
         pwidth => 1,
-          name => LedgerSMB::Report::text('Allocated'), },
+          name => $self->Text('Allocated'), },
 
       { col_id => 'cogs_sold',
           type => 'text',
         pwidth => 1,
-          name => LedgerSMB::Report::text('COGS'), },
+          name => $self->Text('COGS'), },
 
     ];
 }
@@ -151,15 +152,16 @@ sub columns {
 =cut
 
 sub header_lines {
+    my ($self) = @_;
     return [
        { name => 'from_date',
-         text => LedgerSMB::Report::text('Start Date'), },
+         text => $self->Text('Start Date'), },
        { name => 'to_date',
-         text => LedgerSMB::Report::text('End Date'), },
+         text => $self->Text('End Date'), },
        { name => 'partnumber',
-         text => LedgerSMB::Report::text('Part Number'), },
+         text => $self->Text('Part Number'), },
        { name => 'description',
-         text => LedgerSMB::Report::text('Part Description'), },
+         text => $self->Text('Part Description'), },
     ];
 }
 
@@ -169,7 +171,10 @@ Line Item COGS Report
 
 =cut
 
-sub name { return LedgerSMB::Report::text('Line Item COGS Report'); }
+sub name {
+    my ($self) = @_;
+    return $self->Text('Line Item COGS Report');
+}
 
 =head1 METHODS
 

--- a/lib/LedgerSMB/Report/Invoices/Outstanding.pm
+++ b/lib/LedgerSMB/Report/Invoices/Outstanding.pm
@@ -162,22 +162,22 @@ has on_hold => (is => 'ro', isa => 'Bool', required => 0);
 
 sub columns {
     my ($self, $request) = @_;
-    my $inv_label = LedgerSMB::Report::text('# Invoices');
+    my $inv_label = $self->Text('# Invoices');
     my $details_url = $request->get_relative_url;
     $details_url =~ s/is_detailed=0/is_detailed=1/;
     $details_url =~ s/meta_number=[^&]*//;
     my $inv_type = 'href';
     my $inv_href_base = $details_url . '&meta_number=';
     if ($self->is_detailed){
-        $inv_label = LedgerSMB::Report::text('Invoice');
+        $inv_label = $self->Text('Invoice');
         $inv_type = 'href';
         $inv_href_base = '';
     }
     my $entity_label;
     if ($self->entity_class == 1){
-       $entity_label = LedgerSMB::Report::text('Vendor');
+       $entity_label = $self->Text('Vendor');
     } elsif ($self->entity_class == 2){
-       $entity_label = LedgerSMB::Report::text('Customer');
+       $entity_label = $self->Text('Customer');
     } else {
        die 'invalid entity class';
     }
@@ -187,11 +187,11 @@ sub columns {
            type => 'text',
          pwidth => 1, },
         {col_id => 'transdate',
-           name => LedgerSMB::Report::text('Date'),
+           name => $self->Text('Date'),
            type => 'text',
          pwidth => 4, },
         {col_id => 'id',
-           name => LedgerSMB::Report::text('ID'),
+           name => $self->Text('ID'),
            type => 'text',
          pwidth => 2, },
         {col_id => 'invnumber',
@@ -200,15 +200,15 @@ sub columns {
       href_base => $inv_href_base,
          pwidth => 10, },
         {col_id => 'ordnumber',
-           name => LedgerSMB::Report::text('Order'),
+           name => $self->Text('Order'),
            type => 'text',
          pwidth => 10, },
         {col_id => 'ponumber',
-           name => LedgerSMB::Report::text('PO Number'),
+           name => $self->Text('PO Number'),
            type => 'text',
          pwidth => 10, },
         {col_id => 'meta_number',
-           name => LedgerSMB::Report::text('Account'),
+           name => $self->Text('Account'),
            type => 'text',
          pwidth => 10, },
         {col_id => 'entity_name',
@@ -217,64 +217,64 @@ sub columns {
       href_base => 'contact.pl?action=edit&',
          pwidth => 15, },
         {col_id => 'netamount',
-           name => LedgerSMB::Report::text('Amount'),
+           name => $self->Text('Amount'),
            type => 'text',
           money => 1,
          pwidth => 8, },
         {col_id => 'tax',
-           name => LedgerSMB::Report::text('Tax'),
+           name => $self->Text('Tax'),
            type => 'text',
           money => 1,
          pwidth => 8, },
         {col_id => 'amount',
-           name => LedgerSMB::Report::text('Total'),
+           name => $self->Text('Total'),
            type => 'text',
           money => 1,
          pwidth => 8, },
         {col_id => 'paid',
-           name => LedgerSMB::Report::text('Paid'),
+           name => $self->Text('Paid'),
            type => 'text',
           money => 1,
          pwidth => 8, },
         {col_id => 'due',
-           name => LedgerSMB::Report::text('Amount Due'),
+           name => $self->Text('Amount Due'),
            type => 'text',
           money => 1,
          pwidth => 8, },
         {col_id => 'curr',
-           name => LedgerSMB::Report::text('Curr'),
+           name => $self->Text('Curr'),
            type => 'text',
          pwidth => 8, },
         {col_id => 'last_paydate',
-           name => LedgerSMB::Report::text('Date Paid'),
+           name => $self->Text('Date Paid'),
            type => 'text',
          pwidth => 8, },
         {col_id => 'duedate',
-           name => LedgerSMB::Report::text('Due Date'),
+           name => $self->Text('Due Date'),
            type => 'text',
          pwidth => 8, },
         {col_id => 'notes',
-           name => LedgerSMB::Report::text('Notes'),
+           name => $self->Text('Notes'),
            type => 'text',
          pwidth => 15, },
         {col_id => 'till',
-           name => LedgerSMB::Report::text('Till'),
+           name => $self->Text('Till'),
            type => 'text',
          pwidth => 8, },
         {col_id => 'employee_name',
-           name => LedgerSMB::Report::text('Salesperson'),
+           name => $self->Text('Salesperson'),
            type => 'text',
          pwidth => 10, },
         {col_id => 'manager_name',
-           name => LedgerSMB::Report::text('Manager'),
+           name => $self->Text('Manager'),
            type => 'text',
          pwidth => 10, },
         {col_id => 'shipping_point',
-           name => LedgerSMB::Report::text('Shipping Point'),
+           name => $self->Text('Shipping Point'),
            type => 'text',
          pwidth => 10, },
         {col_id => 'ship_via',
-           name => LedgerSMB::Report::text('Ship Via'),
+           name => $self->Text('Ship Via'),
            type => 'text',
          pwidth => 10, },
     ];
@@ -299,9 +299,9 @@ Returns either the localized strings for "AR Outstanding" or "AP Outstanding"
 sub name {
     my $self = shift;
     if ($self->entity_class == 1) {
-        return LedgerSMB::Report::text('AP Outstanding');
+        return $self->Text('AP Outstanding');
     } elsif ($self->entity_class == 2) {
-        return LedgerSMB::Report::text('AR Outstanding');
+        return $self->Text('AR Outstanding');
     }
 }
 

--- a/lib/LedgerSMB/Report/Invoices/Payments.pm
+++ b/lib/LedgerSMB/Report/Invoices/Payments.pm
@@ -112,15 +112,15 @@ sub columns {
     my ($self) = @_;
     my $meta_number;
     if ($self->entity_class == 1){
-       $meta_number = LedgerSMB::Report::text('Vendor Number');
+       $meta_number = $self->Text('Vendor Number');
     } elsif ($self->entity_class == 2){
-       $meta_number = LedgerSMB::Report::text('Customer Number');
+       $meta_number = $self->Text('Customer Number');
     } else {
         die 'Invalid entity class';
     }
     my $cols =  [
         {col_id => 'select',
-           name => LedgerSMB::Report::text('Selected'),
+           name => $self->Text('Selected'),
            type => 'checkbox'},
         {col_id => 'credit_id',
            type => 'hidden', },
@@ -134,25 +134,25 @@ sub columns {
            type => 'hidden', },
         {col_id => 'date_paid',
            type => 'text',
-           name => LedgerSMB::Report::text('Date Paid'), },
+           name => $self->Text('Date Paid'), },
         {col_id => 'amount',
            type => 'text',
-           name => LedgerSMB::Report::text('Total Paid'), },
+           name => $self->Text('Total Paid'), },
         {col_id => 'source',
            type => 'text',
-           name => LedgerSMB::Report::text('Source'), },
+           name => $self->Text('Source'), },
         {col_id => 'meta_number',
            name => $meta_number,
            type => 'text', },
         {col_id => 'company_paid',
            type => 'text',
-           name => LedgerSMB::Report::text('Company Name'), },
+           name => $self->Text('Company Name'), },
         {col_id => 'batch_description',
            type => 'text',
-           name => LedgerSMB::Report::text('Batch Description'), },
+           name => $self->Text('Batch Description'), },
         {col_id => 'batch_control',
            type => 'text',
-           name => LedgerSMB::Report::text('Batch'), },
+           name => $self->Text('Batch'), },
     ];
     shift @$cols unless $self->batch_id;
     return $cols;
@@ -182,19 +182,19 @@ sub header_lines {
     my ($self) = @_;
     my $meta_number;
     if ($self->entity_class == 1){
-       $meta_number = LedgerSMB::Report::text('Vendor Number');
+       $meta_number = $self->Text('Vendor Number');
     } elsif ($self->entity_class == 2){
-       $meta_number = LedgerSMB::Report::text('Customer Number');
+       $meta_number = $self->Text('Customer Number');
     } else {
         die 'Invalid entity class';
     }
     return [{name => 'meta_number', text => $meta_number },
             {name => 'cash_accno',
-             text => LedgerSMB::Report::text('Account Number') },
+             text => $self->Text('Account Number') },
             {name => 'from_date',
-             text => LedgerSMB::Report::text('From Date')},
+             text => $self->Text('From Date')},
             {name => 'to_date',
-             text => LedgerSMB::Report::text('To Date')}
+             text => $self->Text('To Date')}
            ];
 }
 
@@ -206,8 +206,8 @@ Either "Payment Results" or "Receipt Results" depending on entity_class
 
 sub name {
     my ($self) = @_;
-    return LedgerSMB::Report::text('Payment Results') if 1 == $self->entity_class;
-    return LedgerSMB::Report::text('Receipt Results') if 2 == $self->entity_class;
+    return $self->Text('Payment Results') if 1 == $self->entity_class;
+    return $self->Text('Receipt Results') if 2 == $self->entity_class;
     die 'Invalid Entity Class';
 }
 
@@ -223,7 +223,7 @@ Runs the report and sets $self->rows
 
 sub run_report{
     my ($self) = @_;
-    die LedgerSMB::Report::text('Must have cash account in batch')
+    die $self->Text('Must have cash account in batch')
         if $self->batch_id and not defined $self->cash_accno;
     local $ENV{LSMB_ALWAYS_MONEY} = 1;
     my @rows = $self->call_dbmethod(funcname => 'payment__search');
@@ -235,7 +235,7 @@ sub run_report{
     }
     $self->rows(\@rows);
     $self->buttons([{
-        text => LedgerSMB::Report::text('Reverse Payments'),
+        text => $self->Text('Reverse Payments'),
         name => 'action',
         type => 'submit',
        class => 'submit',

--- a/lib/LedgerSMB/Report/Invoices/Transactions.pm
+++ b/lib/LedgerSMB/Report/Invoices/Transactions.pm
@@ -244,19 +244,19 @@ sub columns {
     my $meta_number_label;
     my $entity_name_label;
     if ($self->entity_class == 1){
-       $meta_number_label = LedgerSMB::Report::text('Vendor Account');
-       $entity_name_label = LedgerSMB::Report::text('Vendor');
+       $meta_number_label = $self->Text('Vendor Account');
+       $entity_name_label = $self->Text('Vendor');
     } elsif ($self->entity_class == 2){
-       $meta_number_label = LedgerSMB::Report::text('Customer Account');
-       $entity_name_label = LedgerSMB::Report::text('Customer');
+       $meta_number_label = $self->Text('Customer Account');
+       $entity_name_label = $self->Text('Customer');
     }
 
     return [
        { col_id => 'id',
-           name => LedgerSMB::Report::text('ID'),
+           name => $self->Text('ID'),
            type => 'text'},
        { col_id => 'transdate',
-           name => LedgerSMB::Report::text('Date'),
+           name => $self->Text('Date'),
            type => 'text'},
        { col_id => 'meta_number',
            name => $meta_number_label,
@@ -266,46 +266,46 @@ sub columns {
        href_base =>'contact.pl?action=get&entity_class='.$self->entity_class,
            type => 'href', },
        { col_id => 'invnumber',
-           name => LedgerSMB::Report::text('Invoice'),
+           name => $self->Text('Invoice'),
            type => 'href'},
        { col_id => 'netamount',
-           name => LedgerSMB::Report::text('Amount'),
+           name => $self->Text('Amount'),
            type => 'text'},
        { col_id => 'tax',
-           name => LedgerSMB::Report::text('Tax'),
+           name => $self->Text('Tax'),
            type => 'text'},
        { col_id => 'amount',
-           name => LedgerSMB::Report::text('Total'),
+           name => $self->Text('Total'),
            type => 'text'},
        { col_id => 'paid',
-           name => LedgerSMB::Report::text('Paid'),
+           name => $self->Text('Paid'),
            type => 'text'},
        { col_id => 'due',
-           name => LedgerSMB::Report::text('Due'),
+           name => $self->Text('Due'),
            type => 'text'},
        { col_id => 'last_payment',
-           name => LedgerSMB::Report::text('Date Paid'),
+           name => $self->Text('Date Paid'),
            type => 'text'},
        { col_id => 'due_date',
-           name => LedgerSMB::Report::text('Due Date'),
+           name => $self->Text('Due Date'),
            type => 'text'},
        { col_id => 'notes',
-           name => LedgerSMB::Report::text('Notes'),
+           name => $self->Text('Notes'),
            type => 'text'},
        { col_id => 'till',
-           name => LedgerSMB::Report::text('Till'),
+           name => $self->Text('Till'),
            type => 'text'},
        { col_id => 'salesperson',
-           name => LedgerSMB::Report::text('Salesperson'),
+           name => $self->Text('Salesperson'),
            type => 'text'},
        { col_id => 'manager',
-           name => LedgerSMB::Report::text('Manager'),
+           name => $self->Text('Manager'),
            type => 'text'},
        { col_id => 'shipping_point',
-           name => LedgerSMB::Report::text('Shipping Point'),
+           name => $self->Text('Shipping Point'),
            type => 'text'},
        { col_id => 'ship_via',
-           name => LedgerSMB::Report::text('Ship Via'),
+           name => $self->Text('Ship Via'),
            type => 'text'},
     ];
 }
@@ -329,8 +329,8 @@ sub header_lines {
 
 sub name {
     my $self = shift;
-    return LedgerSMB::Report::text('Search AP') if $self->entity_class == 1;
-    return LedgerSMB::Report::text('Search AR') if $self->entity_class == 2;
+    return $self->Text('Search AP') if $self->entity_class == 1;
+    return $self->Text('Search AR') if $self->entity_class == 2;
     return;
 }
 

--- a/lib/LedgerSMB/Report/Listings/Asset.pm
+++ b/lib/LedgerSMB/Report/Listings/Asset.pm
@@ -84,22 +84,23 @@ has salvage_value   => (is => 'ro', isa => 'LedgerSMB::Moose::Number',
 =cut
 
 sub columns {
+    my ($self) = @_;
     return [
      { col_id => 'tag',
-         name => LedgerSMB::Report::text('Tag'),
+         name => $self->Text('Tag'),
          type => 'href',
     href_base => 'asset.pl?action=asset_edit&id=', },
     {  col_id => 'description',
-         name => LedgerSMB::Report::text('Description'),
+         name => $self->Text('Description'),
          type => 'text', },
     {  col_id => 'purchase_date',
-         name => LedgerSMB::Report::text('Purchase Date'),
+         name => $self->Text('Purchase Date'),
          type => 'text', },
     {  col_id => 'purchase_value',
-         name => LedgerSMB::Report::text('Purchase Value'),
+         name => $self->Text('Purchase Value'),
          type => 'text', },
     {  col_id => 'usable_life',
-         name => LedgerSMB::Report::text('Usable Life'),
+         name => $self->Text('Usable Life'),
          type => 'text', },
    ];
 }
@@ -122,12 +123,13 @@ sub columns {
 =cut
 
 sub header_lines {
+    my ($self) = @_;
     return  [
-     { name => 'tag',         text => LedgerSMB::Report::text('Tag') },
-     { name => 'description', text => LedgerSMB::Report::text('Description') },
-     {name => 'purchase_date',text => LedgerSMB::Report::text('Purchase Date')},
+     { name => 'tag',         text => $self->Text('Tag') },
+     { name => 'description', text => $self->Text('Description') },
+     {name => 'purchase_date',text => $self->Text('Purchase Date')},
      {name => 'purchase_value',
-        text => LedgerSMB::Report::text('Purchase Value') },
+        text => $self->Text('Purchase Value') },
    ];
 }
 
@@ -137,7 +139,10 @@ Asset Listing
 
 =cut
 
-sub name { return LedgerSMB::Report::text('Asset Listing') }
+sub name {
+    my ($self) = @_;
+    return $self->Text('Asset Listing');
+}
 
 =head1 METHODS
 

--- a/lib/LedgerSMB/Report/Listings/Asset_Class.pm
+++ b/lib/LedgerSMB/Report/Listings/Asset_Class.pm
@@ -65,22 +65,23 @@ has dep_account_id    => (is => 'ro', isa => 'Int', required => 0);
 =cut
 
 sub columns {
+    my ($self) = @_;
     return [
    {  col_id => 'id',
-        name => LedgerSMB::Report::text('ID'),
+        name => $self->Text('ID'),
         type => 'text' },
    {  col_id => 'label',
-        name =>  LedgerSMB::Report::text('Label'),
+        name =>  $self->Text('Label'),
         type => 'href',
    href_base => 'asset.pl?action=edit_asset_class&id=', },
   {   col_id => 'method',
-        name => LedgerSMB::Report::text('Depreciation Method'),
+        name => $self->Text('Depreciation Method'),
         type => 'text' },
    {  col_id => 'asset_description',
-        name => LedgerSMB::Report::text('Asset Account'),
+        name => $self->Text('Asset Account'),
         type => 'text' },
    {  col_id => 'dep_description',
-        name => LedgerSMB::Report::text('Depreciation Account'),
+        name => $self->Text('Depreciation Account'),
         type => 'text' },
    ];
 }
@@ -92,11 +93,12 @@ Label and method
 =cut
 
 sub header_lines {
+    my ($self) = @_;
     return [
        {name => 'label',
-        text => LedgerSMB::Report::text('Label') },
+        text => $self->Text('Label') },
        {name => 'method',
-        text => LedgerSMB::Report::text('Depreciation Method') },
+        text => $self->Text('Depreciation Method') },
     ];
 }
 
@@ -107,7 +109,10 @@ Asset Class List
 
 =cut
 
-sub name { return LedgerSMB::Report::text('Asset Class List') };
+sub name {
+    my ($self) = @_;
+    return $self->Text('Asset Class List');
+};
 
 =head1 METHODS
 

--- a/lib/LedgerSMB/Report/Listings/Business_Type.pm
+++ b/lib/LedgerSMB/Report/Listings/Business_Type.pm
@@ -42,18 +42,19 @@ extends 'LedgerSMB::Report';
 =cut
 
 sub columns {
+    my ($self) = @_;
     return [{
       col_id => 'description',
         type => 'href',
      p_width => '10',
-        name => LedgerSMB::Report::text('Description'),
+        name => $self->Text('Description'),
    href_base => 'am.pl?action=edit_business&id=',
     },
     {
       col_id => 'discount',
         type => 'text',
      p_width => '1',
-        name => LedgerSMB::Report::text('Discount (%)'),
+        name => $self->Text('Discount (%)'),
     }];
 };
 
@@ -72,7 +73,8 @@ sub header_lines {
 =cut
 
 sub name {
-    return LedgerSMB::Report::text('List of Business Types');
+    my ($self) = @_;
+    return $self->Text('List of Business Types');
 }
 
 =back

--- a/lib/LedgerSMB/Report/Listings/Business_Unit.pm
+++ b/lib/LedgerSMB/Report/Listings/Business_Unit.pm
@@ -51,23 +51,24 @@ has id => (is => 'ro', isa => 'Int');
 =cut
 
 sub columns {
+    my ($self) = @_;
     return [
       { col_id => 'control_code',
           type => 'href',
      href_base => 'business_unit.pl?action=edit&id=',
-          name => LedgerSMB::Report::text('Control Code') },
+          name => $self->Text('Control Code') },
 
       { col_id => 'description',
           type => 'text',
-          name => LedgerSMB::Report::text('Description') },
+          name => $self->Text('Description') },
 
       { col_id => 'start_date',
           type => 'text',
-          name => LedgerSMB::Report::text('Start Date') },
+          name => $self->Text('Start Date') },
 
       { col_id => 'end_date',
           type => 'text',
-          name => LedgerSMB::Report::text('End Date') },
+          name => $self->Text('End Date') },
     ];
 }
 
@@ -85,7 +86,10 @@ Business Units List
 
 =cut
 
-sub name { return LedgerSMB::Report::text('Business Unit List'); }
+sub name {
+    my ($self) = @_;
+    return $self->Text('Business Unit List');
+}
 
 =head1 METHODS
 

--- a/lib/LedgerSMB/Report/Listings/GIFI.pm
+++ b/lib/LedgerSMB/Report/Listings/GIFI.pm
@@ -40,15 +40,16 @@ together for other reporting uses.
 =cut
 
 sub columns {
+    my ($self) = @_;
     return [
     { col_id => 'accno',
         type => 'href',
    href_base => 'am.pl?action=edit_gifi&coa=1&accno=',
-        name => LedgerSMB::Report::text('GIFI'), },
+        name => $self->Text('GIFI'), },
 
     { col_id => 'description',
         type => 'text',
-        name => LedgerSMB::Report::text('Description'), },
+        name => $self->Text('Description'), },
 
     ];
 }
@@ -67,7 +68,10 @@ GIFI
 
 =cut
 
-sub name { return LedgerSMB::Report::text('GIFI'); }
+sub name {
+    my ($self) = @_;
+    return $self->Text('GIFI');
+}
 
 =head1 REPORT CRITERIA
 

--- a/lib/LedgerSMB/Report/Listings/Language.pm
+++ b/lib/LedgerSMB/Report/Listings/Language.pm
@@ -41,15 +41,16 @@ None
 =cut
 
 sub columns {
+    my ($self) = @_;
     return [{
       col_id => 'code',
         type => 'href',
    href_base => 'am.pl?action=edit_language&code=',
-        name => LedgerSMB::Report::text('Code'), },
+        name => $self->Text('Code'), },
 
     { col_id => 'description',
         type => 'text',
-        name => LedgerSMB::Report::text('Description'), },
+        name => $self->Text('Description'), },
     ];
 }
 
@@ -67,7 +68,10 @@ Languages
 
 =cut
 
-sub name { return LedgerSMB::Report::text('Language'); }
+sub name {
+    my ($self) = @_;
+    return $self->Text('Language');
+}
 
 =head1 METHODS
 

--- a/lib/LedgerSMB/Report/Listings/Overpayments.pm
+++ b/lib/LedgerSMB/Report/Listings/Overpayments.pm
@@ -77,7 +77,8 @@ localized string 'Overpayments'
 =cut
 
 sub name {
-    return LedgerSMB::Report::text('Overpayments');
+    my ($self) = @_;
+    return $self->Text('Overpayments');
 }
 
 =head2 header_lines
@@ -99,12 +100,13 @@ sub name {
 =cut
 
 sub header_lines {
+    my ($self) = @_;
     return [
-      {name => 'meta_number', text => LedgerSMB::Report::text('Counterparty Code')}.
-      {name => 'date_from',   text => LedgerSMB::Report::text('Date From')},
-      {name => 'date_to',     text => LedgerSMB::Report::text('Date To')},
-      {name => 'amount_from', text => LedgerSMB::Report::text('Amount From')},
-      {name => 'amount_to',   text =>  LedgerSMB::Report::text('Amount To')},
+      {name => 'meta_number', text => $self->Text('Counterparty Code')}.
+      {name => 'date_from',   text => $self->Text('Date From')},
+      {name => 'date_to',     text => $self->Text('Date To')},
+      {name => 'amount_from', text => $self->Text('Amount From')},
+      {name => 'amount_to',   text =>  $self->Text('Amount To')},
     ];
 }
 
@@ -125,25 +127,26 @@ sub header_lines {
 =cut
 
 sub columns {
+    my ($self) = @_;
     return [{
         col_id => 'select',
           name => '',
           type => 'checkbox',
     },
     {   col_id => 'entity_name',
-          name => LedgerSMB::Report::text('Counterparty'),
+          name => $self->Text('Counterparty'),
           type => 'text',
     },
     {   col_id => 'transdate',
-          name => LedgerSMB::Report::text('Date'),
+          name => $self->Text('Date'),
           type => 'text',
     },
     {   col_id => 'amount',
-          name => LedgerSMB::Report::text('Paid'),
+          name => $self->Text('Paid'),
           type => 'text',
     },
     {   col_id => 'available',
-          name => LedgerSMB::Report::text('Available'),
+          name => $self->Text('Available'),
           type => 'text',
     }];
 }
@@ -158,7 +161,7 @@ sub set_buttons {
    my $self = shift;
    return [
           { name => 'action',
-            text => LedgerSMB::Report::text('Reverse'),
+            text => $self->Text('Reverse'),
            value => 'reverse_overpayment',
             type => 'submit',
            class => 'submit'

--- a/lib/LedgerSMB/Report/Listings/SIC.pm
+++ b/lib/LedgerSMB/Report/Listings/SIC.pm
@@ -39,15 +39,16 @@ None
 =cut
 
 sub columns {
+    my ($self) = @_;
     return [
       { col_id => 'code',
           type => 'href',
      href_base => 'am.pl?action=edit_sic&code=',
-          name => LedgerSMB::Report::text('Code'), },
+          name => $self->Text('Code'), },
 
       { col_id => 'description',
           type => 'text',
-          name => LedgerSMB::Report::text('Description'), }
+          name => $self->Text('Description'), }
     ];
 }
 
@@ -65,7 +66,10 @@ Standard Industrial Codes
 
 =cut
 
-sub name { return LedgerSMB::Report::text('Standard Industrial Codes'); }
+sub name {
+    my ($self) = @_;
+    return $self->Text('Standard Industrial Codes');
+}
 
 =head1 METHODS
 

--- a/lib/LedgerSMB/Report/Listings/TemplateTrans.pm
+++ b/lib/LedgerSMB/Report/Listings/TemplateTrans.pm
@@ -64,7 +64,7 @@ sub columns {
      }, {
       col_id => 'id',
         type => 'href',
-        name => LedgerSMB::Report::text('ID'),
+        name => $self->Text('ID'),
    href_base => $href_base,
     }, {
       col_id => 'journal_type',
@@ -73,12 +73,12 @@ sub columns {
     }, {
       col_id => 'description',
         type => 'href',
-        name => LedgerSMB::Report::text('Description'),
+        name => $self->Text('Description'),
    href_base => $href_base,
     }, {
       col_id => 'entity_name',
         type => 'text',
-        name => LedgerSMB::Report::text('Counterparty'),
+        name => $self->Text('Counterparty'),
     }];
 }
 
@@ -97,9 +97,10 @@ none
 =cut
 
 sub set_buttons {
+    my ($self) = @_;
     return [
         { name => 'action',
-            text => LedgerSMB::Report::text('Delete'),
+            text => $self->Text('Delete'),
            value => 'delete',
             type => 'submit',
            class => 'submit'
@@ -115,7 +116,7 @@ Template Transactions
 
 sub name {
     my $self = shift;
-    return LedgerSMB::Report::text('Template Transactions');
+    return $self->Text('Template Transactions');
 }
 
 =head2 run_report

--- a/lib/LedgerSMB/Report/Listings/Templates.pm
+++ b/lib/LedgerSMB/Report/Listings/Templates.pm
@@ -47,13 +47,14 @@ has language_code => (is => 'ro', isa => 'Str', required => 0);
 =cut
 
 sub columns {
+    my ($self) = @_;
     return [
       { col_id => 'template_name',
-          name => LedgerSMB::Report::text('File Name'),
+          name => $self->Text('File Name'),
           type => 'href',
      href_base => 'templates.pl?action=display&' },
       { col_id => 'format',
-          name => LedgerSMB::Report::text('Format'),
+          name => $self->Text('Format'),
           type => 'text' },
    ];
 }
@@ -65,16 +66,21 @@ Just the language_code
 
 =cut
 
-sub header_lines { return [
-      { name => 'language_code', text => LedgerSMB::Report::text('Language') },
-    ]
+sub header_lines {
+    my ($self) = @_;
+    return [
+        { name => 'language_code', text => $self->Text('Language') },
+        ];
 };
 
 =head2 name
 
 =cut
 
-sub name { return LedgerSMB::Report::text('Template Listing') };
+sub name {
+    my ($self) = @_;
+    return $self->Text('Template Listing');
+};
 
 =head1 METHODS
 

--- a/lib/LedgerSMB/Report/Listings/Warehouse.pm
+++ b/lib/LedgerSMB/Report/Listings/Warehouse.pm
@@ -38,11 +38,12 @@ None
 =cut
 
 sub columns {
+    my ($self) = @_;
     return [{
        col_id => 'description',
         type  => 'href',
    href_base  => 'am.pl?action=edit_warehouse&id=',
-        name  => LedgerSMB::Report::text('Description'),
+        name  => $self->Text('Description'),
     }];
 }
 
@@ -60,7 +61,10 @@ Warehouses
 
 =cut
 
-sub name { return LedgerSMB::Report::text('Warehouses'); }
+sub name {
+    my ($self) = @_;
+    return $self->Text('Warehouses');
+}
 
 =head1 METHODS
 

--- a/lib/LedgerSMB/Report/Payroll/Deduction_Types.pm
+++ b/lib/LedgerSMB/Report/Payroll/Deduction_Types.pm
@@ -28,16 +28,17 @@ This module provides for searching for deduction types.
 =cut
 
 sub columns {
+    my ($self) = @_;
     return [
         { col_id => 'country_name',
-            name => LedgerSMB::Report::text('Country'),
+            name => $self->Text('Country'),
             type => 'text',
         },
         { col_id => 'deduction_class',
-            name => LedgerSMB::Report::text('Deduction Class'),
+            name => $self->Text('Deduction Class'),
             type => 'text' },
         { col_id => 'label',
-            name => LedgerSMB::Report::text('Label'),
+            name => $self->Text('Label'),
             type => 'href',
        href_base => 'payrol.pl?action=edit&id=' },
     ];
@@ -55,7 +56,10 @@ sub header_lines {
 
 =cut
 
-sub name { return LedgerSMB::Report::text('Deduction Types') }
+sub name {
+    my ($self) = @_;
+    return $self->Text('Deduction Types');
+}
 
 =back
 

--- a/lib/LedgerSMB/Report/Payroll/Income_Types.pm
+++ b/lib/LedgerSMB/Report/Payroll/Income_Types.pm
@@ -28,16 +28,17 @@ This module provides for searching for income types.
 =cut
 
 sub columns {
+    my ($self) = @_;
     return [
         { col_id => 'country_name',
-            name => LedgerSMB::Report::text('Country'),
+            name => $self->Text('Country'),
             type => 'text',
         },
         { col_id => 'income_class',
-            name => LedgerSMB::Report::text('Income Class'),
+            name => $self->Text('Income Class'),
             type => 'text' },
         { col_id => 'label',
-            name => LedgerSMB::Report::text('Label'),
+            name => $self->Text('Label'),
             type => 'href',
        href_base => 'payrol.pl?action=edit&id=' },
     ];
@@ -55,7 +56,10 @@ sub header_lines {
 
 =cut
 
-sub name { return LedgerSMB::Report::text('Income Types') }
+sub name {
+    my ($self) = @_;
+    return $self->Text('Income Types');
+}
 
 =back
 

--- a/lib/LedgerSMB/Report/Reconciliation/Summary.pm
+++ b/lib/LedgerSMB/Report/Reconciliation/Summary.pm
@@ -130,31 +130,32 @@ Username of the one who approved the report
 =cut
 
 sub columns {
+    my ($self) = @_;
     return [ {col_id => 'account',
-                name => LedgerSMB::Report::text('Account'),
+                name => $self->Text('Account'),
                 type => 'text', },
              {col_id => 'end_date',
-                name => LedgerSMB::Report::text('Statement Date'),
+                name => $self->Text('Statement Date'),
                 type => 'href',
            href_base => 'recon.pl?action=display_report&report_id=', },
              {col_id => 'their_total',
-                name => LedgerSMB::Report::text('Statement Balance'),
+                name => $self->Text('Statement Balance'),
                money => 1,
                 type => 'text', },
              {col_id => 'approved',
-                name => LedgerSMB::Report::text('Approved'),
+                name => $self->Text('Approved'),
                 type => 'text', },
              {col_id => 'submitted',
-                name => LedgerSMB::Report::text('Submitted'),
+                name => $self->Text('Submitted'),
                 type => 'text', },
              {col_id => 'updated',
-                name => LedgerSMB::Report::text('Last Updated'),
+                name => $self->Text('Last Updated'),
                 type => 'text', },
              {col_id => 'entered_by',
-                name => LedgerSMB::Report::text('Entered By'),
+                name => $self->Text('Entered By'),
                 type => 'text', },
              {col_id => 'approved_by',
-                name => LedgerSMB::Report::text('Approved By'),
+                name => $self->Text('Approved By'),
                 type => 'text', },
           ];
 }
@@ -174,14 +175,15 @@ sub columns {
 =cut
 
 sub header_lines {
+    my ($self) = @_;
     return [{name => 'date_from',
-             text => LedgerSMB::Report::text('From Date')},
+             text => $self->Text('From Date')},
             {name => 'date_to',
-             text => LedgerSMB::Report::text('To Date') },
+             text => $self->Text('To Date') },
             {name => 'amount_from',
-             text => LedgerSMB::Report::text('From Amount')},
+             text => $self->Text('From Amount')},
             {name => 'amount_to',
-             text => LedgerSMB::Report::text('To Amount')}
+             text => $self->Text('To Amount')}
      ];
 }
 
@@ -192,7 +194,8 @@ sub header_lines {
 =cut
 
 sub name {
-    return LedgerSMB::Report::text('Reconciliation Reports');
+    my ($self) = @_;
+    return $self->Text('Reconciliation Reports');
 }
 
 =head1 METHODS

--- a/lib/LedgerSMB/Report/Taxform/Details.pm
+++ b/lib/LedgerSMB/Report/Taxform/Details.pm
@@ -70,34 +70,35 @@ has meta_number => (is => 'ro', isa => 'Str', required => '1');
 =cut
 
 sub columns {
+    my ($self) = @_;
     return [{
         col_id => 'legal_name',
         type   => 'text',
-        name   => LedgerSMB::Report::text('Company'), },
+        name   => $self->Text('Company'), },
 
       { col_id => 'account_type',
         type   => 'text',
-        name   => LedgerSMB::Report::text('Account Type'), },
+        name   => $self->Text('Account Type'), },
 
       { col_id => 'meta_number',
         type   => 'text',
-        name   => LedgerSMB::Report::text('Account Number'), },
+        name   => $self->Text('Account Number'), },
 
      { col_id  => 'invnumber',
        type    => 'text',
-       name    => LedgerSMB::Report::text('Invoice Number') },
+       name    => $self->Text('Invoice Number') },
 
      { col_id  => 'acc_sum',
        type    => 'text',
-       name    => LedgerSMB::Report::text('Ledger sum') },
+       name    => $self->Text('Ledger sum') },
 
      { col_id  => 'invoice_sum',
        type    => 'text',
-       name    => LedgerSMB::Report::text('Invoice sum') },
+       name    => $self->Text('Invoice sum') },
 
      { col_id  => 'total',
        type    => 'text',
-       name    => LedgerSMB::Report::text('Total') },
+       name    => $self->Text('Total') },
      ];
 }
 
@@ -106,11 +107,12 @@ sub columns {
 =cut
 
 sub header_lines {
+    my ($self) = @_;
     return [
-       { name => 'from_date', text => LedgerSMB::Report::text('From Date') },
-       { name => 'to_date',   text => LedgerSMB::Report::text('To Date') },
-       { name => 'taxform',   text => LedgerSMB::Report::text('Tax Form') },
-       { name => 'meta_number',   text => LedgerSMB::Report::text('Account Number') },
+       { name => 'from_date', text => $self->Text('From Date') },
+       { name => 'to_date',   text => $self->Text('To Date') },
+       { name => 'taxform',   text => $self->Text('Tax Form') },
+       { name => 'meta_number',   text => $self->Text('Account Number') },
     ];
 }
 
@@ -119,7 +121,8 @@ sub header_lines {
 =cut
 
 sub name {
-    return LedgerSMB::Report::text('Tax Form Details Report');
+    my ($self) = @_;
+    return $self->Text('Tax Form Details Report');
 }
 
 =head2 buttons
@@ -127,9 +130,10 @@ sub name {
 =cut
 
 sub buttons {
+    my ($self) = @_;
     return [{name => 'action',
              type => 'submit',
-             text => LedgerSMB::Report::text('Print'),
+             text => $self->Text('Print'),
             value => 'print'}];
 }
 

--- a/lib/LedgerSMB/Report/Taxform/Details.pm
+++ b/lib/LedgerSMB/Report/Taxform/Details.pm
@@ -13,6 +13,8 @@ LedgerSMB
 
 =cut
 
+use LedgerSMB::DBObject::TaxForm;
+
 use Moose;
 use namespace::autoclean;
 extends 'LedgerSMB::Report';

--- a/lib/LedgerSMB/Report/Taxform/List.pm
+++ b/lib/LedgerSMB/Report/Taxform/List.pm
@@ -43,19 +43,20 @@ none
 =cut
 
 sub columns {
+    my ($self) = @_;
     return [
       {col_id => 'form_name',
          type => 'href',
     href_base => 'taxform.pl?action=edit&id=',
-         name => LedgerSMB::Report::text('Form Name')},
+         name => $self->Text('Form Name')},
 
       {col_id => 'country_name',
          type => 'text',
-         name => LedgerSMB::Report::text('Country Name')},
+         name => $self->Text('Country Name')},
 
       {col_id => 'default_reportable',
          type => 'text',
-         name => LedgerSMB::Report::text('Default Reportable')}
+         name => $self->Text('Default Reportable')}
     ];
 }
 
@@ -71,15 +72,18 @@ Tax Form List
 
 =cut
 
-sub name { return LedgerSMB::Report::text('Tax Form List'); }
+sub name {
+    my ($self) = @_;
+    return $self->Text('Tax Form List'); }
 
 =head2 buttons
 
 =cut
 
 sub buttons {
+    my ($self) = @_;
     return  [{
-         text => LedgerSMB::Report::text('Add New Tax Form'),
+         text => $self->Text('Add New Tax Form'),
         value => 'add_taxform',
          name => 'action',
          type => 'submit',
@@ -99,8 +103,8 @@ sub run_report {
     for my $row(@rows){
         $row->{row_id} = $row->{id};
         $row->{default_reportable} = ($row->{default_reportable})
-                                     ? LedgerSMB::Report::text('Yes')
-                                     : LedgerSMB::Report::text('No');
+                                     ? $self->Text('Yes')
+                                     : $self->Text('No');
     }
     return $self->rows(\@rows);
 }

--- a/lib/LedgerSMB/Report/Taxform/Summary.pm
+++ b/lib/LedgerSMB/Report/Taxform/Summary.pm
@@ -67,35 +67,36 @@ has taxform => (is => 'rw', isa => 'Str', required => 0);
 =cut
 
 sub columns {
+    my ($self) = @_;
     return [{
         col_id => 'legal_name',
         type   => 'text',
-        name   => LedgerSMB::Report::text('Company'), },
+        name   => $self->Text('Company'), },
 
       { col_id => 'account_type',
         type   => 'text',
-        name   => LedgerSMB::Report::text('Account Type'), },
+        name   => $self->Text('Account Type'), },
 
       { col_id => 'meta_number',
         type   => 'text',
-        name   => LedgerSMB::Report::text('Account Number'), },
+        name   => $self->Text('Account Number'), },
 
      { col_id  => 'control_code',
        type    => 'text',
-       name    => LedgerSMB::Report::text('Control Code') },
+       name    => $self->Text('Control Code') },
 
      { col_id  => 'acc_sum',
        type    => 'text',
-       name    => LedgerSMB::Report::text('Acc_trans Sum') },
+       name    => $self->Text('Acc_trans Sum') },
 
      { col_id  => 'invoice_sum',
        type    => 'text',
-       name    => LedgerSMB::Report::text('Invoice Sum') },
+       name    => $self->Text('Invoice Sum') },
 
      { col_id  => 'total',
        type    => 'href',
        href_base => 'taxform.pl?action=generate_report&',
-       name    => LedgerSMB::Report::text('Total') },
+       name    => $self->Text('Total') },
      ];
 }
 
@@ -104,10 +105,11 @@ sub columns {
 =cut
 
 sub header_lines {
+    my ($self) = @_;
     return [
-       { name => 'from_date', text => LedgerSMB::Report::text('From Date') },
-       { name => 'to_date',   text => LedgerSMB::Report::text('To Date') },
-       { name => 'taxform',   text => LedgerSMB::Report::text('Tax Form') },
+       { name => 'from_date', text => $self->Text('From Date') },
+       { name => 'to_date',   text => $self->Text('To Date') },
+       { name => 'taxform',   text => $self->Text('Tax Form') },
     ];
 }
 
@@ -116,7 +118,8 @@ sub header_lines {
 =cut
 
 sub name {
-    return LedgerSMB::Report::text('Tax Form Report');
+    my ($self) = @_;
+    return $self->Text('Tax Form Report');
 }
 
 =head2 buttons
@@ -124,9 +127,10 @@ sub name {
 =cut
 
 sub buttons {
+    my ($self) = @_;
     return [{name => 'action',
              type => 'submit',
-             text => LedgerSMB::Report::text('Print'),
+             text => $self->Text('Print'),
             value => 'print'}];
 }
 

--- a/lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm
+++ b/lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm
@@ -86,39 +86,40 @@ before payments.  For payments, receipts, and GL, it is the sum of the credits.
 =cut
 
 sub columns {
+    my ($self) = @_;
     return [
     {col_id => 'select',
        name => '',
        type => 'checkbox' },
 
     {col_id => 'id',
-       name => LedgerSMB::Report::text('ID'),
+       name => $self->Text('ID'),
        type => 'text',
      pwidth => 1, },
 
     {col_id => 'batch_class',
-       name => LedgerSMB::Report::text('Batch Class'),
+       name => $self->Text('Batch Class'),
        type => 'text',
      pwidth => 2, },
 
     {col_id => 'default_date',
-       name => LedgerSMB::Report::text('Date'),
+       name => $self->Text('Date'),
        type => 'text',
      pwidth => '4', },
 
     {col_id => 'Reference',
-       name => LedgerSMB::Report::text('Reference'),
+       name => $self->Text('Reference'),
        type => 'href',
   href_base => '',
      pwidth => '3', },
 
     {col_id => 'description',
-       name => LedgerSMB::Report::text('Description'),
+       name => $self->Text('Description'),
        type => 'text',
      pwidth => '6', },
 
     {col_id => 'amount',
-       name => LedgerSMB::Report::text('Amount'),
+       name => $self->Text('Amount'),
        type => 'text',
       money => 1,
      pwidth => '2', },
@@ -134,7 +135,8 @@ Returns the localized template name
 =cut
 
 sub name {
-    return LedgerSMB::Report::text('Voucher List');
+    my ($self) = @_;
+    return $self->Text('Voucher List');
 }
 
 =item header_lines
@@ -144,8 +146,9 @@ Returns the inputs to display on header.
 =cut
 
 sub header_lines {
+    my ($self) = @_;
     return [{name => 'batch_id',
-             text => LedgerSMB::Report::text('Batch ID')}, ]
+             text => $self->Text('Batch ID')}, ]
 }
 
 =item subtotal_cols
@@ -211,33 +214,33 @@ sub run_report{
     $self->buttons([{
                     name  => 'action',
                     type  => 'submit',
-                    text  => LedgerSMB::Report::text('Post Batch'),
+                    text  => $self->Text('Post Batch'),
                     value => 'single_batch_approve',
                     class => 'submit',
                  },{
                     name  => 'action',
                     type  => 'submit',
-                    text  => LedgerSMB::Report::text('Delete Batch'),
+                    text  => $self->Text('Delete Batch'),
                     value => 'single_batch_delete',
                     class => 'submit',
                  },{
                     name  => 'action',
                     type  => 'submit',
-                    text  => LedgerSMB::Report::text('Delete Vouchers'),
+                    text  => $self->Text('Delete Vouchers'),
                     value => 'batch_vouchers_delete',
                     class => 'submit',
                 },
                 {
                     name  => 'action',
                     type  => 'submit',
-                    text  => LedgerSMB::Report::text('Unlock Batch'),
+                    text  => $self->Text('Unlock Batch'),
                     value => 'single_batch_unlock',
                     class => 'submit',
                 },
                 {
                     name  => 'action',
                     type  => 'submit',
-                    text  => LedgerSMB::Report::text('Print Batch'),
+                    text  => $self->Text('Print Batch'),
                     value => 'print_batch',
                     class => 'submit',
                 }, ]);

--- a/lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm
+++ b/lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm
@@ -31,15 +31,15 @@ LedgerSMB::Report::Unapproved::Batch_Overview instead.
 
 =cut
 
+use LedgerSMB::Business_Unit_Class;
+use LedgerSMB::Business_Unit;
+use LedgerSMB::Setting;
+use LedgerSMB::Sysconfig;
+
 use Moose;
 use namespace::autoclean;
 use LedgerSMB::DBObject::User;
 extends 'LedgerSMB::Report';
-
-use LedgerSMB::Business_Unit_Class;
-use LedgerSMB::Business_Unit;
-use LedgerSMB::Setting;
-
 
 =head1 PROPERTIES
 

--- a/lib/LedgerSMB/Report/Unapproved/Drafts.pm
+++ b/lib/LedgerSMB/Report/Unapproved/Drafts.pm
@@ -74,38 +74,39 @@ Amount
 =cut
 
 sub columns {
+    my ($self) = @_;
     return [
     {col_id => 'select',
        name => '',
        type => 'checkbox' },
 
     {col_id => 'type',
-       name => LedgerSMB::Report::text('Type'),
+       name => $self->Text('Type'),
        type => 'text' },
 
     {col_id => 'id',
-       name => LedgerSMB::Report::text('ID'),
+       name => $self->Text('ID'),
        type => 'href',
      pwidth => 1, },
 
     {col_id => 'transdate',
-       name => LedgerSMB::Report::text('Date'),
+       name => $self->Text('Date'),
        type => 'text',
      pwidth => '4', },
 
     {col_id => 'reference',
-       name => LedgerSMB::Report::text('Reference'),
+       name => $self->Text('Reference'),
        type => 'href',
   href_base => '',
      pwidth => '3', },
 
     {col_id => 'description',
-       name => LedgerSMB::Report::text('Description'),
+       name => $self->Text('Description'),
        type => 'text',
      pwidth => '6', },
 
     {col_id => 'amount',
-       name => LedgerSMB::Report::text('AR/AP/GL Amount'),
+       name => $self->Text('AR/AP/GL Amount'),
        type => 'text',
       money => 1,
      pwidth => '2', },
@@ -121,7 +122,8 @@ Returns the localized template name
 =cut
 
 sub name {
-    return LedgerSMB::Report::text('Draft Search');
+    my ($self) = @_;
+    return $self->Text('Draft Search');
 }
 
 =item header_lines
@@ -131,14 +133,15 @@ Returns the inputs to display on header.
 =cut
 
 sub header_lines {
+    my ($self) = @_;
     return [{name => 'type',
-             text => LedgerSMB::Report::text('Draft Type')},
+             text => $self->Text('Draft Type')},
             {name => 'reference',
-             text => LedgerSMB::Report::text('Reference')},
+             text => $self->Text('Reference')},
             {name => 'amount_gt',
-             text => LedgerSMB::Report::text('Amount Greater Than')},
+             text => $self->Text('Amount Greater Than')},
             {name => 'amount_lt',
-             text => LedgerSMB::Report::text('Amount Less Than')}, ]
+             text => $self->Text('Amount Less Than')}, ]
 }
 
 =item subtotal_cols
@@ -202,16 +205,17 @@ has 'amount_lt' => (is => 'rw', coerce => 1, isa =>'LedgerSMB::Moose::Number');
 =cut
 
 sub set_buttons {
-return [
+    my ($self) = @_;
+    return [
       {name => 'action',
        type => 'submit',
-       text => LedgerSMB::Report::text('Approve'),
+       text => $self->Text('Approve'),
       value => 'approve',
       class => 'submit', },
 
       {name => 'action',
        type => 'submit',
-       text => LedgerSMB::Report::text('Delete'),
+       text => $self->Text('Delete'),
       value => 'delete',
       class => 'submit', },
     ];

--- a/lib/LedgerSMB/Report/co/Balance_y_Mayor.pm
+++ b/lib/LedgerSMB/Report/co/Balance_y_Mayor.pm
@@ -62,38 +62,39 @@ Account name
 =cut
 
 sub columns {
+    my ($self) = @_;
 
     my @COLS = (
     {col_id => 'accno',
-       name => LedgerSMB::Report::text('Account'),
+       name => $self->Text('Account'),
        type => 'href',
      pwidth => 3,
   href_base => '', },
 
     {col_id => 'description',
-       name => LedgerSMB::Report::text('Description'),
+       name => $self->Text('Description'),
        type => 'text',
      pwidth => '12', },
 
     {col_id => 'starting_balance',
-       name => LedgerSMB::Report::text('Starting Balance'),
+       name => $self->Text('Starting Balance'),
        type => 'text',
       money => 1,
      pwidth => '3', },
 
     {col_id => 'debits',
-       name => LedgerSMB::Report::text('Debit'),
+       name => $self->Text('Debit'),
        type => 'text',
       money => 1,
      pwidth => '4', },
 
     {col_id => 'credits',
-       name => LedgerSMB::Report::text('Credit'),
+       name => $self->Text('Credit'),
        type => 'text',
       money => 1,
      pwidth => '4', },
     {col_id => 'ending_balance',
-       name => LedgerSMB::Report::text('Balance'),
+       name => $self->Text('Balance'),
        type => 'text',
       money => 1,
      pwidth => '3', },
@@ -131,10 +132,11 @@ Returns the inputs to display on header.
 =cut
 
 sub header_lines {
+    my ($self) = @_;
     return [{name => 'date_from',
-             text => LedgerSMB::Report::text('Start Date')},
+             text => $self->Text('Start Date')},
             {name => 'date_to',
-             text =>  LedgerSMB::Report::text('End Date')},]
+             text =>  $self->Text('End Date')},]
 }
 
 =back

--- a/lib/LedgerSMB/Report/co/Caja_Diaria.pm
+++ b/lib/LedgerSMB/Report/co/Caja_Diaria.pm
@@ -64,31 +64,32 @@ Account name
 
 
 sub columns {
+    my ($self) = @_;
     return [
     {col_id => 'accno',
-       name => LedgerSMB::Report::text('Account'),
+       name => $self->Text('Account'),
        type => 'href',
      pwidth => 3,
   href_base => '', },
 
     {col_id => 'description',
-       name => LedgerSMB::Report::text('Description'),
+       name => $self->Text('Description'),
        type => 'text',
      pwidth => '12', },
 
     {col_id => 'document_type',
-       name => LedgerSMB::Report::text('Document'),
+       name => $self->Text('Document'),
        type => 'text',
      pwidth => '3', },
 
     {col_id => 'debits',
-       name => LedgerSMB::Report::text('Debit'),
+       name => $self->Text('Debit'),
        type => 'text',
       money => 1,
      pwidth => '4', },
 
     {col_id => 'credits',
-       name => LedgerSMB::Report::text('Credit'),
+       name => $self->Text('Credit'),
        type => 'text',
       money => 1,
      pwidth => '4', },
@@ -123,14 +124,15 @@ Returns the inputs to display on header.
 =cut
 
 sub header_lines {
+    my ($self) = @_;
     return [{name => 'date_from',
-             text => LedgerSMB::Report::text('Start Date')},
+             text => $self->Text('Start Date')},
             {name => 'date_to',
-             text => LedgerSMB::Report::text('End Date')},
+             text => $self->Text('End Date')},
             {name => 'accno',
-             text => LedgerSMB::Report::text('Account Number Start')},
+             text => $self->Text('Account Number Start')},
             {name => 'reference',
-             text => LedgerSMB::Report::text('Account Number End')},]
+             text => $self->Text('Account Number End')},]
 }
 
 =back

--- a/lib/LedgerSMB/Scripts/account.pm
+++ b/lib/LedgerSMB/Scripts/account.pm
@@ -22,10 +22,12 @@ maintainable.
 use strict;
 use warnings;
 
-use Template;
+use Log::Log4perl;
+
+use LedgerSMB;
 use LedgerSMB::DBObject::Account;
 use LedgerSMB::DBObject::EOY;
-use Log::Log4perl;
+use LedgerSMB::Template;
 
 
 my $logger = Log::Log4perl::get_logger('LedgerSMB::DBObject::Account');

--- a/lib/LedgerSMB/Scripts/asset.pm
+++ b/lib/LedgerSMB/Scripts/asset.pm
@@ -15,16 +15,20 @@ Asset Management workflow script
 
 =cut
 
-use LedgerSMB::Magic qw( MONTHS_PER_YEAR  RC_PARTIAL_DISPOSAL RC_DISPOSAL );
-use LedgerSMB::Template;
+use strict;
+use warnings;
+
+use Text::CSV;
+
 use LedgerSMB::DBObject::Asset_Class;
 use LedgerSMB::DBObject::Asset;
 use LedgerSMB::DBObject::Asset_Report;
+use LedgerSMB::Magic qw( MONTHS_PER_YEAR  RC_PARTIAL_DISPOSAL RC_DISPOSAL );
+use LedgerSMB::PGNumber;
 use LedgerSMB::Report::Assets::Net_Book_Value;
 use LedgerSMB::Report::Listings::Asset_Class;
 use LedgerSMB::Report::Listings::Asset;
-use strict;
-use warnings;
+use LedgerSMB::Template;
 
 our @file_columns = qw(tag purchase_date description asset_class location vendor
                       invoice department asset_account purchase_value

--- a/lib/LedgerSMB/Scripts/budgets.pm
+++ b/lib/LedgerSMB/Scripts/budgets.pm
@@ -14,6 +14,13 @@ Budget workflow scripts.
 use strict;
 use warnings;
 
+use LedgerSMB::App_State;
+use LedgerSMB::Budget;
+use LedgerSMB::Business_Unit;
+use LedgerSMB::Business_Unit_Class;
+use LedgerSMB::Magic qw( EDIT_BUDGET_ROWS NEW_BUDGET_ROWS );
+use LedgerSMB::Template;
+
 =head1 REQUIRES
 
 =over
@@ -21,14 +28,6 @@ use warnings;
 =item LedgerSMB::Budget
 
 =back
-
-=cut
-
-use LedgerSMB::Budget;
-use LedgerSMB::Business_Unit;
-use LedgerSMB::Business_Unit_Class;
-use LedgerSMB::Magic qw( EDIT_BUDGET_ROWS NEW_BUDGET_ROWS );
-
 
 =head1 METHODS
 

--- a/lib/LedgerSMB/Scripts/business_unit.pm
+++ b/lib/LedgerSMB/Scripts/business_unit.pm
@@ -15,15 +15,18 @@ This module doesn't specify any methods.
 
 =cut
 
-use LedgerSMB::Business_Unit_Class;
-use LedgerSMB::App_Module;
-use LedgerSMB::Business_Unit;
-use LedgerSMB::Template;
-use LedgerSMB::Setting::Sequence;
-use LedgerSMB::Report::Listings::Business_Unit;
-use Carp;
 use strict;
 use warnings;
+
+use Carp;
+
+use LedgerSMB::App_Module;
+use LedgerSMB::Business_Unit;
+use LedgerSMB::Business_Unit_Class;
+use LedgerSMB::PGDate;
+use LedgerSMB::Report::Listings::Business_Unit;
+use LedgerSMB::Setting::Sequence;
+use LedgerSMB::Template;
 
 $Carp::Verbose = 1;
 

--- a/lib/LedgerSMB/Scripts/configuration.pm
+++ b/lib/LedgerSMB/Scripts/configuration.pm
@@ -20,11 +20,13 @@ This module does not specify any methods.
 
 =cut
 
-use LedgerSMB::Setting;
-use LedgerSMB::Setting::Sequence;
-use LedgerSMB::App_State;
 use strict;
 use warnings;
+
+use LedgerSMB::App_State;
+use LedgerSMB::Setting;
+use LedgerSMB::Setting::Sequence;
+use LedgerSMB::Template;
 
 sub _default_settings {
     my ($request) = @_;

--- a/lib/LedgerSMB/Scripts/contact.pm
+++ b/lib/LedgerSMB/Scripts/contact.pm
@@ -18,7 +18,11 @@ This module is the UI controller for the customer, vendor, etc functions; it
 use strict;
 use warnings;
 
-use LedgerSMB::Part;
+use Try::Tiny;
+
+use LedgerSMB;
+use LedgerSMB::App_State;
+use LedgerSMB::Scripts::employee::country;
 use LedgerSMB::Entity::Company;
 use LedgerSMB::Entity::Person;
 use LedgerSMB::Entity::Credit_Account;
@@ -32,10 +36,9 @@ use LedgerSMB::Entity::Note;
 use LedgerSMB::Entity::User;
 use LedgerSMB::File;
 use LedgerSMB::Magic qw( EC_EMPLOYEE );
-use LedgerSMB::App_State;
+use LedgerSMB::Part;
 use LedgerSMB::Setting;
 use LedgerSMB::Template;
-use Try::Tiny;
 
 use LedgerSMB::old_code qw(dispatch);
 

--- a/lib/LedgerSMB/Scripts/file.pm
+++ b/lib/LedgerSMB/Scripts/file.pm
@@ -24,6 +24,9 @@ Requires that id and file_class be set.
 use strict;
 use warnings;
 
+use DBD::Pg qw(:pg_types);
+use HTTP::Status qw( HTTP_OK HTTP_SEE_OTHER );
+
 use LedgerSMB::File;
 use LedgerSMB::File::Transaction;
 use LedgerSMB::File::Order;
@@ -32,10 +35,9 @@ use LedgerSMB::File::Entity;
 use LedgerSMB::File::ECA;
 use LedgerSMB::File::Internal;
 use LedgerSMB::File::Incoming;
-use DBD::Pg qw(:pg_types);
-use LedgerSMB::Magic qw(  FC_TRANSACTION FC_ORDER FC_PART FC_ENTITY FC_ECA 
-            FC_INTERNAL FC_INCOMING);
-use HTTP::Status qw( HTTP_OK HTTP_SEE_OTHER );
+use LedgerSMB::Magic qw(  FC_TRANSACTION FC_ORDER FC_PART FC_ENTITY FC_ECA
+    FC_INTERNAL FC_INCOMING);
+use LedgerSMB::Template;
 
 our $fileclassmap = {
    FC_TRANSACTION()   => 'LedgerSMB::File::Transaction',

--- a/lib/LedgerSMB/Scripts/import_csv.pm
+++ b/lib/LedgerSMB/Scripts/import_csv.pm
@@ -133,7 +133,7 @@ sub _aa_multi {
         }
     }
     for my $ref (@$entries){
-        my $form = Form->new();
+        my $form = Form->new(); ## no critic
         $form->{dbh} = $request->{dbh};
         my $default_currency = LedgerSMB::Setting->get('curr');
         $form->{rowcount} = 1;
@@ -163,7 +163,9 @@ sub _aa_multi {
         ($form->{vendor_id}) = $sth->fetchrow_array;
         $form->{customer_id} = $form->{vendor_id};
 
-        AA->post_transaction($request->{_user}, $form);
+        # The 'AA' package is used as 'LedgerSMB::AA'
+        # which is a problem for Perl::Critic
+        AA->post_transaction($request->{_user}, $form); ## no critic
     }
     return 1;
 }
@@ -172,8 +174,8 @@ sub _inventory_single_date {
     my ($request, $entries, $report_id, $transdate) = @_;
     use LedgerSMB::IS;
     use LedgerSMB::IR;
-    my $ar_form = Form->new();
-    my $ap_form = Form->new();
+    my $ar_form = Form->new(); ## no critic
+    my $ap_form = Form->new(); ## no critic
     my $dbh = $request->{dbh};
 
     $ar_form->{dbh} = $ap_form->{dbh} = $dbh;
@@ -241,8 +243,10 @@ sub _inventory_single_date {
     $ap_form->{vendor_id} = $ap_eca->{id};
 
     # POST
-    IS->post_invoice(undef, $ar_form) if $ar_form->{rowcount};
-    IR->post_invoice(undef, $ap_form) if $ap_form->{rowcount};
+    IS->post_invoice(undef, $ar_form) ## no critic
+        if $ar_form->{rowcount};
+    IR->post_invoice(undef, $ap_form) ## no critic
+        if $ap_form->{rowcount};
 
     $ar_form->{id} = 'NULL'
         if ! $ar_form->{id};
@@ -272,7 +276,7 @@ sub _process_ap_multi {
 sub _process_gl {
     use LedgerSMB::GL;
     my ($request, $entries) = @_;
-    my $form = Form->new();
+    my $form = Form->new(); ## no critic
     $form->{reference} = $request->{reference};
     $form->{description} = $request->{description};
     $form->{transdate} = $request->{transdate};
@@ -300,8 +304,8 @@ sub _process_gl {
         }
         ++$form->{rowcount};
     }
-    return GL->post_transaction($request->{_user}, $form,
-                         $request->{_locale});
+    return GL->post_transaction( ## no critic
+        $request->{_user}, $form, $request->{_locale});
 }
 
 sub _process_chart {

--- a/lib/LedgerSMB/Scripts/inventory.pm
+++ b/lib/LedgerSMB/Scripts/inventory.pm
@@ -16,11 +16,12 @@ This module implements inventory adjustment entry points.
 use strict;
 use warnings;
 
-use LedgerSMB::Template;
 use LedgerSMB::Inventory::Adjust;
 use LedgerSMB::Inventory::Adjust_Line;
 use LedgerSMB::Report::Inventory::Search_Adj;
 use LedgerSMB::Report::Inventory::Adj_Details;
+use LedgerSMB::Scripts::reports;
+use LedgerSMB::Template;
 
 =over
 
@@ -129,7 +130,7 @@ sub adjustment_save {
 
 sub adjustment_list {
     my ($request) = @_;
-    my $report = LedgerSMB::Report::Inventory::Adjustments->new(%$request);
+    my $report = LedgerSMB::Report::Inventory::Search_Adj->new(%$request);
     return $report->render($request);
 }
 

--- a/lib/LedgerSMB/Scripts/inventory.pm
+++ b/lib/LedgerSMB/Scripts/inventory.pm
@@ -19,7 +19,6 @@ use warnings;
 use LedgerSMB::Template;
 use LedgerSMB::Inventory::Adjust;
 use LedgerSMB::Inventory::Adjust_Line;
-use LedgerSMB::Report::Inventory::Adjustments;
 use LedgerSMB::Report::Inventory::Search_Adj;
 use LedgerSMB::Report::Inventory::Adj_Details;
 
@@ -140,7 +139,7 @@ sub adjustment_list {
 
 sub adjustment_approve {
     my ($request) = @_;
-    my $adjust = LedgerSMB::Inventory::Adjustment->new(%$request);
+    my $adjust = LedgerSMB::Inventory::Adjust->new(%$request);
     $adjust->approve;
     $request->{report_name} = 'list_inventory_counts';
     return LedgerSMB::Scripts::reports::start_report($request);
@@ -154,7 +153,7 @@ sub adjustment_approve {
 
 sub adjustment_delete {
     my ($request) = @_;
-    my $adjust = LedgerSMB::Inventory::Adjustment->new(%$request);
+    my $adjust = LedgerSMB::Inventory::Adjust->new(%$request);
     $adjust->delete;
     $request->{report_name} = 'list_inventory_counts';
     return LedgerSMB::Scripts::reports::start_report($request);

--- a/lib/LedgerSMB/Scripts/inventory.pm
+++ b/lib/LedgerSMB/Scripts/inventory.pm
@@ -19,6 +19,7 @@ use warnings;
 use LedgerSMB::Template;
 use LedgerSMB::Inventory::Adjust;
 use LedgerSMB::Inventory::Adjust_Line;
+use LedgerSMB::Report::Inventory::Adjustments;
 use LedgerSMB::Report::Inventory::Search_Adj;
 use LedgerSMB::Report::Inventory::Adj_Details;
 

--- a/lib/LedgerSMB/Scripts/login.pm
+++ b/lib/LedgerSMB/Scripts/login.pm
@@ -15,19 +15,18 @@ This script contains the request handlers for logging in and out of LedgerSMB.
 
 =cut
 
+use strict;
+use warnings;
+
+use HTTP::Status qw( HTTP_OK ) ;
+use Try::Tiny;
 
 use LedgerSMB::Locale;
-use HTTP::Status qw( HTTP_OK ) ;
-
 use LedgerSMB::PSGI::Util;
 use LedgerSMB::Scripts::menu;
 use LedgerSMB::Sysconfig;
+use LedgerSMB::Template;
 use LedgerSMB::User;
-
-use Try::Tiny;
-
-use strict;
-use warnings;
 
 our $VERSION = 1.0;
 

--- a/lib/LedgerSMB/Scripts/payment.pm
+++ b/lib/LedgerSMB/Scripts/payment.pm
@@ -46,19 +46,22 @@ Original copyright notice below.
 
 =cut
 
+use strict;
+use warnings;
 
-use LedgerSMB::Template;
-use LedgerSMB::Setting;
-use LedgerSMB::Sysconfig;
+use List::Util qw/sum/;
+
+use LedgerSMB::Company_Config;
 use LedgerSMB::DBObject::Payment;
 use LedgerSMB::DBObject::Date;
 use LedgerSMB::Magic qw( MAX_DAYS_IN_MONTH EC_VENDOR );
 use LedgerSMB::PGNumber;
-use LedgerSMB::Scripts::reports;
 use LedgerSMB::Report::Invoices::Payments;
-use strict;
-use warnings;
-use List::Util qw/sum/;
+use LedgerSMB::Scripts::reports;
+use LedgerSMB::Setting;
+use LedgerSMB::Sysconfig;
+use LedgerSMB::Template;
+
 
 # CT:  A few notes for future refactoring of this code:
 # 1:  I don't think it is a good idea to make the UI too dependant on internal

--- a/lib/LedgerSMB/Scripts/recon.pm
+++ b/lib/LedgerSMB/Scripts/recon.pm
@@ -17,14 +17,17 @@ interfacing with the Core Logic and database layers.
 # NOTE:  This is a first draft modification to use the current parameter type.
 # It will certainly need some fine tuning on my part.  Chris
 
-use LedgerSMB::Template;
-use LedgerSMB::DBObject::Reconciliation;
-use HTTP::Status qw( HTTP_BAD_REQUEST);
-use LedgerSMB::Setting;
-use LedgerSMB::Scripts::reports;
-use LedgerSMB::Report::Reconciliation::Summary;
 use strict;
 use warnings;
+
+use HTTP::Status qw( HTTP_BAD_REQUEST);
+
+use LedgerSMB::DBObject::Reconciliation;
+use LedgerSMB::PGNumber;
+use LedgerSMB::Report::Reconciliation::Summary;
+use LedgerSMB::Scripts::reports;
+use LedgerSMB::Setting;
+use LedgerSMB::Template;
 
 =over
 

--- a/lib/LedgerSMB/Scripts/report_aging.pm
+++ b/lib/LedgerSMB/Scripts/report_aging.pm
@@ -13,14 +13,21 @@ This module provides AR/AP aging reports and statements for LedgerSMB.
 
 =cut
 
-use LedgerSMB::Template;
+use strict;
+use warnings;
+
+use LedgerSMB::App_State;
 use LedgerSMB::Business_Unit;
+use LedgerSMB::Entity;
+use LedgerSMB::Entity::Company;
+use LedgerSMB::Entity::Contact;
+use LedgerSMB::Entity::Credit_Account;
+use LedgerSMB::Entity::Location;
 use LedgerSMB::Legacy_Util;
 use LedgerSMB::Report::Aging;
 use LedgerSMB::Scripts::reports;
 use LedgerSMB::Setting;
-use strict;
-use warnings;
+use LedgerSMB::Template;
 
 our $VERSION = '1.0';
 
@@ -68,10 +75,7 @@ email.
 
 sub generate_statement {
     my ($request) = @_;
-    use LedgerSMB::Entity::Company;
-    use LedgerSMB::Entity::Credit_Account;
-    use LedgerSMB::Entity::Location;
-    use LedgerSMB::Entity::Contact;
+
     _strip_specials($request);
 
     my $rtype = $request->{report_type}; # in case we need it later

--- a/lib/LedgerSMB/Scripts/reports.pm
+++ b/lib/LedgerSMB/Scripts/reports.pm
@@ -13,20 +13,22 @@ This module holds common workflow routines for reports.
 
 =cut
 
-use LedgerSMB::Template;
+use strict;
+use warnings;
+
+use LedgerSMB::App_State;
+use LedgerSMB::DBObject::Payment; # To move this off after rewriting payments
 use LedgerSMB::Business_Unit;
 use LedgerSMB::Business_Unit_Class;
 use LedgerSMB::Report::Balance_Sheet;
 use LedgerSMB::Report::Listings::Business_Type;
 use LedgerSMB::Report::Listings::GIFI;
-use LedgerSMB::Report::Listings::Warehouse;
 use LedgerSMB::Report::Listings::Language;
 use LedgerSMB::Report::Listings::SIC;
 use LedgerSMB::Report::Listings::Overpayments;
+use LedgerSMB::Report::Listings::Warehouse;
 use LedgerSMB::Setting;
-use LedgerSMB::DBObject::Payment; # To move this off after rewriting payments
-use strict;
-use warnings;
+use LedgerSMB::Template;
 
 our $VERSION = '1.0';
 

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -31,10 +31,12 @@ use File::Temp;
 use HTTP::Status qw( HTTP_OK HTTP_UNAUTHORIZED );
 use List::Util qw( first );
 use Locale::Country;
+use Log::Log4perl;
 use MIME::Base64;
 use Try::Tiny;
 use Version::Compare;
 
+use LedgerSMB;
 use LedgerSMB::App_State;
 use LedgerSMB::Database;
 use LedgerSMB::Database::Config;
@@ -46,6 +48,7 @@ use LedgerSMB::PSGI::Util;
 use LedgerSMB::Setting;
 use LedgerSMB::Setup::SchemaChecks qw( html_formatter_context );
 use LedgerSMB::Sysconfig;
+use LedgerSMB::Template;
 use LedgerSMB::Template::DB;
 use LedgerSMB::Upgrade_Preparation;
 use LedgerSMB::Upgrade_Tests;
@@ -304,7 +307,7 @@ Checks for common setup issues and errors if admin tasks cannot be completed/
 
 sub sanity_checks {
     my ($database) = @_;
-    `psql --help` || die LedgerSMB::App_State::Locale->text(
+    `psql --help` || die LedgerSMB::App_State::Locale()->text(
                                  'psql not found.'
                               );
     return;

--- a/lib/LedgerSMB/Scripts/taxform.pm
+++ b/lib/LedgerSMB/Scripts/taxform.pm
@@ -22,15 +22,15 @@ information depending on what one clicks.
 use strict;
 use warnings;
 
+use LedgerSMB::App_State;
 use LedgerSMB::Company_Config;
-use LedgerSMB::Template;
 use LedgerSMB::DBObject::TaxForm;
 use LedgerSMB::DBObject::Date;
-use LedgerSMB::Template;
 use LedgerSMB::Form;
 use LedgerSMB::Report::Taxform::Summary;
 use LedgerSMB::Report::Taxform::Details;
 use LedgerSMB::Report::Taxform::List;
+use LedgerSMB::Template;
 
 our $VERSION = '1.0';
 
@@ -139,7 +139,7 @@ sub _generate_report {
 
 sub generate_report {
     my ($request) = @_;
-    die $LedgerSMB::App_State::Locale->text('No tax form selected')
+    die LedgerSMB::App_State::Locale()->text('No tax form selected')
         unless $request->{tax_form_id};
     my $report = _generate_report($request);
     return $report->render($request);

--- a/lib/LedgerSMB/Scripts/template.pm
+++ b/lib/LedgerSMB/Scripts/template.pm
@@ -24,10 +24,11 @@ To edit:
 use strict;
 use warnings;
 
-use LedgerSMB::Template::DB;
+use LedgerSMB;
+use LedgerSMB::App_State;
 use LedgerSMB::Report::Listings::Templates;
 use LedgerSMB::Template;
-use LedgerSMB::App_State;
+use LedgerSMB::Template::DB;
 
 =head1 METHODS
 
@@ -143,7 +144,7 @@ sub upload {
     # the template name and extension. Is this appropriate/necessary?
     die 'No content' unless $fdata;
     my $testname = $request->{template_name} . '.' . $request->{format};
-    die LedgerSMB::App_State::Locale->text(
+    die LedgerSMB::App_State::Locale()->text(
                 'Unexpected file name, expected [_1], got [_2]',
                  $testname, $upload->basename)
           unless $upload->basename eq $testname;

--- a/lib/LedgerSMB/Scripts/timecard.pm
+++ b/lib/LedgerSMB/Scripts/timecard.pm
@@ -21,19 +21,22 @@ This module does not specify any methods.
 
 =cut
 
+use strict;
+use warnings;
 
+use DateTime;
+
+use LedgerSMB::Business_Unit_Class;
+use LedgerSMB::Business_Unit;
+use LedgerSMB::Company_Config;
+use LedgerSMB::Magic qw( MIN_PER_HOUR SEC_PER_HOUR SUNDAY SATURDAY );
+use LedgerSMB::PGDate;
+use LedgerSMB::Report::Timecards;
+use LedgerSMB::Setting;
+use LedgerSMB::Sysconfig;
 use LedgerSMB::Template;
 use LedgerSMB::Timecard;
 use LedgerSMB::Timecard::Type;
-use LedgerSMB::Report::Timecards;
-use LedgerSMB::Company_Config;
-use LedgerSMB::Business_Unit_Class;
-use LedgerSMB::Business_Unit;
-use LedgerSMB::Magic qw( MIN_PER_HOUR SEC_PER_HOUR SUNDAY SATURDAY );
-use LedgerSMB::Setting;
-use DateTime;
-use strict;
-use warnings;
 
 =head1 ROUTINES
 

--- a/lib/LedgerSMB/Scripts/transtemplate.pm
+++ b/lib/LedgerSMB/Scripts/transtemplate.pm
@@ -43,10 +43,11 @@ Views the transaction template.  Requires that id be set.
 sub _run_update {
     my ($transtemplate, $journal_type) = @_;
 
-    convert_to_form($transtemplate, $lsmb_legacy::form, $journal_type);
-    $lsmb_legacy::form->{title} = 'Add';
+    convert_to_form($transtemplate, $lsmb_legacy::form, ## no critic
+                    $journal_type);
+    $lsmb_legacy::form->{title} = 'Add'; ## no critic
 
-    return lsmb_legacy::update();
+    return lsmb_legacy::update(); ## no critic
 }
 
 sub view {

--- a/lib/LedgerSMB/Scripts/user.pm
+++ b/lib/LedgerSMB/Scripts/user.pm
@@ -24,11 +24,13 @@ and defaults to indefinite validity.
 
 =cut
 
-use LedgerSMB::Template;
-use LedgerSMB::DBObject::User;
-use LedgerSMB::App_State;
 use strict;
 use warnings;
+
+use LedgerSMB::App_State;
+use LedgerSMB::DBObject::User;
+use LedgerSMB::Locale;
+use LedgerSMB::Template;
 
 our $VERSION = 1.0;
 

--- a/lib/LedgerSMB/Scripts/vouchers.pm
+++ b/lib/LedgerSMB/Scripts/vouchers.pm
@@ -411,41 +411,42 @@ my %print_dispatch = (
        script => 'ar.pl',
        entrypoint => sub {
            my ($voucher, $request) = @_;
-           $lsmb_legacy::form->{ARAP} = 'AR';
-           $lsmb_legacy::form->{arap} = 'ar';
-           $lsmb_legacy::form->{vc} = 'customer';
-           $lsmb_legacy::form->{id} = $voucher->{transaction_id}
+           $lsmb_legacy::form->{ARAP} = 'AR'; ## no critic
+           $lsmb_legacy::form->{arap} = 'ar'; ## no critic
+           $lsmb_legacy::form->{vc} = 'customer'; ## no critic
+           $lsmb_legacy::form->{id} = $voucher->{transaction_id} ## no critic
                 if ref $voucher;
-           $lsmb_legacy::form->{formname} = 'ar_transaction';
+           $lsmb_legacy::form->{formname} = 'ar_transaction'; ## no critic
 
-           lsmb_legacy::create_links();
-           $lsmb_legacy::form->{media} = $request->{media};
-           lsmb_legacy::print();
+           lsmb_legacy::create_links(); ## no critic
+           $lsmb_legacy::form->{media} = $request->{media}; ## no critic
+           lsmb_legacy::print(); ## no critic
        }
     },
     BC_SALES_INVOICE() => {
         script => 'is.pl',
         entrypoint => sub {
             my ($voucher, $request) = @_;
-            $lsmb_legacy::form->{formname} = 'invoice';
-            $lsmb_legacy::form->{id} = $voucher->{transaction_id}
+            $lsmb_legacy::form->{formname} = 'invoice'; ## no critic
+            $lsmb_legacy::form->{id} = ## no critic
+                $voucher->{transaction_id}
                                if ref $voucher;
 
-            lsmb_legacy::create_links();
-            $lsmb_legacy::form->{media} = $request->{media};
-            lsmb_legacy::print();
+            lsmb_legacy::create_links(); ## no critic
+            $lsmb_legacy::form->{media} = $request->{media}; ## no critic
+            lsmb_legacy::print(); ## no critic
         }
     },
    BC_VENDOR_INVOICE() => {
        script => 'is.pl',
        entrypoint => sub {
            my ($voucher, $request) = @_;
-           $lsmb_legacy::form->{formname} = 'product_receipt';
-           $lsmb_legacy::form->{id} = $voucher->{transaction_id}
+           $lsmb_legacy::form->{formname} = 'product_receipt'; ## no critic
+           $lsmb_legacy::form->{id} = $voucher->{transaction_id} ## no critic
                 if ref $voucher;
 
-           lsmb_legacy::create_links();
-           lsmb_legacy::print();
+           lsmb_legacy::create_links(); ## no critic
+           lsmb_legacy::print(); ## no critic
        }
     },
     );

--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -333,6 +333,7 @@ use LedgerSMB::Setting;
 use LedgerSMB::Sysconfig;
 use LedgerSMB::Template::DBProvider;
 
+use Template;
 use Template::Parser;
 use Log::Log4perl;
 use File::Spec;

--- a/lib/LedgerSMB/Template/DBProvider.pm
+++ b/lib/LedgerSMB/Template/DBProvider.pm
@@ -19,8 +19,9 @@ LedgerSMB::Template::Provider - Implements template loading from database
 use strict;
 use warnings;
 
-use Template::Provider;
+use Log::Log4perl;
 use PGObject::Type::DateTime;
+use Template::Provider;
 
 use Moose;
 use namespace::autoclean;

--- a/lib/LedgerSMB/Template/LaTeX.pm
+++ b/lib/LedgerSMB/Template/LaTeX.pm
@@ -22,12 +22,13 @@ valid filetype specifiers are 'pdf' and 'ps'.
 
 use warnings;
 use strict;
+use charnames ':full';
 
-use Template::Plugin::Latex;
 use Log::Log4perl;
+use Template::Latex;
+use Template::Plugin::Latex;
 use TeX::Encode::charmap;
 use TeX::Encode;
-use charnames ':full';
 
 BEGIN {
     delete $TeX::Encode::charmap::ACCENTED_CHARS{

--- a/lib/LedgerSMB/Template/XLSX.pm
+++ b/lib/LedgerSMB/Template/XLSX.pm
@@ -21,6 +21,7 @@ use warnings;
 use IO::Scalar;
 use Excel::Writer::XLSX;
 use Spreadsheet::WriteExcel;
+use XML::Twig;
 
 my $binmode = undef;
 my $extension = 'xlsx';

--- a/lib/LedgerSMB/X12/EDI850.pm
+++ b/lib/LedgerSMB/X12/EDI850.pm
@@ -58,7 +58,10 @@ sub _order {
     my ($self) = @_;
     $self->parse;
     my $sep = $self->parser->get_element_separator;
-    my $form = Form->new;
+    # Suppressing critic for the line below: We *did* include
+    # but as LedgerSMB::Form (which is the module), but the module
+    # creates the package called 'Form' (not 'LedgerSMB::Form')
+    my $form = Form->new; ## no critic
     my $sender_idx;
     my $sender_id;
 

--- a/lib/LedgerSMB/X12/EDI894.pm
+++ b/lib/LedgerSMB/X12/EDI894.pm
@@ -56,7 +56,10 @@ has order => (is => 'ro', isa => 'HashRef[Any]', lazy => 1,
 sub _order {
     my ($self) = @_;
     my $sep = $self->parser->get_element_separator;
-    my $form = Form->new;
+    # Suppressing critic for the line below: We *did* include
+    # but as LedgerSMB::Form (which is the module), but the module
+    # creates the package called 'Form' (not 'LedgerSMB::Form')
+    my $form = Form->new; ## no critic
     my $sender_idx;
     my $sender_id;
 

--- a/xt/perlcriticrc
+++ b/xt/perlcriticrc
@@ -113,7 +113,7 @@ pager = less
 [Modules::RequireEndWithOne]
     set_themes = lsmb lsmb_new lsmb_old
 [Modules::RequireExplicitInclusion]
-    set_themes = lsmb lsmb_wip
+    set_themes = lsmb lsmb_new
 [Modules::RequireExplicitPackage]
     set_themes = lsmb lsmb_new lsmb_old
 [Modules::RequireFilenameMatchesPackage]


### PR DESCRIPTION
Note that this is only for new code. Old code would take too much effort to make compliant.

Closes #3315.