### PR TITLE
Add BDD tests for Transaction Approval-Batches

### DIFF
--- a/xt/66-cucumber/14-transaction_approval/search-batches.feature
+++ b/xt/66-cucumber/14-transaction_approval/search-batches.feature
@@ -1,0 +1,88 @@
+@weasel
+Feature: Search Batches
+  As a LedgerSMB user I want to be able to search for previously created
+  voucher batches according to parameters which I specify, with the results
+  presented as a list.
+
+Background:
+  Given a standard test company
+    And a logged in admin user
+
+Scenario: Search for all unapproved batches
+ Given batches with these properties:
+       | Type    | Date       | Batch Number | Description | Approved |
+       | ap      | 2018-01-01 | B-1001       | Batch-1     | no       |
+       | ar      | 2018-02-01 | B-1002       | Batch-ABC-2 | no       |
+       | payment | 2018-03-01 | B-1003       | Batch-3     | no       |
+       | payment | 2018-04-01 | B-1004       | Batch-4     | yes      |
+  When I navigate the menu and select the item at "Transaction Approval > Batches"
+  Then I should see the Search Batches screen
+  When I press "Search"
+  Then I should see the Batch Search Report screen
+   And I should see these headings:
+       | Heading             | Contents     |
+       | Report Name         | Batch Search |
+       | Company             | standard-0   |
+       | Transaction Type    |              |
+       | Description         |              |
+       | Amount Greater Than |              |
+       | Amount Less Than    |              |
+   And I expect the report to contain 3 rows
+   And I expect the 'Type' report column to contain 'ap' for Batch Number 'B-1001'
+   And I expect the 'Date' report column to contain '2018-01-01' for Batch Number 'B-1001'
+   And I expect the 'Description' report column to contain 'Batch-1' for Batch Number 'B-1001'
+   And I expect the 'AR/AP/GL Amount' report column to contain '0.00' for Batch Number 'B-1001'
+   And I expect the 'Payment Amount' report column to contain '0.00' for Batch Number 'B-1001'
+
+Scenario: Search for batches, filtering by batch type
+  When I navigate the menu and select the item at "Transaction Approval > Batches"
+  Then I should see the Search Batches screen
+  When I select "payment" from the drop down "Transaction Type"
+   And I press "Search"
+  Then I should see the Batch Search Report screen
+   And I should see these headings:
+       | Heading             | Contents     |
+       | Report Name         | Batch Search |
+       | Company             | standard-0   |
+       | Transaction Type    | payment      |
+       | Description         |              |
+       | Amount Greater Than |              |
+       | Amount Less Than    |              |
+   And I expect the report to contain 1 row
+   And I expect the 'Description' report column to contain 'Batch-3' for Batch Number 'B-1003'
+
+ Scenario: Search for batches, filtering by description
+  When I navigate the menu and select the item at "Transaction Approval > Batches"
+  Then I should see the Search Batches screen
+  When I enter "ABC" into "Description"
+   And I press "Search"
+  Then I should see the Batch Search Report screen
+   And I should see these headings:
+       | Heading             | Contents     |
+       | Report Name         | Batch Search |
+       | Company             | standard-0   |
+       | Transaction Type    |              |
+       | Description         | ABC          |
+       | Amount Greater Than |              |
+       | Amount Less Than    |              |
+   And I expect the report to contain 1 row
+   And I expect the 'Description' report column to contain 'Batch-ABC-2' for Batch Number 'B-1002'
+
+Scenario: Search for all approved batches
+  When I navigate the menu and select the item at "Transaction Approval > Batches"
+  Then I should see the Search Batches screen
+  When I select "Approved"
+   And I press "Search"
+  Then I should see the Batch Search Report screen
+   And I should see these headings:
+       | Heading             | Contents     |
+       | Report Name         | Batch Search |
+       | Company             | standard-0   |
+       | Transaction Type    |              |
+       | Description         |              |
+       | Amount Greater Than |              |
+       | Amount Less Than    |              |
+   And I expect the report to contain 1 row
+   And I expect the 'Description' report column to contain 'Batch-4' for Batch Number 'B-1004'
+
+

