### PR TITLE
Add Timecard - make date required field

### DIFF
--- a/UI/timecards/entry_filter.html
+++ b/UI/timecards/entry_filter.html
@@ -34,6 +34,7 @@
         type = 'text'
         size = 12
        class = 'date'
+    required = 'true'
 } ?>
 </div></div>
 <?lsmb PROCESS button element_data = {


### PR DESCRIPTION
When adding a timecard, the first step is to complete the
"Timecard Criteria" form. If the `Starting Date` field is left
blank, an error relating to operations on an undefined value
is displayed.

This patch marks the `Starting Date` field as `required` to
provide user feedback if the field is not filled-in and to avoid
triggering the error.