### PR TITLE
Fix Save Groups clears all user permissions, add tests

### DIFF
--- a/UI/Contact/contact.html
+++ b/UI/Contact/contact.html
@@ -5,6 +5,7 @@ PROCESS "dynatable.html"  ?>
 <?lsmb  # Target_div handling now moved to controller script -- CT -?>
 
 <body class="lsmb <?lsmb dojo_theme ?>">
+<div id="edit_contact">
 
     <?lsmb IF name ?>
 <div class="pageheading"><?lsmb text('Company') ?>: <?lsmb name ?></div>
@@ -40,5 +41,7 @@ PROCESS "dynatable.html"  ?>
       INCLUDE $INCLUDEDIV;
   END;
   ?>
+</div>
+
 </div>
 </body>

--- a/UI/Contact/divs/user.html
+++ b/UI/Contact/divs/user.html
@@ -172,7 +172,7 @@
                                title = role.description
                                label = role.description
                                value = 1
-                               name = role.rolname
+                               name = "role__" _ role.rolname
                                id = role.rolname
                                checked = rolcheck
                          }, label_pos = 1 ?>

--- a/lib/LedgerSMB/Scripts/contact.pm
+++ b/lib/LedgerSMB/Scripts/contact.pm
@@ -933,18 +933,25 @@ Saves the user's permissions
 
 sub save_roles {
     my ($request) = @_;
-    if ($request->close_form){
-       my $user = LedgerSMB::Entity::User->get($request->{entity_id});
-       my $roles = [];
-       $request->{_role_prefix} = "lsmb_$request->{company}__"
-           unless defined $request->{_role_prefix};
-       for my $key(keys %$request){
-           if ($key =~ /$request->{_role_prefix}/ and $request->{$key}){
-               push @$roles, $key;
-           }
-       }
-       $user->save_roles($roles);
+    my $roles = [];
+
+    $request->close_form or die "Form submission is invalid";
+
+    foreach my $key (keys %$request) {
+
+        # Role parameters are distinguished by a special prefix
+        $key =~ m/^role__/ or next;
+        $request->{$key} or next;
+
+        # Strip prefix to obtain 'global' role name
+        $key =~ s/^role__//;
+
+        push @$roles, $key;
     }
+
+    my $user = LedgerSMB::Entity::User->get($request->{entity_id});
+    $user->save_roles($roles);
+
     return get($request);
 }
 

--- a/lib/LedgerSMB/Scripts/contact.pm
+++ b/lib/LedgerSMB/Scripts/contact.pm
@@ -935,7 +935,7 @@ sub save_roles {
     my ($request) = @_;
     my $roles = [];
 
-    $request->close_form or die "Form submission is invalid";
+    $request->close_form or die 'Form submission is invalid';
 
     foreach my $key (keys %$request) {
 

--- a/xt/66-cucumber/01-basic/menu.feature
+++ b/xt/66-cucumber/01-basic/menu.feature
@@ -75,7 +75,7 @@ Scenario Outline: Navigate to menu and open screen
 #   | Cash > Vouchers > Reverse Overpay          |                          |
 #   | Cash > Vouchers > Reverse Payment          |                          |
 #   | Cash > Vouchers > Reverse Receipts         |                          |
-    | Contacts > Search                          | Contact search           |
+    | Contacts > Search                          | Contact Search           |
 #   | Fixed Assets > Asset Classes               |                          |
 #   | Fixed Assets > Asset Classes > Add Class   |                          |
 #   | Fixed Assets > Asset Classes > List Classes|                          |

--- a/xt/66-cucumber/04-users/change-permissions.feature
+++ b/xt/66-cucumber/04-users/change-permissions.feature
@@ -1,0 +1,40 @@
+@weasel
+Feature: Change user permissions
+  As a LedgerSMB administrator I want to change the permissions of an
+  existing user.
+
+Background:
+  Given a standard test company
+    And a logged in admin user
+
+Scenario: Remove a user permission
+  When I navigate the menu and select the item at "Contacts > Search"
+  Then I should see the Contact Search screen
+  When I press "Search"
+  Then I should see the Contact Search Report screen
+  When I click Control Code "A-00002"
+  Then I should see the Edit Contact screen
+  When I select the "User" tab
+  Then I expect the "account all" checkbox to be selected
+  When I deselect checkbox "account all"
+   And I press "Save Groups"
+   And I wait for the page to load
+  Then I should see the Edit Contact screen
+  When I select the "User" tab
+  Then I expect the "account all" checkbox to be not selected
+
+Scenario: Add a user permission
+  When I navigate the menu and select the item at "Contacts > Search"
+  Then I should see the Contact Search screen
+  When I press "Search"
+  Then I should see the Contact Search Report screen
+  When I click Control Code "A-00002"
+  Then I should see the Edit Contact screen
+  When I select the "User" tab
+  Then I expect the "account all" checkbox to be not selected
+  When I select checkbox "account all"
+   And I press "Save Groups"
+   And I wait for the page to load
+  Then I should see the Edit Contact screen
+  When I select the "User" tab
+  Then I expect the "account all" checkbox to be selected

--- a/xt/66-cucumber/04-users/step_definitions/pageobject_steps.pl
+++ b/xt/66-cucumber/04-users/step_definitions/pageobject_steps.pl
@@ -1,0 +1,22 @@
+#!perl
+
+use lib 'xt/lib';
+use strict;
+use warnings;
+
+use Test::More;
+use Test::BDD::Cucumber::StepFile;
+
+
+When qr/^I click Control Code "(.*)"$/, sub {
+    my $page = S->{ext_wsl}->page->body->maindiv->content;
+    my $link_text = $1;
+
+    my $link = $page->find(
+        qq{.//td[contains(\@class,"entity_control_code")]/a[.="$link_text"]}
+    ) or die "failed to find link for Control Code $link_text";
+
+    ok($link->click, "clicked link for Control Code $link_text");
+};
+
+1;

--- a/xt/lib/PageObject/App/Contacts/EditContact.pm
+++ b/xt/lib/PageObject/App/Contacts/EditContact.pm
@@ -1,0 +1,28 @@
+package PageObject::App::Contacts::EditContact;
+
+use strict;
+use warnings;
+
+use Carp;
+use PageObject;
+use Moose;
+use namespace::autoclean;
+extends 'PageObject';
+
+__PACKAGE__->self_register(
+    'edit_contact',
+    './/div[@id="edit_contact"]',
+    tag_name => 'div',
+    attributes => {
+        id => 'edit_contact',
+    }
+);
+
+sub _verify {
+    my ($self) = @_;
+    return $self;
+}
+
+
+__PACKAGE__->meta->make_immutable;
+1;

--- a/xt/lib/Pherkin/Extension/ledgersmb_steps/common_steps.pl
+++ b/xt/lib/Pherkin/Extension/ledgersmb_steps/common_steps.pl
@@ -371,8 +371,9 @@ When qr/I wait for the page to load$/, sub {
     S->{ext_wsl}->page->body->maindiv->wait_for_content;
 };
 
-When qr/^I select checkbox "(.*)"$/, sub {
-    my $label = $1;
+When qr/^I (select|deselect) checkbox "(.*)"$/, sub {
+    my $wanted_status = ($1 eq 'select');
+    my $label = $2;
     my $element = S->{ext_wsl}->page->find(
         "*labeled", text => $label
     );
@@ -382,11 +383,15 @@ When qr/^I select checkbox "(.*)"$/, sub {
     is($element->get_attribute('type'), 'checkbox', 'element is an checkbox');
 
     my $checked = $element->get_attribute('checked');
-    $checked && $checked eq 'checked' or $element->click;
+
+    if($checked xor $wanted_status) {
+        $element->click;
+    }
 };
 
-Then qr/^I expect the "(.*)" checkbox to be selected/, sub {
+Then qr/^I expect the "(.*)" checkbox to be (selected|not selected)/, sub {
     my $label = $1;
+    my $wanted_status = $2;
     my $element = S->{ext_wsl}->page->find(
         "*labeled", text => $label
     );
@@ -396,7 +401,13 @@ Then qr/^I expect the "(.*)" checkbox to be selected/, sub {
     is($element->get_attribute('type'), 'checkbox', 'element is an checkbox');
 
     my $checked = $element->get_attribute('checked');
-    ok($checked, 'checkbox is selected');
+
+    if($wanted_status eq 'selected') {
+        ok($checked, 'checkbox is selected');
+    }
+    else {
+        ok(!$checked, 'checkbox is not selected');
+    }
 };
 
 Then qr/^I expect "(.*)" to be selected for "(.*)"$/, sub {

--- a/xt/lib/Pherkin/Extension/pageobject_steps/nav_steps.pl
+++ b/xt/lib/Pherkin/Extension/pageobject_steps/nav_steps.pl
@@ -18,7 +18,7 @@ my %pages = (
     "setup admin"         => "PageObject::Setup::Admin",
     "setup user list"     => "PageObject::Setup::UsersList",
     "edit user"           => "PageObject::Setup::EditUser",
-    );
+);
 
 When qr/I navigate to the application root/, sub {
     my $module = "PageObject::App::Login";
@@ -57,7 +57,9 @@ When qr/I navigate the menu and select the item at "(.*)"/, sub {
 };
 
 my %screens = (
-    'Contact search' => 'PageObject::App::Search::Contact',
+    'Contact Search' => 'PageObject::App::Search::Contact',
+    'Contact Search Report' => 'PageObject::App::Search::ReportDynatable',
+    'Edit Contact' => 'PageObject::App::Contacts::EditContact',
     'AR transaction entry' => 'PageObject::App::AR::Transaction',
     'AR invoice entry' => 'PageObject::App::AR::Invoice',
     'AR note entry' => 'PageObject::App::AR::Note',
@@ -115,6 +117,7 @@ Then qr/I should see the (.*) screen/, sub {
     my $page_name = $1;
     die "Unknown screen '$page_name'"
         unless exists $screens{$page_name};
+
     use_module($screens{$page_name});
 
     my $page;


### PR DESCRIPTION
This PR fixes a bug where, on editing user permissions and clicking `Save Groups`,
all user permissions are removed. BDD tests are added for this functionality.

See individual commits for details.