--- a/xt/66-cucumber/14-transaction_approval/search-batches.feature
+++ b/xt/66-cucumber/14-transaction_approval/search-batches.feature
@@ -18,6 +18,7 @@ Scenario: Search for all unapproved batches
   When I navigate the menu and select the item at "Transaction Approval > Batches"
   Then I should see the Search Batches screen
   When I press "Search"
+   And I wait 2 seconds
   Then I should see the Batch Search Report screen
    And I should see these headings:
        | Heading             | Contents     |
@@ -39,6 +40,7 @@ Scenario: Search for batches, filtering by batch type
   Then I should see the Search Batches screen
   When I select "payment" from the drop down "Transaction Type"
    And I press "Search"
+   And I wait 2 seconds
   Then I should see the Batch Search Report screen
    And I should see these headings:
        | Heading             | Contents     |
@@ -56,6 +58,7 @@ Scenario: Search for batches, filtering by batch type
   Then I should see the Search Batches screen
   When I enter "ABC" into "Description"
    And I press "Search"
+   And I wait 2 seconds
   Then I should see the Batch Search Report screen
    And I should see these headings:
        | Heading             | Contents     |
@@ -73,6 +76,7 @@ Scenario: Search for all approved batches
   Then I should see the Search Batches screen
   When I select "Approved"
    And I press "Search"
+   And I wait 2 seconds
   Then I should see the Batch Search Report screen
    And I should see these headings:
        | Heading             | Contents     |
@@ -84,5 +88,4 @@ Scenario: Search for all approved batches
        | Amount Less Than    |              |
    And I expect the report to contain 1 row
    And I expect the 'Description' report column to contain 'Batch-4' for Batch Number 'B-1004'
-
 

--- a/xt/66-cucumber/14-transaction_approval/search-batches.feature
+++ b/xt/66-cucumber/14-transaction_approval/search-batches.feature
@@ -18,7 +18,6 @@ Scenario: Search for all unapproved batches
   When I navigate the menu and select the item at "Transaction Approval > Batches"
   Then I should see the Search Batches screen
   When I press "Search"
-   And I wait 2 seconds
   Then I should see the Batch Search Report screen
    And I should see these headings:
        | Heading             | Contents     |
@@ -40,7 +39,6 @@ Scenario: Search for batches, filtering by batch type
   Then I should see the Search Batches screen
   When I select "payment" from the drop down "Transaction Type"
    And I press "Search"
-   And I wait 2 seconds
   Then I should see the Batch Search Report screen
    And I should see these headings:
        | Heading             | Contents     |
@@ -58,7 +56,6 @@ Scenario: Search for batches, filtering by batch type
   Then I should see the Search Batches screen
   When I enter "ABC" into "Description"
    And I press "Search"
-   And I wait 2 seconds
   Then I should see the Batch Search Report screen
    And I should see these headings:
        | Heading             | Contents     |
@@ -76,7 +73,6 @@ Scenario: Search for all approved batches
   Then I should see the Search Batches screen
   When I select "Approved"
    And I press "Search"
-   And I wait 2 seconds
   Then I should see the Batch Search Report screen
    And I should see these headings:
        | Heading             | Contents     |
@@ -88,4 +84,5 @@ Scenario: Search for all approved batches
        | Amount Less Than    |              |
    And I expect the report to contain 1 row
    And I expect the 'Description' report column to contain 'Batch-4' for Batch Number 'B-1004'
+
 

