### PR TITLE
Fix #3850 Add Budget gives error

### DIFF
--- a/lib/LedgerSMB/Scripts/budgets.pm
+++ b/lib/LedgerSMB/Scripts/budgets.pm
@@ -42,7 +42,7 @@ defaults however.
 sub new_budget {
     my ($request) = @_;
     $request->{rowcount} ||= 0;
-    my $budget = LedgerSMB::Budget->from_input($request);
+    my $budget = LedgerSMB::Budget->new($request);
     return _render_screen($budget);
 }
 

--- a/xt/66-cucumber/01-basic/menu.feature
+++ b/xt/66-cucumber/01-basic/menu.feature
@@ -56,7 +56,7 @@ Scenario Outline: Navigate to menu and open screen
 #   | AR > Vouchers > AR Voucher                 |                          |
 #   | AR > Vouchers > Import AR Batch            |                          |
 #   | AR > Vouchers > Invoice Vouchers           |                          |
-#   | Budgets > Add Budget                       |                          |
+    | Budgets > Add Budget                       | Budget                   |
     | Budgets > Search                           | Budget search            |
 #   | Cash > Payment                             |                          |
 #   | Cash > Receipt                             |                          |

--- a/xt/lib/PageObject/App/Menu.pm
+++ b/xt/lib/PageObject/App/Menu.pm
@@ -53,6 +53,7 @@ my %menu_path_pageobject_map = (
     "Transaction Approval > Batches" => 'PageObject::App::TransactionApproval::Batches',
     "Transaction Approval > Inventory" => 'PageObject::App::Parts::AdjustSearchUnapproved',
 
+    "Budgets > Add Budget" => 'PageObject::App::Budget',
     "Budgets > Search" => 'PageObject::App::Search::Budget',
     "HR > Employees > Search" => 'PageObject::App::Search::Contact',
 

--- a/xt/lib/Pherkin/Extension/pageobject_steps/nav_steps.pl
+++ b/xt/lib/Pherkin/Extension/pageobject_steps/nav_steps.pl
@@ -70,6 +70,7 @@ my %screens = (
     'AP debit invoice entry' => 'PageObject::App::AP::DebitInvoice',
     'AP search' => 'PageObject::App::Search::AP',
     'Batch import' => 'PageObject::App::BatchImport',
+    'Budget' => 'PageObject::App::Budget',
     'Budget search' => 'PageObject::App::Search::Budget',
     'Employee search' => 'PageObject::App::Search::Contact',
     'Sales order search' => 'PageObject::App::Search::Order',


### PR DESCRIPTION
Fixes an error after clicking Batches > Add Batches from the menu and adds a test
to ensure that this menu option displays the appropriate screen without error.
