### PR TITLE
LedgerSMB::Batch - fix create() return value, add tests, pod.

### DIFF
--- a/old/lib/LedgerSMB/Batch.pm
+++ b/old/lib/LedgerSMB/Batch.pm
@@ -36,7 +36,18 @@ sub get_new_info {
 
 =item create
 
-Saves the batch info and populates the id hashref value with the id inserted.
+Inserts a new batch and populates the class C<id> attribute with the id of
+the inserted batch record.
+
+The following object attributes must be defined before calling this method:
+
+  * dbh
+  * batch_number [populates control_code field]
+  * batch_class  [ap|ar|gl... See batch_class table)
+  * batch_date   [populates default_date field]
+  * description
+
+This method returns the C<id> of the newly inserted batch on success.
 
 =cut
 
@@ -44,7 +55,7 @@ sub create {
     my $self = shift @_;
     my ($ref) = $self->call_dbmethod(funcname => 'batch_create');
     $self->{id} = $ref->{batch_create};
-    return $ref->{id};
+    return $self->{id};
 }
 
 =item delete_voucher($id)
@@ -194,7 +205,10 @@ sub post {
 
 =item delete
 
-Deletes the unapproved batch and all vouchers under it.
+Deletes the batch with C<id> matching the current object's C<batch_id>
+attribute and all vouchers under it.
+
+Returns the C<id> of the deleted batch.
 
 =cut
 
@@ -205,6 +219,7 @@ sub delete {
 }
 
 =item list_vouchers
+
 Returns a list of all vouchers in the batch and attaches that list to
 $self->{vouchers}
 
@@ -218,7 +233,36 @@ sub list_vouchers {
 
 =item get
 
-Gets the batch and merges information with the current batch object.
+Retrieves the batch with C<id> matching the current object's C<batch_id>
+attribute, setting object properties according to the retrieved record's
+fields.
+
+The following object attributes must be defined before calling this method:
+
+  * dbh
+  * batch_id
+
+Note that the C<batch_id> attribute used to specify retrieval is different
+to the C<id> attribute used for the returned result field (though they
+will match after a successful retrieval).
+
+Returns a reference to the current object regardless of whether a matching
+batch was found. If no match was found, the object's C<id> field will be
+C<undef>.
+
+After successful retrieval, the following object attributes will be populated
+according to the retrieved record:
+
+    * id
+    * batch_class_id
+    * control_code
+    * description
+    * default_date
+    * created_by
+    * approved_on
+    * created_on
+    * locked_by
+    * approved_by
 
 =cut
 

--- a/old/lib/LedgerSMB/Batch.pm
+++ b/old/lib/LedgerSMB/Batch.pm
@@ -208,14 +208,14 @@ sub post {
 Deletes the batch with C<id> matching the current object's C<batch_id>
 attribute and all vouchers under it.
 
-Returns the C<id> of the deleted batch.
+Returns true on success.
 
 =cut
 
 sub delete {
     my ($self) = @_;
-    ($self->{delete_ref}) = $self->call_dbmethod(funcname => 'batch_delete');
-    return $self->{delete_ref};
+    my ($ref) = $self->call_dbmethod(funcname => 'batch_delete');
+    return $ref->{batch_delete};
 }
 
 =item list_vouchers

--- a/old/lib/LedgerSMB/Batch.pm
+++ b/old/lib/LedgerSMB/Batch.pm
@@ -4,7 +4,35 @@ LedgerSMB::Batch - Batch/voucher management model for LedgerSMB 1.3
 
 =head1 SYNOPSIS
 
-Batch/voucher management model for LedgerSMB 1.3
+    use LedgerSMB::Batch
+
+    # Create a new batch
+    my $data = {
+        dbh => $dbh,
+        batch_number => 'TEST-001',
+        batch_class => 'ap',
+        batch_date => '2018-09-08',
+        description => 'Test Description',
+    };
+    my $batch = LedgerSMB::Batch->new({ base => $data });
+    my $id = $batch->create;
+
+    # Retrieve a batch
+    $data = {
+        dbh => $dbh,
+        batch_id => $id,
+    };
+    $batch = LedgerSMB::Batch->new({ base => $data });
+    my $result = $batch->get;
+    my $description = $result->{description};
+
+    # Delete a batch
+    $data = {
+        dbh => $dbh,
+        batch_id => $id,
+    };
+    $batch = LedgerSMB::Batch->new({ base => $data });
+    $batch->delete;
 
 =head1 METHODS
 
@@ -276,7 +304,7 @@ sub get {
 
 =back
 
-=head1 Copyright (C) 2009, The LedgerSMB core team.
+=head1 Copyright (C) 2009-2018, The LedgerSMB core team.
 
 This file is licensed under the Gnu General Public License version 2, or at your
 option any later version.  A copy of the license should have been included with

--- a/xt/45.4-ledgersmb-batch.t
+++ b/xt/45.4-ledgersmb-batch.t
@@ -1,0 +1,111 @@
+#!/usr/bin/perl
+
+=head1 UNIT TESTS FOR LedgerSMB::Batch
+
+Unit tests for the LedgerSMB::Batch module that exercise
+interaction with a test database.
+
+Currently tests only creation, retrieval and deletion.
+
+=cut
+
+use strict;
+use warnings;
+
+use DBI;
+use Test::More;
+use LedgerSMB::Batch;
+
+
+# Create test run conditions
+my $batch;
+my $id;
+my $data;
+my $result;
+my $dbh = DBI->connect(
+    "dbi:Pg:dbname=$ENV{LSMB_NEW_DB}",
+    undef,
+    undef,
+    { AutoCommit => 0, PrintError => 0 }
+) or BAIL_OUT "Can't connect to template database: " . DBI->errstr;
+
+
+# The test database should already have batch classes defined
+my $q = $dbh->prepare("SELECT id FROM batch_class WHERE class='ap'")
+  or BAIL_OUT 'Failed to prepare batch_class query: ' . DBI->errstr;
+$q->execute
+  or BAIL_OUT 'Failed to execute batch_class query: ' . DBI->errstr;
+my ($batch_class_id) = $q->fetchrow_array
+  or BAIL_OUT 'Failed to retrieve batch class "ap": ' . DBI->errstr;
+
+
+plan tests => (26);
+
+
+# Create a batch
+$data = {
+    dbh => $dbh,
+    batch_number => 'TEST-001',
+    batch_class => 'ap',
+    batch_date => '2018-09-08',
+    description => 'Test Description',
+};
+$batch = LedgerSMB::Batch->new({ base => $data });
+isa_ok($batch, 'LedgerSMB::Batch', 'instantiated object with data');
+$id = $batch->create;
+ok($id, 'batch creation returns true');
+like($id, qr/^\d+$/, 'batch creation returns numeric id');
+is($id, $batch->{id}, 'id object property matches returned id');
+
+
+# Retrieve a batch
+$data = {
+    dbh => $dbh,
+    batch_id => $id,
+};
+$batch = LedgerSMB::Batch->new({ base => $data });
+isa_ok($batch, 'LedgerSMB::Batch', 'instantiated object');
+$result = $batch->get;
+isa_ok($result, 'LedgerSMB::Batch', 'object returned after retrieving batch');
+is($result->{id}, $id, 'retrieved batch id matches requested id');
+is($result->{id}, $batch->{batch_id}, 'retrieved id property');
+is($result->{description}, 'Test Description', 'retrieved description');
+is($result->{batch_class_id}, $batch_class_id, 'retrieved batch_class_id');
+is($result->{control_code}, 'TEST-001', 'retrieved control_code');
+is($result->{default_date}, '2018-09-08', 'retrieved default_date');
+ok(exists $result->{created_by}, 'retrieved created_by');
+ok(exists $result->{approved_on}, 'retrieved approved_on');
+is($result->{approved_on}, undef, 'retrieved approved_on is undef');
+like($result->{created_on}, qr/^\d{4}-\d{2}-\d{2}$/, 'retrieved created on');
+ok(exists $result->{locked_by}, 'retrieved locked_by');
+is($result->{loked_by}, undef, 'retrieved locked_by is undef');
+ok(exists $result->{approved_by}, 'retrieved approved_by');
+is($result->{approved_by}, undef, 'retrieved approved_by is undef');
+
+
+# Delete a batch
+$data = {
+    dbh => $dbh,
+    batch_id => $id,
+};
+$batch = LedgerSMB::Batch->new({ base => $data });
+isa_ok($batch, 'LedgerSMB::Batch', 'instantiated object');
+$result = $batch->delete;
+ok($result, 'deleting a batch returns true');
+
+
+# Retrieve a non-existent batch
+$data = {
+    dbh => $dbh,
+    id => $id,
+};
+$batch = LedgerSMB::Batch->new({ base => $data });
+isa_ok($batch, 'LedgerSMB::Batch', 'instantiated object');
+$result = $batch->get;
+isa_ok($result, 'LedgerSMB::Batch', 'object returned after retrieving non-existent batch');
+ok(exists $result->{id}, 'id property exists after retrieving non-existent batch');
+is($result->{id}, undef, 'retrieved batch id undef after retrieving non-existent batch');
+
+
+# Don't commit any of our changes
+$dbh->rollback;


### PR DESCRIPTION
This PR adds unit tests and pod documentation for `LedgerSMB::Batch`.
It fixes a bug in the return value of the `create()` method.
It removes an unused property `delete_ref`.