### PR TITLE
Use Plack::Request to initialise LedgerSMB object

### DIFF
--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -159,9 +159,8 @@ my $json = JSON::MaybeXS->new( pretty => 1,
 
 
 sub new {
-    my ($class, $cgi_args, $script_name, $query_string,
-        $uploads, $cookies, $auth, $db, $company, $session_id,
-        $create_session_cb, $invalidate_session_cb) = @_;
+
+    my ($class, $request, $auth) = @_;
     my $self = {};
     bless $self, $class;
 
@@ -175,18 +174,18 @@ sub new {
     $self->{version} = $VERSION;
     $self->{dbversion} = $VERSION;
     $self->{VERSION} = $VERSION;
-    $self->{_uploads} = $uploads  if defined $uploads;
-    $self->{_cookies} = $cookies  if defined $cookies;
-    $self->{query_string} = $query_string if defined $query_string;
+    $self->{_uploads} = $request->uploads if defined $request->uploads;
+    $self->{_cookies} = $request->cookies if defined $request->cookies;
+    $self->{query_string} = $request->query_string if defined $request->query_string;
     $self->{_auth} = $auth;
-    $self->{script} = $script_name;
-    $self->{dbh} = $db;
-    $self->{company} = $company;
-    $self->{_session_id} = $session_id;
-    $self->{_create_session} = $create_session_cb;
-    $self->{_logout} = $invalidate_session_cb;
+    $self->{script} = $request->env->{'lsmb.script'};
+    $self->{dbh} = $request->env->{'lsmb.db'};
+    $self->{company} = $request->env->{'lsmb.company'};
+    $self->{_session_id} = $request->env->{'lsmb.session_id'};
+    $self->{_create_session} = $request->env->{'lsmb.create_session_cb'};
+    $self->{_logout} = $request->env->{'lsmb.invalidate_session_cb'};
 
-    $self->_process_args($cgi_args);
+    $self->_process_args($request->parameters);
     $self->_set_default_locale();
 
     return $self;

--- a/lib/LedgerSMB/PSGI.pm
+++ b/lib/LedgerSMB/PSGI.pm
@@ -99,12 +99,7 @@ sub psgi_app {
     my $auth = LedgerSMB::Auth::factory($env);
 
     my $psgi_req = Plack::Request::WithEncoding->new($env);
-    my $request = LedgerSMB->new(
-        $psgi_req->parameters, $env->{'lsmb.script'}, $env->{QUERY_STRING},
-        $psgi_req->uploads, $psgi_req->cookies, $auth, $env->{'lsmb.db'},
-        $env->{'lsmb.company'},
-        $env->{'lsmb.session_id'}, $env->{'lsmb.create_session_cb'},
-        $env->{'lsmb.invalidate_session_cb'});
+    my $request = LedgerSMB->new($psgi_req, $auth);
 
     $request->{action} = $env->{'lsmb.action_name'};
     my $res;

--- a/t/02-number-handling.t
+++ b/t/02-number-handling.t
@@ -16,6 +16,7 @@ use LedgerSMB::Form;
 use LedgerSMB::PGNumber;
 use DBI;
 use LedgerSMB::App_State;
+use Plack::Request;
 
 use Log::Log4perl qw( :easy );
 Log::Log4perl->easy_init($OFF);
@@ -34,7 +35,8 @@ my $form = Form->new;
 my %myconfig;
 ok(defined $form);
 isa_ok($form, 'Form');
-my $lsmb = LedgerSMB->new;
+my $request = Plack::Request->new({});
+my $lsmb = LedgerSMB->new($request);
 ok(defined $lsmb);
 isa_ok($lsmb, 'LedgerSMB');
 

--- a/t/03-date-handling.t
+++ b/t/03-date-handling.t
@@ -13,6 +13,7 @@ use LedgerSMB;
 use LedgerSMB::Form;
 use LedgerSMB::Locale;
 use LedgerSMB::App_State;
+use Plack::Request;
 
 use Log::Log4perl qw( :easy );
 Log::Log4perl->easy_init($OFF);
@@ -28,7 +29,8 @@ my $locale_es = LedgerSMB::Locale->get_handle('es');
 my %myconfig;
 ok(defined $form);
 isa_ok($form, 'Form');
-my $lsmb = LedgerSMB->new;
+my $request = Plack::Request->new({});
+my $lsmb = LedgerSMB->new($request);
 ok(defined $lsmb);
 isa_ok($lsmb, 'LedgerSMB');
 

--- a/t/04-template-handling.t
+++ b/t/04-template-handling.t
@@ -13,6 +13,7 @@ use LedgerSMB::Locale;
 use LedgerSMB::Legacy_Util;
 use LedgerSMB::Template;
 use LedgerSMB::Template::HTML;
+use Plack::Request;
 
 use Log::Log4perl qw(:easy);
 Log::Log4perl->easy_init($OFF);
@@ -328,7 +329,8 @@ my $contact_request = {
                 ]
 }; # Company with Credit Accounts and business types.
 
-my $payment = LedgerSMB->new();
+my $request = Plack::Request->new({});
+my $payment = LedgerSMB->new($request);
 $payment->merge({
         contact_1 => 1, source_1 => 1, action=>'dispay_payments', id_1 => 1,
         id_1_1    => 1,

--- a/t/11-ledgersmb.t
+++ b/t/11-ledgersmb.t
@@ -11,12 +11,14 @@ use Math::BigFloat;
 use LedgerSMB::Sysconfig;
 use LedgerSMB;
 use LedgerSMB::App_State;
+use Plack::Request;
 
 use Log::Log4perl qw(:easy);
 Log::Log4perl->easy_init($OFF);
 
 
 my $lsmb;
+my $request = Plack::Request->new({});
 
 
 sub redirect {
@@ -33,7 +35,7 @@ sub lsmb_error_func {
 ##merge
 
 
-$lsmb = LedgerSMB->new();
+$lsmb = LedgerSMB->new($request);
 my $utfstr;
 my @r;
 
@@ -41,12 +43,12 @@ ok(defined $lsmb);
 isa_ok($lsmb, 'LedgerSMB');
 
 # $lsmb->escape checks
-$lsmb = LedgerSMB->new();
+$lsmb = LedgerSMB->new($request);
 $utfstr = "\xd8\xad";
 utf8::decode($utfstr);
 
 # $lsmb->new checks
-$lsmb = LedgerSMB->new();
+$lsmb = LedgerSMB->new($request);
 ok(defined $lsmb, 'new: blank, defined');
 isa_ok($lsmb, 'LedgerSMB', 'new: blank, correct type');
 ok(defined $lsmb->{dbversion}, 'new: blank, dbversion defined');
@@ -56,7 +58,7 @@ ok(defined $lsmb->{version}, 'new: blank, version defined');
 SKIP: {
         skip 'Skipping call_procedure tests, no db specified', 5
                 if !defined $ENV{PGDATABASE};
-        $lsmb = LedgerSMB->new();
+        $lsmb = LedgerSMB->new($request);
         my $pghost = "";
         $pghost = ";host=" . $ENV{PGHOST}
             if $ENV{PGHOST} && $ENV{PGHOST} ne 'localhost';
@@ -91,19 +93,19 @@ SKIP: {
 }
 
 # $lsmb->merge checks
-$lsmb = LedgerSMB->new();
+$lsmb = LedgerSMB->new($request);
 $lsmb->merge({'apple' => 1, 'pear' => 2, 'peach' => 3}, 'keys' => ['apple', 'pear']);
 ok(!defined $lsmb->{peach}, 'merge: Did not add unselected key');
 is($lsmb->{apple}, 1, 'merge: Added unselected key apple');
 is($lsmb->{pear}, 2, 'merge: Added unselected key pear');
 
-$lsmb = LedgerSMB->new();
+$lsmb = LedgerSMB->new($request);
 $lsmb->merge({'apple' => 1, 'pear' => 2, 'peach' => 3});
 is($lsmb->{apple}, 1, 'merge: No key, added apple');
 is($lsmb->{pear}, 2, 'merge: No key, added pear');
 is($lsmb->{peach}, 3, 'merge: No key, added peach');
 
-$lsmb = LedgerSMB->new();
+$lsmb = LedgerSMB->new($request);
 $lsmb->merge({'apple' => 1, 'pear' => 2, 'peach' => 3}, 'index' => 1);
 is($lsmb->{apple_1}, 1, 'merge: Index 1, added apple as apple_1');
 is($lsmb->{pear_1}, 2, 'merge: Index 1, added pear as pear_1');

--- a/t/16-schema-upgrade-html.t
+++ b/t/16-schema-upgrade-html.t
@@ -9,6 +9,7 @@ use Digest::MD5 qw( md5_hex );
 use File::Temp qw( :seekable );
 use IO::Scalar;
 use MIME::Base64;
+use Plack::Request;
 
 use Log::Log4perl qw( :easy );
 Log::Log4perl->easy_init($OFF);
@@ -24,7 +25,8 @@ use LedgerSMB::Setup::SchemaChecks qw( html_formatter_context );
 
 
 sub test_request {
-    my $req = LedgerSMB->new();
+    my $plack_req = Plack::Request->new({});
+    my $req = LedgerSMB->new($plack_req);
 
     $req->{script} = 'script.pl';
     $req->{query_string} = 'action=rebuild';

--- a/xt/09-versioning.t
+++ b/xt/09-versioning.t
@@ -9,15 +9,16 @@ use LedgerSMB;
 use LedgerSMB::Form;
 use LedgerSMB::App_State;
 use Log::Log4perl qw(:easy);
+use Plack::Request;
+
 Log::Log4perl->easy_init($OFF);
 
 $ENV{REQUEST_METHOD} = 'GET';
      # Suppress warnings from LedgerSMB::_process_cookies
 
+my $request = Plack::Request->new({});
 
-
-
-my $lsmb = LedgerSMB->new;
+my $lsmb = LedgerSMB->new($request);
 ok(defined $lsmb, 'lsmb: defined');
 isa_ok($lsmb, 'LedgerSMB', 'lsmb: correct type');
 ok(defined $lsmb->{version}, 'lsmb: version set');

--- a/xt/40-dbsetup.t
+++ b/xt/40-dbsetup.t
@@ -7,6 +7,7 @@ use LedgerSMB::Sysconfig;
 use LedgerSMB::DBObject::Admin;
 use strict;
 use DBI;
+use Plack::Request;
 
 # This entire test suite will be skipped unless environment
 # variable LSMB_TEST_DB is true
@@ -113,7 +114,8 @@ SKIP: {
                 or !defined $ENV{LSMB_ADMIN_FNAME}
                 or !defined $ENV{LSMB_ADMIN_LNAME});
      # Move to LedgerSMB::DBObject::Admin calls.
-     my $lsmb = LedgerSMB->new;
+     my $request = Plack::Request->new({});
+     my $lsmb = LedgerSMB->new($request);
      ok(defined $lsmb, '$lsmb defined');
      isa_ok($lsmb, 'LedgerSMB');
      $lsmb->{dbh} = DBI->connect("dbi:Pg:dbname=$ENV{PGDATABASE}",

--- a/xt/62-api-legacy.t
+++ b/xt/62-api-legacy.t
@@ -9,6 +9,7 @@ BEGIN {
     use LedgerSMB::DBTest;
     use LedgerSMB::App_State;
     use LedgerSMB::Locale;
+    use Plack::Request;
 }
 
 # TODO: FIXME
@@ -82,7 +83,8 @@ for my $test (@$test_request_data){
         if (ref $test->{'_pre_test_sub'} eq 'CODE'){
                 $test->{'_pre_test_sub'}();
         }
-    my $request = LedgerSMB->new();
+    my $plack_request = Plack::Request->new({});
+    my $request = LedgerSMB->new($plack_request);
         if (lc $test->{_codebase} eq 'old'){
                 next; # skip old codebase tests for now
                 #old_code_test::_load_script($test->{module});


### PR DESCRIPTION
Rather thank unpacking selected parts of a `Plack::Request` object to initialise
a new `LedgerSMB` object, pass the whole unmodified `Plack::Request` object.
    
This then becomes a standard, documented interface and reduces complexity.
    
This opens the way to simplifying the `LedgerSMB` module, making the
`Plack::Request` object reference one of it's properties and providing attribute
getters/setters so that users of the `LedgerSMB` module no longer directly
manipulate its internal state.