### PR TITLE
Remove unused App_State::all_periods and associated UI element

### DIFF
--- a/UI/lib/report_base.html
+++ b/UI/lib/report_base.html
@@ -278,26 +278,6 @@ END # BLOCK -?>
         </div>
 <?lsmb END #BLOCK -?>
 
-<?lsmb- BLOCK date_period_type_div ?>
-    <?lsmb
-        IF !label.defined();    label    = text('Period type');      END;
-    ?>
-        <div class="input_row">
-          <div class="input_group">
-              <?lsmb
-                all_periods.values.sort('order');
-                all_periods.unshift({}); # Add empty item at beginning of the list
-                INCLUDE select element_data = {
-                    name = "interval"
-                      id = "interval"
-                   label = label
-                 options = all_periods
-              };
-              ?>
-          </div>
-        </div>
-<?lsmb END #BLOCK -?>
-
 <?lsmb- BLOCK date_row_div ?>
         <div class="input_row">
         <?lsmb INCLUDE date_from_date_div required=required SUFFIX=SUFFIX ?>

--- a/lib/LedgerSMB/App_State.pm
+++ b/lib/LedgerSMB/App_State.pm
@@ -205,60 +205,6 @@ sub run_with_state {
     return $block->();
 }
 
-=head2 all_periods(is_short $bool)
-
-Returns hashref of localized date data with following members:
-
-If $is_short is set and true, returns short names (D, W, M, Q, Y) instead of
-long names (Days, Weeks, Months, Quarters, Years).
-
-=over
-
-=item dropdown
-
-Period information in drop down format.
-
-=item hashref
-
-Period info in hashref format in D => Days format
-
-=back
-
-=cut
-
-sub all_periods {
-    my ($self, $is_short) = @_;
-    my $i18n = $Locale;
-    my $periods = {
-           # XXX That's asking for trouble below.  Need to update .po files
-           # before changing however. --CT
-     'day'     => { long => $i18n->text('Days'),
-                    short => $i18n->text('D'), order => 1 },
-     'week'    => { long => $i18n->text('Weeks'),
-                    short => $i18n->text('W'), order => 2 },
-     'month'   => { long => $i18n->text('Months'),
-                    short => $i18n->text('M'), order => 3 },
-     'quarter' => { long => $i18n->text('Quarters'),
-                    short => $i18n->text('Q'), order => 4 },
-     'year'    => { long => $i18n->text('Years'),
-                    short => $i18n->text('Y'), order => 5 },
-    };
-
-    my $for_dropdown = [];
-    my $as_hashref = {};
-    for my $key (sort { $periods->{$a}->{order} <=> $periods->{$b}->{order}} keys %$periods){
-        my $mname;
-        if ($is_short){
-           $mname = $periods->{$key}->{short};
-        } else {
-           $mname = $periods->{$key}->{long};
-        }
-        $as_hashref->{$key} = $mname;
-        push @$for_dropdown, {text => $mname, value => $key};
-    }
-    return { as_hashref => $as_hashref, dropdown=> $for_dropdown };
-}
-
 =head2 all_months(is_short $bool)
 
 Returns hashref of localized date data with following members:

--- a/lib/LedgerSMB/Scripts/reports.pm
+++ b/lib/LedgerSMB/Scripts/reports.pm
@@ -92,8 +92,7 @@ sub start_report {
     $_ = {id => $_, text => $_} for @{$request->{currencies}};
     my $months = LedgerSMB::App_State::all_months();
     $request->{all_months} = $months->{dropdown};
-    my $periods = LedgerSMB::App_State::all_periods();
-    $request->{all_periods} = $periods->{dropdown};
+
     if (!$request->{report_name}){
         die $request->{_locale}->text('No report specified');
     }


### PR DESCRIPTION
`App_State::all_periods()` is not in use. There is one UI library
element which makes use of it - `date_period_type_div`, but that
is not included in any templates.

The `App_State::all_periods()` and `date_period_type_div` template
element are therefore removed.