### PR TITLE
Refactor and add BDD tests for editing Account

### DIFF
--- a/UI/accounts/edit.html
+++ b/UI/accounts/edit.html
@@ -25,7 +25,7 @@
         type = 'hidden'
 } ?>
 <div class="inputline" id="accno-line">
-  <label class="line"><?lsmb text('Account Number') ?></label>
+  <label class="line" for="accno-h"><?lsmb text('Account Number') ?></label>
   <div class="inputgroup">
     <?lsmb
     INCLUDE input element_data = {
@@ -75,7 +75,34 @@
    </div>
 </div>
 <hr size="3" noshade="noshade" />
-<?lsmb FOREACH button IN buttons; INCLUDE button element_data=button; END ?>
+
+<?lsmb
+    INCLUDE button element_data={
+       name = 'action',
+       value = 'save'
+       text = text('Save')
+       accesskey = 'S'
+    };
+
+    IF form.id;
+        INCLUDE button element_data={
+           name = 'action',
+           value = 'save_as_new'
+           text = text('Save as new')
+           accesskey = 'N'
+        };
+    END;
+
+    IF form.orphaned;
+        INCLUDE button element_data={
+           name = 'action',
+           value = 'delete'
+           text = text('Delete')
+           accesskey = 'D'
+        };
+    END;
+?>
+
 <hr />
 </form>
 </div>
@@ -95,7 +122,7 @@
         type = 'hidden'
 } ?>
 <div class="inputline" id="accno-line2">
-  <label class="line"><?lsmb text('Account Number') ?></label>
+  <label class="line" for="accno-a"><?lsmb text('Account Number') ?></label>
   <div class="inputgroup">
     <?lsmb
     INCLUDE input element_data = {
@@ -104,6 +131,7 @@
      value = form.accno
       type = 'text'
      class = 'control-code'
+        id = "accno-a"
     } ?>
   </div>
 </div>
@@ -160,14 +188,14 @@
    <label class="line"><?lsmb text('GIFI') ?></label>
    <div class="inputgroup">
        <?lsmb
-          FOREACH g IN form.all_gifi;
+          FOREACH g IN form.gifi_list;
              g.text = g.accno _ '--' _ g.description;
           END;
-          form.all_gifi.unshift({});
+          form.gifi_list.unshift({});
           INCLUDE select element_data={
             name = 'gifi_accno'
           default_values = [form.gifi_accno]
-            options = form.all_gifi
+            options = form.gifi_list
            text_attr='text'
           value_attr='accno' } ?>
    </div>
@@ -208,14 +236,11 @@
    </div>
    <div class="inputgroup">
      <?lsmb
-        IF form.recon;
-           recon = 'CHECKED';
-        END;
         INCLUDE input element_data={
                name = 'recon'
                type = 'checkbox',
               label = text('Recon')
-            checked = recon
+            checked = form.is_recon ? 'checked' : ''
               value = '1'
         } ?>
    </div>
@@ -457,15 +482,42 @@
    </div>
 </div>
 </div> <!-- dropdown div -->
-<?lsmb FOREACH hidden IN hiddens.keys;
-        INCLUDE input element_data={
-                type = 'hidden',
-                name = hidden,
-                value = hiddens.item(hidden)
-                }; END ?>
 
 <hr size="3" noshade="noshade" />
-<?lsmb FOREACH button IN buttons; button.id = button.value _ '-A'; INCLUDE button element_data=button; END ?>
+
+<?lsmb
+    PROCESS input element_data = {
+        value = form.id
+        name = 'id'
+        type = 'hidden'
+    };
+
+    INCLUDE button element_data={
+       name = 'action',
+       value = 'save'
+       text = text('Save')
+       accesskey = 'S'
+    };
+
+    IF form.id;
+        INCLUDE button element_data={
+           name = 'action',
+           value = 'save_as_new'
+           text = text('Save as new')
+           accesskey = 'N'
+        };
+    END;
+
+    IF form.orphaned;
+        INCLUDE button element_data={
+           name = 'action',
+           value = 'delete'
+           text = text('Delete')
+           accesskey = 'D'
+        };
+    END;
+?>
+
 <hr />
 </form>
 </div>
