### PR TITLE
Fix #3759 Display template transaction

### DIFF
--- a/lib/LedgerSMB/App_State.pm
+++ b/lib/LedgerSMB/App_State.pm
@@ -170,7 +170,6 @@ Deletes all objects attached here.
 sub cleanup {
     if ($DBH){
         $DBH->commit;
-        $DBH->disconnect;
     }
     $Locale           = LedgerSMB::Locale->get_handle(
                             $LedgerSMB::Sysconfig::language

--- a/old/lib/LedgerSMB/old_code.pm
+++ b/old/lib/LedgerSMB/old_code.pm
@@ -79,6 +79,12 @@ sub dispatch {
             $lsmb_legacy::form->{$_} = $form_args->{$_} for (keys %$form_args);
             $lsmb_legacy::locale = $LedgerSMB::App_State::Locale;
             %lsmb_legacy::myconfig = %$LedgerSMB::App_State::User;
+
+            # This is a forked process, but we're using the parent's
+            # database handle. Don't destroy the database handle when
+            # this forked process exits, so the parent can continue using it.
+            $LedgerSMB::App_State::DBH->{AutoInactiveDestroy} = 1;
+
             {
                 # Note that we're only loading this code *after* the fork,
                 # so, we're only ever "polluting" the namespaces of the

--- a/old/lib/LedgerSMB/old_code.pm
+++ b/old/lib/LedgerSMB/old_code.pm
@@ -57,7 +57,8 @@ Wraps a "call" to old code, returning a PSGI triplet for the response.
 sub dispatch {
     my $script = shift;
     my $entrypoint = shift;
-    my $args = shift;
+    my $form_args = shift;
+    my @entrypoint_args = @_;
 
     my $stdout = IO::File->new_tmpfile;
     if (my $cpid = fork()) {
@@ -75,7 +76,7 @@ sub dispatch {
         try {
             local *STDOUT = $stdout;
             $lsmb_legacy::form = Form->new();
-            $lsmb_legacy::form->{$_} = $args->{$_} for (keys %$args);
+            $lsmb_legacy::form->{$_} = $form_args->{$_} for (keys %$form_args);
             $lsmb_legacy::locale = $LedgerSMB::App_State::Locale;
             %lsmb_legacy::myconfig = %$LedgerSMB::App_State::User;
             {
@@ -96,7 +97,7 @@ sub dispatch {
                 }
             }
             if (ref $entrypoint eq "CODE") {
-                $entrypoint->(@_);
+                $entrypoint->(@entrypoint_args);
             }
             else {
                 no strict 'refs';


### PR DESCRIPTION
Displaying template transactions was throwing an error as the database
handle was being closed prematurely. This caused an error when
`LedgerSMB::Middleware::DisableBackButton` was trying to read
configuration settings from the database.

There was a further problem that
`LedgerSMB::oldcode::dispatch` was not passing arguments through to
the called endpoint, causing the transaction form to be rendered
without being populated with data.

This PR corrects both issues to fix #3759.

This needs backporting to 1.6 and partially applying to 1.5. 