--- a/xt/66-cucumber/14-transaction_approval/step_definitions/pageobject_steps.pl
+++ b/xt/66-cucumber/14-transaction_approval/step_definitions/pageobject_steps.pl
@@ -1,0 +1,20 @@
+#!perl
+
+use lib 'xt/lib';
+use strict;
+use warnings;
+
+use Test::More;
+use Test::BDD::Cucumber::StepFile;
+
+
+When qr/I select "(Approved|Unapproved)"$/, sub {
+    my $label_text = $1;
+    my $page = S->{ext_wsl}->page->body->maindiv;
+    my $radio_button = $page->find(
+         qq{//tr[td/label[.="$label_text"]]/td/div/input[\@type="radio"]}
+    );
+    $radio_button->click;
+};
+
+1;

--- a/xt/lib/PageObject/App/Menu.pm
+++ b/xt/lib/PageObject/App/Menu.pm
@@ -50,7 +50,9 @@ my %menu_path_pageobject_map = (
 
     "Cash > Vouchers > Payments" => 'PageObject::App::Cash::Vouchers::Payments',
 
+    "Transaction Approval > Batches" => 'PageObject::App::TransactionApproval::Batches',
     "Transaction Approval > Inventory" => 'PageObject::App::Parts::AdjustSearchUnapproved',
+
     "Budgets > Search" => 'PageObject::App::Search::Budget',
     "HR > Employees > Search" => 'PageObject::App::Search::Contact',
 

--- a/xt/lib/PageObject/App/Search/ReportDynatable.pm
+++ b/xt/lib/PageObject/App/Search/ReportDynatable.pm
@@ -39,6 +39,18 @@ sub rows {
     } @rows;
 }
 
+sub find_heading {
+    my $self = shift;
+    my $heading = shift;
+    my $header_div = $self->find(
+        '//form[@id="search-report-dynatable"]'.
+        '/div[@class="heading_section"]'.
+        qq{/div[label[.="$heading->{Heading}:"]]}.
+        qq{/span[\@class="report_header" and normalize-space(.)="$heading->{Contents}"]}
+    ) or die "Matching heading not found '$heading->{Heading}' : '$heading->{Contents}'";
+    return $header_div;
+}
+
 sub _verify {
     my ($self) = @_;
 

--- a/xt/lib/PageObject/App/TransactionApproval/Batches.pm
+++ b/xt/lib/PageObject/App/TransactionApproval/Batches.pm
@@ -1,0 +1,30 @@
+package PageObject::App::TransactionApproval::Batches;
+
+use strict;
+use warnings;
+
+use Carp;
+use PageObject;
+use Moose;
+use namespace::autoclean;
+extends 'PageObject';
+
+__PACKAGE__->self_register(
+    'transactionapproval-batches',
+    './/div[@id="batch_search"]',
+    tag_name => 'div',
+    attributes => {
+        id => 'batch_search',
+    }
+);
+
+
+sub _verify {
+    my ($self) = @_;
+
+    return $self;
+}
+
+
+__PACKAGE__->meta->make_immutable;
+1;

--- a/xt/lib/Pherkin/Extension/pageobject_steps/nav_steps.pl
+++ b/xt/lib/Pherkin/Extension/pageobject_steps/nav_steps.pl
@@ -99,6 +99,8 @@ my %screens = (
     'Create New Batch' => 'PageObject::App::Cash::Vouchers::Payments',
     'Filtering Payments' => 'PageObject::App::Cash::Vouchers::Payments::Filter',
     'Payments Detail' => 'PageObject::App::Cash::Vouchers::Payments::Detail',
+    'Search Batches' => 'PageObject::App::TransactionApproval::Batches',
+    'Batch Search Report' => 'PageObject::App::Search::ReportDynatable',
 );
 
 Then qr/I should see the (.*) screen/, sub {

--- a/xt/lib/Pherkin/Extension/pageobject_steps/report_steps.pl
+++ b/xt/lib/Pherkin/Extension/pageobject_steps/report_steps.pl
@@ -61,8 +61,14 @@ Then qr/I expect the '(.*)' report column to contain '(.*)' for (.*) '(.*)'/, su
 Then qr/I should see a heading "(.*)" displaying "(.*)"$/, sub {
     my $heading = $1;
     my $contents = $2;
+
+    my $found = S->{ext_wsl}->page->body->maindiv->content->find_heading({
+        Heading => $heading,
+        Contents => $contents
+    });
+
     ok(
-        find_report_heading({Heading => $heading, Contents => $contents}),
+        $found,
         "Found header '$heading' displaying '$contents'"
     );
 };
@@ -70,26 +76,16 @@ Then qr/I should see a heading "(.*)" displaying "(.*)"$/, sub {
 
 Then qr/I should see these headings:$/, sub {
     my $data = C->data;
+    my $page = S->{ext_wsl}->page->body->maindiv->content;
 
     foreach my $wanted(@{$data}) {
         ok(
-            find_report_heading($wanted),
+            $page->find_heading($wanted),
             "Found header '$wanted->{Heading}' displaying '$wanted->{Contents}'",
         );
     }
 };
 
-
-sub find_report_heading {
-    my $heading = shift;
-    my $header_div = S->{ext_wsl}->page->body->maindiv->find(
-        '//form[@id="search-report-dynatable"]'.
-        '/div[@class="heading_section"]'.
-        qq{/div[label[.="$heading->{Heading}:"]]}.
-        qq{/span[\@class="report_header" and normalize-space(.)="$heading->{Contents}"]}
-    ) or die "Matching heading not found '$heading->{Heading}' : '$heading->{Contents}'";
-    return $header_div;
-}
 
 
 1;

--- a/xt/lib/Pherkin/Extension/pageobject_steps/report_steps.pl
+++ b/xt/lib/Pherkin/Extension/pageobject_steps/report_steps.pl
@@ -1,6 +1,5 @@
 #!perl
 
-
 use strict;
 use warnings;
 
@@ -8,11 +7,11 @@ use Test::More;
 use Test::BDD::Cucumber::StepFile;
 
 
-
 When qr/I search with these parameters:/, sub {
     my %h = map { $_->{parameter} => $_->{value} } @{C->data};
     S->{ext_wsl}->page->body->maindiv->content->search(%h);
 };
+
 
 Then qr/the Balance Sheet per (.{10}) looks like:/, sub {
     my $date = $1;
@@ -29,6 +28,23 @@ Then qr/the Balance Sheet per (.{10}) looks like:/, sub {
 };
 
 
+Then qr/I expect the report to contain (\d+) rows?$/, sub {
+    my $wanted_row_count = $1;
+    my @rows = S->{ext_wsl}->page->body->maindiv->content->find_all(
+        './/table/tbody/tr'
+    );
+    my $row_count = scalar @rows;
+
+    # Discount final row if it contains totals
+    my $final_element = pop @rows;
+    if($final_element->get_attribute('class') =~ m/listtotal/) {
+        $row_count --;
+    }
+
+    is(scalar @rows, $wanted_row_count, "report contains $wanted_row_count rows");
+};
+
+
 Then qr/I expect the '(.*)' report column to contain '(.*)' for (.*) '(.*)'/, sub {
     my @rows = S->{ext_wsl}->page->body->maindiv->content->rows;
     my $column = $1;
@@ -41,6 +57,39 @@ Then qr/I expect the '(.*)' report column to contain '(.*)' for (.*) '(.*)'/, su
        "Column '$column' contains '$value' for row '$row_id' ($row)");
 };
 
+
+Then qr/I should see a heading "(.*)" displaying "(.*)"$/, sub {
+    my $heading = $1;
+    my $contents = $2;
+    ok(
+        find_report_heading({Heading => $heading, Contents => $contents}),
+        "Found header '$heading' displaying '$contents'"
+    );
+};
+
+
+Then qr/I should see these headings:$/, sub {
+    my $data = C->data;
+
+    foreach my $wanted(@{$data}) {
+        ok(
+            find_report_heading($wanted),
+            "Found header '$wanted->{Heading}' displaying '$wanted->{Contents}'",
+        );
+    }
+};
+
+
+sub find_report_heading {
+    my $heading = shift;
+    my $header_div = S->{ext_wsl}->page->body->maindiv->find(
+        '//form[@id="search-report-dynatable"]'.
+        '/div[@class="heading_section"]'.
+        qq{/div[label[.="$heading->{Heading}:"]]}.
+        qq{/span[\@class="report_header" and normalize-space(.)="$heading->{Contents}"]}
+    ) or die "Matching heading not found '$heading->{Heading}' : '$heading->{Contents}'";
+    return $header_div;
+}
 
 
 1;


### PR DESCRIPTION
BDD tests searching for Batches, with filter parameters and result
screen with headings.

Expands general capabilities for BDD test interaction
with Dynatable pages, adding:

* `I expect the report to contain (\d+) rows?`
* `I should see a heading "(.*)" displaying "(.*)"`
* `I should see these headings:`