### PR TITLE
Drop LedgerSMB module VERSION property

### DIFF
--- a/UI/login.html
+++ b/UI/login.html
@@ -1,5 +1,5 @@
 <?lsmb INCLUDE 'ui-header.html'
-        titlebar = "LedgerSMB $VERSION"
+        titlebar = "LedgerSMB $version"
         include_stylesheet = ["login.css", "ledgersmb.css"]
         include_script = [ 'login.js' ]
 ?>
@@ -40,7 +40,7 @@
             </div>
           <div style="z-index:10; position:absolute; top:0; left:0; width:100%; height:100%;">
           <h1 class="login" align="center">
-            LedgerSMB <?lsmb VERSION ?>
+            LedgerSMB <?lsmb version ?>
           </h1>
           <div align="center">
             <div id="company_div"

--- a/UI/setup/credentials.html
+++ b/UI/setup/credentials.html
@@ -24,7 +24,7 @@
                         alt="LedgerSMB Logo" />
                 </a>
                 <h2 align="center" style="margin-top: 0">
-                    LedgerSMB <?lsmb VERSION ?>
+                    LedgerSMB <?lsmb version ?>
                 </h2>
                 <div class="listtop">
                     <?lsmb text('Database administrator credentials') ?>

--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -181,7 +181,6 @@ sub new {
     $self->{login} = $auth->get_credentials->{login} if defined $auth;
     $self->{version} = $VERSION;
     $self->{dbversion} = $VERSION;
-    $self->{VERSION} = $VERSION;
     $self->{_uploads} = $request->uploads if defined $request->uploads;
     $self->{_cookies} = $request->cookies if defined $request->cookies;
     $self->{query_string} = $request->query_string if defined $request->query_string;

--- a/lib/LedgerSMB/Scripts/login.pm
+++ b/lib/LedgerSMB/Scripts/login.pm
@@ -76,7 +76,7 @@ sub __default {
     my ($request) = @_;
 
     $request->{stylesheet} = 'ledgersmb.css';
-    $request->{titlebar} = "LedgerSMB $request->{VERSION}";
+    $request->{titlebar} = "LedgerSMB $request->{version}";
     my $template = LedgerSMB::Template::UI->new_UI;
     return $template->render($request, 'login', $request);
 }
@@ -120,7 +120,7 @@ sub login {
         return __default($request);
     }
 
-    $request->{title} = "LedgerSMB $request->{VERSION} -- ".
+    $request->{title} = "LedgerSMB $request->{version} -- ".
     "$request->{login} -- $request->{company}";
 
     my $template = LedgerSMB::Template::UI->new_UI;


### PR DESCRIPTION
The `LedgerSMB` module had both `version` and a `VERSION` property.
Both were explicitly set to the the same value and therefore duplicate
one another.

To remove this duplication, the `VERSION` property has been deleted and
uses of it replaced with `version`.

The lowercase version was retained to be consistent with the other object
properties which are also lowercase.