### PR TITLE
Fix #3722 Error deleting transaction template

### DIFF
--- a/lib/LedgerSMB/Report/Listings/TemplateTrans.pm
+++ b/lib/LedgerSMB/Report/Listings/TemplateTrans.pm
@@ -45,6 +45,20 @@ Always false
 
 has approved => (is => 'ro', isa => 'Bool', default => 0);
 
+=head2 can_delete
+
+Boolean option which determines if option to delete is displayed.
+Initialised according to whether the current user has the role
+C<transaction_template_delete>.
+
+=cut
+
+has can_delete => (
+    is => 'ro',
+    isa => 'Bool',
+    lazy => 1,
+    builder => '_has_delete_permission'
+);
 
 
 =head1 METHODS
@@ -56,12 +70,19 @@ has approved => (is => 'ro', isa => 'Bool', default => 0);
 sub columns {
     my ($self) = @_;
     my $href_base='transtemplate.pl?action=view&id=';
-    return [ {
-        col_id => 'row_select',
-        type => 'checkbox',
-        name => '',
+    my @columns;
 
-     }, {
+    # Checkbox is only needed for delete option
+    if ($self->can_delete) {
+        push @columns, {
+            col_id => 'row_select',
+            type => 'checkbox',
+            name => '',
+        };
+    }
+
+    # Other fields are always displayed
+    push @columns, {
       col_id => 'id',
         type => 'href',
         name => $self->Text('ID'),
@@ -79,7 +100,9 @@ sub columns {
       col_id => 'entity_name',
         type => 'text',
         name => $self->Text('Counterparty'),
-    }];
+    };
+
+    return \@columns;
 }
 
 =head2 header_lines
@@ -98,14 +121,19 @@ none
 
 sub set_buttons {
     my ($self) = @_;
-    return [
-        { name => 'action',
+    my @buttons;
+
+    if ($self->can_delete) {
+        push @buttons, {
+            name => 'action',
             text => $self->Text('Delete'),
            value => 'delete',
             type => 'submit',
            class => 'submit'
-        },
-        ];
+        };
+    }
+
+    return \@buttons;
 }
 
 =head2 name
@@ -140,9 +168,28 @@ sub run_report {
     return $self->rows(\@rows);
 }
 
+
+# PRIVATE METHODS
+
+# has_delete_permission()
+#
+# returns true if current user has transaction_template_delete role,
+# false otherwise.
+
+sub _has_delete_permission {
+    my ($self) = @_;
+    my $r = $self->call_dbmethod(
+        funcname => 'lsmb__is_allowed_role',
+        args => {rolelist => ['transaction_template_delete']}
+    );
+
+    return $r->{lsmb__is_allowed_role};
+}
+
+
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2016 The LedgerSMB Core Team
+Copyright (C) 2016-2018 The LedgerSMB Core Team
 
 This module may be used under the terms of the GNU General Public License
 version 2 or at your option any later version.  Please see the enclosed

--- a/sql/modules/Roles.sql
+++ b/sql/modules/Roles.sql
@@ -968,6 +968,11 @@ SELECT lsmb__create_role('recurring');
 SELECT lsmb__grant_menu('recurring', 115, 'allow');
 SELECT lsmb__grant_menu('recurring', 28, 'allow');
 
+\echo TEMPLATE TRANSACTIONS
+SELECT lsmb__create_role('transaction_template_delete');
+SELECT lsmb__grant_perms('transaction_template_delete', 'journal_entry', 'DELETE');
+SELECT lsmb__grant_perms('transaction_template_delete', 'journal_line', 'DELETE');
+
 \echo TAX FORMS
 SELECT lsmb__create_role('tax_form_save');
 SELECT lsmb__grant_perms('tax_form_save', 'country_tax_form', 'ALL');


### PR DESCRIPTION
This PR fixes deletion of transaction templates, which was broken because
there was no way to assign the necessary permission.

A new role `transaction_template_delete` is added.

The Transaction Templates report is updated so that the delete option
is shown only when the user has this role.