### PR TITLE
Cleanup and add tests for Batch_Overview module

### DIFF
--- a/lib/LedgerSMB/Report.pm
+++ b/lib/LedgerSMB/Report.pm
@@ -17,13 +17,38 @@ LedgerSMB::DBObject::Report provides basic utility functions for reporting in
 LedgerSMB.  It is an abstract class.  Individual report types MUST inherit this
 out.
 
-Subclasses MUST define the following subroutines:
+Subclasses MUST define the following methods:
 
 =over
 
-=item get_columns
+=item header_lines
 
-This MUST return a list of hashrefs for the columns per the dynatable block.
+This must return an arrayref of the header fields to be displayed on the
+report. The array elements must be hashrefs comprising the following keys:
+
+  text - The localized header title
+  name - The request parameter to be displayed for this heading
+
+An example return value from a C<header_lines()> method might be:
+
+  [
+      {
+          text => 'Invoice Number',
+          name => 'invoice_no'
+      },
+      {
+          text => 'Date',
+          name => 'post_date'
+      }
+  ]
+
+=item name
+
+This must return the localized report name (usually displayed as a title
+for the report).
+
+=item options
+
 
 =back
 

--- a/lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm
+++ b/lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm
@@ -209,11 +209,31 @@ sub run_report{
                     value => 'batch_unlock',
                     class => 'submit',
                 }]);
+    $self->get_rows();
+    return;
+}
+
+=head2 get_rows()
+
+Queries the database for batches which fulfil the filter criteria, populating
+the object C<rows> property.
+
+For each row, the retrieved C<id> field is copied to an additional C<row_id>
+field.
+
+Returns the object's C<rows> property.
+
+=cut
+
+sub get_rows {
+    my ($self) = @_;
     my @rows = $self->call_dbmethod(funcname => 'batch__search');
     for my $r (@rows){
        $r->{row_id} = $r->{id};
     }
-    return $self->rows(\@rows);
+
+    $self->rows(\@rows);
+    return $self->rows;
 }
 
 

--- a/lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm
+++ b/lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm
@@ -23,7 +23,7 @@ use LedgerSMB::Report::Unapproved::Batch_Detail instead.
 
 =over
 
-=item LedgerSMB::Report;
+=item L<LedgerSMB::Report>
 
 =back
 
@@ -35,48 +35,63 @@ extends 'LedgerSMB::Report';
 
 =head1 PROPERTIES
 
-=over
+=head2 Query Filter Properties:
 
-=item columns
-
-Read-only accessor, returns a list of columns.
+Note that in all cases, undef matches everything.
 
 =over
 
-=item select
+=item description (text)
 
-Select boxes for selecting the returned items.
-
-=item id
-
-ID of transaction
-
-=item post_date
-
-Post date of transaction
-
-=item reference text
-
-Invoice number or GL reference
-
-=item description
-
-Description of transaction
-
-=item transaction_total
-
-Total of AR/AP/GL vouchers (GL vouchers credit side only is counted)
-
-=item payment_total
-
-Total of payment lines (credit side)
-
-Amount
-
-=back
+Partial match on batch C<description> field.
 
 =cut
 
+has 'description' => (is => 'rw', isa => 'Maybe[Str]');
+
+=item class_id
+
+The batch class_id, as detailed in the C<batch_class> database
+table. (1=>AP, 2=>AR, 3=>Payment etc).
+
+=cut
+
+has class_id => (is => 'rw', isa => 'Int');
+
+=item amount_gt
+
+The batch amount must be greater than or equal to this.
+
+=cut
+
+has 'amount_gt' => (is => 'rw', isa => 'Maybe[Str]');
+
+=item amount_lt
+
+The batch amount must be less than or equal to this.
+
+=cut
+
+has 'amount_lt' => (is => 'rw', isa => 'Maybe[Str]');
+
+=item approved
+
+Bool:  if approved show only approved batches.  If not, show unapproved
+
+=cut
+
+has approved => (is => 'rw', 'isa' => 'Maybe[Bool]');
+
+=back
+
+
+=head1 METHODS
+
+=head2 columns()
+
+Read-only accessor, returns a list of columns.
+
+=cut
 
 sub columns {
     my ($self) = @_;
@@ -126,7 +141,7 @@ sub columns {
     return \@COLUMNS;
 }
 
-=item name
+=head2 name
 
 Returns the localized template name
 
@@ -137,7 +152,7 @@ sub name {
     return $self->_locale->text('Batch Search');
 }
 
-=item header_lines
+=head2 header_lines
 
 Returns the inputs to display on header.
 
@@ -157,7 +172,7 @@ sub header_lines {
              text => $self->_locale->text('(Locked)')}, ]
 }
 
