### PR TITLE
Standardise terminology for "Batch Number"

### DIFF
--- a/UI/create_batch.html
+++ b/UI/create_batch.html
@@ -72,7 +72,7 @@ PROCESS dynatable
                attributes = {id = 'batch_list'}
                tbody = {rows = batch.search_results}
                columns = [
-        { col_id='control_code', type='href', name=text('Control Number'), #'
+        { col_id='control_code', type='href', name=text('Batch Number'), #'
        href_base="vouchers.pl?action=add_vouchers" _
                    hidden_url_base _ "&amp;batch_id=" }
         { col_id='description', type='text', name = text('Description') }

--- a/lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm
+++ b/lib/LedgerSMB/Report/Unapproved/Batch_Overview.pm
@@ -140,7 +140,7 @@ sub columns {
          pwidth => '4', },
 
         {col_id => 'control_code',
-         name => $self->_locale->text('Control Code'),
+         name => $self->_locale->text('Batch Number'),
          type => 'href',
          href_base => 'vouchers.pl?action=get_batch&batch_id=',
          pwidth => '3', },

--- a/xt/66-cucumber/13-cash/step_definitions/pageobject_steps.pl
+++ b/xt/66-cucumber/13-cash/step_definitions/pageobject_steps.pl
@@ -32,12 +32,12 @@ Then qr/I should see a payment line with these values:/, sub {
 };
 
 
-When qr/I click on the Batch with Control Number "(.*)"/, sub {
+When qr/I click on the Batch with Batch Number "(.*)"/, sub {
     my $page = S->{ext_wsl}->page->body->maindiv->content;
-    my $control_code = $1;
+    my $batch_number = $1;
 
-    my $link = $page->batch_link(control_code => $control_code);
-    ok($link->click, "clicked batch link with Control Number $control_code");
+    my $link = $page->batch_link(batch_number => $batch_number);
+    ok($link->click, "clicked link for Batch Number $batch_number");
 };
 
 

--- a/xt/66-cucumber/13-cash/vouchers-payment.feature
+++ b/xt/66-cucumber/13-cash/vouchers-payment.feature
@@ -44,9 +44,9 @@ Scenario: Add payments to an existing batch
   When I navigate the menu and select the item at "Cash > Vouchers > Payments"
   Then I should see the Create New Batch screen
    And I should see a Batch with these values:
-       | Control Number | Description | Post Date  |
-       | B-1001         | Test Batch  | 2018-01-01 |
-  When I click on the Batch with Control Number "B-1001"
+       | Batch Number | Description | Post Date  |
+       | B-1001       | Test Batch  | 2018-01-01 |
+  When I click on the Batch with Batch Number "B-1001"
   Then I should see the Filtering Payments screen
    And I should see the title "Filtering Payments"
   When I enter "2001" into "Start Source Numbering At"

--- a/xt/lib/PageObject/App/Cash/Vouchers/Payments.pm
+++ b/xt/lib/PageObject/App/Cash/Vouchers/Payments.pm
@@ -59,7 +59,7 @@ sub parse_batch_row {
     my $self = shift;
     my $row = shift;
     my $rv = {
-        'Control Number' => $row->find('./td[contains(@class, "control_code")]')->get_text,
+        'Batch Number' => $row->find('./td[contains(@class, "control_code")]')->get_text,
         'Description' => $row->find('./td[contains(@class, "description")]')->get_text,
         'Post Date' => $row->find('./td[contains(@class, "default_date")]')->get_text,
     };
@@ -75,7 +75,7 @@ sub parse_batch_row {
 #
 # For example:
 # my $element = find_batch_row({
-#     'Control Number' => 'B-11001',
+#     'Batch Number' => 'B-11001',
 #     'Description' => 'Batch B-11001',
 #     'Post Date' => '2018-01-01'
 # });
@@ -100,7 +100,7 @@ sub find_batch_row {
 }
 
 
-# batch_link(control_code => $control_code)
+# batch_link(batch_number => $batch_number)
 #
 # Returns the first link from the table of existing batches having
 # the specified control_number
@@ -111,7 +111,7 @@ sub batch_link {
 
     my $row = $self->find(
         "//table[\@id='batch_list']/tbody/tr/td/a[" .
-        "  normalize-space(.)='$params{control_code}'" .
+        "  normalize-space(.)='$params{batch_number}'" .
         "]"
     );
 


### PR DESCRIPTION
In various places we were using Control Code, Control Number, Batch Number
to refer to the same data field. Now standardised to "Batch Number" to
minimise confusion and provide a more polished UX.