### PR TITLE
* Improve response times from the menu JSON request (350+ms -> ~100ms)

### DIFF
--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -481,15 +481,10 @@ sub merge {
 sub to_json {
     my ($self, $output) = @_;
 
-    my $response_data = LedgerSMB::Template::preprocess(
-        $output,
-        sub {return shift} # no escaping
-    );
-
     return [
         HTTP_OK,
         [ 'Content-Type' => 'application/json; charset=UTF-8' ],
-        [ $json->encode($response_data) ],
+        [ $json->encode($output) ],
     ];
 }
 


### PR DESCRIPTION
Note that the mentioned times are on my machine; however
the general direction seems to be significant.

Note also that the removed code was actually a no-op in
terms of 'encoding' the result, because the escape function
passed in did nothing but return the argument unchanged.

However, the consequence of the operation _was_ to 'unpack'
object references into plain hash references.