### PR TITLE
Fix #3763 - Reverse Receipts wrong search screen

### DIFF
--- a/UI/Reports/filters/payments.html
+++ b/UI/Reports/filters/payments.html
@@ -27,6 +27,11 @@
                 name  = "entity_class"
                 value = entity_class
         } ?>
+        <?lsmb INCLUDE input element_data = {
+                type  = "hidden"
+                name  = "account_class"
+                value = account_class
+        } ?>
 <div class="listtop" id="page_title"><?lsmb TITLE ?></div>
 <div class="inputrow">
 <div class="input" id="vendor_input_div">

--- a/lib/LedgerSMB/Scripts/payment.pm
+++ b/lib/LedgerSMB/Scripts/payment.pm
@@ -277,6 +277,7 @@ sub get_search_results {
         currency => $request->{currency},
     exchangerate => $request->{exchangerate},
    date_reversed => $request->{date_reversed},
+   account_class => $request->{account_class},
     };
     return $report->render($request);
 }
@@ -319,11 +320,7 @@ sub reverse_payments {
         }
     }
 
-    # TODO This needs to be set to the appropriate class rather than being
-    # hard-coded to a single class of transaction, otherwise we cannot
-    # search Customers for more transactions when reversing receipts.
-    # This bug exists at least as far back as 1.4.
-    $request->{account_class} = 1;
+    # Go back to search for more payments/receipts to reverse
     return get_search_criteria($request);
 }
 


### PR DESCRIPTION
This patch ensures that `account_class` is passed through
the screens in the Reverse Receipts workflow. With this in place,
the correct search screen is shown after a voucher has been
submitted. This corrects a bug dating back to at least 1.4.