### PR TITLE
Remove unused submit_allowed method and MONEY_EPSILON constant

### DIFF
--- a/lib/LedgerSMB/Magic.pm
+++ b/lib/LedgerSMB/Magic.pm
@@ -44,7 +44,6 @@ our @EXPORT_OK = qw(
     JRNL_GJ
     MAX_DAYS_IN_MONTH
     MIN_PER_HOUR
-    MONEY_EPSILON
     MONTHS_PER_QUARTER
     MONTHS_PER_YEAR
     NC_ENTITY
@@ -277,8 +276,6 @@ use constant SATURDAY           => 6;
 
 =head3  LedgerSMB miscellaneous contants
 
-    MONEY_EPSILON       0.001
-
     EDIT_BUDGET_ROWS     5
     NEW_BUDGET_ROWS     25
 
@@ -287,7 +284,6 @@ a budget.
 
 =cut
 
-use constant MONEY_EPSILON      => 0.001;
 use constant EDIT_BUDGET_ROWS => 5;
 use constant NEW_BUDGET_ROWS  => 25;
 

--- a/old/lib/LedgerSMB/DBObject/Reconciliation.pm
+++ b/old/lib/LedgerSMB/DBObject/Reconciliation.pm
@@ -53,7 +53,6 @@ use base qw(LedgerSMB::PGOld);
 use List::Util qw(sum);
 use LedgerSMB::Reconciliation::CSV;
 use LedgerSMB::PGNumber;
-use LedgerSMB::Magic qw( MONEY_EPSILON);
 
 
 # don't need new
@@ -72,10 +71,7 @@ sub update {
     my $beginning_balance = $self->{beginning_balance} // 0;
     my $total_cleared_credits = $self->{total_cleared_credits} // 0;
     my $total_cleared_debits = $self->{total_cleared_debits} // 0;
-    return $self->{submit_allowed} =
-        abs(($their_total - $beginning_balance)
-            - ($total_cleared_credits - $total_cleared_debits))
-        >= MONEY_EPSILON;
+    return;
 }
 
 sub _pre_save {


### PR DESCRIPTION
Remove unused `submit_allowed` property from `LedgerSMB::DBObject::Reconciliation`.

Remove `MONEY_EPSILON` constant from `LedgerSMB::Magic` which is no longer
needed a a result.