### PR TITLE
Add CoA 'Add Account' button and BDD tests

### DIFF
--- a/UI/accounts/edit.html
+++ b/UI/accounts/edit.html
@@ -14,11 +14,9 @@
 <body class="lsmb <?lsmb dojo_theme ?>">
 <div id="account-tabs"
      data-dojo-type="dijit/layout/TabContainer">
-<?lsmb IF !form.id OR form.charttype == 'H'; ?>
+<?lsmb IF form.charttype == 'H'; ?>
 <div data-dojo-type="dijit/layout/ContentPane"
-     <?lsmb IF form.charttype == 'H'; ?>
      data-dojo-props="selected:true"
-     <?lsmb END; ?>
      title="<?lsmb text('Heading') ?>" id="H">
   <?lsmb # if we put the FORM tag as the toplevel tab element,
          # we get trouble: content gets cut off; wrap in a div
@@ -113,11 +111,9 @@
 </div>
 </div>
 <?lsmb END ?>
-<?lsmb IF !form.id OR form.charttype == 'A' ?>
+<?lsmb IF form.charttype == 'A' ?>
 <div data-dojo-type="dijit/layout/ContentPane"
-     <?lsmb IF form.charttype == 'A'; ?>
      data-dojo-props="selected:true"
-     <?lsmb END; ?>
      title="<?lsmb text('Account') ?>" id="A">
   <div>
 <form data-dojo-type="lsmb/Form" method="post" action="account.pl">

