### PR TITLE
* Move 'root_doc' rendering to login.pl (from menu.pl)

### DIFF
--- a/lib/LedgerSMB/Scripts/login.pm
+++ b/lib/LedgerSMB/Scripts/login.pm
@@ -122,7 +122,14 @@ sub login {
         return __default($request);
     }
 
-    return LedgerSMB::Scripts::menu::root_doc($request);
+    $request->{title} = "LedgerSMB $request->{VERSION} -- ".
+    "$request->{login} -- $request->{company}";
+
+    my $template = LedgerSMB::Template->new_UI(
+        $request,
+        template => 'main',
+    );
+    return $template->render($request);
 }
 
 =item logout

--- a/lib/LedgerSMB/Scripts/menu.pm
+++ b/lib/LedgerSMB/Scripts/menu.pm
@@ -27,55 +27,6 @@ our $VERSION = '1.0';
 
 =over
 
-=item __default
-
-This pseudomethod is used to trap menu clicks that come back through the file
-and route to the appropriate function.  It routes to expanding_menu.
-
-=back
-
-=cut
-
-sub __default {
-    my ($request) = @_;
-
-    return root_doc($request);
-}
-
-=pod
-
-=over
-
-=item root_doc
-
-Creates the root document.
-
-=back
-
-
-=cut
-
-sub root_doc {
-    my ($request) = @_;
-    my $template;
-
-    $request->{title} = "LedgerSMB $request->{VERSION} -- ".
-    "$request->{login} -- $request->{company}";
-
-    my $menu = LedgerSMB::DBObject::Menu->new({base => $request});
-    $menu->generate();
-
-    $template = LedgerSMB::Template->new_UI(
-        $request,
-        template => 'main',
-    );
-    return $template->render($menu);
-}
-
-=pod
-
-=over
-
 =item menuitems_json
 
 Returns the menu items in JSON format


### PR DESCRIPTION
Note that the 'root doc' really originally was the frameset and today
is just the skeleton that serves as the Single Page Application, with
the Dojo AMD hints for loading further assets.
To start loading the assets ASAP, we want to get the initial response
out as fast as we can. This one takes it from 350ms and over to less
than 55ms.
