### PR TITLE
Fix #3761 - Reverse Payment Error adding to batch

### DIFF
--- a/lib/LedgerSMB/Scripts/payment.pm
+++ b/lib/LedgerSMB/Scripts/payment.pm
@@ -55,6 +55,7 @@ use LedgerSMB::Company_Config;
 use LedgerSMB::DBObject::Payment;
 use LedgerSMB::DBObject::Date;
 use LedgerSMB::Magic qw( MAX_DAYS_IN_MONTH EC_VENDOR );
+use LedgerSMB::PGDate;
 use LedgerSMB::PGNumber;
 use LedgerSMB::Report::Invoices::Payments;
 use LedgerSMB::Scripts::reports;
@@ -288,21 +289,42 @@ This reverses payments selected in the search results.
 
 sub reverse_payments {
     my ($request) = @_;
-    $request->dates('date_reversed');
-    $request->dates_series(0, $request->{rowcount_}, 'date_paid');
-    $request->{account_class} = 1;
-    my $payment = LedgerSMB::DBObject::Payment->new({base => $request});
-    for my $count (1 .. $payment->{rowcount_}){
-        if ($payment->{"select_$count"}){
-           $payment->{account_class} = $payment->{"entity_class_$count"};
-           $payment->{credit_id} = $payment->{"credit_id_$count"};
-           $payment->{date_paid} = $payment->{"date_paid_$count"};
-           $payment->{source} = $payment->{"source_$count"};
-           $payment->{voucher_id} = $payment->{"voucher_id_$count"};
-           $payment->reverse;
+
+    my $date_reversed = LedgerSMB::PGDate->from_input(
+        $request->{date_reversed}
+    );
+
+    foreach my $count (1 .. $request->{rowcount_}) {
+        # Reverse only the selected payments
+        if ($request->{"select_$count"}) {
+
+            my $data = {
+                          dbh => $request->{dbh},
+                date_reversed => $date_reversed,
+                     batch_id => $request->{batch_id},
+                   cash_accno => $request->{cash_accno},
+                     currency => $request->{currency},
+                 exchangerate => $request->{exchangerate},
+                       source => $request->{"source_$count"},
+                    credit_id => $request->{"credit_id_$count"},
+                account_class => $request->{"entity_class_$count"},
+                   voucher_id => $request->{"voucher_id_$count"},
+                    date_paid => LedgerSMB::PGDate->from_input(
+                                     $request->{"date_paid_$count"}
+                                 ),
+            };
+
+            my $payment = LedgerSMB::DBObject::Payment->new({base => $data});
+            $payment->reverse;
         }
     }
-    return get_search_criteria($payment);
+
+    # TODO This needs to be set to the appropriate class rather than being
+    # hard-coded to a single class of transaction, otherwise we cannot
+    # search Customers for more transactions when reversing receipts.
+    # This bug exists at least as far back as 1.4.
+    $request->{account_class} = 1;
+    return get_search_criteria($request);
 }
 
 =item post_payments_bulk


### PR DESCRIPTION
Submitting payment reversal vouchers to a batch broke in 1.6 because the
`$request->dates` and `$request->dates_series` methods are no longer available
to `payment.pm`.

This patch refactors the `payment.pm` `reverse_payments` function to call
the underlying `LedgerSMB::PGDate->from_input` method directly.

In doing so, it only processes dates for rows being added to a batch.
Previously all rows were processed whether needed or not.

Previously the entire request, including every candidate payment row,
was stuffed into a single `LedgerSMB::DBObject::Payment`
object, then that object's internal state was manipulated to iterate
and reverse each selected payment row. That blurs separation of concerns
and breaks the principle of object encapsulation of data - we should not
be manipulating an object's private internal state.

We now create a clean Payment object for each payment being reversed.
Its properties are explicitly set to document what data is being used in
its construction and minimise its size. Being explicit at such interfaces
makes it easier to test, debug and understand the code.