### PR TITLE
Show reconciliation Approved/Submitted status as checkmark

### DIFF
--- a/UI/lib/dynatable.html
+++ b/UI/lib/dynatable.html
@@ -33,7 +33,7 @@
 
    # the elements in the 'columns' array support these attributes:
    #  - type         : can be any of 'input_text', 'href', 'hidden', 'checkbox'
-   #                   'radio', 'mirrored', 'text'
+   #                   'radio', 'mirrored', 'text', 'boolean_checkmark'
    #  - col_id       : the internal identifier for the column
    #  - class        : the (additional) css classes to be applied to the column
    #  - data_dojo_type : Dojo type for the inputs in the column
@@ -133,8 +133,14 @@ END; ?>
                           name=PFX _ COL.col_id _ '_' _ ROWCOUNT
                           class=COL.class
                           value=ROW.row_id
-                          checked=CHECKED } ?>
-         <?lsmb- ELSIF TYPE == 'radio' ?>
+                          checked=CHECKED };
+
+               ELSIF TYPE == 'boolean_checkmark';
+                   IF ROW.${COL.col_id};
+                       ?>✓<?lsmb
+                   END;
+
+               ELSIF TYPE == 'radio' ?>
          <?lsmb PROCESS input element_data = {
                                          id=COL.col_id _ '-' _ ROWCOUNT
                                          type="radio"

--- a/lib/LedgerSMB/Report/Reconciliation/Summary.pm
+++ b/lib/LedgerSMB/Report/Reconciliation/Summary.pm
@@ -61,7 +61,7 @@ has balance_to => (is => 'ro', isa => 'LedgerSMB::Moose::Number', required => 0,
 
 =item account_id
 
-Show repoirts only for this specific account
+Show reports only for this specific account
 
 =cut
 
@@ -146,10 +146,10 @@ sub columns {
                 type => 'text', },
              {col_id => 'approved',
                 name => $self->Text('Approved'),
-                type => 'text', },
+                type => 'boolean_checkmark', },
              {col_id => 'submitted',
                 name => $self->Text('Submitted'),
-                type => 'text', },
+                type => 'boolean_checkmark', },
              {col_id => 'updated',
                 name => $self->Text('Last Updated'),
                 type => 'text', },
@@ -182,9 +182,9 @@ sub header_lines {
              text => $self->Text('From Date')},
             {name => 'date_to',
              text => $self->Text('To Date') },
-            {name => 'amount_from',
+            {name => 'balance_from',
              text => $self->Text('From Amount')},
-            {name => 'amount_to',
+            {name => 'balance_to',
              text => $self->Text('To Amount')}
      ];
 }

--- a/xt/01-html-checks.t
+++ b/xt/01-html-checks.t
@@ -40,7 +40,7 @@ sub content_test {
 
     my ($fh, @tab_lines, @trailing_space_lines, $text);
     $text = '';
-    open $fh, '<', $filename
+    open $fh, '<:encoding(UTF-8)', $filename
         or BAIL_OUT("failed to open $filename for reading $!");
     $is_snippet = 1
         if ($filename !~ m#(log(in|out))|main|(setup/(?!upgrade/))#
@@ -86,6 +86,12 @@ sub content_test {
                     return 0;
                 }
             },
+            'text-use-entity' => sub {
+                # As per W3C guidance, prefer characters in their normal form
+                # rather than requiring named or numeric character references.
+                # https://www.w3.org/International/questions/qa-escapes
+                return 1;
+            },
         },
     });
     $lint->parse($text);
@@ -109,6 +115,8 @@ sub content_test {
         next if ($is_snippet
                  && $error->as_string =~ m/<body> tag is required/ );
 
+use Data::Dumper;
+diag Dumper $error;
         push @reportable_errors, $error->as_string;
     }
     ok(scalar @reportable_errors == 0, "Source critique for '$filename'")

--- a/xt/01-html-checks.t
+++ b/xt/01-html-checks.t
@@ -115,8 +115,6 @@ sub content_test {
         next if ($is_snippet
                  && $error->as_string =~ m/<body> tag is required/ );
 
-use Data::Dumper;
-diag Dumper $error;
         push @reportable_errors, $error->as_string;
     }
     ok(scalar @reportable_errors == 0, "Source critique for '$filename'")

--- a/xt/66-cucumber/13-cash/reconciliation-search.feature
+++ b/xt/66-cucumber/13-cash/reconciliation-search.feature
@@ -1,5 +1,5 @@
 @weasel
-Feature: Reconciliation Report Searcg
+Feature: Reconciliation Report Search
   As a LedgerSMB user I want to be able to search for reconciliation
   reports according to various attributes.
 
@@ -20,6 +20,17 @@ Scenario: Default search with no filter
   Then I should see the Reconciliation Search Report screen
    And I expect the report to contain 4 rows
    And I expect the 'Account' report column to contain '1060 Checking Account' for Statement Date '2018-02-01'
