### PR TITLE
Simplify LedgerSMB::PGOld, reduce App_State::DBH dependency

### DIFF
--- a/lib/LedgerSMB/Scripts/account.pm
+++ b/lib/LedgerSMB/Scripts/account.pm
@@ -143,7 +143,19 @@ sub save_as_new {
 sub _display_account_screen {
     my ($form) = @_;
     my $account = LedgerSMB::DBObject::Account->new({base => $form});
-    $account->set_dbh($form->dbh);
+
+    # If the base $form does not include a `dbh` element as an initialiser
+    # we must explicitly set the dbh. This will depend on how we are called.
+    #
+    # If $form is a `LedgerSMB` object reference, $form->{dbh} will be
+    # defined and no further initialisation is needed. (But note that no
+    # $form->dbh method is available).
+    #
+    # If $form is an object based on `LedgerSMB::PGOld`, $form->{dbh} will
+    # be undefined (as the internal private attribute is called `_dbh`) but
+    # we can call its $form->dbh method to obtain the datbase handle.
+    $account->dbh or $account->set_dbh($form->dbh);
+
     @{$form->{all_headings}} = $account->list_headings();
     @{$form->{all_gifi}} = $account->gifi_list();
     $form->{recon} = $account->is_recon();

--- a/lib/LedgerSMB/Scripts/account.pm
+++ b/lib/LedgerSMB/Scripts/account.pm
@@ -143,6 +143,7 @@ sub save_as_new {
 sub _display_account_screen {
     my ($form) = @_;
     my $account = LedgerSMB::DBObject::Account->new({base => $form});
+    $account->set_dbh($form->dbh);
     @{$form->{all_headings}} = $account->list_headings();
     @{$form->{all_gifi}} = $account->gifi_list();
     $form->{recon} = $account->is_recon();

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -345,7 +345,8 @@ Lists all users in the selected database
 sub list_users {
     my ($request) = @_;
     _init_db($request);
-    my $user = LedgerSMB::DBObject::User->new($request);
+    my $user = LedgerSMB::DBObject::User->new();
+    $user->set_dbh($request->{dbh});
     my $users = $user->get_all_users;
     $request->{users} = [];
     for my $u (@$users) {
@@ -1375,10 +1376,12 @@ sub edit_user_roles {
     _init_db($request)
         unless $request->{dbh};
 
-    my $admin = LedgerSMB::DBObject::Admin->new($request);
+    my $admin = LedgerSMB::DBObject::Admin->new();
+    $admin->set_dbh($request->{dbh});
     my $all_roles = $admin->get_roles($request->{database});
 
-    my $user_obj = LedgerSMB::DBObject::User->new($request);
+    my $user_obj = LedgerSMB::DBObject::User->new();
+    $user_obj->set_dbh($request->{dbh});
     $user_obj->get($request->{id});
 
     # LedgerSMB::DBObject::User doesn't retrieve the username

--- a/old/bin/gl.pl
+++ b/old/bin/gl.pl
@@ -325,6 +325,7 @@ sub save_temp {
     my ($department_name, $department_id) = split/--/, $form->{department};
 
     my $data = {
+        dbh => $form->{dbh},
         department_id => $department_id,
         reference => $form->{reference},
         description => $form->{description},

--- a/old/lib/LedgerSMB/DBObject/Account.pm
+++ b/old/lib/LedgerSMB/DBObject/Account.pm
@@ -147,7 +147,8 @@ sub get {
     for my $ref (@accounts){
         bless $ref, 'LedgerSMB::DBObject::Account';
         $ref->merge($self, keys => ['_user', '_locale', 'stylesheet', '_request']);
-        $ref->set_dbh;
+        $ref->set_dbh($self->dbh);
+
         if ($ref->{is_temp} and ($ref->{category} eq 'Q')){
             $ref->{category} = 'Qt';
         }

--- a/old/lib/LedgerSMB/DBObject/Account.pm
+++ b/old/lib/LedgerSMB/DBObject/Account.pm
@@ -7,7 +7,7 @@ LedgerSMB::DBObject::Account - Base class for chart of accounts entries
 This class contains methods for managing chart of accounts entries (headings
 and accounts).
 
-=head1 INEHRITS
+=head1 INHERITS
 
 =over
 

--- a/old/lib/LedgerSMB/DBObject/Account.pm
+++ b/old/lib/LedgerSMB/DBObject/Account.pm
@@ -2,12 +2,12 @@
 
 LedgerSMB::DBObject::Account - Base class for chart of accounts entries
 
-=head1 SYNOPSYS
+=head1 SYNOPSIS
 
 This class contains methods for managing chart of accounts entries (headings
 and accounts).
 
-=head1 INERITS
+=head1 INEHRITS
 
 =over
 

--- a/old/lib/LedgerSMB/DBObject/TransTemplate.pm
+++ b/old/lib/LedgerSMB/DBObject/TransTemplate.pm
@@ -58,7 +58,7 @@ sub save {
    for my $line (@{$self->{journal_lines}}){
        my $l = bless $line, 'LedgerSMB::PGOld';
        $l->{_locale} = $self->{_locale};
-       $l->set_dbh(LedgerSMB::App_State::DBH());
+       $l->set_dbh();
        $l->{journal_id} = $self->{id};
        my ($ref) = $l->call_dbmethod(funcname => 'account__get_from_accno');
        $l->{account_id} = $ref->{id};

--- a/old/lib/LedgerSMB/DBObject/TransTemplate.pm
+++ b/old/lib/LedgerSMB/DBObject/TransTemplate.pm
@@ -58,7 +58,7 @@ sub save {
    for my $line (@{$self->{journal_lines}}){
        my $l = bless $line, 'LedgerSMB::PGOld';
        $l->{_locale} = $self->{_locale};
-       $l->set_dbh();
+       $l->set_dbh($self->dbh);
        $l->{journal_id} = $self->{id};
        my ($ref) = $l->call_dbmethod(funcname => 'account__get_from_accno');
        $l->{account_id} = $ref->{id};

--- a/old/lib/LedgerSMB/PGOld.pm
+++ b/old/lib/LedgerSMB/PGOld.pm
@@ -48,10 +48,6 @@ A hashref which is imported as properties of the new object.
 sub new {
     my $pkg = shift;
     my $args = (ref $_[0]) ? $_[0] : { @_ };
-    if ($args->{_DBH}) {
-        $args->{dbh} = $args->{_DBH};
-        delete $args->{_DBH};
-    };
 
     my $self = PGObject::Simple::new($pkg, %{$args->{base}});
     $self->__validate__  if $self->can('__validate__');

--- a/old/lib/LedgerSMB/PGOld.pm
+++ b/old/lib/LedgerSMB/PGOld.pm
@@ -56,14 +56,13 @@ sub new {
 
 =item set_dbh
 
-Attribute _DBH builder.  Should probably have been named _set_dbh.
+Set database handle to that defined by C<LedgerSMB::App_State::DBH()>.
 
 =cut
 
 sub set_dbh {
     my ($self) = @_;
-    $self->{_DBH} =  LedgerSMB::App_State::DBH();
-    return  LedgerSMB::App_State::DBH();
+    return $self->SUPER::set_dbh(LedgerSMB::App_State::DBH());
 }
 
 =item dbh

--- a/old/lib/LedgerSMB/PGOld.pm
+++ b/old/lib/LedgerSMB/PGOld.pm
@@ -54,17 +54,6 @@ sub new {
     return $self;
 }
 
-=item set_dbh
-
-Set database handle to that defined by C<LedgerSMB::App_State::DBH()>.
-
-=cut
-
-sub set_dbh {
-    my ($self) = @_;
-    return $self->SUPER::set_dbh(LedgerSMB::App_State::DBH());
-}
-
 =item $self->merge(\%base, %args)
 
 Sets the values from hash 'base' in $self, optionally limited by the

--- a/old/lib/LedgerSMB/PGOld.pm
+++ b/old/lib/LedgerSMB/PGOld.pm
@@ -65,19 +65,6 @@ sub set_dbh {
     return $self->SUPER::set_dbh(LedgerSMB::App_State::DBH());
 }
 
-=item dbh
-
-This is a wrapper around PGObject::Simple->dbh with the exception that we provide a
-a static/class invocation possibility as well.
-
-=cut
-
-sub dbh {
-    my ($self) = @_;
-    return $self->SUPER::dbh() if ref $self;
-    return LedgerSMB::App_State::DBH();
-}
-
 =item $self->merge(\%base, %args)
 
 Sets the values from hash 'base' in $self, optionally limited by the

--- a/xt/lib/Pherkin/Extension/ledgersmb_steps/common_steps.pl
+++ b/xt/lib/Pherkin/Extension/ledgersmb_steps/common_steps.pl
@@ -141,7 +141,9 @@ Given qr/a vendor '(.*)'$/, sub {
     $company = $company->save;
 
     local $LedgerSMB::App_State::DBH = $admin_dbh;
-    my @accounts = LedgerSMB::DBObject::Account->new()->list();
+    my $account = LedgerSMB::DBObject::Account->new();
+    $account->set_dbh($admin_dbh);
+    my @accounts = $account->list();
     my %accno_ids = map { $_->{accno} => $_->{id} } @accounts;
 
     my $vendor = LedgerSMB::Entity::Credit_Account->new(

--- a/xt/lib/Pherkin/Extension/ledgersmb_steps/common_steps.pl
+++ b/xt/lib/Pherkin/Extension/ledgersmb_steps/common_steps.pl
@@ -171,7 +171,7 @@ Given qr/a part with these properties:$/, sub {
     local $LedgerSMB::App_State::DBH = S->{ext_lsmb}->admin_dbh;
     my $account = LedgerSMB::DBObject::Account->new();
     $account->set_dbh(S->{ext_lsmb}->admin_dbh);
-    my @accounts = $account->new()->list();
+    my @accounts = $account->list();
     my %accno_ids = map { $_->{accno} => $_->{id} } @accounts;
 
     $total_props{partnumber} //= 'P-' . ($part_count++);

--- a/xt/lib/Pherkin/Extension/ledgersmb_steps/common_steps.pl
+++ b/xt/lib/Pherkin/Extension/ledgersmb_steps/common_steps.pl
@@ -169,7 +169,9 @@ Given qr/a part with these properties:$/, sub {
     my %total_props = (%part_props, %props);
 
     local $LedgerSMB::App_State::DBH = S->{ext_lsmb}->admin_dbh;
-    my @accounts = LedgerSMB::DBObject::Account->new()->list();
+    my $account = LedgerSMB::DBObject::Account->new();
+    $account->set_dbh(S->{ext_lsmb}->admin_dbh);
+    my @accounts = $account->new()->list();
     my %accno_ids = map { $_->{accno} => $_->{id} } @accounts;
 
     $total_props{partnumber} //= 'P-' . ($part_count++);


### PR DESCRIPTION
This patch reduces the dependency on `LedgerSMB::App_State::DBH()`,
which we wish to deprecate to simplify testing and re-use of lsmb
modules outside the web application.

It simplifies and reduces the code in LedgerSMB::PGOld, another
module we wish to deprecate, delegating directly to the
underlying libraries, making lsmb more 'standard' in its behaviour.

A visual audit of code using LedgerSMB::PGOld and user-testing has
been conducted to check for any unwanted breakage - no issues
have been found.

This PR improves code structure and separation and removes undocumented
action-at-a-distance, making it easier to follow, debug and ultimately
remove older code.

