### PR TITLE
Fix Account 'Returns' checkbox not saved or displayed

### DIFF
--- a/UI/accounts/edit.html
+++ b/UI/accounts/edit.html
@@ -359,13 +359,13 @@
              value = 'IC_cogs'} ?>
    </div>
    <div class="inputgroup">
-      <?lsmb IF form.IC_expense;IC_expense= 'CHECKED'; END;
+      <?lsmb IF form.IC_returns;IC_returns= 'CHECKED'; END;
          INCLUDE input element_data={
               name = 'IC_returns',
               type = 'checkbox',
              label = text('Returns'),
            checked = IC_returns,
-             value = ' IC_returns'} ?>
+             value = 'IC_returns'} ?>
    </div>
    <div class="inputgroup">
       <?lsmb IF form.IC_taxpart; IC_taxpart= 'CHECKED'; END;


### PR DESCRIPTION
On the Account edit screen, the 'Include in drop-down menus' Returns
checkbox did not display the correct status, or retain the setting
when saving. This is because it was using the wrong request parameter.