### PR TITLE
* Harmonize logging across tests: disable logging

### DIFF
--- a/t/02-number-handling.t
+++ b/t/02-number-handling.t
@@ -16,9 +16,9 @@ use LedgerSMB::Form;
 use LedgerSMB::PGNumber;
 use DBI;
 use LedgerSMB::App_State;
-use Log::Log4perl;
-Log::Log4perl::init(\$LedgerSMB::Sysconfig::log4perl_config);
 
+use Log::Log4perl qw( :easy );
+Log::Log4perl->easy_init($OFF);
 
 my $skipdbtests = 1;
 

--- a/t/03-date-handling.t
+++ b/t/03-date-handling.t
@@ -13,8 +13,9 @@ use LedgerSMB;
 use LedgerSMB::Form;
 use LedgerSMB::Locale;
 use LedgerSMB::App_State;
-use Log::Log4perl;
-Log::Log4perl::init(\$LedgerSMB::Sysconfig::log4perl_config);
+
+use Log::Log4perl qw( :easy );
+Log::Log4perl->easy_init($OFF);
 
 
 $ENV{REQUEST_METHOD} = 'GET';

--- a/t/04-template-handling.t
+++ b/t/04-template-handling.t
@@ -13,8 +13,9 @@ use LedgerSMB::Locale;
 use LedgerSMB::Legacy_Util;
 use LedgerSMB::Template;
 use LedgerSMB::Template::HTML;
-use Log::Log4perl;
-Log::Log4perl::init(\$LedgerSMB::Sysconfig::log4perl_config);
+
+use Log::Log4perl qw(:easy);
+Log::Log4perl->easy_init($OFF);
 
 
 my $template;

--- a/t/11-ledgersmb.t
+++ b/t/11-ledgersmb.t
@@ -11,8 +11,9 @@ use Math::BigFloat;
 use LedgerSMB::Sysconfig;
 use LedgerSMB;
 use LedgerSMB::App_State;
-use Log::Log4perl;
-Log::Log4perl::init(\$LedgerSMB::Sysconfig::log4perl_config);
+
+use Log::Log4perl qw(:easy);
+Log::Log4perl->easy_init($OFF);
 
 
 my $lsmb;

--- a/t/16-schema-upgrade-html.t
+++ b/t/16-schema-upgrade-html.t
@@ -8,19 +8,19 @@ use DBI;
 use Digest::MD5 qw( md5_hex );
 use File::Temp qw( :seekable );
 use IO::Scalar;
-use Log::Log4perl qw( :easy );
 use MIME::Base64;
+
+use Log::Log4perl qw( :easy );
+Log::Log4perl->easy_init($OFF);
 
 use Test::More 'no_plan';
 use Test::Exception;
-
 
 use LedgerSMB;
 use LedgerSMB::Database::ChangeChecks qw( run_checks load_checks );
 use LedgerSMB::Setup::SchemaChecks qw( html_formatter_context );
 
 
-Log::Log4perl->easy_init($OFF);
 
 
 sub test_request {

--- a/xt/09-versioning.t
+++ b/xt/09-versioning.t
@@ -8,8 +8,8 @@ use Test::More tests => 12;
 use LedgerSMB;
 use LedgerSMB::Form;
 use LedgerSMB::App_State;
-use Log::Log4perl;
-Log::Log4perl::init(\$LedgerSMB::Sysconfig::log4perl_config);
+use Log::Log4perl qw(:easy);
+Log::Log4perl->easy_init($OFF);
 
 $ENV{REQUEST_METHOD} = 'GET';
      # Suppress warnings from LedgerSMB::_process_cookies

--- a/xt/44-templates.t
+++ b/xt/44-templates.t
@@ -11,10 +11,8 @@ use LedgerSMB::Database;
 use LedgerSMB::Template::DBProvider;
 use Test::More;
 
-use Log::Log4perl;
-use Log::Log4perl::Level ();
-
-Log::Log4perl->easy_init( Log::Log4perl::Level::to_priority( 'OFF' ) );
+use Log::Log4perl qw(:easy);
+Log::Log4perl->easy_init($OFF);
 
 my @missing = grep { ! $ENV{$_} } (qw(LSMB_NEW_DB LSMB_TEST_DB));
 plan skip_all => (join ', ', @missing) . ' not set' if @missing;


### PR DESCRIPTION
Note that most tests used the logger as configured in
LedgerSMB::Sysconfig; however, that log config contains
the custom '%Z' token which is defined in one of the
Middlewares (which the tests don't use). As a result,
the tests generate warnings in some configurations.
This commit initializes logging to be off, thereby
eliminating the warnings regarding the undefined
logger token (as the config from LedgerSMB::Syslog
is no longer being used as initialization).