### PR TITLE
* Remove logger initialization from modules

### DIFF
--- a/lib/LedgerSMB/Database.pm
+++ b/lib/LedgerSMB/Database.pm
@@ -47,8 +47,6 @@ use LedgerSMB::Sysconfig;
 use LedgerSMB::Database::Loadorder;
 
 
-Log::Log4perl::init(\$LedgerSMB::Sysconfig::log4perl_config);
-
 our $VERSION = '1.2';
 
 my $logger = Log::Log4perl->get_logger('LedgerSMB::Database');


### PR DESCRIPTION
Note that logger initialization is an application responsibility,
not a responsibility of a library. Initialising logging from a
module may even interfere with initialization being done by the
using application.