-=item subtotal_cols
+=head2 subtotal_cols
 
 Returns list of columns for subtotals
 
@@ -172,69 +187,7 @@ sub text {
     return $self->_locale->maketext(@_);
 }
 
-=back
-
-=head2 Criteria Properties
-
-Note that in all cases, undef matches everything.
-
-=over
-
-=item reference (text)
-
-Exact match on reference or invoice number.
-
-=cut
-
-has 'reference' => (is => 'rw', isa => 'Maybe[Str]');
-
-=item type
-
-ar for AR drafts, ap for AP drafts, gl for GL ones.
-
-=cut
-
-has 'type' => (is => 'rw', isa => 'Int');
-
-=item class_id
-
-class id associated with type
-
-=cut
-
-has class_id => (is => 'rw', isa => 'Int');
-
-=item amount_gt
-
-The amount of the draft must be greater than this for it to show up.
-
-=cut
-
-has 'amount_gt' => (is => 'rw', isa => 'Maybe[Str]');
-
-=item amount_lt
-
-The amount of the draft must be less than this for it to show up.
-
-=cut
-
-has 'amount_lt' => (is => 'rw', isa => 'Maybe[Str]');
-
-=item approved
-
-Bool:  if approved show only approved batches.  If not, show unapproved
-
-=cut
-
-has approved => (is => 'rw', 'isa' => 'Maybe[Bool]');
-
-=back
-
-=head1 METHODS
-
-=over
-
-=item run_report()
+=head2 run_report()
 
 Runs the report, and assigns rows to $self->rows.
 
@@ -269,7 +222,6 @@ sub run_report{
     return $self->rows(\@rows);
 }
 
-=back
 
 =head1 LICENSE AND COPYRIGHT
 

--- a/lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm
+++ b/lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm
@@ -56,7 +56,7 @@ table. (1=>AP, 2=>AR, 3=>Payment etc).
 
 =cut
 
-has class_id => (is => 'rw', isa => 'Int');
+has class_id => (is => 'rw', isa => 'Maybe[Int]');
 
 =item amount_gt
 

--- a/lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm
+++ b/lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm
@@ -172,16 +172,6 @@ sub header_lines {
              text => $self->_locale->text('(Locked)')}, ]
 }
 
-=head2 subtotal_cols
-
-Returns list of columns for subtotals
-
-=cut
-
-sub subtotal_cols {
-    return [];
-}
-
 =head2 run_report()
 
 Runs the report, and assigns rows to $self->rows.

