### PR TITLE
1.6 fix #3850 Add Budget gives error

### DIFF
--- a/lib/LedgerSMB/Scripts/budgets.pm
+++ b/lib/LedgerSMB/Scripts/budgets.pm
@@ -41,7 +41,7 @@ defaults however.
 sub new_budget {
     my ($request) = @_;
     $request->{rowcount} ||= 0;
-    my $budget = LedgerSMB::Budget->from_input($request);
+    my $budget = LedgerSMB::Budget->new($request);
     return _render_screen($budget);
 }
 

--- a/xt/66-cucumber/01-basic/menu.feature
+++ b/xt/66-cucumber/01-basic/menu.feature
@@ -56,7 +56,7 @@ Scenario Outline: Navigate to menu and open screen
 #   | AR > Vouchers > AR Voucher                 |                          |
 #   | AR > Vouchers > Import AR Batch            |                          |
 #   | AR > Vouchers > Invoice Vouchers           |                          |
-#   | Budgets > Add Budget                       |                          |
+    | Budgets > Add Budget                       | Budget                   |
     | Budgets > Search                           | Budget search            |
 #   | Cash > Payment                             |                          |
 #   | Cash > Receipt                             |                          |

--- a/xt/lib/PageObject/App/Menu.pm
+++ b/xt/lib/PageObject/App/Menu.pm
@@ -50,7 +50,10 @@ my %menu_path_pageobject_map = (
     "AP > Reports > Customer History" => '',
 
     "Transaction Approval > Inventory" => 'PageObject::App::Parts::AdjustSearchUnapproved',
+
+    "Budgets > Add Budget" => 'PageObject::App::Budget',
     "Budgets > Search" => 'PageObject::App::Search::Budget',
+
     "HR > Employees > Search" => 'PageObject::App::Search::Contact',
 
     "Order Entry > Sales Order" => "PageObject::App::Orders::Sales",

--- a/xt/lib/Pherkin/Extension/pageobject_steps/nav_steps.pl
+++ b/xt/lib/Pherkin/Extension/pageobject_steps/nav_steps.pl
@@ -70,6 +70,7 @@ my %screens = (
     'AP debit invoice entry' => 'PageObject::App::AP::DebitInvoice',
     'AP search' => 'PageObject::App::Search::AP',
     'Batch import' => 'PageObject::App::BatchImport',
+    'Budget' => 'PageObject::App::Budget',
     'Budget search' => 'PageObject::App::Search::Budget',
     'Employee search' => 'PageObject::App::Search::Contact',
     'Sales order search' => 'PageObject::App::Search::Order',


### PR DESCRIPTION
Backport from master.

Fixes an error after clicking Batches > Add Batches from the menu and adds a test
to ensure that this menu option displays the appropriate screen without error.