### PR TITLE
Search Batches UX Improvements

### DIFF
--- a/UI/Reports/filters/batches.html
+++ b/UI/Reports/filters/batches.html
@@ -1,9 +1,6 @@
 <?lsmb
     PROCESS "elements.html";
     PROCESS 'report_base.html';
-
-    # Empty item at top of batch class list - Allow any class
-    batch_classes.unshift({});
 ?>
 
 <body class="lsmb <?lsmb dojo_theme ?>">
@@ -19,6 +16,7 @@
                 value_attr = "id"
                 text_attr = "class"
                 name = "class_id"
+                default_blank = "true"
             } ?>
         </div>
 

--- a/UI/Reports/filters/batches.html
+++ b/UI/Reports/filters/batches.html
@@ -1,27 +1,23 @@
 <?lsmb
     PROCESS "elements.html";
     PROCESS 'report_base.html';
-    action = 'list_batches';
 
-    FOR CLS IN batch_classes;
-        CLS.text = CLS.class;
-        CLS.value = CLS.id;
-    END;
+    # Empty item at top of batch class list - Allow any class
     batch_classes.unshift({});
 ?>
 
 <body class="lsmb <?lsmb dojo_theme ?>">
 <div id="batch_search">
 <form data-dojo-type="lsmb/Form" action="vouchers.pl" method="get">
-    <div class="listtop" id="title_div"><?lsmb text('Search Unapproved Transactions') ?></div>
+    <div class="listtop" id="title_div"><?lsmb text('Search Batches') ?></div>
     <div data-dojo-type="lsmb/TabularForm" data-dojo-props="cols:1">
 
         <div class="input" id="batch_class_div">
             <?lsmb INCLUDE select element_data = {
                 title = text('Transaction Type') #'
                 options = batch_classes
-                value_attr = "value"
-                text_attr = "text"
+                value_attr = "id"
+                text_attr = "class"
                 name = "class_id"
             } ?>
         </div>
@@ -75,7 +71,7 @@
         <?lsmb INCLUDE button element_data = {
             text = text('Search')
             name = "action"
-            value = action
+            value = "list_batches"
             class = "submit"
             type = "submit"
         } ?>

--- a/lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm
+++ b/lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm
@@ -35,6 +35,26 @@ extends 'LedgerSMB::Report';
 
 =head1 PROPERTIES
 