--- a/lib/LedgerSMB/Report/COA.pm
+++ b/lib/LedgerSMB/Report/COA.pm
@@ -151,15 +151,10 @@ sub subtotal_cols {
 
 =back
 
-=head2 Criteria Properties
-
-No criteria required.
 
 =head1 METHODS
 
-=over
-
-=item run_report()
+=head2 run_report()
 
 Runs the report, and assigns rows to $self->rows.
 
@@ -193,7 +188,55 @@ sub run_report{
     return $self->rows(\@rows);
 }
 
-=back
+=head2 set_buttons()
+
+Returns a set of buttons to be displayed at the bottom of the report.
+
+=cut
+
+sub set_buttons {
+    my ($self) = @_;
+    my @buttons = ();
+
+    if($self->_can_create_account) {
+        push @buttons, (
+            {
+                name  => 'action',
+                type  => 'submit',
+                text  => $self->_locale->text('Create Account'),
+                value => 'new_account',
+                class => 'submit',
+            },
+            {
+                name  => 'action',
+                type  => 'submit',
+                text  => $self->_locale->text('Create Heading'),
+                value => 'new_heading',
+                class => 'submit',
+            },
+        );
+    }
+
+    return \@buttons;
+}
+
+# PRIVATE METHODS
+
+# _can_create_account()
+#
+# Returns true if current user has create_account permissions
+
+sub _can_create_account {
+    my ($self) = @_;
+    my $r = $self->call_dbmethod(
+        funcname => 'lsmb__is_allowed_role',
+        args => {rolelist => ['account_create']}
+    );
+
+    return $r->{lsmb__is_allowed_role};
+}
+
+
 
 =head1 LICENSE AND COPYRIGHT
 

--- a/lib/LedgerSMB/Scripts/account.pm
+++ b/lib/LedgerSMB/Scripts/account.pm
@@ -36,12 +36,29 @@ Displays a screen to create a new account.
 
 =cut
 
-sub new {
+sub new_account {
     my ($request) = @_;
 
     my $account = LedgerSMB::DBObject::Account->new({base => {
         dbh => $request->{dbh},
         charttype => 'A',
+    }});
+
+    return _display_account_screen($request, $account);
+}
+
+=item new_heading
+
+Displays a screen to create a new Chart of Accounts heading.
+
+=cut
+
+sub new_heading {
+    my ($request) = @_;
+
+    my $account = LedgerSMB::DBObject::Account->new({base => {
+        dbh => $request->{dbh},
+        charttype => 'H',
     }});
 
     return _display_account_screen($request, $account);

--- a/lib/LedgerSMB/Scripts/account.pm
+++ b/lib/LedgerSMB/Scripts/account.pm
@@ -30,7 +30,7 @@ use LedgerSMB::DBObject::EOY;
 use LedgerSMB::Template::UI;
 
 
-=item new
+=item new_account
 
 Displays a screen to create a new account.
 

--- a/lib/LedgerSMB/Scripts/journal.pm
+++ b/lib/LedgerSMB/Scripts/journal.pm
@@ -10,22 +10,18 @@ LedgerSMB::Scripts::journal - Web entrypoint for ajax account search.
 A script for ajax requests: accepts a search string and returns a
 list of matching accounts in a ul/li pair
 
-=head1 METHODS
-
 =cut
 
 use LedgerSMB::Report::GL;
 use LedgerSMB::Report::COA;
+use LedgerSMB::Scripts::account;
 use strict;
 use warnings;
 
-our $VERSION = '1.0';
 
-=pod
+=head1 METHODS
 
-=over
-
-=item chart_json
+=head2 chart_json
 
 Returns a json array of all accounts
 
@@ -46,7 +42,7 @@ sub chart_json {
     return $request->to_json(\@results);
 }
 
-=item chart_of_accounts
+=head2 chart_of_accounts
 
 Returns and displays the chart of accounts
 
@@ -54,13 +50,18 @@ Returns and displays the chart of accounts
 
 sub chart_of_accounts {
     my ($request) = @_;
+
     my $report = LedgerSMB::Report::COA->new();
     $report->set_dbh($request->{dbh});
     $report->run_report();
+
+    # Buttons on the Chart of Account screen are handled by a different script
+    $request->{script} = 'account.pl';
+
     return $report->render($request);
 }
 
-=item delete_account
+=head2 delete_account
 
 This deletes an account and returns to the chart of accounts screen.
 
@@ -77,7 +78,7 @@ sub delete_account {
     return chart_of_accounts($request);
 }
 
-=item search
+=head2 search
 
 Runs a search and displays results.
 
@@ -95,7 +96,7 @@ sub search {
     return LedgerSMB::Report::GL->new(%$request)->render($request);
 }
 
-=item search_purchases
+=head2 search_purchases
 
 Runs a search of AR or AP transactions and displays results.
 

--- a/lib/LedgerSMB/Scripts/journal.pm
+++ b/lib/LedgerSMB/Scripts/journal.pm
@@ -129,7 +129,6 @@ sub search_purchases {
     }
 };
 
-=back
 
 =head1 LICENSE AND COPYRIGHT
 

--- a/sql/changes/1.7/drop-menu-add-accounts.sql
+++ b/sql/changes/1.7/drop-menu-add-accounts.sql
@@ -1,0 +1,5 @@
+-- Now that the Chart of Accounts screen has 'Add Account' and 'Add Heading'
+-- buttons. The menu option 'Add Accounts' is no longer required.
+DELETE FROM menu_acl WHERE node_id=137;
+DELETE FROM menu_attribute WHERE node_id=137;
+DELETE FROM menu_node WHERE id=137;

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -80,3 +80,4 @@
 1.7/drop-custom-catalog.sql
 1.7/alter-menu-attributes.sql
 1.7/drop-duplicate-gifi-index.sql
+1.7/drop-menu-add-accounts.sql

--- a/sql/modules/Roles.sql
+++ b/sql/modules/Roles.sql
@@ -1003,7 +1003,7 @@ SELECT lsmb__grant_perms('account_create', obj, 'INSERT')
 SELECT lsmb__grant_perms('account_create', obj, 'ALL')
   FROM unnest(array['account_id_seq'::text, 'account_heading_id_seq']) obj;
 SELECT lsmb__grant_menu('account_create', id, 'allow')
-  FROM unnest(array[137,246]) id;
+  FROM unnest(array[246]) id;
 
 SELECT lsmb__create_role('account_edit');
 SELECT lsmb__grant_perms('account_edit', obj, perm)

--- a/xt/66-cucumber/01-basic/menu.feature
+++ b/xt/66-cucumber/01-basic/menu.feature
@@ -89,7 +89,6 @@ Scenario Outline: Navigate to menu and open screen
 #   | Fixed Assets > Assets > Reports > Disposal |                          |
 #   | Fixed Assets > Assets > Reports > Net Book Value |                    |
 #   | Fixed Assets > Assets > Search Assets      |                          |
-#   | General Journal > Add Accounts             |                          |
     | General Journal > Chart of Accounts        | Chart of Accounts        |
 #   | General Journal > Import                   |                          |
 #   | General Journal > Import Chart             |                          |

--- a/xt/66-cucumber/10-gl/account-add-delete.feature
+++ b/xt/66-cucumber/10-gl/account-add-delete.feature
@@ -1,0 +1,30 @@
+@weasel
+Feature: Add and delete new account
+  As a LedgerSMB user I want to be able to add a new account and see that
+  this new account is listed in the chart of accounts. I then want to delete
+  the newly created account.
+
+Background:
+  Given a standard test company
+    And a logged in admin user
+
+Scenario: Add a new account
+  When I navigate the menu and select the item at "General Journal > Chart of Accounts"
+  Then I should see the Chart of Accounts screen
+   And I expect the report to contain 78 rows
+  When I press "Create Account"
+  Then I should see the Account screen
+  When I enter "T0001" into "Account Number"
+   And I enter "New Account" into "Description"
+   And I press "Save"
+  Then I should see the Account screen
+
+Scenario: Delete the account from the chart of accounts
+  When I navigate the menu and select the item at "General Journal > Chart of Accounts"
+  Then I should see the Chart of Accounts screen
+   And I expect the report to contain 79 rows
+   And I expect the 'Description' report column to contain 'New Account' for Account Number 'T0001'
+  When I click "[Delete]" for the row with Account Number "T0001"
+   And I wait for the page to load
+  Then I should see the Chart of Accounts screen
+   And I expect the report to contain 78 rows

--- a/xt/66-cucumber/10-gl/account-heading-add-delete.feature
+++ b/xt/66-cucumber/10-gl/account-heading-add-delete.feature
@@ -1,0 +1,30 @@
+@weasel
+Feature: Add and delete new account heading
+  As a LedgerSMB user I want to be able to add a new account heading and see
+  that this new heading is listed in the chart of accounts. I then want to
+  delete the newly created heading.
+
+Background:
+  Given a standard test company
+    And a logged in admin user
+
+Scenario: Add a new account
+  When I navigate the menu and select the item at "General Journal > Chart of Accounts"
+  Then I should see the Chart of Accounts screen
+   And I expect the report to contain 78 rows
+  When I press "Create Heading"
+  Then I should see the Account screen
+  When I enter "H0001" into "Account Number"
+   And I enter "New Heading" into "Description"
+   And I press "Save"
+  Then I should see the Account screen
+
+Scenario: Delete the account from the chart of accounts
+  When I navigate the menu and select the item at "General Journal > Chart of Accounts"
+  Then I should see the Chart of Accounts screen
+   And I expect the report to contain 79 rows
+   And I expect the 'Description' report column to contain 'New Heading' for Account Number 'H0001'
+  When I click "[Delete]" for the row with Account Number "H0001"
+   And I wait for the page to load
+  Then I should see the Chart of Accounts screen
+   And I expect the report to contain 78 rows

--- a/xt/66-cucumber/10-gl/step_definitions/pageobject_steps.pl
+++ b/xt/66-cucumber/10-gl/step_definitions/pageobject_steps.pl
@@ -43,6 +43,26 @@ When qr/^I (select|deselect) every checkbox in "(.*)"$/, sub {
 };
 
 
+When qr/^I click "(.*)" for the row with (.*) "(.*)"$/, sub {
+    my $link_text = $1;
+    my $column = $2;
+    my $value = $3;
+    my @rows = S->{ext_wsl}->page->body->maindiv->content->rows;
+
+    foreach my $row(@rows) {
+        if ($row->{$column} eq $value) {
+            my $link = $row->{_element}->find(
+                qq{.//a[.="$1"]}
+            );
+            ok($link, "found $link_text link for $column '$value'");
+            $link->click;
+            last;
+        }
+    }
+
+};
+
+ 
 Then qr/^I expect to see (\d+) selected checkboxes in "(.*)"$/, sub {
     my $wanted_count = $1;
     my $section = $2;

--- a/xt/66-cucumber/10-gl/step_definitions/pageobject_steps.pl
+++ b/xt/66-cucumber/10-gl/step_definitions/pageobject_steps.pl
@@ -62,7 +62,7 @@ When qr/^I click "(.*)" for the row with (.*) "(.*)"$/, sub {
 
 };
 
- 
+
 Then qr/^I expect to see (\d+) selected checkboxes in "(.*)"$/, sub {
     my $wanted_count = $1;
     my $section = $2;


### PR DESCRIPTION
This PR adds 'Create Account' and 'Create Heading' buttons to the Chart of Accounts
screen and removes the 'Add Account' menu option.

BDD tests are added for account and account heading addition and deletion.