### PR TITLE
Filter Payments screen field clean-up

### DIFF
--- a/UI/payments/payments_detail.html
+++ b/UI/payments/payments_detail.html
@@ -106,12 +106,18 @@
                 } ?>
         </div>
 
-        <div id="date_filter_row">
-                <label for="filter_from"><?lsmb text('Filtering From') ?></label>
-                <span id="filter_from"><?lsmb payment.date_from ?></span>
-                <label for="filter_to"><?lsmb text('To') ?></label>
-                <span id="filter_to"><?lsmb payment.date_to ?></span>
+        <?lsmb IF payment.date_from ?>
+        <div class="info" id="date_filter_from_row">
+            <label for="filter_from"><?lsmb text('Filtering From') ?></label>
+            <span id="filter_from"><?lsmb payment.date_from ?></span>
         </div>
+        <?lsmb END ?>
+        <?lsmb IF payment.date_to ?>
+        <div class="info" id="date_filter_to_row">
+            <label for="filter_to"><?lsmb text('To') ?></label>
+            <span id="filter_to"><?lsmb payment.date_to ?></span>
+        </div>
+        <?lsmb END ?>
 
         <!-- the department will be shown if it was selected in the first step -->
         <?lsmb IF payment.department.value  # Only process element if one exists. As in project above ?>
@@ -173,10 +179,12 @@
                 </div>
         <?lsmb END # if business ?>
 
+        <?lsmb IF payment.payment_type ?>
         <div class="payment_type" id="payment_type_label_div">
                 <label for="filter_type_label"><?lsmb text('Payment Type') ?></label>
                 <span id="filter_type_label"><?lsmb payment_type_return_label ?> </span>
         </div>
+        <?lsmb END ?>
 
         <div class="info" id="cash_account_div">
                 <?lsmb INCLUDE input element_data = {

--- a/UI/payments/payments_filter.html
+++ b/UI/payments/payments_filter.html
@@ -30,31 +30,7 @@
         type = "hidden"
         name = "batch_date"
 } ?>
-<div id = "payments-filter-categories" class="inputgroup">
-<?lsmb IF payment.projects ?>
-<div id = "payments-filter-projects" class="inputgroup">
-  <label for="project"><?lsmb text('Project') ?></label>
-  <?lsmb PROCESS select element_data = {
-                        name="project_id"
-                        id="project"
-                        options=payment.projects
-                        text_attr='projectnumber'
-                        value_attr='id' } ?>
-</div>
-<?lsmb END ?>
 
-<?lsmb IF payment.departments ?>
-<div id = "payments-filter-departments" class="inputgroup">
-  <label for="department"><?lsmb text('Department') ?></label>
-  <?lsmb PROCESS select element_data = {
-                        name="department_id"
-                        id="department"
-                        default_blank=1
-                        options=payment.departments
-                        value_attr='id'
-                        text_attr='description' } ?>
-</div>
-<?lsmb END ?>
 
 <?lsmb IF request.account_class == 1 ?>
 <?lsmb vendor_customer_code = text("Vendor Number") # ' ?>
@@ -70,18 +46,6 @@
         size = '15'
 } ?>
 
-<?lsmb IF payment.businesses ?>
-<div id = "payments-filter-businesses" class="inputgroup">
-  <label for="businesses"><?lsmb text('Business Class') ?></label>
-  <?lsmb PROCESS select element_data = {
-                        name="business_id"
-                        id="businesses"
-                        default_blank=1
-                        options=payment.businesses
-                        value_attr='id'
-                        text_attr='description' } ?>
-</div>
-<?lsmb END ?>
 <div class="inputgroup" id="account_input">
     <?lsmb
      FOREACH a = payment.debt_accounts;
@@ -96,25 +60,7 @@
  default_values = [payment.account]
     } ?>
 </div>
-<div id = "payments-filter-daterow" class = "inputgroup">
-<div class="input">
-<?lsmb PROCESS input element_data = {
-        label = text('Date From')
-        type = "text"
-        class = "date"
-        value = payment.date_from
-        name = "date_from"
-        size = 12
-} # ' ?></div><div class="input">
-<?lsmb PROCESS input element_data = {
-        label = text('Date To')
-        type = "text"
-        class = "date"
-        value = payment.date_to
-        name = "date_to"
-        size = 12
-} # ' ?></div>
-</div>
+
 <div id = "payments-filter-currency-row" class="inputgroup">
 <label for="currency"><?lsmb text('Currency')?></label>
 <?lsmb
@@ -130,7 +76,7 @@
    }
 ?>
 </div>
-</div>
+
 <div class="listtop"><?lsmb text('Payment Processing') ?></div>
 
       <?lsmb

--- a/xt/66-cucumber/13-cash/vouchers-payment.feature
+++ b/xt/66-cucumber/13-cash/vouchers-payment.feature
@@ -13,11 +13,7 @@ Scenario: Add payments to a new batch
   When I enter "2018-01-01" into "Batch Date"
    And I press "Continue"
   Then I should see the Filtering Payments screen
-  When I enter "2017-12-01" into "Date From"
-   And I enter "2017-12-31" into "Date To"
-   And I enter "1001" into "Start Source Numbering At"
+  When I enter "1001" into "Start Source Numbering At"
    And I press "Continue"
   Then I should see the Payments Detail screen
    And I expect to see the 'date_paid' value of '2018-01-01'
-   And I expect to see the 'filter_from' value of '2017-12-01'
-   And I expect to see the 'filter_to' value of '2017-12-31'


### PR DESCRIPTION
This PR removes spurious fields from the Filter Payments screen for which there is currently no support in the database backend:
    
* categories
* department
* businesses
* date_from
* date_to
    
The underlying `payment_get_all_contact_invoices` database procedure appears to
support filtering on these fields, but on close inspection, the query it runs does not
take notice of these parameters.
    
It is unclear in any case exactly what date the from/to filters should operate on -
due date, tax point, entry date - it's ambiguous.
    
Removing these fields ensures that we present only working functionality which
we are able to test, without the distraction of features yet to be implemented.
They can easily be added back as and when anybody requires these features
and is willing to implement them.

To complement this, the Payments Detail screen now displays the `Date From`,
`Date To` and `Payment Type` fields only if their respective values are defined.