### PR TITLE
1.6 fix account heading display

### DIFF
--- a/UI/accounts/edit.html
+++ b/UI/accounts/edit.html
@@ -137,7 +137,7 @@
    </div>
 </div>
 <div class="inputline" id="heading-line2">
-   <label class="line"><?lsmb text('Heading') ?></label>
+   <label class="line" for="heading-a"><?lsmb text('Heading') ?></label>
    <div class="inputgroup">
       <?lsmb
     FOREACH h IN form.all_headings;
@@ -147,10 +147,11 @@
     INCLUDE select element_data = {
                   name = 'heading'
                options = form.all_headings
-        default_values = [form.account_heading]
+        default_values = [form.heading]
              text_attr = 'text'
             value_attr = 'id'
                  class = 'account'
+                    id = 'heading-a'
     }; ?>
    </div>
 </div>

--- a/UI/accounts/edit.html
+++ b/UI/accounts/edit.html
@@ -1,4 +1,16 @@
-<?lsmb PROCESS elements.html ?>
+<?lsmb
+    PROCESS elements.html;
+
+    # Build text for dropdown options
+    FOREACH h IN form.all_headings;
+        h.text = h.accno _ '--' _ h.description;
+    END;
+
+    null_heading = [{
+        id = -1,
+        text = '-- ' _ text('NONE') _ ' --'
+    }];
+?>
 <body class="lsmb <?lsmb dojo_theme ?>">
 <div id="account-tabs"
      data-dojo-type="dijit/layout/TabContainer">
@@ -56,17 +68,10 @@
    <label class="line"><?lsmb text('Heading') ?></label>
    <div class="inputgroup">
       <?lsmb
-    FOREACH h IN form.all_headings;
-        h.text = h.accno _ '--' _ h.description;
-    END;
-    form.all_headings.push({id = -1, text = '-- NONE --' });
-    IF (! form.account_heading);
-       form.account_heading = -1;
-    END;
     INCLUDE select element_data = {
                   name = 'parent'
-               options = form.all_headings
-        default_values = [form.account_heading]
+               options = null_heading.merge(form.all_headings)
+        default_values = [form.parent_id]
              text_attr = 'text'
             value_attr = 'id'
                  class = 'account'
@@ -140,10 +145,6 @@
    <label class="line" for="heading-a"><?lsmb text('Heading') ?></label>
    <div class="inputgroup">
       <?lsmb
-    FOREACH h IN form.all_headings;
-        h.text = h.accno _ '--' _ h.description;
-    END;
-    form.all_headings.unshift({});
     INCLUDE select element_data = {
                   name = 'heading'
                options = form.all_headings


### PR DESCRIPTION
Fixes:

* Account Heading edit screen not displaying correct parent heading
* Account edit screen not displaying correct heading
* Account creation screen offering invalid null heading option
* Needlessly repeated iteration through heading list preparing option text