### PR TITLE
Refactor LedgerSMB::Settings and add tests

### DIFF
--- a/old/lib/LedgerSMB/Setting.pm
+++ b/old/lib/LedgerSMB/Setting.pm
@@ -14,8 +14,6 @@ use base qw(LedgerSMB::PGOld Exporter);
 use strict;
 use warnings;
 
-our $VERSION = '1.0.0';
-
 our @EXPORT_OK = qw( increment_process );
 
 =head1 METHODS

--- a/old/lib/LedgerSMB/Setting.pm
+++ b/old/lib/LedgerSMB/Setting.pm
@@ -73,7 +73,11 @@ sub get {
 
 =head2 increment($myconfig, $key)
 
-TODO
+Reads the given setting C<key> from the C<defaults> table, increments it,
+updating the database, and returns the new value.
+
+Only the last block of digits in any text is incremented. Any text
+is ignored and left unchanged.
 
 =cut
 

--- a/old/lib/LedgerSMB/Setting.pm
+++ b/old/lib/LedgerSMB/Setting.pm
@@ -1,18 +1,47 @@
-=head1 NAME
-
-LedgerSMB::Setting - LedgerSMB class for managing Business Locations
-
-=head1 SYNOPSIS
-
-This module creates object instances based on LedgerSMB's in-database ORM.
-
-=cut
-
 package LedgerSMB::Setting;
+
 use LedgerSMB::App_State;
 use base qw(LedgerSMB::PGOld Exporter);
 use strict;
 use warnings;
+
+=head1 NAME
+
+LedgerSMB::Setting - Interact with LedgerSMB company settings.
+
+=head1 SYNOPSIS
+
+    use LedgerSMB::Setting;
+
+    $setting = LedgerSMB::Setting->new();
+    $setting->set_dbh($dbh);
+
+    # Write to the defaults table
+    $setting->set('company_name' => 'Bar Foo')
+
+    # Get from the defaults table
+    $name = $setting->get('company_name');
+
+    # Display all accounts
+    $accounts = $setting->all_accounts;
+    foreach my $account (@{$accounts}) {
+        print $account->{description} . "\n";
+    }
+
+    # Display all AR tax accounts
+    $accounts = $setting->accounts_by_link('AR_tax');
+    foreach my $account (@{$accounts}) {
+        print $account->{description} . "\n";
+    }
+
+    # Get defined currencies
+    @currencies = $setting->get_currencies;
+
+=head1 EXPORTS
+
+C<increment_process>
+
+=cut
 
 our @EXPORT_OK = qw( increment_process );
 

--- a/old/lib/LedgerSMB/Setting.pm
+++ b/old/lib/LedgerSMB/Setting.pm
@@ -88,7 +88,7 @@ sub increment {
                                              args => [$key]) ;
     my $value = $retval->{setting_increment};
 
-    my $var = increment_process($value, $self, $myconfig);
+    my $var = increment_process($value, $self);
 
     $self->{value} = $var if $self->{key};
     return $var;

--- a/old/lib/LedgerSMB/Setting.pm
+++ b/old/lib/LedgerSMB/Setting.pm
@@ -1,56 +1,10 @@
-
 =head1 NAME
 
 LedgerSMB::Setting - LedgerSMB class for managing Business Locations
 
-=head1 SYOPSIS
+=head1 SYNOPSIS
 
 This module creates object instances based on LedgerSMB's in-database ORM.
-
-=head1 METHODS
-
-The following method is static:
-
-=over
-
-=item new ($LedgerSMB object);
-
-=back
-
-The following methods are passed through to stored procedures:
-
-=over
-
-=item get ($self->{key})
-
-=item set ($self->{key}, $self->{value})
-
-=item increment ($self->{key})
-
-=item all_accounts()
-
-=item accounts_by_link($link)
-
-=item get_currencies()
-
-Returns a list of all accounts on the system.
-
-=item parse_increment ($self->{key})
-
-This function updates a default entry in the database, incrimenting the last
-set of digits not including <?lsmb ?> tags or non-digits, and then parses the
-returned value, doing tag substitution.  The final value is then returned by
-the function.
-
-=back
-
-The above list may grow over time, and may depend on other installed modules.
-
-=head1 Copyright (C) 2007, The LedgerSMB core team.
-
-This file is licensed under the Gnu General Public License version 2, or at your
-option any later version.  A copy of the license should have been included with
-your software.
 
 =cut
 
@@ -63,6 +17,17 @@ use warnings;
 our $VERSION = '1.0.0';
 
 our @EXPORT_OK = qw( increment_process );
+
+=head1 METHODS
+
+Inherits from L<LedgerSMB::PGOld>
+
+=head2 get($key)
+
+Retrieve the value of the specified C<key> from the database C<defaults>
+table.
+
+=cut
 
 sub get {
     my $self = shift;
@@ -78,6 +43,12 @@ sub get {
     }
     return undef;
 }
+
+=head2 increment($myconfig, $key)
+
+TODO
+
+=cut
 
 sub increment {
 
@@ -96,8 +67,17 @@ sub increment {
     return $var;
 }
 
-# Increment processing routine, used by only related classes.
-#
+=head2 increment_process
+
+Increment processing subroutine (NOT an object method), used by only related classes.
+
+This function updates a default entry in the database, incrementing the last
+set of digits not including <?lsmb ?> tags or non-digits, and then parses the
+returned value, doing tag substitution.  The final value is then returned by
+the function.
+
+=cut
+
 sub increment_process{
     my ($value, $self ) = @_;
 # check for and replace
@@ -186,12 +166,24 @@ sub increment_process{
     return $var;
 }
 
+=head2 get_currencies()
+
+Returns an array of currencies defined for the current company.
+
+=cut
+
 sub get_currencies {
     my $self = shift;
     my @data = $self->call_dbmethod(funcname => 'setting__get_currencies');
     $self->{currencies} = $data[0]->{setting__get_currencies};
     return @{$self->{currencies}};
 }
+
+=head2 set($key, $value)
+
+Update the C<defaults> database table with the specified key/value pair.
+
+=cut
 
 sub set {
     my ($self, $key, $value) = @_;
@@ -200,6 +192,15 @@ sub set {
     return $self->call_procedure(funcname => 'setting__set',
                               args => [$key, $value]);
 }
+
+=head2 accounts_by_link($link_description)
+
+Returns an arrayref containing all accounts having the specified
+C<link_description> (AP, AR, AR_tax, IC_cogs etc).
+
+Useful for populating drop-down lists.
+
+=cut
 
 sub accounts_by_link {
     my ($self, $link) = @_;
@@ -210,6 +211,12 @@ sub accounts_by_link {
     }
     return \@results;
 }
+
+=head2 all_accounts()
+
+Returns an arrayref containing all accounts.
+
+=cut
 
 sub all_accounts {
     my ($self) = @_;
@@ -222,5 +229,13 @@ sub all_accounts {
     }
     return \@results;
 }
+
+=head1 Copyright (C) 2007-2018, The LedgerSMB core team.
+
+This file is licensed under the Gnu General Public License version 2, or at your
+option any later version.  A copy of the license should have been included with
+your software.
+
+=cut
 
 1;

--- a/xt/45.3-ledgersmb-setting.t
+++ b/xt/45.3-ledgersmb-setting.t
@@ -81,7 +81,7 @@ is($setting->get('TEST_SETTING_KEY'), 'new-test-value', 'retrieved updated setti
 # Order of returned list is important as first element indicates default
 ok($setting->set('curr', 'EUR:CAD:SEK:GBP'), 'set currencies');
 my @currencies = $setting->get_currencies;
-is_deeply(\@currencies, [qw( EUR CAD SEK GBP )], 'get currencies ok'); 
+is_deeply(\@currencies, [qw( EUR CAD SEK GBP )], 'get currencies ok');
 
 # Getting all accounts
 $accounts = $setting->all_accounts;

--- a/xt/45.3-ledgersmb-setting.t
+++ b/xt/45.3-ledgersmb-setting.t
@@ -1,0 +1,104 @@
+#!/usr/bin/perl
+
+=head1 UNIT TESTS FOR LedgerSMB::Setting
+
+Unit tests for the LedgerSMB::Setting module that exercise
+interaction with a test database.
+
+=cut
+
+use strict;
+use warnings;
+
+use DBI;
+use Test::More;
+use LedgerSMB::Setting;
+use LedgerSMB::App_State;
+
+
+# Create test run conditions
+my $setting;
+my $accounts;
+my $dbh = DBI->connect(
+    "dbi:Pg:dbname=$ENV{LSMB_NEW_DB}",
+    undef,
+    undef,
+    { AutoCommit => 0, PrintError => 0 }
+) or BAIL_OUT "Can't connect to template database: " . DBI->errstr;
+
+# Needed until LedgerSMB::Setting->get() is refactored to use its
+# class dbh, rather than App_State
+LedgerSMB::App_State::set_DBH($dbh);
+
+# Add some sample accounts
+$dbh->do("INSERT INTO account_heading (accno) VALUES ('0000')")
+   or BAIL_OUT 'Failed to insert test account: ' . DBI->errstr;
+
+my $heading_id = $dbh->last_insert_id(
+    undef,
+    undef,
+    'account_heading',
+    undef,
+);
+
+my $q = $dbh->prepare("
+    INSERT INTO account (accno, description, category, heading)
+    VALUES (?, ?, 'A', ?)
+") or BAIL_OUT 'Failed to prepare query to insert accounts: ' . DBI->errstr;
+
+$q->execute('1001', 'ACCOUNT-1001', $heading_id)
+   or BAIL_OUT 'Failed to insert test account: ' . DBI->errstr;
+$q->execute('1002', 'ACCOUNT-1002', $heading_id)
+   or BAIL_OUT 'Failed to insert test account: ' . DBI->errstr;
+
+# Add sample account link
+$dbh->do("
+    INSERT INTO account_link_description (description, summary, custom)
+    VALUES ('TEST_DESCRIPTION', FALSE, FALSE)
+") or BAIL_OUT 'Failed to insert account_link_description: ' . DBI->errstr;
+
+$dbh->do("
+    INSERT INTO account_link (account_id, description)
+    SELECT MAX(id), 'TEST_DESCRIPTION' FROM account
+") or BAIL_OUT 'Failed to insert account_link: ' . DBI->errstr;
+
+
+plan tests => (17);
+
+# Initialise Object
+$setting = LedgerSMB::Setting->new();
+isa_ok($setting, 'LedgerSMB::Setting', 'instantiated object');
+ok($setting->set_dbh($dbh), 'set dbh');
+
+# Getting/Setting keys in the defaults table
+is($setting->get('TEST_SETTING_KEY'), undef, 'getting non-existent setting key returns undef');
+ok($setting->set('TEST_SETTING_KEY', 'test-value'), 'set new setting key');
+is($setting->get('TEST_SETTING_KEY'), 'test-value', 'retrieved new setting key');
+ok($setting->set('TEST_SETTING_KEY', 'new-test-value'), 'updated existing setting key');
+is($setting->get('TEST_SETTING_KEY'), 'new-test-value', 'retrieved updated setting key');
+
+# Getting/Setting currencies
+# Order of returned list is important as first element indicates default
+ok($setting->set('curr', 'EUR:CAD:SEK:GBP'), 'set currencies');
+my @currencies = $setting->get_currencies;
+is_deeply(\@currencies, [qw( EUR CAD SEK GBP )], 'get currencies ok'); 
+
+# Getting all accounts
+$accounts = $setting->all_accounts;
+is(ref $accounts, 'ARRAY', 'all_accounts method returns arrayref');
+is(scalar @{$accounts}, 2, 'all_accounts returns correct number of accounts');
+
+# Get accounts with a particular link description
+$accounts = $setting->accounts_by_link('TEST_DESCRIPTION');
+is(ref $accounts, 'ARRAY', 'all_accounts method returns arrayref');
+is(scalar @{$accounts}, 1, 'all_accounts returns correct number of accounts');
+is($$accounts[0]->{accno}, '1002', 'accounts_by_link returns correct account');
+
+# Increment a field
+ok($setting->set('TEST_SETTING_KEY', 'A-123-1234-B'), 'set increment test key');
+is($setting->increment(undef, 'TEST_SETTING_KEY'), 'A-123-1235-B', 'increment returned ok');
+is($setting->get('TEST_SETTING_KEY'), 'A-123-1235-B', 'increment round-trip from database');
+
+
+# Don't commit any of our changes
+$dbh->rollback;


### PR DESCRIPTION
This PR adds tests interacting with the database for `LedgerSMB::Setting`.
POD is updated to provide a synopsis with example usage and document every method.
Code is unchanged apart from removal of an unused `$myconfig` argument in an internal function call.
