### PR TITLE
Remove PGOld duplicated base parameter processing

### DIFF
--- a/old/lib/LedgerSMB/PGOld.pm
+++ b/old/lib/LedgerSMB/PGOld.pm
@@ -53,11 +53,7 @@ sub new {
         delete $args->{_DBH};
     };
 
-    # key/value pairs from the `base` argument become
-    # properties of the new object.
-    my $self = { map { $_ => $args->{base}->{$_} } keys %{$args->{base}} };
-
-    $self =  PGObject::Simple::new($pkg, %$self);
+    my $self = PGObject::Simple::new($pkg, %{$args->{base}});
     $self->__validate__  if $self->can('__validate__');
     return $self;
 }

--- a/xt/46.1-pgold.t
+++ b/xt/46.1-pgold.t
@@ -1,0 +1,40 @@
+#!/usr/bin/perl
+
+=head1 UNIT TESTS FOR LedgerSMB::PGOld
+
+Partial tests for the LedgerSMB::PGOld module which subclasses
+PGObject::Simple.
+
+=cut
+
+
+use strict;
+use warnings;
+
+use Test::More;
+use LedgerSMB::PGOld;
+
+my $pgold;
+
+plan tests => (4);
+
+# Basic construction with no base properties to import
+isa_ok(
+    $pgold = LedgerSMB::PGOld->new(),
+    'LedgerSMB::PGOld',
+    'object created with no imported properties'
+);
+
+# Construction with base properties
+my $base = {
+    key1 => 'value1',
+    key2 => ['a', 'b'],
+};
+
+isa_ok(
+    $pgold = LedgerSMB::PGOld->new({base => $base}),
+    'LedgerSMB::PGOld',
+    'object created with base properties'
+);
+is($pgold->{key1}, 'value1', 'property key1 initialised ok');
+is_deeply($pgold->{key2}, ['a', 'b'], 'property key2 initialised ok');


### PR DESCRIPTION
`LedgerSMB::PGOld` subclasses `PGObject::Simple`.

`LedgerSMB::PGOld->new()` accepts a `base` hashref parameter which
is used to initialise the new object's properties.

It was copying this base hashref to a new hash, before passing
to `PGObject::Simple`, which repeated the process, copying again
to a new hash to initialise the object.

This patch removes the redundant hash copy, passing the base hashref
directly to `PGObject::Simple`'s initialiser.

A unit test is added to ensure the object property initialisation is
performed correctly.