### PR TITLE
Fix minimum Plack::Request version to access QUERY_STRING

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -41,7 +41,7 @@ requires 'PGObject::Type::DateTime', '1.0.4';
 requires 'PGObject::Type::ByteString', '1.1.1';
 requires 'PGObject::Util::DBMethod';
 requires 'PGObject::Util::DBAdmin', '0.120';
-requires 'Plack';
+requires 'Plack', '1.0031';
 requires 'Plack::App::File';
 requires 'Plack::Builder';
 requires 'Plack::Builder::Conditionals';


### PR DESCRIPTION
We need at least 1.0031 for query_string shortcut to access QUERY_STRING in PSGI environment