### PR TITLE
Remove duplicate COPYRIGHT pod section from LedgerSMB::Template

### DIFF
--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -300,12 +300,6 @@ Returns the MIME content-type for the rendered template.
 
 =back
 
-=head1 Copyright 2007-2018, The LedgerSMB Core Team
-
-This file is licensed under the GNU General Public License version 2, or at your
-option any later version.  A copy of the license should have been included with
-your software.
-
 =cut
 
 package LedgerSMB::Template;


### PR DESCRIPTION
Standardised `LICENSE AND COPYRIGHT` section is present elsewhere
in the file.