### PR TITLE
Require 'Start Source Numbering' field

### DIFF
--- a/UI/payments/payments_filter.html
+++ b/UI/payments/payments_filter.html
@@ -172,6 +172,7 @@
         type = "text"
         size = "20"
         name = "source_start"
+        required = "true"
         label = text('Start Source Numbering At:')
 } # ?>
 </div>


### PR DESCRIPTION
When adding payments to a voucher batch, the `Start Source Numbering At`
field must be filled in, otherwise an error is triggered.

This PR marks the field as `required` so that user-friendly feedback
is provided in the UI, rather than a somewhat cryptic error message.