### PR TITLE
Use `get` not `get_one` to retrieve request parameters

### DIFF
--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -308,14 +308,12 @@ sub upload {
         return map { $_->basename } $self->{_uploads}->values;
     }
 
-    # Hash::MultiValue croaks when the key doesn't exist;
-    # we want it to return C<undef> instead.
-    my $tmpfname = eval { $self->{_uploads}->get_one($name)->path };
-    return undef unless defined $tmpfname;
+    my $upload = $self->{_uploads}->get($name) or return undef;
+    my $tmpfname = $upload->path;
 
     my $headers = HTTP::Headers::Fast->new(
-        Content_Type => $self->{_uploads}->get_one($name)->content_type
-        );
+        Content_Type => $upload->content_type
+    );
     my $encoding = ':bytes';
     my $charset = $headers->content_type_charset;
     if ($charset) {

--- a/lib/LedgerSMB/Middleware/AuthenticateSession.pm
+++ b/lib/LedgerSMB/Middleware/AuthenticateSession.pm
@@ -113,10 +113,10 @@ sub call {
     }
     elsif ($env->{'lsmb.dbonly'}) {
         $env->{'lsmb.company'} ||=
-            eval { $req->parameters->get_one('company') } ||
+            $req->parameters->get('company') ||
             # temporarily accept a 'database' parameter too,
             # while we cut over 'setup.pl' in a later commit.
-            eval { $req->parameters->get_one('database') } ||
+            $req->parameters->get('database') ||
             # we fall back to what the cookie has to offer before
             # falling back to using the default database, because
             # login.pl::logout() does not require a valid session

--- a/lib/LedgerSMB/Middleware/ClearDownloadCookie.pm
+++ b/lib/LedgerSMB/Middleware/ClearDownloadCookie.pm
@@ -47,7 +47,7 @@ sub call {
     my $req = Plack::Request->new($env);
     my $res = $self->app->($env);
 
-    my $cookie = eval { $req->parameters->get_one('request.download-cookie'); };
+    my $cookie = $req->parameters->get('request.download-cookie');
     my $secure = ($env->{SERVER_PROTOCOL} eq 'https') ? '; Secure' : '';
     my $path = $env->{SCRIPT_NAME};
     $path =~ s|[^/]*$||g;

--- a/lib/LedgerSMB/Middleware/DynamicLoadWorkflow.pm
+++ b/lib/LedgerSMB/Middleware/DynamicLoadWorkflow.pm
@@ -61,8 +61,7 @@ sub call {
         unless use_module($module);
 
     my $req = Plack::Request->new($env);
-    my $action_name =
-        eval { $req->parameters->get_one('action') } // '__default';
+    my $action_name = $req->parameters->get('action') // '__default';
     my $action = $module->can($action_name);
     return  LedgerSMB::PSGI::Util::internal_server_error(
         "Action Not Defined: $action_name"


### PR DESCRIPTION
In lsmb, we've been using `Hash::MultiValue`'s `get_one` method
to retrieve requst parameter values, in the mistaken understanding
that this will return a single value if the request contains
multiple parameters with the wanted key.

In fact, from the `Hash::MultiValue` documentation for `get_one`:

> This method croaks if there is no value or multiple
> values associated with the key

We actually want to use the `get` method:

> Returns a single value for the given $key. If there are multiple
> values, the last one (not first one) is returned.

This PR changes uses of `get_one` to `get`. As `get` returns undef
when a given parameter key is not present, rather than croaking,
these calls no longer need to be wrapped in an `eval` block.

This fixes an issue found during development of BDD tests and is
hoped to fix the outstanding problem with issue #3799. 