+=over
+
+=item class_name
+
+Read-only property returning the class name (e.g. 'AP', 'AR, 'Payment')
+corresponding to the specified C<class_id> filter parameter.
+
+Updated automatically when C<class_id> is set. Is C<undef> if C<class_id>
+has not been set.
+
+=cut
+
+has 'class_name' => (
+    is => 'ro',
+    isa => 'Maybe[Str]',
+    writer => '_set_class_name',
+);
+
+=back
+
 =head2 Query Filter Properties:
 
 Note that in all cases, undef matches everything.
@@ -56,7 +76,12 @@ table. (1=>AP, 2=>AR, 3=>Payment etc).
 
 =cut
 
-has class_id => (is => 'rw', isa => 'Maybe[Int]');
+has class_id => (
+    is => 'rw',
+    isa => 'Maybe[Int]',
+    predicate => 'has_class_id',
+    trigger => \&_build_class_name,
+);
 
 =item amount_gt
 
@@ -160,47 +185,81 @@ Returns the inputs to display on header.
 
 sub header_lines {
     my ($self) = @_;
-    return [{name => 'batch_class',
-             text => $self->_locale->text('Batch Type')},
-            {name => 'reference',
-             text => $self->_locale->text('Reference')},
+    return [
+            {name => 'class_name',
+             text => $self->_locale->text('Transaction Type')},
+            {name => 'description',
+             text => $self->_locale->text('Description')},
             {name => 'amount_gt',
              text => $self->_locale->text('Amount Greater Than')},
             {name => 'amount_lt',
              text => $self->_locale->text('Amount Less Than')},
-            {name => 'locked',
-             text => $self->_locale->text('(Locked)')}, ]
+    ];
 }
 
 =head2 run_report()
 
-Runs the report, and assigns rows to $self->rows.
+Calls C<get_buttons> and C<get_rows> methods to query database for batches
+matching our filter properties, then populate C<rows> and C<buttons>
+properties.
 
 =cut
 
 sub run_report{
     my ($self) = @_;
-    $self->buttons([{
-                    name  => 'action',
-                    type  => 'submit',
-                    text  => $self->_locale->text('Post'),
-                    value => 'batch_approve',
-                    class => 'submit',
-                 },{
-                    name  => 'action',
-                    type  => 'submit',
-                    text  => $self->_locale->text('Delete'),
-                    value => 'batch_delete',
-                    class => 'submit',
-                 },{
-                    name  => 'action',
-                    type  => 'submit',
-                    text  => $self->_locale->text('Unlock'),
-                    value => 'batch_unlock',
-                    class => 'submit',
-                }]);
+    $self->get_buttons();
     $self->get_rows();
     return;
+}
+
+=head2 get_buttons()
+
+Sets the object's C<buttons> property to define which buttons are shown
+on the report.
+
+If the report includes 'approved' batches, no buttons are displayed, as
+their actions are not possible once a batch has been approved (meaning its
+vouchers have been posted to the books).
+
+Returns the object's C<buttons> property.
+
+=cut
+
+sub get_buttons {
+    my ($self) = @_;
+
+    if($self->approved || !defined $self->approved) {
+        # Results include approved batches which cannot be altered
+        $self->buttons([]);
+    }
+    else {
+        # Results comprise only unapproved batches
+        $self->buttons([
+            {
+                name  => 'action',
+                type  => 'submit',
+                text  => $self->_locale->text('Post'),
+                value => 'batch_approve',
+                class => 'submit',
+            },
+            {
+                name  => 'action',
+                type  => 'submit',
+                text  => $self->_locale->text('Delete'),
+                value => 'batch_delete',
+                class => 'submit',
+            },
+            {
+                name  => 'action',
+                type  => 'submit',
+                text  => $self->_locale->text('Unlock'),
+                value => 'batch_unlock',
+                class => 'submit',
+            }
+        ]);
+    }
+
+    return $self->buttons;
 }
 
 =head2 get_rows()
@@ -225,6 +284,27 @@ sub get_rows {
     $self->rows(\@rows);
     return $self->rows;
 }
+
+
+# PRIVATE METHODS
+
+# _build_class_name()
+#
+# Returns the class_name corresponding to the object's class_id property,
+# or undef if that is not defined. Sets the object's class_name property.
+
+sub _build_class_name {
+    my ($self, $class_id) = @_;
+    my $class_name;
+
+    if($class_id) {
+        my $r = $self->call_dbmethod(funcname => 'batch_get_class_name');
+        $class_name = $r->{batch_get_class_name};
+    }
+
+    return $self->_set_class_name($class_name);
+}
+
 
 
 =head1 LICENSE AND COPYRIGHT

--- a/lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm
+++ b/lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm
@@ -199,7 +199,7 @@ sub header_lines {
 
 =head2 run_report()
 
-Calls C<get_buttons> and C<get_rows> methods to query database for batches
+Calls C<get_rows> method to query database for batches
 matching our filter properties, then populate C<rows> and C<buttons>
 properties.
 
@@ -207,34 +207,31 @@ properties.
 
 sub run_report{
     my ($self) = @_;
-    $self->get_buttons();
     $self->get_rows();
     return;
 }
 
-=head2 get_buttons()
+=head2 set_buttons()
 
-Sets the object's C<buttons> property to define which buttons are shown
-on the report.
+Returns a list of buttons to be displayed at the bottom of the form.
 
-If the report includes 'approved' batches, no buttons are displayed, as
+If the report includes 'approved' batches, no buttons are returned, as
 their actions are not possible once a batch has been approved (meaning its
 vouchers have been posted to the books).
 
-Returns the object's C<buttons> property.
-
 =cut
 
-sub get_buttons {
+sub set_buttons {
     my ($self) = @_;
+    my $buttons;
 
     if($self->approved || !defined $self->approved) {
         # Results include approved batches which cannot be altered
-        $self->buttons([]);
+        $buttons = [];
     }
     else {
         # Results comprise only unapproved batches
-        $self->buttons([
+        $buttons = [
             {
                 name  => 'action',
                 type  => 'submit',
@@ -256,10 +253,10 @@ sub get_buttons {
                 value => 'batch_unlock',
                 class => 'submit',
             }
-        ]);
+        ];
     }
 
-    return $self->buttons;
+    return $buttons;
 }
 
 =head2 get_rows()

--- a/lib/LedgerSMB/Scripts/vouchers.pm
+++ b/lib/LedgerSMB/Scripts/vouchers.pm
@@ -237,16 +237,22 @@ sub add_vouchers {
 
 =head2 list_batches
 
-This function displays the search results.
+This endpoint searches for batches and displays the results, by passing the
+request to L<LedgerSMB::Report::Unapproved::Batch_Overview>.
 
-No inputs are required, but amount_lt and amount_gt can specify range
-Also description can be a partial match.
+The following request parameters are accepted and are optional:
 
-empty specifies only voucherless batches
+    * class_id
+    * description
+    * amount_lt
+    * amount_gt
+    * approved
 
-approved (true or false) specifies whether the batch has been approved
+These may be used to filter the search results. If omitted or set to
+C<undef>, they have no effect on the returned results.
 
-class_id and created_by are exact matches
+See L<LedgerSMB::Report::Unapproved::Batch_Overview> for full details
+of these parameters.
 
 =cut
 


### PR DESCRIPTION
A number of improvements and fixes to polish the Search Batches results screen:

* Change title s/Search Unapproved Transactions/Search Batches/.
* Change title s/Batch Type/Transaction Type/ to be consistent with previous screen.
* Fix display of `Transaction Type` (the batch class name) by adding trigger to
  Moose class to look up the batch class name whenever the id property is changed.
* Fix display of `Description` - was previously showing non-existent field `Reference`.
* Don't display buttons when showing approved batches - the approve, delete, unlock
  actions they present cannot be used once a batch is approved.
* Removed meaningless `(Locked)` heading field - we don't allow searching on this and it
  was not being populated - it has meaning only for an individual batch, not a result set.

Internal changes:

* Simplify template processing. Don't loop through Batch Class list re-mapping
  variables. Instead specify appropriate key names to use when building the dropdown,
  so that the class list can be used unmodified.
* Expand and correct pod for `list_batches` method.