### PR TITLE
Respect additional menu clicks v2

### DIFF
--- a/UI/js-src/lsmb/menus/Tree.js
+++ b/UI/js-src/lsmb/menus/Tree.js
@@ -81,6 +81,12 @@ define(["dojo/_base/declare",
                             + location.search + '#' + url, "_blank");
             }
             else {
+                // Add timestamp to url so that it is unique.
+                // A workaround for the blocking of multiple multiple clicks
+                // for the same url (see the MainContentPane.js load_link
+                // function).
+                url += '#' + Date.now();
+
                 var mainDiv = registry.byId("maindiv");
                 mainDiv.load_link(url);
             }


### PR DESCRIPTION
Revised PR following discussion in chat.

The purpose of this PR is to ensure that menu links provide a
predictable user experience - that they always load the associated
page, even if this page is already displayed.

This is useful to return to a known 'clean' state, it is useful for
automated testing and it specifically handles a situation where
the page content has been replaced by a form post, but the tracked
page url hasn't changed.

This is required because the MainContentPane.js load_link function
traps and blocks multiple requests to the same url. We work around
this by making each menu click generate a unique url, through
appending a timestamp.