### PR TITLE
Remove redundant GIFI 'Copy to COA' button

### DIFF
--- a/old/bin/am.pl
+++ b/old/bin/am.pl
@@ -187,11 +187,6 @@ sub gifi_footer {
         }
     }
 
-    if ( $form->{coa} ) {
-        $button{'copy_to_coa'} =
-          { ndx => 7, key => 'C', value => $locale->text('Copy to COA') };
-    }
-
     for ( sort { $button{$a}->{ndx} <=> $button{$b}->{ndx} } keys %button ) {
         push @{$buttons}, {
             name => 'action',


### PR DESCRIPTION
This removes the `Copy to COA` button from the GIFI account editing
screen. This button was non-functional and is not required. Once a
GIFI number/account is created, it can immediately be used as a mapping
for accounts in the main COA.