### PR TITLE
Remove unused subtotal_cols() method from Report modules

### DIFF
--- a/lib/LedgerSMB/Report/COA.pm
+++ b/lib/LedgerSMB/Report/COA.pm
@@ -139,16 +139,6 @@ sub name {
     return $self->Text('Chart of Accounts');
 }
 
-=item subtotal_cols
-
-Returns list of columns for subtotals
-
-=cut
-
-sub subtotal_cols {
-    return [];
-}
-
 =back
 
 

--- a/lib/LedgerSMB/Report/GL.pm
+++ b/lib/LedgerSMB/Report/GL.pm
@@ -26,9 +26,7 @@ searching for and reporting financial transactions.
 
 =cut
 
-use LedgerSMB::App_State;
 use LedgerSMB::Business_Unit_Class;
-use LedgerSMB::Business_Unit;
 use LedgerSMB::Report;
 
 use Moose;
@@ -216,16 +214,6 @@ sub header_lines {
              text => $self->Text('Reference')},
             {name => 'source',
              text => $self->Text('Source')}];
-}
-
-=item subtotal_cols
-
-Returns list of columns for subtotals
-
-=cut
-
-sub subtotal_cols {
-    return ['debits', 'credits'];
 }
 
 =back

--- a/lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm
+++ b/lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm
@@ -31,8 +31,6 @@ LedgerSMB::Report::Unapproved::Batch_Overview instead.
 
 =cut
 
-use LedgerSMB::Business_Unit_Class;
-use LedgerSMB::Business_Unit;
 use LedgerSMB::Setting;
 use LedgerSMB::Sysconfig;
 
@@ -149,16 +147,6 @@ sub header_lines {
     my ($self) = @_;
     return [{name => 'batch_id',
              text => $self->Text('Batch ID')}, ]
-}
-
-=item subtotal_cols
-
-Returns list of columns for subtotals
-
-=cut
-
-sub subtotal_cols {
-    return [];
 }
 
 =back

--- a/lib/LedgerSMB/Report/Unapproved/Drafts.pm
+++ b/lib/LedgerSMB/Report/Unapproved/Drafts.pm
@@ -144,16 +144,6 @@ sub header_lines {
              text => $self->Text('Amount Less Than')}, ]
 }
 
-=item subtotal_cols
-
-Returns list of columns for subtotals
-
-=cut
-
-sub subtotal_cols {
-    return [];
-}
-
 =back
 
 =head2 Criteria Properties


### PR DESCRIPTION
A number of Report modules included a method `subtotal_cols`.
This method was never called and has been removed.

Additionally some were needlessly use-ing modules, whose imports
have now been removed.