### PR TITLE
Lazy initialisation of shared LedgerSMB::Settings object

### DIFF
--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -499,8 +499,8 @@ sub setting {
 
     unless($self->{_setting}) {
         $self->{dbh} or croak(
-            "cannot initialise LedgerSMB::Setting object -".
-            "database handler is undefined"
+            'cannot initialise LedgerSMB::Setting object -'.
+            'database handler is undefined'
         );
         $self->{_setting} = LedgerSMB::Setting->new();
         $self->{_setting}->set_dbh($self->{dbh});

--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -101,12 +101,14 @@ PSGI response triplet (status, headers, body).
 Returns a hashref with the keys being system information sections,
 each being a hashref detailing configuration items with their values.
 
-=item setting
+=item setting()
 
-Accessor method for a shared LedgerSMB::Setting instance.
+Accessor method and lazy initialisation for a shared LedgerSMB::Setting
+instance.
+
+Returns a reference to an initialised LedgerSMB::Setting instance.
 
 =back
-
 
 
 =head1 Copyright (C) 2006-2017, The LedgerSMB core team.
@@ -151,6 +153,7 @@ use LedgerSMB::App_State;
 use LedgerSMB::Locale;
 use LedgerSMB::User;
 use LedgerSMB::Company_Config;
+use LedgerSMB::Setting;
 use LedgerSMB::Template;
 
 our $VERSION = '1.7.0-dev';
@@ -493,6 +496,16 @@ sub system_info {
 
 sub setting {
     my ($self) = @_;
+
+    unless($self->{_setting}) {
+        $self->{dbh} or croak(
+            "cannot initialise LedgerSMB::Setting object -".
+            "database handler is undefined"
+        );
+        $self->{_setting} = LedgerSMB::Setting->new();
+        $self->{_setting}->set_dbh($self->{dbh});
+    }
+
     return $self->{_setting};
 }
 
@@ -508,5 +521,3 @@ your software.
 
 
 1;
-
-

--- a/lib/LedgerSMB/Middleware/AuthenticateSession.pm
+++ b/lib/LedgerSMB/Middleware/AuthenticateSession.pm
@@ -79,7 +79,6 @@ use LedgerSMB::Auth;
 use LedgerSMB::App_State;
 use LedgerSMB::DBH;
 use LedgerSMB::PSGI::Util;
-use LedgerSMB::Setting;
 use LedgerSMB::Sysconfig;
 
 =head1 METHODS
@@ -191,9 +190,6 @@ sub call {
             return $extended_cookie;
         };
     }
-
-    $env->{'lsmb.setting'} = LedgerSMB::Setting->new();
-    $env->{'lsmb.setting'}->set_dbh($dbh);
 
     my $res = $self->app->($env);
     $dbh->rollback;


### PR DESCRIPTION
Initialises the shared LedgerSMB::Settings object only when required.
This moves the initialisation into the main `LedgerSMB` module,
rather than doing initialisation in the otherwise unrelated
`AuthenticateSession` module.