### PR TITLE
SQL fix batch__search - interpretation of in_approved parameter

### DIFF
--- a/sql/modules/Voucher.sql
+++ b/sql/modules/Voucher.sql
@@ -221,9 +221,11 @@ $$
                                 in_description IS NULL) AND
                         (in_created_by_eid = b.created_by OR
                                 in_created_by_eid IS NULL) AND
-                        (((in_approved = false OR in_approved IS NULL)
-                          AND approved_on IS NULL)
-                         OR (in_approved = true AND approved_on IS NOT NULL))
+                        (
+                          (in_approved = false AND approved_on IS NULL)
+                          OR (in_approved = true AND approved_on IS NOT NULL)
+                          OR in_approved IS NULL
+                        )
                         and (in_date_from IS NULL
                                 or b.default_date >= in_date_from)
                         and (in_date_to IS NULL


### PR DESCRIPTION
SQL function `batch__search` is documented that setting any of the
filtering input parameters to `NULL` will accept any value for the
respective field.

For the `in_approved` input parameter, the query was interpreting
both `NULL` and `FALSE` to mean only unapproved batches should be
returned.

The query has been fixed to match the documentation:

* in_approved = NULL  -- both approved and unapproved batches
* in_approved = TRUE  -- only approved batches
* in_approved = FALSE -- only unapproved batches