@@ -483,10 +535,10 @@
    PROCESS input element_data = {
        type="hidden"
        name="languagecount"
-       value=form.languages.size
+       value=languages.size
    };
    lang_index = 0;
-   FOREACH language IN form.languages;
+   FOREACH language IN languages;
      lang_index = lang_index + 1; ?>
   <tr>
     <td><?lsmb language.description ?>

--- a/UI/accounts/edit.html
+++ b/UI/accounts/edit.html
@@ -541,7 +541,10 @@
    FOREACH language IN languages;
      lang_index = lang_index + 1; ?>
   <tr>
-    <td><?lsmb language.description ?>
+    <td>
+      <label for="heading-languagetranslation-<?lsmb lang_index ?>">
+        <?lsmb language.description ?>
+      </label>
       <?lsmb PROCESS input element_data = {
              type="hidden"
              name = 'languagecode_' _ lang_index
@@ -552,6 +555,7 @@
                id = 'heading-languagetranslation-' _ lang_index
                class = 'translation'
                value = form.translations.${language.code}.description
+               title = text(language.description)
        } ?>
       </td>
     </tr>
@@ -573,7 +577,7 @@
     value = 'update_translations',
     type = 'submit',
     class = 'submit',
-    text = text('Save'),
+    text = text('Save Translations'),
 } ?>
 </form>
 </div>

--- a/UI/accounts/edit.html
+++ b/UI/accounts/edit.html
@@ -166,7 +166,7 @@
    </div>
 </div>
 <div class="inputline" id="heading-line2">
-   <label class="line"><?lsmb text('Heading') ?></label>
+   <label class="line" for="heading-a"><?lsmb text('Heading') ?></label>
    <div class="inputgroup">
       <?lsmb
     FOREACH h IN form.all_headings;
@@ -176,10 +176,11 @@
     INCLUDE select element_data = {
                   name = 'heading'
                options = form.all_headings
-        default_values = [form.account_heading]
+        default_values = [form.heading]
              text_attr = 'text'
             value_attr = 'id'
                  class = 'account'
+                    id = 'heading-a'
     }; ?>
    </div>
 </div>

--- a/UI/accounts/edit.html
+++ b/UI/accounts/edit.html
@@ -240,7 +240,7 @@
                name = 'recon'
                type = 'checkbox',
               label = text('Recon')
-            checked = form.is_recon ? 'checked' : ''
+            checked = form.account__is_recon ? 'checked' : ''
               value = '1'
         } ?>
    </div>

--- a/UI/accounts/edit.html
+++ b/UI/accounts/edit.html
@@ -1,4 +1,16 @@
-<?lsmb PROCESS elements.html ?>
+<?lsmb
+    PROCESS elements.html;
+
+    # Build text for dropdown options
+    FOREACH h IN form.all_headings;
+        h.text = h.accno _ '--' _ h.description;
+    END;
+
+    null_heading = [{
+        id = -1,
+        text = '-- ' _ text('NONE') _ ' --'
+    }];
+?>
 <body class="lsmb <?lsmb dojo_theme ?>">
 <div id="account-tabs"
      data-dojo-type="dijit/layout/TabContainer">
@@ -56,17 +68,10 @@
    <label class="line"><?lsmb text('Heading') ?></label>
    <div class="inputgroup">
       <?lsmb
