### PR TITLE
Remove code duplication getting default currency

### DIFF
--- a/old/lib/LedgerSMB/DBObject/Payment.pm
+++ b/old/lib/LedgerSMB/DBObject/Payment.pm
@@ -102,6 +102,7 @@ Requires that the following object properties be defined:
 Sets the following object properties:
 
   * currencies
+  * default_currency
   * businesses
   * payment_types
   * debt_accounts
@@ -121,15 +122,12 @@ Additionally if payment_type_id is set:
 sub get_metadata {
     my ($self) = @_;
 
+    $self->get_default_currency;
     $self->get_open_currencies();
     $self->{currencies} = [];
     for my $c (@{$self->{openCurrencies}}) {
         push @{$self->{currencies}}, $c->{payments_get_open_currencies};
     }
-
-    $self->{default_currency} = $self->call_dbmethod(
-        funcname => 'defaults_get_defaultcurrency'
-    )->{defaults_get_defaultcurrency};
 
     @{$self->{businesses}} = $self->call_dbmethod(
         funcname => 'business_type__list'


### PR DESCRIPTION
In `LedgerSMB::DBObject::Payment` there is a method to retrieve
the default currency and set the corresponding object property.

This code was duplicated in the `get_metadata` method, but
has no been simplified by having `get_metadata` call the
`get_default_currency` method.