### PR TITLE
Allow login progress bar to fill width

### DIFF
--- a/UI/login.js
+++ b/UI/login.js
@@ -60,7 +60,6 @@ function send_form() {
 require(["dijit/ProgressBar", "dojo/domReady"],
     function(progressbar){
         var indicator = new progressbar({
-            "style": "width: 10em",
             "id": "login-progressbar",
             "value": 100,
             "indeterminate": true


### PR DESCRIPTION
On the login page, after clicking `Login`, a progress bar is shown.
This had its width explicitly constrained, causing it to appear
left-aligned and extend only part-way across its containing div. It
looked odd.

This PR removes the explicit width setting, allowing CSS to style
the progress bar. It now fills the full width of the containing
div, which I consider kinder on the eye.