### PR TITLE
Fix create bank reconciliation report, add bdd tests

### DIFF
--- a/UI/reconciliation/report.html
+++ b/UI/reconciliation/report.html
@@ -1,5 +1,6 @@
 <?lsmb PROCESS 'elements.html' ?>
 <body class="lsmb <?lsmb dojo_theme ?>">
+<div id="reconciliation">
 <?lsmb IF check.unapproved_transactions
 ?><div class="warning"><a href="drafts.pl?action=list_drafts&amp;to_date=<?lsmb end_date ?>"><?lsmb text('There are [_1] unapproved transactions before the end date of this report.',check.unapproved_transactions)
 ?></a></div>
@@ -23,7 +24,6 @@
         END;
     END;
 END ?>
-<div id="reconciliation">
 <form data-dojo-type="lsmb/Reconciliation" action="recon.pl" method="post" enctype="multipart/form-data">
 <div class="listtop" id="title"><?lsmb text('Reconciliation Report') ?></div>
 <table class="info">

--- a/UI/reconciliation/upload.html
+++ b/UI/reconciliation/upload.html
@@ -18,7 +18,7 @@
         <div id="acc-date-row">
         <?lsmb INCLUDE select element_data = {
                 name = "chart_id",
-                options = accounts,
+                options = recon_accounts,
                 text_attr = "name",
                 value_attr = "id",
                 label = text("Account")

--- a/lib/LedgerSMB/Scripts/recon.pm
+++ b/lib/LedgerSMB/Scripts/recon.pm
@@ -292,23 +292,30 @@ sub _display_report {
 }
 
 
-=item new_report
+=item new_report($request)
 
 Displays the new report screen.
+
+C<$request> is a L<LedgerSMB> object reference. The following request keys
+must be set:
+
+  * dbh
 
 =cut
 
 sub new_report {
     my ($request) = @_;
 
-    my $recon = LedgerSMB::DBObject::Reconciliation->new({
-        base => $request
-    });
+    my $recon = LedgerSMB::DBObject::Reconciliation->new();
+    $recon->set_dbh($request->{dbh});
+    $recon->get_accounts();
 
-    # we can assume we're to generate the "Make a happy new report!" page.
-    @{$recon->{accounts}} = $recon->get_accounts;
     my $template = LedgerSMB::Template::UI->new_UI;
-    return $template->render($request, 'reconciliation/upload', $recon);
+    return $template->render(
+        $request,
+        'reconciliation/upload',
+        $recon
+    );
 }
 
 =item start_report($request)
@@ -329,7 +336,6 @@ sub start_report {
     my $recon = LedgerSMB::DBObject::Reconciliation->new({
         base => $request
     });
-
 
     # Why isn't this testing for errors?
     my ($report_id, $entries) = $recon->new_report($recon->import_file());

--- a/lib/LedgerSMB/Scripts/recon.pm
+++ b/lib/LedgerSMB/Scripts/recon.pm
@@ -50,7 +50,6 @@ sub display_report {
         base => $recon_data,
     });
 
-    $recon->get();
     return _display_report($recon, $request);
 }
 
