### PR TITLE
Fix #3783 Error deleting ap/ar Transaction Template

### DIFF
--- a/sql/modules/Roles.sql
+++ b/sql/modules/Roles.sql
@@ -970,6 +970,7 @@ SELECT lsmb__grant_menu('recurring', 28, 'allow');
 
 \echo TEMPLATE TRANSACTIONS
 SELECT lsmb__create_role('transaction_template_delete');
+SELECT lsmb__grant_perms('transaction_template_delete', 'eca_invoice', 'DELETE');
 SELECT lsmb__grant_perms('transaction_template_delete', 'journal_entry', 'DELETE');
 SELECT lsmb__grant_perms('transaction_template_delete', 'journal_line', 'DELETE');
 

--- a/sql/modules/Transaction_Templates.sql
+++ b/sql/modules/Transaction_Templates.sql
@@ -46,8 +46,8 @@ $$ LANGUAGE SQL;
 
 CREATE OR REPLACE FUNCTION journal__delete(in_journal_id int) RETURNS void AS
 $$
+  DELETE FROM eca_invoice WHERE journal_id = in_journal_id;
   DELETE FROM journal_line WHERE journal_id = in_journal_id;
-
   DELETE FROM journal_entry WHERE id = in_journal_id;
 $$ LANGUAGE SQL;
 


### PR DESCRIPTION
AP/AR Transaction templates create records in the `eca_invoice`
table. These must be deleted before the `journal_line` and
`journal_entry` records are deleted.

The `eca_invoice` table is currently used only for template
transactions, so allowing deletion does not put accounting data
at risk.