### PR TITLE
Remove duplicate index on gifi table

### DIFF
--- a/sql/changes/1.7/drop-duplicate-gifi-index.sql
+++ b/sql/changes/1.7/drop-duplicate-gifi-index.sql
@@ -1,0 +1,4 @@
+-- There were two indexes on the gifi.accno column,
+-- one being the primary key, the other a unique index.
+-- As primary key implies unique, the unique index is not needed.
+DROP INDEX IF EXISTS gifi_accno_key;

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -79,3 +79,4 @@
 # 1.7 changes
 1.7/drop-custom-catalog.sql
 1.7/alter-menu-attributes.sql
+1.7/drop-duplicate-gifi-index.sql


### PR DESCRIPTION
The gifi table had two indexes on `gifi.accno`.

One a primary key, the other a unique index. As the primary key
implies that the column is unique, we do not need the extra unique
index, which is removed by this PR.