### PR TITLE
Fix save gl template

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -7,6 +7,12 @@ Forthcoming
 Changelog for 1.6 Series
 Released 2018-06-10
 
+Changelog for 1.6.4
+* Fix GL Save Template gives error (Nick P, #3754)
+
+Nick P is Nick Prater
+
+
 Changelog for 1.6.3
 * Fix for menu System > Templates fails to execute SQL script (Erik H, #3588)
 * Fix for GL journal buttons displaying in random order (Erik H, #3680)

--- a/old/bin/gl.pl
+++ b/old/bin/gl.pl
@@ -324,7 +324,7 @@ sub display_form
 sub save_temp {
     my ($department_name, $department_id) = split/--/, $form->{department};
 
-    my $data = { 
+    my $data = {
         department_id => $department_id,
         reference => $form->{reference},
         description => $form->{description},

--- a/old/bin/gl.pl
+++ b/old/bin/gl.pl
@@ -323,27 +323,32 @@ sub display_form
 
 sub save_temp {
     my ($department_name, $department_id) = split/--/, $form->{department};
-    $lsmb->{department_id} = $department_id;
-    $lsmb->{reference} = $form->{reference};
-    $lsmb->{description} = $form->{description};
-    $lsmb->{department_id} = $department_id;
-    $lsmb->{post_date} = $form->{transdate};
-    $lsmb->{type} = 'gl';
-    $lsmb->{journal_lines} = [];
+
+    my $data = { 
+        department_id => $department_id,
+        reference => $form->{reference},
+        description => $form->{description},
+        department_id => $department_id,
+        post_date => $form->{transdate},
+        type => 'gl',
+        journal_lines => [],
+    };
+
     for my $iter (0 .. $form->{rowcount}){
         if ($form->{"accno_$iter"} and
                   (($form->{"credit_$iter"} != 0) or ($form->{"debit_$iter"} != 0))){
              my ($acc_id, $acc_name) = split /--/, $form->{"accno_$iter"};
              my $amount = $form->{"credit_$iter"} || ( $form->{"debit_$iter"}
                                                      * -1 );
-             push @{$lsmb->{journal_lines}},
+             push @{$data->{journal_lines}},
                   {accno => $acc_id,
                    amount => $amount,
                    cleared => false,
                   };
         }
     }
-    $template = LedgerSMB::DBObject::TransTemplate->new({base => $form});
+
+    $template = LedgerSMB::DBObject::TransTemplate->new({base => $data});
     $template->save;
     $form->redirect( $locale->text('Template Saved!') );
 }


### PR DESCRIPTION
Fix #3754 GL Save Template gives error
    
Fixes bug introduced by commit 4d65f09c24cbae8e55c8d7a300da596369b3bbdc
    
Save Template from GL transaction gives an error `null value in
column "post_date" violates not-null constraint`.
    
TransTemplate was being created with form data, rather than the
prepared transaction data.
    
Code refactored to make it clearer that transaction data is being
prepared as a simple hash. In 1.5 and earlier, a full-fat LedgerSMB
object was used.

