### PR TITLE
* Implement a mechanism for fixes to schema changes

### DIFF
--- a/t/data/loadorder/test4.sql
+++ b/t/data/loadorder/test4.sql
@@ -1,0 +1,2 @@
+
+select 'this is a test also!';

--- a/t/data/loadorder/test4.sql@1
+++ b/t/data/loadorder/test4.sql@1
@@ -1,0 +1,2 @@
+
+select 'this is a test as well!';


### PR DESCRIPTION
Note that there are still strict conditions for this to work
e.g. that the original schema changes still need to be stored
together with the new schema change files.
However, this new situation is a lot less rigid than the one
we had before where schema change files had to be completely
immutable.
