### PR TITLE
Documentation and remove duplicate method call

### DIFF
--- a/lib/LedgerSMB/Scripts/payment.pm
+++ b/lib/LedgerSMB/Scripts/payment.pm
@@ -462,9 +462,34 @@ sub update_payments {
     return display_payments(@_);
 }
 
-=item display_payments
+=item display_payments($request)
 
 This displays the bulk payment screen with current data.
+
+C<$request> is a L<LedgerSMB> object reference.
+
+Required request parameters:
+
+  * dbh
+  * action
+  * account_class [1|2]
+  * batch_id
+  * batch_date
+  * currency
+  * source_start
+
+Optionally accepts the following filtering parameters:
+
+  * ar_ap_accno
+  * meta_number
+
+Though the following filtering parameters appear to be available,
+they are not supported by the underlying C<payment_get_all_contact_invoices>
+database query:
+
+  * business_id
+  * date_from
+  * date_to
 
 =cut
 

--- a/lib/LedgerSMB/Scripts/payment.pm
+++ b/lib/LedgerSMB/Scripts/payment.pm
@@ -471,7 +471,6 @@ This displays the bulk payment screen with current data.
 sub display_payments {
     my ($request) = @_;
     my $payment =  LedgerSMB::DBObject::Payment->new({'base' => $request});
-    $payment->{default_currency} =  $payment->get_default_currency();;
     $payment->get_payment_detail_data();
     $request->open_form();
     my $db_fx = $payment->get_exchange_rate($payment->{currency},

--- a/old/lib/LedgerSMB/DBObject/Payment.pm
+++ b/old/lib/LedgerSMB/DBObject/Payment.pm
@@ -562,9 +562,37 @@ sub get_vc_info {
  return ${$self->{vendor_customer_info}}[0];
 }
 
-=item get_payment_detail_data
+=item get_payment_detail_data($request)
 
-This method sets appropriate project, department, etc. fields.
+This method calls C<get_metadata()> to populate various object properties.
+See that method's documentation for details.
+
+Additionally a set of contact invoices properties are set,
+filtered according to the supplied parameters.
+
+C<$request> is a L<LedgerSMB> request object.
+
+Required request parameters:
+
+  * dbh
+  * action
+  * account_class [1|2]
+  * batch_id
+  * source_start (unless account_class == 2)
+
+Optionally accepts the following filtering parameters:
+
+  * currency [e.g. 'GBP']
+  * ar_ap_accno
+  * meta_number
+
+Though the following filtering parameters appear to be available,
+they are not supported by the underlying C<payment_get_all_contact_invoices>
+database query:
+
+  * business_id
+  * date_from
+  * date_to
 
 =cut
 


### PR DESCRIPTION
Adds pod documentation for methods relating to payment voucher processing.

Removes a call to `$payment->get_default_currency()` now rendered superfluous
following recent changes to other modules.