### PR TITLE
Stop caching the last-inspected entry_id

### DIFF
--- a/sql/changes/1.6/add-recon-index.sql
+++ b/sql/changes/1.6/add-recon-index.sql
@@ -1,0 +1,8 @@
+
+
+CREATE INDEX acc_trans_recon_idx ON acc_trans (chart_id, entry_id)
+    WHERE not cleared;
+
+COMMENT ON INDEX acc_trans_recon_id IS
+$$This index serves to optimize finding the minimum entry_id
+of uncleared journal lines for a given account.$$;

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -75,3 +75,10 @@
 1.6/add_empty_salutation.sql
 1.6/missing-countries.sql
 1.6/constrain_default_password_duration.sql
+1.6/add-recon-index.sql
+#
+# 1.7 changes
+1.7/drop-custom-catalog.sql
+1.7/alter-menu-attributes.sql
+1.7/drop-duplicate-gifi-index.sql
+1.7/drop-menu-add-accounts.sql

--- a/sql/modules/Reconciliation.sql
+++ b/sql/modules/Reconciliation.sql
@@ -509,15 +509,15 @@ $$
                      OR (t_recon_fx is true
                          AND (gl.table <> 'gl'
                               OR ac.fx_transaction IS TRUE)))
-                AND (ac.entry_id > coalesce(r.max_ac_id, 0))
+                AND (ac.entry_id > (select min(entry_id) from acc_trans
+                                     where acc_trans.chart_id = r.chart_id))
         GROUP BY gl.ref, ac.source, ac.transdate,
                 ac.memo, ac.voucher_id, gl.table,
                 case when gl.table = 'gl' then gl.id else 1 end
         HAVING count(rl.id) = 0;
 
         UPDATE cr_report set updated = date_trunc('second', now()),
-                their_total = coalesce(in_their_total, their_total),
-                max_ac_id = (select max(entry_id) from acc_trans)
+                their_total = coalesce(in_their_total, their_total)
         where id = in_report_id;
 
     RETURN in_report_id;


### PR DESCRIPTION
Instead, consult a partial index to find the actual value instead
of the cached proxy.

Fix #3904 and fix ##3909.