-    FOREACH h IN form.all_headings;
-        h.text = h.accno _ '--' _ h.description;
-    END;
-    form.all_headings.push({id = -1, text = '-- NONE --' });
-    IF (! form.account_heading);
-       form.account_heading = -1;
-    END;
     INCLUDE select element_data = {
                   name = 'parent'
-               options = form.all_headings
-        default_values = [form.account_heading]
+               options = null_heading.merge(form.all_headings)
+        default_values = [form.parent_id]
              text_attr = 'text'
             value_attr = 'id'
                  class = 'account'
@@ -169,10 +174,6 @@
    <label class="line" for="heading-a"><?lsmb text('Heading') ?></label>
    <div class="inputgroup">
       <?lsmb
-    FOREACH h IN form.all_headings;
-        h.text = h.accno _ '--' _ h.description;
-    END;
-    form.all_headings.unshift({});
     INCLUDE select element_data = {
                   name = 'heading'
                options = form.all_headings

--- a/UI/accounts/edit.html
+++ b/UI/accounts/edit.html
@@ -385,13 +385,13 @@
              value = 'IC_cogs'} ?>
    </div>
    <div class="inputgroup">
-      <?lsmb IF form.IC_expense;IC_expense= 'CHECKED'; END;
+      <?lsmb IF form.IC_returns;IC_returns= 'CHECKED'; END;
          INCLUDE input element_data={
               name = 'IC_returns',
               type = 'checkbox',
              label = text('Returns'),
            checked = IC_returns,
-             value = ' IC_returns'} ?>
+             value = 'IC_returns'} ?>
    </div>
    <div class="inputgroup">
       <?lsmb IF form.IC_taxpart; IC_taxpart= 'CHECKED'; END;

--- a/UI/accounts/edit.html
+++ b/UI/accounts/edit.html
@@ -187,7 +187,7 @@
 </div>
 <div id="accdetails">
 <div class="inputline" id="gifi-line">
-   <label class="line"><?lsmb text('GIFI') ?></label>
+   <label class="line" for="gifi-a"><?lsmb text('GIFI') ?></label>
    <div class="inputgroup">
        <?lsmb
           FOREACH g IN form.gifi_list;
@@ -195,15 +195,18 @@
           END;
           form.gifi_list.unshift({});
           INCLUDE select element_data={
-            name = 'gifi_accno'
-          default_values = [form.gifi_accno]
-            options = form.gifi_list
-           text_attr='text'
-          value_attr='accno' } ?>
+              name = 'gifi_accno'
+              default_values = [form.gifi_accno]
+              options = form.gifi_list
+              text_attr = 'text'
+              value_attr = 'accno'
+              id = 'gifi-a'
+          };
+       ?>
    </div>
 </div>
 <div class="inputline" id="acctype-line">
-   <label class="line"><?lsmb text('Account Type') ?></label>
+   <label class="line" for="category-a"><?lsmb text('Account Type') ?></label>
    <div class="inputgroup">
       <?lsmb
         a_types = [
@@ -218,6 +221,7 @@
                   name = 'category'
                options = a_types
         default_values = [form.category]
+                    id = 'category-a'
     }; ?>
   </div>
 </div>
@@ -258,7 +262,7 @@
    </div>
 </div>
 <div class="inputline" id="summary-line">
-   <label class="line"><?lsmb text('Summary account for') ?></label>
+   <label class="line" for="summary-a"><?lsmb text('Summary account for') ?></label>
    <div class="inputgroup">
    <?lsmb # fixed_asset may eventually go in here too depending on future
           # directions in development.
@@ -276,6 +280,7 @@
                name = "summary"
             options = s_accts
      default_values = [summary]
+                 id = 'summary-a'
       }; ?>
    </div>
 </div>

--- a/lib/LedgerSMB/Scripts/account.pm
+++ b/lib/LedgerSMB/Scripts/account.pm
@@ -27,11 +27,7 @@ use Log::Log4perl;
 use LedgerSMB;
 use LedgerSMB::DBObject::Account;
 use LedgerSMB::DBObject::EOY;
-use LedgerSMB::Template;
 use LedgerSMB::Template::UI;
-
-
-my $logger = Log::Log4perl::get_logger('LedgerSMB::DBObject::Account');
 
 
 =item new
@@ -42,9 +38,13 @@ Displays a screen to create a new account.
 
 sub new {
     my ($request) = @_;
-    $request->{title} = $request->{_locale}->text('Add Account');
-    $request->{charttype} = 'A';
-    return _display_account_screen($request);
+
+    my $account = LedgerSMB::DBObject::Account->new({base => {
+        dbh => $request->{dbh},
+        charttype => 'A',
+    }});
+
+    return _display_account_screen($request, $account);
 }
 
 =item edit
