### PR TITLE
1.6 Fix Save Groups clears all user permissions

### DIFF
--- a/UI/Contact/divs/user.html
+++ b/UI/Contact/divs/user.html
@@ -172,7 +172,7 @@
                                title = role.description
                                label = role.description
                                value = 1
-                               name = role.rolname
+                               name = "role__" _ role.rolname
                                id = role.rolname
                                checked = rolcheck
                          }, label_pos = 1 ?>

--- a/lib/LedgerSMB/Scripts/contact.pm
+++ b/lib/LedgerSMB/Scripts/contact.pm
@@ -968,18 +968,25 @@ Saves the user's permissions
 
 sub save_roles {
     my ($request) = @_;
-    if ($request->close_form){
-       my $user = LedgerSMB::Entity::User->get($request->{entity_id});
-       my $roles = [];
-       $request->{_role_prefix} = "lsmb_$request->{company}__"
-           unless defined $request->{_role_prefix};
-       for my $key(keys %$request){
-           if ($key =~ /$request->{_role_prefix}/ and $request->{$key}){
-               push @$roles, $key;
-           }
-       }
-       $user->save_roles($roles);
+    my $roles = [];
+
+    $request->close_form or die 'Form submission is invalid';
+
+    foreach my $key (keys %$request) {
+
+        # Role parameters are distinguished by a special prefix
+        $key =~ m/^role__/ or next;
+        $request->{$key} or next;
+
+        # Strip prefix to obtain 'global' role name
+        $key =~ s/^role__//;
+
+        push @$roles, $key;
     }
+
+    my $user = LedgerSMB::Entity::User->get($request->{entity_id});
+    $user->save_roles($roles);
+
     return get($request);
 }
 


### PR DESCRIPTION
Commit d8b82c0123badcfe7a3f6294fea43acca592f194 changed the way
groups/permissions are handled. We use a company-specific prefix
for each 'global' role. That commit moved the prefix handling
into the database layer, meaning the perl and template code now
deals only in 'global' role names, without a prefix.

`LedgerSMB::Scripts::contact` was still expecting role names to
be prefixed and was applying a parameter filter to that effect. As
a result, on update, it was as though all roles had been deselected.

This PR fixes that issue, but note that, on form submission, role names
are still prefixed (though no longer company-specific) so that role
parameters can be distinguished from other form parameters.