+   And I expect the 'Statement Balance' report column to contain '1000.01' for Statement Date '2018-02-01'
+   And I expect the 'Approved' report column to contain '' for Statement Date '2018-02-01'
+   And I expect the 'Submitted' report column to contain '✓' for Statement Date '2018-02-01'
+   And I expect the 'Account' report column to contain '1060 Checking Account' for Statement Date '2018-03-01'
+   And I expect the 'Statement Balance' report column to contain '1000.02' for Statement Date '2018-03-01'
+   And I expect the 'Approved' report column to contain '✓' for Statement Date '2018-03-01'
+   And I expect the 'Submitted' report column to contain '✓' for Statement Date '2018-03-01'
+   And I expect the 'Statement Date' report column to contain '2018-01-01' for Account '1065 Petty Cash'
+   And I expect the 'Statement Balance' report column to contain '100.00' for Account '1065 Petty Cash'
+   And I expect the 'Approved' report column to contain '' for Account '1065 Petty Cash'
+   And I expect the 'Submitted' report column to contain '' for Account '1065 Petty Cash'
 
 Scenario: Filter by "Statement Date From"
  When I navigate the menu and select the item at "Cash > Reports > Reconciliation"
@@ -27,6 +38,14 @@ Scenario: Filter by "Statement Date From"
   When I enter "2018-02-01" into "Statement Date From"
    And I press "Search"
   Then I should see the Reconciliation Search Report screen
+   And I should see these headings:
+       | Heading             | Contents               |
+       | Report Name         | Reconciliation Reports |
+       | Company             | standard-0             |
+       | From Date           | 2018-02-01             |
+       | To Date             |                        |
+       | From Amount         |                        |
+       | To Amount           |                        |
    And I expect the report to contain 2 rows
    And I expect the 'Account' report column to contain '1060 Checking Account' for Statement Date '2018-02-01'
    And I expect the 'Account' report column to contain '1060 Checking Account' for Statement Date '2018-03-01'
@@ -37,6 +56,14 @@ Scenario: Filter by "Statement Date To"
   When I enter "2018-02-01" into "Statement Date To"
    And I press "Search"
   Then I should see the Reconciliation Search Report screen
+   And I should see these headings:
+       | Heading             | Contents               |
+       | Report Name         | Reconciliation Reports |
+       | Company             | standard-0             |
+       | From Date           |                        |
+       | To Date             | 2018-02-01             |
+       | From Amount         |                        |
+       | To Amount           |                        |
    And I expect the report to contain 3 rows
    And I expect the 'Account' report column to contain '1060 Checking Account' for Statement Date '2018-02-01'
 
@@ -46,6 +73,13 @@ Scenario: Filter by "Amount From"
   When I enter "1000.01" into "Amount From"
    And I press "Search"
   Then I should see the Reconciliation Search Report screen
+       | Heading             | Contents               |
+       | Report Name         | Reconciliation Reports |
+       | Company             | standard-0             |
+       | From Date           |                        |
+       | To Date             |                        |
+       | From Amount         | 1000.01                |
+       | To Amount           |                        |
    And I expect the report to contain 2 rows
    And I expect the 'Account' report column to contain '1060 Checking Account' for Statement Date '2018-02-01'
    And I expect the 'Account' report column to contain '1060 Checking Account' for Statement Date '2018-03-01'
@@ -56,6 +90,13 @@ Scenario: Filter by "Amount To"
   When I enter "100.00" into "Amount To"
    And I press "Search"
   Then I should see the Reconciliation Search Report screen
+       | Heading             | Contents               |
+       | Report Name         | Reconciliation Reports |
+       | Company             | standard-0             |
+       | From Date           |                        |
+       | To Date             |                        |
+       | From Amount         |                        |
+       | To Amount           | 1000.01                |
    And I expect the report to contain 1 row
    And I expect the 'Account' report column to contain '1065 Petty Cash' for Statement Date '2018-01-01'
 

--- a/xt/66-cucumber/13-cash/reconciliation.feature
+++ b/xt/66-cucumber/13-cash/reconciliation.feature
@@ -50,8 +50,8 @@ Scenario: Search for reconciliation report and delete it,
    And I expect the report to contain 1 row
    And I expect the 'Account' report column to contain '1060 Checking Account' for Statement Date '2018-01-01'
    And I expect the 'Statement Balance' report column to contain '101.00' for Statement Date '2018-01-01'
-   And I expect the 'Approved' report column to contain '0' for Statement Date '2018-01-01'
-   And I expect the 'Submitted' report column to contain '0' for Statement Date '2018-01-01'
+   And I expect the 'Approved' report column to contain '' for Statement Date '2018-01-01'
+   And I expect the 'Submitted' report column to contain '' for Statement Date '2018-01-01'
    And I expect the 'Entered By' report column to contain '1' for Statement Date '2018-01-01'
    And I expect the 'Approved By' report column to contain '' for Statement Date '2018-01-01'
   When I click the "2018-01-01" link


### PR DESCRIPTION
Following discussion in chat, change the Reconciliation Search report to show the
submitted and approved status as a checkmark, rather than the previous 0|1 value.

BDD tests updated to reflect this change and to additionally test report headings.