### PR TITLE
Fix and refactor Search Reconciliation Reports

### DIFF
--- a/old/lib/LedgerSMB/DBObject/Reconciliation.pm
+++ b/old/lib/LedgerSMB/DBObject/Reconciliation.pm
@@ -451,16 +451,19 @@ sub get {
 
 =item get_accounts
 
-This is a simple wrapper around reconciliation__account_list
+This is a simple wrapper around reconciliation__account_list. It sets
+the object's C<recon_accounts> property.
 
 =cut
 
 sub get_accounts {
     my $self = shift @_;
 
-    return $self->call_dbmethod(
+    @{$self->{recon_accounts}} = $self->call_dbmethod(
         funcname=>'reconciliation__account_list',
     );
+
+    return $self->{recon_accounts};
 }
 
 =back


### PR DESCRIPTION
Fixes breakage caused by introduction of shared `LedgerSMB::Setting` object.

Be explicit about parameters used to initialise
`LedgerSMB::DBObject::Reconciliation` object.

Make `LedgerSMB::DBObject::Reconciliation` responsible for initialising
its own `recon_accounts` property, rather than having an external
module mess with its internal state.

Use `LedgerSMB::Template::UI` directly to render Search Reconciliation
Reports screen, rather than via `LedgerSMB::Scripts::reports`