### PR TITLE
Cleanup Reconciliation Report Approve

### DIFF
--- a/old/lib/LedgerSMB/DBObject/Reconciliation.pm
+++ b/old/lib/LedgerSMB/DBObject/Reconciliation.pm
@@ -154,36 +154,20 @@ sub unapproved_checks {
 
 =item approve($self,$reportid)
 
-Approves the pending report $reportid.
-Checks for error codes in the pending report, and approves the report if none
-are found.
-
-Limitations: The creating user may not approve the report.
-
-Returns 1 on success.
+Approves the specified reconciliation report and marks associated transactions
+as cleared.
 
 =cut
 
 sub approve {
+    my $self = shift;
+    my $report_id = shift;
 
-    my $self = shift @_;
-    # the user should be embedded into the $self object.
-    my $report_id = shift @_;
+    $self->call_procedure(
+        funcname => 'reconciliation__report_approve',
+        args => [$report_id],
+    );
 
-    my $code = $self->call_procedure(
-                           funcname=>'reconciliation__report_approve',
-                               args=> [$report_id]); # user
-
-    if ($code == 0) {  # no problem.
-        return $code;
-    }
-    # this is destined to change as we figure out the Error system.
-    elsif ($code == 99) {  ## no critic (ProhibitMagicNumbers) sniff
-
-        return $self->error(
-                "User $self->{user}->{name} cannot approve report, "
-                ."must be a different user.");
-    }
     return;
 }
 

--- a/sql/modules/Reconciliation.sql
+++ b/sql/modules/Reconciliation.sql
@@ -190,29 +190,10 @@ Note that currently contra accounts will show negative balances.$$;
 
 CREATE OR REPLACE FUNCTION reconciliation__report_approve (in_report_id INT) returns INT as $$
 
-    -- Does some basic checks before allowing the approval to go through;
-    -- moves the approval to "cr_report_line", I guess, or some other "final" table.
-    --
-    -- Pending may just be a single flag in the database to mark that it is
-    -- not finalized. Will need to discuss with Chris.
-
     DECLARE
         current_row RECORD;
-        completed cr_report_line;
-        total_errors INT;
-        in_user TEXT;
         ac_entries int[];
     BEGIN
-        in_user := current_user;
-
-        -- so far, so good. Different user, and no errors remain. Therefore,
-        -- we can move it to completed reports.
-        --
-        -- User may not be necessary - I would think it better to use the
-        -- in_user, to note who approved the report, than the user who
-        -- filed it. This may require clunkier syntax..
-
-        --
         ac_entries := '{}';
         UPDATE cr_report SET approved = 't',
                 approved_by = person__get_my_entity_id(),


### PR DESCRIPTION
Remove legacy comments and variable declarations from sql function
`reconciliation__report_approve` - no basic checks are done
before allowing approval. Comments regarding user no longer apply
as this is no longer required as an input parameter.

Cleanup perl function `approve`. Database return code is no longer
relevant - the database raises an exception on error, or returns
`1` on success. It never returns the `0` or `99` responses
that were being checked.

Removed incorrect pod documentation which wrongly stated that
`1` was returned on success and that the creating user may not
approve the report.