### PR TITLE
Add sql function `batch get class name`

### DIFF
--- a/sql/modules/Voucher.sql
+++ b/sql/modules/Voucher.sql
@@ -267,6 +267,14 @@ $$ language sql;
 COMMENT ON FUNCTION batch_get_class_id (in_type text) IS
 $$ returns the batch class id associated with the in_type label provided.$$;
 
+CREATE OR REPLACE FUNCTION batch_get_class_name (in_class_id int) returns text AS
+$$
+SELECT class FROM batch_class WHERE id = $1;
+$$ language sql;
+
+COMMENT ON FUNCTION batch_get_class_name (in_class_id int) IS
+$$ returns the batch class name associated with the in_class_id id provided.$$;
+
 CREATE OR REPLACE FUNCTION
 batch_search_mini
 (in_class_id int, in_description text, in_created_by_eid int, in_approved bool)

--- a/xt/42-voucher.pg
+++ b/xt/42-voucher.pg
@@ -4,7 +4,7 @@ BEGIN;
 
     -- Plan the tests.
 
-    SELECT plan(26);
+    SELECT plan(29);
 
     -- Add data
 
@@ -23,6 +23,7 @@ BEGIN;
     SELECT has_function('batch_create',ARRAY['text','text','text','date']);
     SELECT has_function('batch_delete',ARRAY['integer']);
     SELECT has_function('batch_get_class_id',ARRAY['text']);
+    SELECT has_function('batch_get_class_name',ARRAY['integer']);
     SELECT has_function('batch_get_users',ARRAY['']);
     SELECT has_function('batch_list_classes',ARRAY['']);
     SELECT has_function('batch_post',ARRAY['integer']);
@@ -139,6 +140,14 @@ BEGIN;
     PREPARE test AS SELECT count(*) = 0
     FROM batch where id = currval('batch_id_seq');
     SELECT results_eq('test',ARRAY[true],'Batch is deleted');
+    DEALLOCATE test;
+
+    PREPARE test AS SELECT batch_get_class_id('payment') = 3;
+    SELECT results_eq('test',ARRAY[true],'get batch class_id from batch class name');
+    DEALLOCATE test;
+
+    PREPARE test AS SELECT batch_get_class_name(3) = 'payment';
+    SELECT results_eq('test',ARRAY[true],'get batch class name from batch class id');
     DEALLOCATE test;
 
     -- Finish the tests and clean up.


### PR DESCRIPTION
The database has a function `batch_get_class_id` to obtain the batch
class id corresponding to a particular batch class name.

This PR adds the inverse function, `batch_get_class_name` to return 
the batch class name for a specified batch class id.

This is needed to enable the Batch Search report to display the name
of the batch class being filtered in the heading section.

SQL tests are added for both existing function `batch_get_class_id`
and new function `batch_get_class_name`.