@@ -216,6 +215,8 @@ sub _display_report {
     $recon->add_entries($recon->import_file($contents))
         if $contents && !$recon->{submitted};
     $recon->{can_approve} = $request->is_allowed_role({allowed_roles => ['reconciliation_approve']});
+
+
     $recon->get();
     $recon->{form_id} = $request->{form_id};
     $recon->{sort_options} = [
@@ -228,6 +229,7 @@ sub _display_report {
     if (!$recon->{line_order}){
        $recon->{line_order} = 'scn';
     }
+
     for my $field (qw/ total_cleared_credits total_cleared_debits total_uncleared_credits total_uncleared_debits /) {
       $recon->{"$field"} = LedgerSMB::PGNumber->from_input(0);
     }
@@ -236,6 +238,7 @@ sub _display_report {
        $recon->{their_total} *= -1;
        $neg_factor = -1;
     }
+
     # Credit/Debit separation (useful for some)
     for my $l (@{$recon->{report_lines}}){
         if ($l->{their_balance} > 0){

--- a/old/lib/LedgerSMB/DBObject/Reconciliation.pm
+++ b/old/lib/LedgerSMB/DBObject/Reconciliation.pm
@@ -192,31 +192,26 @@ sub approve {
 
 =item new_report
 
-Creates a new report with data entered.
+Creates a new reconciliation report. Returns the id of the inserted report
+record.
+
+Expects the following object parameters:
+
+  * chart_id  (mandatory)
+  * total     (mandatory
+  * end_date  (defaults to now)
+  * recon_fx  (defaults to false)
 
 =cut
 
 sub new_report {
-
     my $self = shift @_;
-    my $total = shift @_;
-    my $month = shift @_;
 
-    # Total is in here somewhere, too
+    my $report = $self->call_dbmethod(funcname=>'reconciliation__new_report_id');
+    $self->{report_id} = $report->{reconciliation__new_report_id};
 
-    # gives us a report ID to insert with.
-    my @reports = $self->call_dbmethod(funcname=>'reconciliation__new_report_id');
-    my $report_id = $reports[0]->{reconciliation__new_report_id};
-    $self->{report_id} = $report_id;
     $self->call_dbmethod(funcname=>'reconciliation__pending_transactions');
-
-    # Now that we have this, we need to create the internal report representation.
-    # Ideally, we OUGHT to not return anything here, save the report number.
-
-
-    return ($report_id,
-            ###TODO-ISSUE-UNDECLARED-ENTRIES $entries
-        ); # returns the report ID.
+    return $self->{report_id};
 }
 
 
@@ -435,12 +430,13 @@ sub get {
         $line->{days} = $report_days{$line->{id}};
     }
     $self->{our_total} = $our_balance;
-    @{$self->{accounts}} = $self->get_accounts;
-    for (@{$self->{accounts}}){
+
+    for (@{$self->{recon_accounts}}){
        if ($_->{id} == $self->{chart_id}){
            $self->{account} = $_->{name};
        }
     }
+
     $self->{format_amount} = sub { return $self->format_amount(@_); };
     if ($self->{account_info}->{category} =~ /(A|E)/){
        $self->{our_total} *= -1;

--- a/old/lib/LedgerSMB/DBObject/Reconciliation.pm
+++ b/old/lib/LedgerSMB/DBObject/Reconciliation.pm
@@ -381,17 +381,16 @@ sub get {
     $self->{account_info} = $ref;
 
     my ($previous) = $self->call_dbmethod(funcname=>'reconciliation__previous_report_date',
-                                args => { in_chart_id => $self->{chart_id},
-                                          in_end_date => $self->{end_date}
+                                args => { chart_id => $self->{chart_id},
+                                          end_date => $self->{end_date}
                                         });
+
     ($ref) = $self->call_dbmethod(funcname=>'reconciliation__get_cleared_balance',
                                 args => { chart_id => $ref->{id},
                                           report_date => $previous->{end_date}
                                         });
 
     my $our_balance = $ref->{reconciliation__get_cleared_balance};
-    warn "$previous->{their_total} should always equal $our_balance"
-        if $previous->{their_total} != $our_balance;
 
     $self->{beginning_balance} = $our_balance;
     $self->{cleared_total} = LedgerSMB::PGNumber->from_db(0);

--- a/xt/66-cucumber/13-cash/reconciliation.feature
+++ b/xt/66-cucumber/13-cash/reconciliation.feature
@@ -1,0 +1,18 @@
+@weasel
+Feature: Reconciliation
+  As a LedgerSMB user I want to be able to create a new bank reconciliation
+  report.
+
+Background:
+  Given a standard test company
+    And a logged in admin user
+
+Scenario: Create new reconciliation report
+  When I navigate the menu and select the item at "Cash > Reconciliation"
+  Then I should see the New Reconciliation Report screen.
+  When I select "1060 Checking Account" from the drop down "Account"
+   And I enter "0.00" into "Statement Balance"
+   And I enter "2018-01-01" into "To Date"
+   And I press "Create New Report"
+  Then I should see the Reconciliation Report screen
+

--- a/xt/66-cucumber/13-cash/reconciliation.feature
+++ b/xt/66-cucumber/13-cash/reconciliation.feature
@@ -14,6 +14,5 @@ Scenario: Create new reconciliation report
    And I enter "0.00" into "Statement Balance"
    And I enter "2018-01-01" into "To Date"
    And I press "Create New Report"
-   And I wait for the page to load
   Then I should see the Reconciliation Report screen
 

--- a/xt/66-cucumber/13-cash/reconciliation.feature
+++ b/xt/66-cucumber/13-cash/reconciliation.feature
@@ -14,5 +14,6 @@ Scenario: Create new reconciliation report
    And I enter "0.00" into "Statement Balance"
    And I enter "2018-01-01" into "To Date"
    And I press "Create New Report"
+   And I wait for the page to load
   Then I should see the Reconciliation Report screen
 

--- a/xt/66-cucumber/13-cash/step_definitions/pageobject_steps.pl
+++ b/xt/66-cucumber/13-cash/step_definitions/pageobject_steps.pl
@@ -6,7 +6,7 @@ use warnings;
 
 use Test::More;
 use Test::BDD::Cucumber::StepFile;
-use PageObject::App::Cash::Reconciliation::Report;
+
 
 Then qr/I should see a Batch with these values:/, sub {
     my $page = S->{ext_wsl}->page->body->maindiv->content;

--- a/xt/66-cucumber/13-cash/step_definitions/pageobject_steps.pl
+++ b/xt/66-cucumber/13-cash/step_definitions/pageobject_steps.pl
@@ -6,7 +6,7 @@ use warnings;
 
 use Test::More;
 use Test::BDD::Cucumber::StepFile;
-
+use PageObject::App::Cash::Reconciliation::Report;
 
 Then qr/I should see a Batch with these values:/, sub {
     my $page = S->{ext_wsl}->page->body->maindiv->content;

--- a/xt/lib/PageObject/App/Cash/Reconciliation/NewReport.pm
+++ b/xt/lib/PageObject/App/Cash/Reconciliation/NewReport.pm
@@ -1,0 +1,30 @@
+package PageObject::App::Cash::Reconciliation::NewReport;
+
+use strict;
+use warnings;
+
+use Carp;
+use PageObject;
+use Moose;
+use namespace::autoclean;
+extends 'PageObject';
+
+__PACKAGE__->self_register(
+    'cash-reconciliation-newreport',
+    './/div[@id="recon1"]',
+    tag_name => 'div',
+    attributes => {
+        id => 'recon1',
+    }
+);
+
+
+sub _verify {
+    my ($self) = @_;
+
+    return $self;
+}
+
+
+__PACKAGE__->meta->make_immutable;
+1;

--- a/xt/lib/PageObject/App/Cash/Reconciliation/Report.pm
+++ b/xt/lib/PageObject/App/Cash/Reconciliation/Report.pm
@@ -1,0 +1,30 @@
+package PageObject::App::Cash::Reconciliation::Report;
+
+use strict;
+use warnings;
+
+use Carp;
+use PageObject;
+use Moose;
+use namespace::autoclean;
+extends 'PageObject';
+
+__PACKAGE__->self_register(
+    'cash-reconciliation-report',
+    './/div[@id="reconciliation"]',
+    tag_name => 'div',
+    attributes => {
+        id => 'reconciliation',
+    }
+);
+
+
+sub _verify {
+    my ($self) = @_;
+
+    return $self;
+}
+
+
+__PACKAGE__->meta->make_immutable;
+1;

--- a/xt/lib/PageObject/App/Menu.pm
+++ b/xt/lib/PageObject/App/Menu.pm
@@ -49,6 +49,7 @@ my %menu_path_pageobject_map = (
     "AP > Reports > Customer History" => '',
 
     "Cash > Vouchers > Payments" => 'PageObject::App::Cash::Vouchers::Payments',
+    "Cash > Reconciliation" => 'PageObject::App::Cash::Reconciliation::NewReport',
 
     "Transaction Approval > Batches" => 'PageObject::App::TransactionApproval::Batches',
     "Transaction Approval > Inventory" => 'PageObject::App::Parts::AdjustSearchUnapproved',

--- a/xt/lib/Pherkin/Extension/pageobject_steps/nav_steps.pl
+++ b/xt/lib/Pherkin/Extension/pageobject_steps/nav_steps.pl
@@ -103,6 +103,8 @@ my %screens = (
     'Search Batches' => 'PageObject::App::TransactionApproval::Batches',
     'Batch Search Report' => 'PageObject::App::Search::ReportDynatable',
     'Payment Batch Summary' => 'PageObject::App::Search::ReportDynatable',
+    'New Reconciliation Report' => 'PageObject::App::Cash::Reconciliation::NewReport',
+    'Reconciliation Report' => 'PageObject::App::Cash::Reconciliation::Report',
 );
 
 Then qr/I should see the (.*) screen/, sub {


### PR DESCRIPTION
This PR fixes the creation of bank reconciliation reports which was broken on master.
In doing so, it documents and cleans-up the code for beginning a new report, removing
some legacy file import code, which is now handled elsewhere.

BDD tests are added to test basic creation of a reconciliation report and will be expanded
in future PRs to more extensively test the reconciliation process.