### PR TITLE
Don't add unused `$request` argument to `run_report()` call

### DIFF
--- a/lib/LedgerSMB/Report.pm
+++ b/lib/LedgerSMB/Report.pm
@@ -289,7 +289,7 @@ sub _render {
 
 
     my $testref = $self->rows;
-    $self->run_report($request) if !defined $testref;
+    $self->run_report if !defined $testref;
     # This is a hook for other modules to use to override the default
     # template --CT
     local $@ = undef;

--- a/lib/LedgerSMB/Report/Listings/Asset.pm
+++ b/lib/LedgerSMB/Report/Listings/Asset.pm
@@ -151,7 +151,7 @@ sub name {
 =cut
 
 sub run_report {
-    my ($self, $request) = @_;
+    my ($self) = @_;
     my @rows = $self->call_dbmethod(funcname => 'asset__search');
     for my $r(@rows){
        $r->{row_id} = $r->{id};

--- a/lib/LedgerSMB/Report/Listings/Overpayments.pm
+++ b/lib/LedgerSMB/Report/Listings/Overpayments.pm
@@ -179,7 +179,7 @@ sub set_buttons {
 =cut
 
 sub run_report {
-    my ($self, $request) = @_;
+    my ($self) = @_;
     my @rows = $self->call_dbmethod(funcname => 'payment__overpayments_list');
     for my $r (@rows){
        $r->{row_id} = $r->{payment_id};


### PR DESCRIPTION
`LedgerSMB::Report` calls a `run_report` method. This used to
include `$request` as a parameter, but this parameter was not used
by any of the modules which implement the `run_report` method.

The argument has therefore been removed from the `run_report` call
to simplify code.