### PR TITLE
Add a shared LedgerSMB::Setting instance to request

### DIFF
--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -188,6 +188,7 @@ sub new {
     $self->{_session_id} = $request->env->{'lsmb.session_id'};
     $self->{_create_session} = $request->env->{'lsmb.create_session_cb'};
     $self->{_logout} = $request->env->{'lsmb.invalidate_session_cb'};
+    $self->{setting} = $request->env->{'lsmb.setting'};
 
     $self->_process_args($request->parameters);
     $self->_set_default_locale();

--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -170,7 +170,8 @@ sub new {
 
     (my $package,my $filename,my $line)=caller;
 
-
+    # Properties prefixed with underscore are hidden from UI templates.
+    #
     # Some tests construct LedgerSMB objects without $auth argument
     # (in fact, without any arguments), so check for having an $auth
     # arg before trying to call methods on it.
@@ -188,7 +189,7 @@ sub new {
     $self->{_session_id} = $request->env->{'lsmb.session_id'};
     $self->{_create_session} = $request->env->{'lsmb.create_session_cb'};
     $self->{_logout} = $request->env->{'lsmb.invalidate_session_cb'};
-    $self->{setting} = $request->env->{'lsmb.setting'};
+    $self->{_setting} = $request->env->{'lsmb.setting'};
 
     $self->_process_args($request->parameters);
     $self->_set_default_locale();
@@ -492,7 +493,7 @@ sub system_info {
 
 sub setting {
     my ($self) = @_;
-    return $self->{setting};
+    return $self->{_setting};
 }
 
 =head1 LICENSE AND COPYRIGHT

--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -101,6 +101,10 @@ PSGI response triplet (status, headers, body).
 Returns a hashref with the keys being system information sections,
 each being a hashref detailing configuration items with their values.
 
+=item setting
+
+Accessor method for a shared LedgerSMB::Setting instance.
+
 =back
 
 
@@ -485,6 +489,10 @@ sub system_info {
     };
 }
 
+sub setting {
+    my ($self) = @_;
+    return $self->{setting};
+}
 
 =head1 LICENSE AND COPYRIGHT
 

--- a/lib/LedgerSMB/Middleware/AuthenticateSession.pm
+++ b/lib/LedgerSMB/Middleware/AuthenticateSession.pm
@@ -79,6 +79,7 @@ use LedgerSMB::Auth;
 use LedgerSMB::App_State;
 use LedgerSMB::DBH;
 use LedgerSMB::PSGI::Util;
+use LedgerSMB::Setting;
 use LedgerSMB::Sysconfig;
 
 =head1 METHODS
@@ -190,6 +191,9 @@ sub call {
             return $extended_cookie;
         };
     }
+
+    $env->{'lsmb.setting'} = LedgerSMB::Setting->new();
+    $env->{'lsmb.setting'}->set_dbh($dbh);
 
     my $res = $self->app->($env);
     $dbh->rollback;

--- a/lib/LedgerSMB/Scripts/admin.pm
+++ b/lib/LedgerSMB/Scripts/admin.pm
@@ -20,7 +20,6 @@ This module provides the workflow scripts for managing users and permissions.
 use LedgerSMB::Template;
 use LedgerSMB::DBObject::Admin;
 use LedgerSMB::DBObject::User;
-use LedgerSMB::Setting;
 use Log::Log4perl;
 
 # I don't really like the code in this module.  The callbacks are per form which

--- a/lib/LedgerSMB/Scripts/configuration.pm
+++ b/lib/LedgerSMB/Scripts/configuration.pm
@@ -24,7 +24,6 @@ use strict;
 use warnings;
 
 use LedgerSMB::App_State;
-use LedgerSMB::Setting;
 use LedgerSMB::Setting::Sequence;
 use LedgerSMB::Template;
 
@@ -169,7 +168,6 @@ Shows the defaults screen
 
 sub defaults_screen{
     my ($request) = @_;
-    my $setting_handle = LedgerSMB::Setting->new({base => $request});
     my @defaults;
     my @default_settings = &_default_settings($request);
     for my $dg (@default_settings) {
@@ -178,7 +176,7 @@ sub defaults_screen{
         }
     }
     for my $skey (@defaults){
-        $request->{$skey} = $setting_handle->get($skey);
+        $request->{$skey} = $request->setting->get($skey);
     }
 
     my @country_list = $request->call_procedure(
@@ -192,11 +190,11 @@ sub defaults_screen{
     unshift @language_code_list, {}
         if ! defined $request->{default_language};
 
-    my $expense_accounts = $setting_handle->accounts_by_link('IC_cogs');
-    my $income_accounts = $setting_handle->accounts_by_link('IC_income');
-    my $fx_loss_accounts = $setting_handle->all_accounts();
-    my $fx_gain_accounts = $setting_handle->all_accounts();
-    my $inventory_accounts = $setting_handle->accounts_by_link('IC');
+    my $expense_accounts = $request->setting->accounts_by_link('IC_cogs');
+    my $income_accounts = $request->setting->accounts_by_link('IC_income');
+    my $fx_loss_accounts = $request->setting->all_accounts();
+    my $fx_gain_accounts = $request->setting->all_accounts();
+    my $inventory_accounts = $request->setting->accounts_by_link('IC');
     my $headings =
         [$request->call_procedure(funcname => 'account__all_headings')];
     for my $ref (@$headings){
@@ -348,7 +346,6 @@ sub save_defaults {
     ){
        die $request->{_locale}->text('Access Denied');
     }
-    my $setting_handle = LedgerSMB::Setting->new({base => $request});
     my @defaults;
     my @default_settings = &_default_settings($request);
     for my $dg (@default_settings){
@@ -358,7 +355,7 @@ sub save_defaults {
     }
     for my $skey (@defaults){
         $request->{$skey} =~ s/--.*$// if $skey =~ /accno_id/;
-        $setting_handle->set($skey, $request->{$skey});
+        $request->setting->set($skey, $request->{$skey});
     }
     return defaults_screen($request);
 }

--- a/lib/LedgerSMB/Scripts/contact.pm
+++ b/lib/LedgerSMB/Scripts/contact.pm
@@ -37,7 +37,6 @@ use LedgerSMB::Entity::User;
 use LedgerSMB::File;
 use LedgerSMB::Magic qw( EC_EMPLOYEE );
 use LedgerSMB::Part;
-use LedgerSMB::Setting;
 use LedgerSMB::Template;
 
 use LedgerSMB::old_code qw(dispatch);
@@ -305,9 +304,8 @@ sub _main_screen {
         push @all_currencies, { text => $curr};
     }
 
-    my $default_country = LedgerSMB::Setting->get('default_country');
-
-    my ($default_language) = LedgerSMB::Setting->get('default_language');
+    my $default_country = $request->setting->get('default_country');
+    my ($default_language) = $request->setting->get('default_language');
 
     my $attach_level_options = [
         {text => $locale->text('Entity'), value => 1} ];

--- a/lib/LedgerSMB/Scripts/import_csv.pm
+++ b/lib/LedgerSMB/Scripts/import_csv.pm
@@ -24,7 +24,6 @@ use Text::CSV;
 
 use LedgerSMB::Template;
 use LedgerSMB::Form;
-use LedgerSMB::Setting;
 use LedgerSMB::Magic qw( EC_VENDOR EC_CUSTOMER );
 
 our $cols = {
@@ -135,7 +134,7 @@ sub _aa_multi {
     for my $ref (@$entries){
         my $form = Form->new(); ## no critic
         $form->{dbh} = $request->{dbh};
-        my $default_currency = LedgerSMB::Setting->get('curr');
+        my $default_currency = $request->setting->get('curr');
         $form->{rowcount} = 1;
         $form->{ARAP} = uc($arap);
         $form->{batch_id} = $batch->{id};

--- a/lib/LedgerSMB/Scripts/recon.pm
+++ b/lib/LedgerSMB/Scripts/recon.pm
@@ -26,7 +26,6 @@ use LedgerSMB::DBObject::Reconciliation;
 use LedgerSMB::PGNumber;
 use LedgerSMB::Report::Reconciliation::Summary;
 use LedgerSMB::Scripts::reports;
-use LedgerSMB::Setting;
 use LedgerSMB::Template;
 
 =over
@@ -197,8 +196,7 @@ it has been created.
 sub _display_report {
     my ($recon, $request) = @_;
     $recon->get();
-    my $setting_handle = LedgerSMB::Setting->new({base => $recon});
-    $recon->{reverse} = $setting_handle->get('reverse_bank_recs');
+    $recon->{reverse} = $request->setting->get('reverse_bank_recs');
     delete $recon->{reverse} unless $recon->{account_info}->{category}
                                     eq 'A';
     $request->close_form;
@@ -286,7 +284,7 @@ sub _display_report {
                                     + $recon->{mismatch_our_total});
     $recon->{out_of_balance} = $recon->{their_total} - $recon->{our_total};
     $recon->{out_of_balance}->bfround(
-        LedgerSMB::Setting->get('decimal_places') * -1
+        $request->setting->get('decimal_places') * -1
     );
     $recon->{submit_enabled} = ($recon->{out_of_balance} == 0);
 

--- a/lib/LedgerSMB/Scripts/report_aging.pm
+++ b/lib/LedgerSMB/Scripts/report_aging.pm
@@ -26,7 +26,6 @@ use LedgerSMB::Entity::Location;
 use LedgerSMB::Legacy_Util;
 use LedgerSMB::Report::Aging;
 use LedgerSMB::Scripts::reports;
-use LedgerSMB::Setting;
 use LedgerSMB::Template;
 
 our $VERSION = '1.0';

--- a/lib/LedgerSMB/Scripts/reports.pm
+++ b/lib/LedgerSMB/Scripts/reports.pm
@@ -27,7 +27,6 @@ use LedgerSMB::Report::Listings::Language;
 use LedgerSMB::Report::Listings::SIC;
 use LedgerSMB::Report::Listings::Overpayments;
 use LedgerSMB::Report::Listings::Warehouse;
-use LedgerSMB::Setting;
 use LedgerSMB::Template;
 
 our $VERSION = '1.0';
@@ -88,7 +87,7 @@ sub start_report {
     @{$request->{all_years}} = $request->call_procedure(
               funcname => 'date_get_all_years'
     );
-    my $curr = LedgerSMB::Setting->get('curr');
+    my $curr = $request->setting->get('curr');
     @{$request->{currencies}} = split /:/, $curr;
     $_ = {id => $_, text => $_} for @{$request->{currencies}};
     my $months = LedgerSMB::App_State::all_months();
@@ -108,7 +107,7 @@ sub start_report {
         funcname => 'person__list_languages'
         );
 
-    $request->{earn_id} = LedgerSMB::Setting->get('earn_id');
+    $request->{earn_id} = $request->setting->get('earn_id');
     my $template = LedgerSMB::Template->new(
         request => $request,
         user => $request->{_user},

--- a/lib/LedgerSMB/Scripts/timecard.pm
+++ b/lib/LedgerSMB/Scripts/timecard.pm
@@ -32,7 +32,6 @@ use LedgerSMB::Company_Config;
 use LedgerSMB::Magic qw( MIN_PER_HOUR SEC_PER_HOUR SUNDAY SATURDAY );
 use LedgerSMB::PGDate;
 use LedgerSMB::Report::Timecards;
-use LedgerSMB::Setting;
 use LedgerSMB::Sysconfig;
 use LedgerSMB::Template;
 use LedgerSMB::Timecard;
@@ -93,7 +92,7 @@ sub display {
     @{$request->{b_units}} = LedgerSMB::Business_Unit->list(
           $request->{bu_class_id}, undef, 0, $request->{transdate}
     );
-    my $curr = LedgerSMB::Setting->get('curr');
+    my $curr = $request->setting->get('curr');
     @{$request->{currencies}} = split /:/, $curr;
     $request->{total} = ($request->{qty}//0) + ($request->{non_billable}//0);
      my $template = LedgerSMB::Template->new(
@@ -121,7 +120,7 @@ sub timecard_screen {
          @{$request->{b_units}} = LedgerSMB::Business_Unit->list(
               $request->{bu_class_id}, undef, 0, $request->{transdate}
          );
-         my $curr = LedgerSMB::Setting->get('curr');
+         my $curr = $request->setting->get('curr');
          @{$request->{currencies}} = split /:/, $curr;
          my $startdate = LedgerSMB::PGDate->from_input($request->{date_from});
 

--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -329,7 +329,6 @@ use Carp;
 
 use LedgerSMB::App_State;
 use LedgerSMB::Locale;
-use LedgerSMB::Setting;
 use LedgerSMB::Sysconfig;
 use LedgerSMB::Template::DBProvider;
 


### PR DESCRIPTION
Many parts of the lsmb code use a `LedgerSMB::Setting` instance. Rather than each having to instantiate its own, often copying the entire request object into the new Setting instance just for the sake of a database handle, this PR provides one instance, initialised in a standard way, with a valid database handle, accessed via the `LedgerSMB` request class, which can be used wherever needed.

This further reduces the need for `LedgerSMB::App_State::DBH()` which we want to deprecate, which is currently used by `LedgerSMB::Setting->get()`. That dependency will be removed in a future PR.