### PR TITLE
* Fix #3910: employee/sales person field not saved for orders

### DIFF
--- a/old/bin/oe.pl
+++ b/old/bin/oe.pl
@@ -945,6 +945,13 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id=intnotes name=intnotes rows
 sub update {
     $form->{nextsub} = 'update';
 
+    $form->get_regular_metadata(
+        \%myconfig,
+        $form->{vc},
+        $form->{transdate},
+        1,
+    );
+    $form->generate_selects;
     $form->{$_} = LedgerSMB::PGDate->from_input($form->{$_})->to_output()
        for qw(transdate reqdate);
 
@@ -976,6 +983,8 @@ sub update {
         $ARAP    = "AP";
     }
 
+    ( $form->{employee}, $form->{employee_id} ) = split /--/, $form->{employee}
+        if $form->{employee} && ! $form->{employee_id};
     if ( $newname = &check_name( $form->{vc} ) ) {
         if($newname>1){return;}#tshvr4 may be dropped if finalize_request() does not return here
     }

--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -1189,8 +1189,12 @@ sub generate_selects {
     if ($form->{all_employee} && @{ $form->{all_employee} }) {
         $form->{selectemployee} = "";
         for (@{ $form->{all_employee} }) {
+            my $value = "$_->{name}--$_->{id}";
+            my $selected = ($form->{employee} eq $value
+                || $form->{employee} eq $_->{name}) ?
+                ' selected="selected"' : "";
             $form->{selectemployee} .=
-                qq|<option value="$_->{name}--$_->{id}">$_->{name}</option>\n|;
+                qq|<option value="$value"$selected>$_->{name}</option>\n|;
         }
     }
 

--- a/old/lib/LedgerSMB/OE.pm
+++ b/old/lib/LedgerSMB/OE.pm
@@ -444,7 +444,7 @@ sub save {
             $form->{shipvia},       $form->{notes},
             $form->{intnotes},      $form->{currency},
             $form->{closed},        $quotation,
-            $form->{person_id},
+            $form->{employee_id},
             $form->{language_code}, $form->{ponumber},
             $form->{terms},         $form->{id}
         );
@@ -605,9 +605,7 @@ sub retrieve {
             FROM oe o
             JOIN entity_credit_account cr ON (cr.id = o.entity_credit_account)
             JOIN entity vc ON (cr.entity_id = vc.id)
-            LEFT JOIN person pe ON (o.person_id = pe.id)
-            LEFT JOIN entity_employee e
-                                  ON (pe.entity_id = e.entity_id)
+            LEFT JOIN person pe ON (o.person_id = pe.entity_id)
                         LEFT JOIN new_shipto ns ON ns.oe_id = o.id
             WHERE o.id = ?|;
         $sth = $dbh->prepare($query);
@@ -2266,7 +2264,7 @@ sub generate_orders {
                 netamount = ?,
                 taxincluded = ?,
                 curr = ?,
-                person_id = (select id from person where entity_id = ?),
+                person_id = ?,
                 department_id = ?,
                 ponumber = ?
             WHERE id = ?|;


### PR DESCRIPTION
This commit synchronizes what is saved in the 'oe.person_id' field with what
gets saved in 'ar.person_id' and 'ap.person_id': a value from
'entity_employee.entity_id'.

Further more, the commit fixes the fact that the value of the selected
employee isn't being retained between page updates.