--- a/lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm
+++ b/lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm
@@ -190,7 +190,6 @@ Runs the report, and assigns rows to $self->rows.
 
 sub run_report{
     my ($self) = @_;
-    $self->class_id($self->type) if $self->type;
     $self->buttons([{
                     name  => 'action',
                     type  => 'submit',
@@ -220,7 +219,7 @@ sub run_report{
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2012 The LedgerSMB Core Team
+Copyright (C) 2012-2018 The LedgerSMB Core Team
 
 This file is licensed under the GNU General Public License version 2, or at your
 option any later version.  A copy of the license should have been included with

--- a/lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm
+++ b/lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm
@@ -182,11 +182,6 @@ sub subtotal_cols {
     return [];
 }
 
-sub text {
-    my ($self) = @_;
-    return $self->_locale->maketext(@_);
-}
-
 =head2 run_report()
 
 Runs the report, and assigns rows to $self->rows.

--- a/lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm
+++ b/lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm
@@ -33,9 +33,6 @@ use Moose;
 use namespace::autoclean;
 extends 'LedgerSMB::Report';
 
-use LedgerSMB::Business_Unit_Class;
-use LedgerSMB::Business_Unit;
-
 =head1 PROPERTIES
 
 =over
@@ -128,8 +125,6 @@ sub columns {
 
     return \@COLUMNS;
 }
-
-    # TODO:  business_units int[]
 
 =item name
 

--- a/t/testrules.yml
+++ b/t/testrules.yml
@@ -12,12 +12,12 @@ seq:
       - xt/{0,1,2,3}*
   - seq:
     - xt/40-dbsetup.t
-    - xt/45*.t
-    - xt/47*.t
-    - xt/48*.t
     - par:
       - xt/40-database.t
       - xt/41-coaload.t
+      - xt/45*.t
+      - xt/47*.t
+      - xt/48*.t
   - seq:
     - par:
       - xt/{43,44,5,7}*.t

--- a/t/testrules.yml
+++ b/t/testrules.yml
@@ -14,6 +14,7 @@ seq:
     - xt/40-dbsetup.t
     - xt/45*.t
     - xt/47*.t
+    - xt/48*.t
     - par:
       - xt/40-database.t
       - xt/41-coaload.t

--- a/xt/48.1-ledgersmb-report-unapproved-batch_overview.t
+++ b/xt/48.1-ledgersmb-report-unapproved-batch_overview.t
@@ -55,7 +55,7 @@ my @test_batches = (
         batch_date => '2017-11-08',
         description => 'Test Payment batch description',
     },
-   
+
 );
 
 foreach my $batch_data(@test_batches) {
@@ -68,7 +68,7 @@ foreach my $batch_data(@test_batches) {
             dbh => $dbh,
             batch_id => $batch_id,
         }});
-        $batch->post or BAIL_OUT 'Failed to post/approve test batch'; 
+        $batch->post or BAIL_OUT 'Failed to post/approve test batch';
     }
 }
 

--- a/xt/48.1-ledgersmb-report-unapproved-batch_overview.t
+++ b/xt/48.1-ledgersmb-report-unapproved-batch_overview.t
@@ -1,0 +1,137 @@
+#!/usr/bin/perl
+
+=head1 UNIT TESTS FOR LedgerSMB::Report::Unapproved::Batch_Overview
+
+Unit tests for the LedgerSMB::Report::Unapproved::Batch_Overview module
+that exercise interaction with a test database.
+
+=cut
+
+use strict;
+use warnings;
+
+use DBI;
+use Test::More;
+use LedgerSMB::Batch;
+use LedgerSMB::Report::Unapproved::Batch_Overview
+
+# Create test run conditions
+my $data;
+my $report;
+my $rows;
+my $row;
+my $dbh = DBI->connect(
+    "dbi:Pg:dbname=$ENV{LSMB_NEW_DB}",
+    undef,
+    undef,
+    { AutoCommit => 0, PrintError => 0 }
+) or BAIL_OUT q{Can't connect to template database: } . DBI->errstr;
+
+
+# Create test batches in database for us to query
+my @test_batches = (
+    {
+        batch_number => 'TEST-001',
+        batch_class => 'ap',
+        batch_date => '2018-09-08',
+        description => 'Test AP batch Description',
+        __POST => 1,
+    },
+    {
+        batch_number => 'TEST-BATCH-100',
+        batch_class => 'ar',
+        batch_date => '2017-09-08',
+        description => 'Test AR batch description',
+    },
+    {
+        batch_number => 'TEST-101',
+        batch_class => 'ar',
+        batch_date => '2017-09-08',
+        description => 'Test AR batch description',
+    },
+    {
+        batch_number => 'TEST-102',
+        batch_class => 'payment',
+        batch_date => '2017-11-08',
+        description => 'Test Payment batch description',
+    },
+   
+);
+
+foreach my $batch_data(@test_batches) {
+    my $batch = LedgerSMB::Batch->new({ base => $batch_data });
+    $batch->set_dbh($dbh);
+    my $batch_id = $batch->create or BAIL_OUT 'Failed to create test batch';
+
+    if($batch_data->{__POST}) {
+        $batch = LedgerSMB::Batch->new({ base => {
+            dbh => $dbh,
+            batch_id => $batch_id,
+        }});
+        $batch->post or BAIL_OUT 'Failed to post/approve test batch'; 
+    }
+}
+
+
+plan tests => (36);
+
+
+# Initialise Object
+$report = LedgerSMB::Report::Unapproved::Batch_Overview->new();
+isa_ok($report, 'LedgerSMB::Report::Unapproved::Batch_Overview', 'instantiated object');
+ok($report->set_dbh($dbh), 'set dbh');
+
+# Query with no filter
+ok($rows = $report->get_rows, 'get_rows() called ok');
+is(ref $rows, 'ARRAY', 'get_rows() returns an arrayref');
+is($rows, $report->rows, 'rows property is set by run_report()');
+is(ref $report->rows, 'ARRAY', 'rows property is an arrayref');
+is(scalar @{$report->rows}, scalar @test_batches, 'returned all rows');
+
+# Query description - should return just 1 row
+ok($report->description('AP batch'), 'set description');
+ok($rows = $report->get_rows, 'get_rows() with description');
+is(scalar @{$rows}, 1, 'querying description returned 1 row');
+$row = $$rows[0];
+is(ref $row, 'HASH', 'first returned element is a hashref');
+ok($row->{id}, 'row id field is defined');
+is($row->{id}, $row->{row_id}, 'row_id field matches id field');
+is($row->{batch_class}, 'ap', 'row batch_class field is correct');
+is($row->{control_code}, 'TEST-001', 'row control_code field is correct');
+is($row->{description}, 'Test AP batch Description', 'row payment field is correct');
+is($row->{default_date}, '2018-09-08', 'row default_date field is correct');
+is($row->{transaction_total}, 0, 'row transaction_total field is correct');
+is($row->{payment_total}, 0, 'row payment_total field is correct');
+like($row->{created_on}, qr/\d{4}-\d{2}-\d{2}/, 'row created_on field is of expected format');
+ok(exists $row->{created_by}, 'row created_by field exists');
+ok(exists $row->{lock_success}, 'row lock_success field exists');
+is($report->description(undef), undef, 'reset description filter');
+
+# Query class_id
+ok($report->class_id(3), 'set class_id filter');
+ok($rows = $report->get_rows, 'get_rows() with batch_class');
+is(scalar @{$rows}, 1, 'querying with class_ids returned 1 row');
+$row = $$rows[0];
+is($row->{description}, 'Test Payment batch description', 'row control_code field is correct');
+is($report->class_id(undef), undef, 'reset class_id filter');
+
+# Query approved
+is($report->approved(1), 1, 'set approved filter = true');
+ok($rows = $report->get_rows, 'get_rows() with approved_filter = true');
+is(scalar @{$rows}, 1, 'querying with approved=true returned 1 row');
+is($report->approved(undef), undef, 'reset approved filter');
+
+# Query unapproved
+is($report->approved(0), 0, 'set approved filter = false');
+ok($rows = $report->get_rows, 'get_rows() with approved_filter = false');
+is(scalar @{$rows}, 3, 'querying with approved=false returned 3 rows');
+is($report->approved(undef), undef, 'reset approved filter');
+
+
+#TODO Query Amount
+# This needs test transactions added into the database.
+# That will change when multi-currency is merged.
+
+
+# Don't commit any of our changes
+$dbh->rollback;


### PR DESCRIPTION
This PR cleans-up and adds test for the module
`LedgerSMB::Report::Unapproved::Batch_Overview`.

* Unused methods `subtotal_cols` and `text` removed
* Unit tests added for `get_rows` method
* Allow explicit `undef` setting of `class_id` property
* Separate `get_rows` database query method from `run_report` for more granular testing
* Reformat and augment pod
* Remove unused module dependencies
* Document subclassing expectations of `LedgerSMB::Report`