### PR TITLE
Require date for batch creation

### DIFF
--- a/UI/create_batch.html
+++ b/UI/create_batch.html
@@ -41,6 +41,7 @@
             type = "date"
             class = "date"
             name = "batch_date"
+            required = "true"
             value = batch.batch_date } ?>
   </div>
 </div>


### PR DESCRIPTION
On the "Create New Batch" screen, an error occurs if `Continue` is
pressed without filling in the `Batch Date` field.

This PR makes the `Batch Date` field a required field, so that
submission cannot be made without filling it in. This prevents
the error from occuring.