### PR TITLE
Respect additional menu clicks

### DIFF
--- a/UI/js-src/lsmb/MainContentPane.js
+++ b/UI/js-src/lsmb/MainContentPane.js
@@ -87,9 +87,6 @@ define([
                       //     });
                   },
                   load_link: function(href) {
-                      if (this.last_page == href) {
-                          return;
-                      }
                       this.last_page = href;
                       return this.load_form(href,{"handlesAs": "text"});
                   },


### PR DESCRIPTION
Previously the menu included logic to ignore further menu clicks
once an item had been selected. This was achieved by keeping track
of the loaded url and ignoring any further requests to load the same
url.

This tracking does not function if pages are loaded by means other
than via the menu (for example a form submit button).

The discarding of user clicks creates unpredictability from a user
perspective. As a user I expect that clicking a menu option will
always have a predictable effect of loading, or reloading a particular
screen. Complicating that with additional logic, which is hidden,
creates needless surprise.

The discarding of user clicks also breaks a valid use-case of
re-loading a screen, perhaps to reset search parameters to their
default. It also breaks automated test scenarios, which would have
to include additional steps to work-around this behaviour.

For some screens, work-arounds have been added for this behaviour,
such as adding a counter parameter to the screen urls.

This PR removes the logic that blocks user menu clicks. Clicking
on a menu item will always load or re-load the requested screen,
even if that screen is already being displayed.