### PR TITLE
Fix Transaction Approval-Batches description search

### DIFF
--- a/UI/Reports/filters/batches.html
+++ b/UI/Reports/filters/batches.html
@@ -1,0 +1,86 @@
+<?lsmb
+    PROCESS "elements.html";
+    PROCESS 'report_base.html';
+    action = 'list_batches';
+
+    FOR CLS IN batch_classes;
+        CLS.text = CLS.class;
+        CLS.value = CLS.id;
+    END;
+    batch_classes.unshift({});
+?>
+
+<body class="lsmb <?lsmb dojo_theme ?>">
+<div id="batch_search">
+<form data-dojo-type="lsmb/Form" action="vouchers.pl" method="get">
+    <div class="listtop" id="title_div"><?lsmb text('Search Unapproved Transactions') ?></div>
+    <div data-dojo-type="lsmb/TabularForm" data-dojo-props="cols:1">
+
+        <div class="input" id="batch_class_div">
+            <?lsmb INCLUDE select element_data = {
+                title = text('Transaction Type') #'
+                options = batch_classes
+                value_attr = "value"
+                text_attr = "text"
+                name = "class_id"
+            } ?>
+        </div>
+
+        <div class="input" id="approved_div">
+            <?lsmb INCLUDE input element_data = {
+                name = "approved"
+                id = "approved-1"
+                value = "1"
+                title = text("Approved")
+                type = "radio"
+           }; ?>
+           <?lsmb INCLUDE input element_data = {
+                name = "approved"
+                id = "approved-0"
+                value = "0"
+                title = text("Unapproved")
+                type = "radio"
+                checked = "CHECKED"
+           }; ?>
+        </div>
+
+        <div class="input" id="description_div">
+            <?lsmb INCLUDE input element_data = {
+                title = text('Description')
+                size = 20
+                name = "description"
+            } ?>
+        </div>
+
+        <div class="input" id="amounts_div">
+            <?lsmb INCLUDE input element_data = {
+                title = "Minimum Value"
+                name = "amount_gt"
+                class = "numeric"
+                size = 20
+                type = "text"
+            } ?>
+            <?lsmb INCLUDE input element_data = {
+                title = "Maximum Value"
+                name = "amount_lt"
+                size = 20
+                class = "numeric"
+                type = "text"
+            } ?>
+        </div>
+
+    </div>
+
+    <div class="input" id="buttons_div">
+        <?lsmb INCLUDE button element_data = {
+            text = text('Search')
+            name = "action"
+            value = action
+            class = "submit"
+            type = "submit"
+        } ?>
+    </div>
+
+</form>
+</div>
+</body>

--- a/UI/Reports/filters/unapproved.html
+++ b/UI/Reports/filters/unapproved.html
@@ -1,7 +1,6 @@
 <?lsmb PROCESS "elements.html";
        PROCESS 'report_base.html';
 
-IF search_type == 'drafts';
    batch_classes = [
        {},
        { text = text('AP'), value = 'ap'},
@@ -10,16 +9,6 @@ IF search_type == 'drafts';
    ];
    script = 'drafts.pl';
    action = 'list_drafts';
-ELSE;
-   script = 'vouchers.pl';
-   action = 'list_batches';
-   FOR CLS IN batch_classes;
-       CLS.text = CLS.class;
-       CLS.value = CLS.id;
-   END;
-   batch_classes.unshift({});
-   SHOW_APPROVED=1;
-END;
 
  ?>
 <body class="lsmb <?lsmb dojo_theme ?>">
@@ -38,37 +27,6 @@ END;
                 default_values = [class_id]
         } ?>
 </div>
-<!--
-Commenting this section out.  Does not seem to be used by API. -CT
-
-<div class="input" id="entered_by_div">
-        <?lsmb INCLUDE select element_data = {
-                title = text('Created By') # '
-                options = users
-                value_attr = "entity_id"
-                text_attr = "username"
-                name = "created_by_eid"
-                default_values = [created_by]
-        } ?></div> -->
-<?lsmb IF SHOW_APPROVED ?>
-<div class="input" id="approved_div">
-  <?lsmb INCLUDE input element_data = {
-          name="approved"
-          id="approved-1"
-          value="1"
-          title = text("Approved")
-          type="radio"
-   };
-   INCLUDE input element_data = {
-          name="approved"
-          id="approved-0"
-          value="0"
-          title = text("Unapproved")
-          type="radio"
-          checked="CHECKED"
-   }; ?>
-</div>
-<?lsmb END ?>
 <div class="input" id="reference_div">
         <?lsmb INCLUDE input element_data = {
                 title = text('Reference') #'

--- a/sql/changes/1.7/alter-menu-attributes.sql
+++ b/sql/changes/1.7/alter-menu-attributes.sql
@@ -1,0 +1,30 @@
+-- Changes url parameters used for
+-- Transaction Approval->Batches menu option to allow `Batches`
+-- to use a separate report filter template to `Drafts`.
+DELETE FROM menu_attribute
+WHERE node_id = 206
+AND   attribute = 'module_name'
+AND   value = 'gl';
+
+DELETE FROM menu_attribute
+WHERE node_id = 206
+AND   attribute = 'search_type'
+AND   value = 'batches';
+
+UPDATE menu_attribute
+SET value = 'batches'
+WHERE node_id = 206
+AND   attribute = 'report_name';
+
+
+-- Drop unneeded attributes from
+-- Transaction Approval->Drafts
+DELETE FROM menu_attribute
+WHERE node_id = 210
+AND   attribute = 'module_name'
+AND   value = 'gl';
+
+DELETE FROM menu_attribute
+WHERE node_id = 210
+AND   attribute = 'search_type'
+AND   value = 'drafts';

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -78,3 +78,4 @@
 #
 # 1.7 changes
 1.7/drop-custom-catalog.sql
+1.7/alter-menu-attributes.sql


### PR DESCRIPTION
The primary purpose of this PR is to fix a broken search for batches
based on their `Description`.

The search filter screen was being shared with a search filter for Drafts,
which uses different terminology and underlying parameter names, referring
to `Reference` rather than `Description`.

Rather than add yet more conditional blocks to a shared template, this PR
separates the Batches and Drafts filter screens into different and dedicated
html templates, without need for conditionals and their associated control
parameters.

Additionally, the `module_name` parameter is removed from the menu url used
to display these reports. This is unnecessary and was causing an additional
code block to be pointlessly executed.

Further simplification is possible in future. Both filter reports are
delivered through the `start_report` routine, which calls 11 database
functions in turn, all of which are unnecessary for these screens.