### PR TITLE
* Add '/' operator to sql 'parser'

### DIFF
--- a/lib/LedgerSMB/Database/Change.pm
+++ b/lib/LedgerSMB/Database/Change.pm
@@ -269,7 +269,7 @@ sub _split_statements {
                       \$\g{_dollar_block}\$)
    (?<String> (?&QuotedString) | (?&DollarQString) )
    (?<Number>[+-]?[0-9]++(\.[0-9]*)? )
-   (?<Operator> [=<>#^%?@!&~|*+-]+|::)
+   (?<Operator> [=<>#^%?@!&~|\/*+-]+|::)
    (?<Array> \[ (?&WhiteSp)
                 (?: (?&ComplexTokenSequence)
                     (?&WhiteSp) )?


### PR DESCRIPTION
While working on the MC branch, the fact that the divide op
was missing in the sql scanner popped out. Here's the fix.
