### PR TITLE
Wrap amount column titles on newlines only

### DIFF
--- a/UI/Reports/PNL.html
+++ b/UI/Reports/PNL.html
@@ -48,7 +48,7 @@ END ;
     <tr class="sectionhead">
         <th colspan="<?lsmb max_path_depth ?>"></th>
 <?lsmb FOREACH col IN report.sorted_col_ids -?>
-        <th style="white-space:pre"><?lsmb report.cheads.ids.$col.props.description ?></th>
+        <th><?lsmb report.cheads.ids.$col.props.description ?></th>
 <?lsmb END -?>
     </tr>
 <?lsmb FOREACH row IN report.sorted_row_ids ;

--- a/UI/Reports/balance_sheet.html
+++ b/UI/Reports/balance_sheet.html
@@ -46,10 +46,9 @@ END ;
 </colgroup>
   <tbody>
     <tr class="report-head">
-      <th colspan="<?lsmb max_path_depth ?>"
-          style="font-weight:bold"> </th>
+      <th colspan="<?lsmb max_path_depth ?>"> </th>
       <?lsmb FOREACH col IN report.sorted_col_ids -?>
-      <th style="white-space:nowrap"><?lsmb report.cheads.ids.$col.props.description ?></th>
+      <th><?lsmb report.cheads.ids.$col.props.description ?></th>
       <?lsmb END -?>
     </tr>
 <?lsmb FOREACH row IN report.sorted_row_ids ;

--- a/UI/css/system/global.css
+++ b/UI/css/system/global.css
@@ -39,6 +39,7 @@ html, body {
 .flat-hierarchy .balancesheet .report-head th {
     text-align: right;
     font-weight: bold;
+    white-space: pre;
 }
 
 .flat-hierarchy .balancesheet .section1.QL,


### PR DESCRIPTION
Most titles are dates for amount columns, so we want to make sure that we don't wrap on dashes or spaces.