### PR TITLE
Add default header_lines to LedgerSMB::Report

### DIFF
--- a/lib/LedgerSMB/Report.pm
+++ b/lib/LedgerSMB/Report.pm
@@ -21,27 +21,6 @@ Subclasses MUST define the following methods:
 
 =over
 
-=item header_lines
-
-This must return an arrayref of the header fields to be displayed on the
-report. The array elements must be hashrefs comprising the following keys:
-
-  text - The localized header title
-  name - The request parameter to be displayed for this heading
-
-An example return value from a C<header_lines()> method might be:
-
-  [
-      {
-          text => 'Invoice Number',
-          name => 'invoice_no'
-      },
-      {
-          text => 'Date',
-          name => 'post_date'
-      }
-  ]
-
 =item name
 
 This must return the localized report name (usually displayed as a title
@@ -55,6 +34,31 @@ for the report).
 Additionally, subclasses MAY define any of the following:
 
 =over
+
+=item header_lines
+
+This must return an arrayref of the header fields to be displayed on the
+report. The array elements must be hashrefs comprising the following keys:
+
+  text - The localized header title
+  name - The request parameter to be displayed for this heading
+
+I<Report Name> and I<Company Name> are always included in the header lines
+shown on a report (they are part of the template) and do not need to be
+specified.
+
+An example return value from a C<header_lines()> method might be:
+
+  [
+      {
+          text => 'Invoice Number',
+          name => 'invoice_no'
+      },
+      {
+          text => 'Date',
+          name => 'post_date'
+      }
+  ]
 
 =item template
 
@@ -440,6 +444,18 @@ sub show_cols {
     return \@retval;
 }
 
+=item header_lines
+
+Default method that specified no header lines. Can be overridden by
+individual reports.
+
+=cut
+
+sub header_lines {
+    return [];
+}
+
+
 =over
 
 =item none
@@ -499,7 +515,7 @@ LedgerSMB::Report subclasses are written typically in a few parts:
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2012 The LedgerSMB Core Team
+Copyright (C) 2012-2018 The LedgerSMB Core Team
 
 This file is licensed under the GNU General Public License version 2, or at your
 option any later version.  A copy of the license should have been included with

--- a/lib/LedgerSMB/Report/Aging.pm
+++ b/lib/LedgerSMB/Report/Aging.pm
@@ -197,16 +197,6 @@ sub template {
     }
 }
 
-=item header_lines
-
-Returns the inputs to display on header.
-
-=cut
-
-sub header_lines {
-    return [];
-}
-
 =back
 
 =head2 Criteria Properties

--- a/lib/LedgerSMB/Report/Assets/Net_Book_Value.pm
+++ b/lib/LedgerSMB/Report/Assets/Net_Book_Value.pm
@@ -116,17 +116,6 @@ sub columns {
   ];
 };
 
-
-=head2 header_lines
-
-None added
-
-=cut
-
-sub header_lines {
-    return [];
-}
-
 =head2 name
 
 Net Book Value

--- a/lib/LedgerSMB/Report/COA.pm
+++ b/lib/LedgerSMB/Report/COA.pm
@@ -31,8 +31,6 @@ use Moose;
 use namespace::autoclean;
 extends 'LedgerSMB::Report';
 
-use LedgerSMB::App_State;
-
 
 =head1 PROPERTIES
 
@@ -141,16 +139,6 @@ sub name {
     return $self->Text('Chart of Accounts');
 }
 
-=item header_lines
-
-Returns the inputs to display on header.
-
-=cut
-
-sub header_lines {
-    return [];
-}
-
 =item subtotal_cols
 
 Returns list of columns for subtotals
@@ -209,7 +197,7 @@ sub run_report{
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2012 The LedgerSMB Core Team
+Copyright (C) 2012-2018 The LedgerSMB Core Team
 
 This file is licensed under the GNU General Public License version 2, or at your
 option any later version.  A copy of the license should have been included with

--- a/lib/LedgerSMB/Report/File/Incoming.pm
+++ b/lib/LedgerSMB/Report/File/Incoming.pm
@@ -63,14 +63,6 @@ sub columns {
     ];
 }
 
-=head2 header_lines
-
-None
-
-=cut
-
-sub header_lines { return []; }
-
 =head2 name
 
 Internal Files (localized)

--- a/lib/LedgerSMB/Report/File/Internal.pm
+++ b/lib/LedgerSMB/Report/File/Internal.pm
@@ -61,14 +61,6 @@ sub columns {
     ];
 }
 
-=head2 header_lines
-
-None
-
-=cut
-
-sub header_lines { return []; }
-
 =head2 name
 
 Internal Files (localized)

--- a/lib/LedgerSMB/Report/Hierarchical.pm
+++ b/lib/LedgerSMB/Report/Hierarchical.pm
@@ -112,18 +112,6 @@ sub columns {
     return [];
 };
 
-=item header_lines
-
-Implement inherited protocol.
-Returns an empty arrayref since this is not applicable.
-
-=cut
-
-sub header_lines {
-    return [];
-}
-
-
 =back
 
 =head1 METHODS

--- a/lib/LedgerSMB/Report/Inventory/History.pm
+++ b/lib/LedgerSMB/Report/Inventory/History.pm
@@ -169,16 +169,6 @@ sub columns {
     ];
 }
 
-=head2 header_lines
-
-None yet
-
-=cut
-
-sub header_lines {
-   return [];
-};
-
 =head2 name
 
 Goods and Services

