### PR TITLE
Add BDD Tests for Batch Delete

### DIFF
--- a/lib/LedgerSMB/Scripts/vouchers.pm
+++ b/lib/LedgerSMB/Scripts/vouchers.pm
@@ -376,8 +376,7 @@ sub batch_approve {
         $batch->{batch_id} = $batch->{"row_$count"};
         $batch->post;
     }
-    $request->{report_name} = 'unapproved';
-    $request->{search_type} = 'batches';
+    $request->{report_name} = 'batches';
     return LedgerSMB::Scripts::reports::start_report($request);
 }
 
@@ -400,8 +399,7 @@ sub batch_unlock {
             $batch->unlock($request->{"row_$count"});
         }
     }
-    $request->{report_name} = 'unapproved';
-    $request->{search_type} = 'batches';
+    $request->{report_name} = 'batches';
     return LedgerSMB::Scripts::reports::start_report($request);
 }
 
@@ -418,14 +416,17 @@ sub batch_delete {
         return list_batches($request);
     }
 
-    my $batch = LedgerSMB::Batch->new(base => $request);
-    for my $count (1 .. $batch->{rowcount_}){
-        next unless $batch->{'select_' . $count};
-        $batch->{batch_id} = $batch->{"row_$count"};
-        $batch->delete;
+    foreach my $count (1 .. $request->{rowcount_}){
+        if ($request->{"select_$count"}) {
+            my $batch = LedgerSMB::Batch->new(base => {
+                dbh => $request->{dbh},
+                batch_id => $request->{"row_$count"},
+            });
+            $batch->delete;
+        }
     }
-    $request->{report_name} = 'unapproved';
-    $request->{search_type} = 'batches';
+
+    $request->{report_name} = 'batches';
     return LedgerSMB::Scripts::reports::start_report($request);
 }
 

--- a/xt/66-cucumber/14-transaction_approval/delete-batches.feature
+++ b/xt/66-cucumber/14-transaction_approval/delete-batches.feature
@@ -1,0 +1,26 @@
+@weasel
+Feature: Delete Batches
+  As a LedgerSMB user I want to search for previously created
+  voucher batches and delete them.
+
+Background:
+  Given a standard test company
+    And a logged in admin user
+
+Scenario: Delete an unapproved batch
+ Given batches with these properties:
+       | Type    | Date       | Batch Number | Description | Approved |
+       | payment | 2018-03-01 | B-1003       | Batch-3     | no       |
+       | payment | 2018-04-01 | B-1004       | Batch-4     | no       |
+  When I navigate the menu and select the item at "Transaction Approval > Batches"
+  Then I should see the Search Batches screen
+  When I press "Search"
+  Then I should see the Batch Search Report screen
+   And I expect the report to contain 2 rows
+  When I select the row where "Batch Number" is "B-1003"
+   And I press "Delete"
+  Then I should see the Search Batches screen
+  When I press "Search"
+  Then I should see the Batch Search Report screen
+   And I expect the report to contain 1 rows
+   And I expect the 'Description' report column to contain 'Batch-4' for Batch Number 'B-1004'

--- a/xt/lib/PageObject/App/Search/ReportDynatable.pm
+++ b/xt/lib/PageObject/App/Search/ReportDynatable.pm
@@ -25,6 +25,13 @@ sub _extract_column_headings {
     return map { $_->get_text } @heading_nodes;;
 }
 
+# rows()
+#
+# Returns an array of hashrefs representing the rows in
+# the table. The hashref contains the text content of each
+# column, keyed by the column heading, plus an additional
+# `_element` key representing the original <tr> element.
+
 sub rows {
     my $self = shift;
 
@@ -35,6 +42,7 @@ sub rows {
         my @cells = $_->find_all('./td | ./th');
         my %row_values;
         @row_values{@headings} = map { $_->get_text } @cells;
+        $row_values{_element} = $_;
         \%row_values;
     } @rows;
 }

--- a/xt/lib/Pherkin/Extension/pageobject_steps/report_steps.pl
+++ b/xt/lib/Pherkin/Extension/pageobject_steps/report_steps.pl
@@ -13,6 +13,23 @@ When qr/I search with these parameters:/, sub {
 };
 
 
+When qr/^I select the rows? where "(.*)" is "(.*)"$/, sub {
+    my @rows = S->{ext_wsl}->page->body->maindiv->content->rows;
+    my $column = $1;
+    my $value = $2;
+
+    foreach my $row(@rows) {
+        if ($row->{$column} eq $value) {
+            my $checkbox = $row->{_element}->find(
+                './td/div/input[@type="checkbox"]'
+            );
+            my $checked = $checkbox->get_attribute('checked');
+            $checked && $checked eq 'true' or $checkbox->click;
+        }
+    }
+};
+
+
 Then qr/the Balance Sheet per (.{10}) looks like:/, sub {
     my $date = $1;
 


### PR DESCRIPTION
* Checks that only selected batch is deleted.

* Checks that Batch Search Report screen is shown after deletion.

* Refactors delete_batch so that Batch object is created only with
  necessary parameters, rather than copying entire request object.

* Fixes display of Batch Search Report screen after deletion - was
  showing Unapproved Transaction search screen following earlier
  PR to separate the two interfaces.