### PR TITLE
Fix LedgerSMB::DBObject::Payment->get_default_currency()

### DIFF
--- a/old/lib/LedgerSMB/DBObject/Payment.pm
+++ b/old/lib/LedgerSMB/DBObject/Payment.pm
@@ -530,14 +530,24 @@ sub get_exchange_rate {
 
 =item get_default_currency
 
-This method gets the default currency
+This method gets the default currency from the database (as a three-character
+currency code), setting the object's C<default_currency> property to this
+value.
+
+Returns:
+The three-character default currency code (e.g. 'USD').
 
 =cut
 
 sub get_default_currency {
- my ($self) = shift @_;
- ($self->{default_currency}) = $self->call_procedure(funcname => 'defaults_get_defaultcurrency');
- return $self->{default_currency}->{defaults_get_defaultcurrency};
+    my ($self) = shift @_;
+
+    my $result = $self->call_procedure(
+        funcname => 'defaults_get_defaultcurrency'
+    );
+
+    $self->{default_currency} = $result->{defaults_get_defaultcurrency};
+    return $self->{default_currency};
 }
 
 =item get_current_date

--- a/t/testrules.yml
+++ b/t/testrules.yml
@@ -13,6 +13,7 @@ seq:
   - seq:
     - xt/40-dbsetup.t
     - xt/45*.t
+    - xt/47*.t
     - par:
       - xt/40-database.t
       - xt/41-coaload.t

--- a/xt/47.1-ledgersmb-dbobject-payment.t
+++ b/xt/47.1-ledgersmb-dbobject-payment.t
@@ -1,0 +1,51 @@
+#!/usr/bin/perl
+
+=head1 UNIT TESTS FOR LedgerSMB::PGObject::Payment
+
+Unit tests for the LedgerSMB::DBObject::Payment module that exercise
+interaction with a test database.
+
+=cut
+
+use strict;
+use warnings;
+
+use DBI;
+use Test::More;
+use LedgerSMB::DBObject::Payment;
+use LedgerSMB::Setting;
+
+
+# Create test run conditions
+my $payment;
+my $dbh = DBI->connect(
+    "dbi:Pg:dbname=$ENV{LSMB_NEW_DB}",
+    undef,
+    undef,
+    { AutoCommit => 0, PrintError => 0 }
+) or BAIL_OUT "Can't connect to template database: " . DBI->errstr;
+
+my $setting = LedgerSMB::Setting->new()
+    or BAIL_OUT('Failed to initialise LedgerSMB::Setting object');
+$setting->set_dbh($dbh)
+    or BAIL_OUT('Failed to initialise LedgerSMB::Setting dbh');
+$setting->set('curr', 'EUR')
+    or BAIL_OUT('Failed to initialise default currency');
+
+
+plan tests => (4);
+
+# Initialise Object
+$payment = LedgerSMB::DBObject::Payment->new({base => {
+    dbh => $dbh,
+    account_class => 1,
+}});
+isa_ok($payment, 'LedgerSMB::DBObject::Payment', 'instantiated object');
+ok($payment->set_dbh($dbh), 'set dbh');
+
+is($payment->get_default_currency(), 'EUR', 'get_default_currency returns expected currency code');
+is($payment->{default_currency}, 'EUR', 'object `default_currency` property set correctly');
+
+
+# Don't commit any of our changes
+$dbh->rollback;

--- a/xt/47.1-ledgersmb-dbobject-payment.t
+++ b/xt/47.1-ledgersmb-dbobject-payment.t
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 
-=head1 UNIT TESTS FOR LedgerSMB::PGObject::Payment
+=head1 UNIT TESTS FOR LedgerSMB::DBObject::Payment
 
 Unit tests for the LedgerSMB::DBObject::Payment module that exercise
 interaction with a test database.


### PR DESCRIPTION
While `LedgerSMB::DBObject::Payment->get_default_currency()` was
returning the expected three-character currency code, it was not
setting the object's `default_currency` property to this value,
which is the expected behaviour.

This PR adds documentation to clarify the method's function and
return value. It adds unit tests to confirm its operation.