--- a/lib/LedgerSMB/Report/Inventory/Search.pm
+++ b/lib/LedgerSMB/Report/Inventory/Search.pm
@@ -308,16 +308,6 @@ sub columns {
     ];
 }
 
-=head2 header_lines
-
-None yet
-
-=cut
-
-sub header_lines {
-   return [];
-};
-
 =head2 name
 
 Goods and Services

--- a/lib/LedgerSMB/Report/Invoices/Outstanding.pm
+++ b/lib/LedgerSMB/Report/Invoices/Outstanding.pm
@@ -280,16 +280,6 @@ sub columns {
     ];
 }
 
-=head2 header_lines
-
-# TODO
-
-=cut
-
-sub header_lines {
-    return [];
-}
-
 =head2 name
 
 Returns either the localized strings for "AR Outstanding" or "AP Outstanding"

--- a/lib/LedgerSMB/Report/Invoices/Transactions.pm
+++ b/lib/LedgerSMB/Report/Invoices/Transactions.pm
@@ -310,17 +310,6 @@ sub columns {
     ];
 }
 
-
-=head2 header_lines
-
-# TODO
-
-=cut
-
-sub header_lines {
-    return [];
-}
-
 =head2 name
 
 'Search AR' or 'Search AP' depending on entity_class

--- a/lib/LedgerSMB/Report/Listings/Business_Type.pm
+++ b/lib/LedgerSMB/Report/Listings/Business_Type.pm
@@ -58,16 +58,6 @@ sub columns {
     }];
 };
 
-=item header_lines
-
-None added
-
-=cut
-
-sub header_lines {
-    return []
-};
-
 =item name
 
 =cut

--- a/lib/LedgerSMB/Report/Listings/Business_Unit.pm
+++ b/lib/LedgerSMB/Report/Listings/Business_Unit.pm
@@ -72,14 +72,6 @@ sub columns {
     ];
 }
 
-=head2 header_lines
-
-None.
-
-=cut
-
-sub header_lines { return [] };
-
 =head2 name
 
 Business Units List

--- a/lib/LedgerSMB/Report/Listings/GIFI.pm
+++ b/lib/LedgerSMB/Report/Listings/GIFI.pm
@@ -54,14 +54,6 @@ sub columns {
     ];
 }
 
-=head2 header_lines
-
-None
-
-=cut
-
-sub header_lines { return []; }
-
 =head2 name
 
 GIFI

--- a/lib/LedgerSMB/Report/Listings/Language.pm
+++ b/lib/LedgerSMB/Report/Listings/Language.pm
@@ -54,14 +54,6 @@ sub columns {
     ];
 }
 
-=head2 header_lines
-
-None
-
-=cut
-
-sub header_lines { return []; }
-
 =head2 name
 
 Languages

--- a/lib/LedgerSMB/Report/Listings/SIC.pm
+++ b/lib/LedgerSMB/Report/Listings/SIC.pm
@@ -52,14 +52,6 @@ sub columns {
     ];
 }
 
-=head2 header_lines
-
-None
-
-=cut
-
-sub header_lines { return []; }
-
 =head2 name
 
 Standard Industrial Codes

--- a/lib/LedgerSMB/Report/Listings/TemplateTrans.pm
+++ b/lib/LedgerSMB/Report/Listings/TemplateTrans.pm
@@ -105,14 +105,6 @@ sub columns {
     return \@columns;
 }
 
-=head2 header_lines
-
-none
-
-=cut
-
-sub header_lines { return [] }
-
 =head2 set_buttons
 
 none

--- a/lib/LedgerSMB/Report/Listings/Warehouse.pm
+++ b/lib/LedgerSMB/Report/Listings/Warehouse.pm
@@ -47,14 +47,6 @@ sub columns {
     }];
 }
 
-=head2 header_lines
-
-None
-
-=cut
-
-sub header_lines { return []; }
-
 =head2 name
 
 Warehouses

--- a/lib/LedgerSMB/Report/Orders.pm
+++ b/lib/LedgerSMB/Report/Orders.pm
@@ -273,14 +273,6 @@ sub columns {
     return $cols;
 }
 
-=head2 header_lines
-
-=cut
-
-sub header_lines {
-    return [];
-}
-
 =head2 name
 
 =cut

--- a/lib/LedgerSMB/Report/Payroll/Deduction_Types.pm
+++ b/lib/LedgerSMB/Report/Payroll/Deduction_Types.pm
@@ -44,14 +44,6 @@ sub columns {
     ];
 }
 
-=item header_lines
-
-=cut
-
-sub header_lines {
-    return [];
-}
-
 =item name
 
 =cut

--- a/lib/LedgerSMB/Report/Payroll/Income_Types.pm
+++ b/lib/LedgerSMB/Report/Payroll/Income_Types.pm
@@ -44,14 +44,6 @@ sub columns {
     ];
 }
 
-=item header_lines
-
-=cut
-
-sub header_lines {
-    return [];
-}
-
 =item name
 
 =cut

--- a/lib/LedgerSMB/Report/Taxform/List.pm
+++ b/lib/LedgerSMB/Report/Taxform/List.pm
@@ -60,12 +60,6 @@ sub columns {
     ];
 }
 
-=head2 header_lines
-
-=cut
-
-sub header_lines { return []; }
-
 =head2 name
 
 Tax Form List


### PR DESCRIPTION
This PR adds a default `header_lines` method to LedgerSMB::Report.
Reports can override this method, but no longer need to implement
this method if they have no additional heading lines to add to
the template-provided Company Name and Report Name headings.

Where reports previously implemented a `header_lines` method
returning an empty arrayref, these methods have been removed as they
are no longer needed.