### PR TITLE
* Update 'package.json' which points to old Dojo version

### DIFF
--- a/UI/js-src/lsmb/package.json
+++ b/UI/js-src/lsmb/package.json
@@ -22,9 +22,9 @@
     "path": "packages/app"
   }],
   "dependencies": {
-    "dojo": "~1.11",
-    "dijit": "~1.11",
-    "dojox": "~1.11"
+    "dojo": "~1.14",
+    "dijit": "~1.14",
+    "dojox": "~1.14"
   },
   "main": "src",
   "homepage": "http://ledgersmb.org/",


### PR DESCRIPTION
Note that dojox 1.11 was pointed out to have a security flaw
by GitHub. We weren't even including 1.11, so, update the
deps in the package.