### PR TITLE
1.6 Fix search for Reconciliation Report by amount

### DIFF
--- a/UI/Reports/filters/reconciliation_search.html
+++ b/UI/Reports/filters/reconciliation_search.html
@@ -29,16 +29,16 @@
                         type = 'text',
                         class = 'money',
                         size = 12,
-                        value = amount_from,
-                        name = 'amount_from'
+                        value = balance_from,
+                        name = 'balance_from'
                 } ?>
                 <?lsmb INCLUDE input element_data = {
                         label = text('To:'),
                         type = 'text',
                         class = 'money',
                         size = 12,
-                        value = amount_to,
-                        name = 'amount_to'
+                        value = balance_to,
+                        name = 'balance_to'
                 } ?>
             </div>
             <div>

--- a/lib/LedgerSMB/Report/Reconciliation/Summary.pm
+++ b/lib/LedgerSMB/Report/Reconciliation/Summary.pm
@@ -37,22 +37,24 @@ reconciled in a specific report.
 
 =over
 
-=item amount_from
+=item balance_from
 
-Only show reports where the amount is greater or equal to this
+Only show reports where the statement ending balance is greater or equal
+to this.
 
 =cut
 
-has amount_from => (is => 'ro', isa => 'LedgerSMB::Moose::Number',
+has balance_from => (is => 'ro', isa => 'LedgerSMB::Moose::Number',
               required => 0, coerce => 1);
 
-=item amount_to
+=item balance_to
 
-Only show reports where the amount is less than or equal to this
+Only show reports where the statement ending balance is less than or equal
+to this.
 
 =cut
 
-has amount_to => (is => 'ro', isa => 'LedgerSMB::Moose::Number', required => 0,
+has balance_to => (is => 'ro', isa => 'LedgerSMB::Moose::Number', required => 0,
               coerce => 1);
 
 =item account_id
@@ -77,7 +79,7 @@ has approved => (is => 'ro', isa => 'Bool', required => 0);
 If undef, show all reports, if true, show ones submitted for approval, and if
 false only show reports in progress.
 
-Note that approved being set to true and submitted bein set to false will never
+Note that approved being set to true and submitted being set to false will never
 match any reports.
 
 =cut


### PR DESCRIPTION
Backport from master:

Search UI and module was using properties `amount_from` `amount_to`
but underlying query uses `balance_from` and `balance_to`.

UI and perl module updated to reflect underlying sql function.