@@ -57,22 +57,15 @@ Requires the id and charttype variables in the request to be set.
 
 sub edit {
     my ($request) = @_;
-    if (!defined $request->{id}){
-        $request->error('No ID provided');
-    } elsif (!defined $request->{charttype}){
-        $request->error('No Chart Type Provided');
-    }
-    $request->{chart_id} = $request->{id};
-    my $account = LedgerSMB::DBObject::Account->new({base => $request});
-    my @accounts = $account->get();
-    my $acc = shift @accounts;
-    if (!$acc){  # This should never happen.  Any occurance of this is a bug.
-         $request->error($request->{_locale}->text('Bug: No such account'));
-    }
-    $acc->{charttype} = $request->{charttype};
-    $acc->{title} = $request->{_locale}->text('Edit Account');
-    $acc->{_locale} = $request->{_locale};
-    return _display_account_screen($acc);
+
+    my $account = LedgerSMB::DBObject::Account->new({base => {
+        dbh => $request->{dbh},
+        id => $request->{id},
+        charttype => $request->{charttype},
+    }});
+
+    $account = $account->get;
+    return _display_account_screen($request, $account);
 }
 
 =item save
@@ -140,82 +133,29 @@ sub save_as_new {
     return save($request);
 }
 
-# copied from AM.pm.  To be refactored.
+
 sub _display_account_screen {
-    my ($form) = @_;
-    my $account = LedgerSMB::DBObject::Account->new({base => $form});
+    my ($form, $account) = @_;
 
-    # If the base $form does not include a `dbh` element as an initialiser
-    # we must explicitly set the dbh. This will depend on how we are called.
-    #
-    # If $form is a `LedgerSMB` object reference, $form->{dbh} will be
-    # defined and no further initialisation is needed. (But note that no
-    # $form->dbh method is available).
-    #
-    # If $form is an object based on `LedgerSMB::PGOld`, $form->{dbh} will
-    # be undefined (as the internal private attribute is called `_dbh`) but
-    # we can call its $form->dbh method to obtain the datbase handle.
-    $account->dbh or $account->set_dbh($form->dbh);
+    @{$account->{all_headings}} = $account->list_headings();
+    $account->is_recon;
+    $account->gifi_list;
 
-    @{$form->{all_headings}} = $account->list_headings();
-    @{$form->{all_gifi}} = $account->gifi_list();
-    $form->{recon} = $account->is_recon();
-    my $locale = $form->{_locale};
-    my $buttons = [];
-    my $checked;
-    my $hiddens;
-    my $logger = Log::Log4perl->get_logger('');
-    $logger->debug("scripts/account.pl Locale: $locale");
-
-    foreach my $item ( split( /:/, $form->{link} ) ) {
-        $form->{$item} = 1;
+    foreach my $item ( split( /:/, $account->{link} ) ) {
+        $account->{$item} = 1;
     }
 
-    @{$form->{languages}} =
-             LedgerSMB->call_procedure(funcname => 'person__list_languages');
-
-    $hiddens->{type} = 'account';
-    $hiddens->{$_} = $form->{$_} foreach qw(id inventory_accno_id income_accno_id expense_accno_id fxgain_accno_id fxloss_accno_id);
-    $checked->{ $form->{charttype} } = 'checked';
-
-    my %button = ();
-
-    if ( $form->{id} ) {
-        $button{'save'} =
-          { ndx => 3, key => 'S', value => $locale->text('Save'),
-           id => 'action_save' };
-        $button{'save_as_new'} =
-          { ndx => 7, key => 'N', value => $locale->text('Save as new'),
-           id => 'action_save_as_new' };
-
-        if ( $form->{orphaned} ) {
-            $button{'delete'} =
-              { ndx => 16, key => 'D', value => $locale->text('Delete') };
-        }
-    }
-    else {
-        $button{'save'} =
-          { ndx => 3, key => 'S', value => $locale->text('Save') };
-    }
-
-    for ( sort { $button{$a}->{ndx} <=> $button{$b}->{ndx} } keys %button ) {
-        push @{$buttons}, {
-            name => 'action',
-            value => $_,
-            accesskey => $button{$_}{key},
-            title => "$button{$_}{value} [Alt-$button{$_}{key}]",
-            text => $button{$_}{value},
-            };
-    }
+    my @languages = LedgerSMB->call_procedure(
+        funcname => 'person__list_languages'
+    );
 
     my $template = LedgerSMB::Template::UI->new_UI;
     return $template->render($form, 'accounts/edit', {
-        form => $form,
-        checked => $checked,
-        buttons => $buttons,
-        hiddens => $hiddens,
+        form => $account,
+        languages => \@languages,
     });
 }
+
 
 =item yearend_info
 

--- a/xt/66-cucumber/10-gl/chart-of-accounts.feature
+++ b/xt/66-cucumber/10-gl/chart-of-accounts.feature
@@ -1,7 +1,8 @@
-@one-db @weasel
+@weasel
 Feature: Chart of Accounts
   As a LedgerSMB user I want to be able to view the chart of accounts
-  and change the description of an account.
+  and change the description of an account and a heading. I want to be able
+  to use an existing account as the basis for creating a new account.
 
 Background:
   Given a standard test company
@@ -38,3 +39,36 @@ Scenario: View the chart of accounts and change the description of an account he
   Then I should see the Chart of Accounts screen
    And I expect the report to contain 78 rows
    And I expect the 'Description' report column to contain 'Assets' for Account Number '1000'
+
+Scenario: Create a new account based on an existing account
+  When I navigate the menu and select the item at "General Journal > Chart of Accounts"
+  Then I should see the Chart of Accounts screen
+   And I expect the report to contain 78 rows
+  When I click Account Number "1060"
+  Then I should see the Account screen
+  When I select the "Account" tab
+   And I enter "TEST-1" into "Account Number"
+   And I enter "New Account" into "Description"
+   And I press "Save as new"
+  Then I should see the Account screen
+  When I navigate the menu and select the item at "General Journal > Chart of Accounts"
+  Then I should see the Chart of Accounts screen
+   And I expect the report to contain 79 rows
+   And I expect the 'Description' report column to contain 'New Account' for Account Number 'TEST-1'
+
+Scenario: Create a new heading based on an existing heading
+  When I navigate the menu and select the item at "General Journal > Chart of Accounts"
+  Then I should see the Chart of Accounts screen
+   And I expect the report to contain 79 rows
+  When I click Account Number "1000"
+  Then I should see the Account screen
+  When I select the "Heading" tab
+   And I enter "TEST-2" into "Account Number"
+   And I enter "New Heading" into "Description"
+   And I press "Save as new"
+  Then I should see the Account screen
+  When I navigate the menu and select the item at "General Journal > Chart of Accounts"
+  Then I should see the Chart of Accounts screen
+   And I expect the report to contain 80 rows
+   And I expect the 'Description' report column to contain 'New Heading' for Account Number 'TEST-2'
+

--- a/xt/66-cucumber/10-gl/chart-of-accounts.feature
+++ b/xt/66-cucumber/10-gl/chart-of-accounts.feature
@@ -14,6 +14,7 @@ Scenario: View the chart of accounts and change the description of an account
    And I expect the 'Description' report column to contain 'Checking Account' for Account Number '1060'
   When I click Account Number "1060"
   Then I should see the Account screen
+   And I expect the "Description" field to contain "Checking Account"
   When I enter "Cheque Account" into "Description"
    And I press "Save"
   Then I should see the Account screen
@@ -29,6 +30,7 @@ Scenario: View the chart of accounts and change the description of an account he
    And I expect the 'Description' report column to contain 'CURRENT ASSETS' for Account Number '1000'
   When I click Account Number "1000"
   Then I should see the Account screen
+   And I expect the "Description" field to contain "CURRENT ASSETS"
   When I enter "Assets" into "Description"
    And I press "Save"
   Then I should see the Account screen

--- a/xt/66-cucumber/10-gl/chart-of-accounts.feature
+++ b/xt/66-cucumber/10-gl/chart-of-accounts.feature
@@ -1,28 +1,56 @@
 @weasel
 Feature: Chart of Accounts
   As a LedgerSMB user I want to be able to view the chart of accounts
-  and change the description of an account and a heading. I want to be able
+  and change the properties of an account and a heading. I want to be able
   to use an existing account as the basis for creating a new account.
 
 Background:
   Given a standard test company
     And a logged in admin user
 
-Scenario: View the chart of accounts and change the description of an account
+Scenario: View the chart of accounts and change every property of an account
+ Given GIFI entries with these properties:
+       | GIFI  | Description |
+       | 1234  | Test GIFI   |
+       | 1235  | Test GIFI 2 |
   When I navigate the menu and select the item at "General Journal > Chart of Accounts"
   Then I should see the Chart of Accounts screen
    And I expect the report to contain 78 rows
-   And I expect the 'Description' report column to contain 'Checking Account' for Account Number '1060'
-  When I click Account Number "1060"
+   And I expect the 'Description' report column to contain 'Office Furniture & Equipment' for Account Number '1820'
+  When I click Account Number "1820"
   Then I should see the Account screen
-   And I expect the "Description" field to contain "Checking Account"
-  When I enter "Cheque Account" into "Description"
+   And I expect the "Description" field to contain "Office Furniture & Equipment"
+   And I expect "1800--CAPITAL ASSETS" to be selected for "Heading"
+   And I expect "Asset" to be selected for "Account Type"
+   And I expect to see 0 selected checkboxes in "Options"
+   And I expect to see 0 selected checkboxes in "Include in drop-down menus"
+  When I select checkbox "Obsolete"
+   And I enter "Chairs" into "Description"
+   And I select "1000--CURRENT ASSETS" from the drop down "Heading"
+   And I select "1234--Test GIFI" from the drop down "GIFI"
+   And I select "Equity" from the drop down "Account Type"
+   And I select every checkbox in "Options"
+   And I select every checkbox in "Include in drop-down menus"
    And I press "Save"
+   And I wait for the page to load
   Then I should see the Account screen
+   And I expect the "Obsolete" checkbox to be selected
+   And I expect the "Description" field to contain "Chairs"
+   And I expect "1000--CURRENT ASSETS" to be selected for "Heading"
+   And I expect "1234--Test GIFI" to be selected for "GIFI"
+   And I expect "Equity" to be selected for "Account Type"
+   And I expect to see 3 selected checkboxes in "Options"
+   And I expect to see 20 selected checkboxes in "Include in drop-down menus"
+  When I select "Inventory" from the drop down "Summary account for"
+   And I deselect every checkbox in "Include in drop-down menus"
+   And I press "Save"
+   And I wait for the page to load
+  Then I expect to see 0 selected checkboxes in "Include in drop-down menus"
+   And I expect "Inventory" to be selected for "Summary account for"
   When I navigate the menu and select the item at "General Journal > Chart of Accounts"
   Then I should see the Chart of Accounts screen
    And I expect the report to contain 78 rows
-   And I expect the 'Description' report column to contain 'Cheque Account' for Account Number '1060'
+   And I expect the 'Description' report column to contain 'Chairs' for Account Number '1820'
 
 Scenario: View the chart of accounts and change the description of an account heading
   When I navigate the menu and select the item at "General Journal > Chart of Accounts"

--- a/xt/66-cucumber/10-gl/edit-account-heading-translation.feature
+++ b/xt/66-cucumber/10-gl/edit-account-heading-translation.feature
@@ -1,0 +1,25 @@
+@weasel
+Feature: Edit account translation
+  As a LedgerSMB user I want to be able to specify account heading
+  descriptions in multiple languages.
+
+Background:
+  Given a standard test company
+    And a logged in admin user
+
+Scenario: Add translations for an account heading description
+  When I navigate the menu and select the item at "General Journal > Chart of Accounts"
+  Then I should see the Chart of Accounts screen
+  When I click Account Number "4000"
+  Then I should see the Account screen
+  When I select the "Translations" tab
+  Then I expect the "Spanish" field to contain ""
+   And I expect the "French" field to contain ""
+  When I enter "Ingresos por ventas" into "Spanish"
+   And I enter "Revenu de vente" into "French"
+   And I press "Save Translations"
+  Then I should see the Account screen
+  When I select the "Translations" tab
+  Then I expect the "Spanish" field to contain "Ingresos por ventas"
+   And I expect the "French" field to contain "Revenu de vente"
+

--- a/xt/66-cucumber/10-gl/edit-account-translation.feature
+++ b/xt/66-cucumber/10-gl/edit-account-translation.feature
@@ -1,0 +1,25 @@
+@weasel
+Feature: Edit account translation
+  As a LedgerSMB user I want to be able to specify account descriptions
+  in multiple languages.
+
+Background:
+  Given a standard test company
+    And a logged in admin user
+
+Scenario: Add translations for an account description
+  When I navigate the menu and select the item at "General Journal > Chart of Accounts"
+  Then I should see the Chart of Accounts screen
+  When I click Account Number "1060"
+  Then I should see the Account screen
+  When I select the "Translations" tab
+  Then I expect the "Spanish" field to contain ""
+   And I expect the "French" field to contain ""
+  When I enter "Cuenta de cheques" into "Spanish"
+   And I enter "Compte courant" into "French"
+   And I press "Save Translations"
+  Then I should see the Account screen
+  When I select the "Translations" tab
+  Then I expect the "Spanish" field to contain "Cuenta de cheques"
+   And I expect the "French" field to contain "Compte courant"
+

--- a/xt/66-cucumber/10-gl/step_definitions/pageobject_steps.pl
+++ b/xt/66-cucumber/10-gl/step_definitions/pageobject_steps.pl
@@ -7,6 +7,7 @@ use warnings;
 use Test::More;
 use Test::BDD::Cucumber::StepFile;
 
+
 When qr/^I click Account Number "(.*)"$/, sub {
     my $page = S->{ext_wsl}->page->body->maindiv->content;
     my $account_number = $1;
@@ -18,5 +19,44 @@ When qr/^I click Account Number "(.*)"$/, sub {
     ok($link->click, "clicked link for Account Number $account_number");
 };
 
+
+When qr/^I (select|deselect) every checkbox in "(.*)"$/, sub {
+    my $wanted_state = ($1 eq 'select');
+    my $section = $2;
+    my $page = S->{ext_wsl}->page->body->maindiv->content;
+    my %section_ids = (
+        'Options' => 'acc-options-line',
+        'Include in drop-down menus' => 'dropdowns',
+    );
+
+    my @checkboxes = $page->find_all(
+        qq{.//div[\@id="$section_ids{$section}"]//input[\@type="checkbox"]}
+    ) or die "failed to find checkboxes";
+
+    foreach my $checkbox (@checkboxes) {
+        my $checked = $checkbox->get_attribute('checked');
+        my $checked_status = $checked && $checked eq 'true';
+        if ($checked_status xor $wanted_state) {
+            $checkbox->click();
+        }
+    }
+};
+
+
+Then qr/^I expect to see (\d+) selected checkboxes in "(.*)"$/, sub {
+    my $wanted_count = $1;
+    my $section = $2;
+    my %section_ids = (
+        'Options' => 'acc-options-line',
+        'Include in drop-down menus' => 'dropdowns',
+    );
+
+    my $page = S->{ext_wsl}->page->body->maindiv->content;
+    my @checkboxes = $page->find_all(
+        qq{.//div[\@id="$section_ids{$section}"]//input[\@type="checkbox" and \@checked="checked"]}
+    );
+
+    is(scalar @checkboxes, $wanted_count, "found $wanted_count selected checkboxes");
+};
 
 1;

--- a/xt/lib/Pherkin/Extension/ledgersmb_steps/common_steps.pl
+++ b/xt/lib/Pherkin/Extension/ledgersmb_steps/common_steps.pl
@@ -348,6 +348,21 @@ Given qr/^(a reconciliation report|reconciliation reports) with these properties
     }
 };
 
+Given qr/^GIFI entries with these properties:$/, sub {
+    my $dbh = S->{ext_lsmb}->admin_dbh;
+    my $q = $dbh->prepare("
+        INSERT INTO gifi (accno, description)
+        VALUES (?,?)
+    ");
+
+    foreach my $gifi_spec (@{C->data}) {
+        $q->execute(
+            $gifi_spec->{GIFI},
+            $gifi_spec->{Description},
+        ) or die "failed to insert GIFI $gifi_spec->{GIFI} :: $gifi_spec->{Description}";
+    }
+};
+
 When qr/I wait (\d+) seconds?$/, sub {
     sleep $1
 };
@@ -356,5 +371,48 @@ When qr/I wait for the page to load$/, sub {
     S->{ext_wsl}->page->body->maindiv->wait_for_content;
 };
 
+When qr/^I select checkbox "(.*)"$/, sub {
+    my $label = $1;
+    my $element = S->{ext_wsl}->page->find(
+        "*labeled", text => $label
+    );
+
+    ok($element, "found element with label '$label'");
+    is($element->tag_name, 'input', 'element is an <input>');
+    is($element->get_attribute('type'), 'checkbox', 'element is an checkbox');
+
+    my $checked = $element->get_attribute('checked');
+    $checked && $checked eq 'checked' or $element->click;
+};
+
+Then qr/^I expect the "(.*)" checkbox to be selected/, sub {
+    my $label = $1;
+    my $element = S->{ext_wsl}->page->find(
+        "*labeled", text => $label
+    );
+
+    ok($element, "found element with label '$label'");
+    is($element->tag_name, 'input', 'element is an <input>');
+    is($element->get_attribute('type'), 'checkbox', 'element is an checkbox');
+
+    my $checked = $element->get_attribute('checked');
+    ok($checked, 'checkbox is selected');
+};
+
+Then qr/^I expect "(.*)" to be selected for "(.*)"$/, sub {
+    my $option_text = $1;
+    my $label_text = $2;
+
+    my $element = S->{ext_wsl}->page->find(
+        "*labeled", text => $label_text
+    );
+    ok($element, "found element labeled '$label_text'");
+
+    my $option = $element->find(
+        qq{//span[\@role="option" and \@aria-selected="true" and .="$option_text"]} 
+    );
+
+    ok($option, "Found option '$option_text' of dropdown '$label_text'");
+};
 
 1;

--- a/xt/lib/Pherkin/Extension/pageobject_steps/nav_steps.pl
+++ b/xt/lib/Pherkin/Extension/pageobject_steps/nav_steps.pl
@@ -168,7 +168,19 @@ Then qr/I expect to see the '(.*)' value of '(.*)'/, sub {
     $actual =~ s/^\s+|\s+$//g;
     is($actual, $value,
        "value for element ($id) equals expected value ($value):" .
-        $actual);
+        $actual
+    );
+};
+
+Then qr/^I expect the "(.*)" field to contain "(.*)"$/, sub {
+    my $label = $1;
+    my $value = $2;
+    my $element = S->{ext_wsl}->page->body->maindiv->find(
+        "*labeled",
+        text => $label
+    );
+    ok($element, "found element with label '$label'");
+    is($element->value, $value, "element with label '$label' contains '$value'");
 };
 
 1;


### PR DESCRIPTION
This PR refactors code in `LedgerSMB::Scripts::account` and `LedgerSMB::DBObject::Account`,
removing redundant code, simplifying the execution path and pushing display concerns away
from perl code into the template.

A number of bugs are fixed regarding the display of fields on the Account and Account Heading
screens.

BDD tests are added to check that every field on the Edit Account screen can be updated and
redisplayed correctly.