### PR TITLE
* Fix #3896: Invoice screen's vendor drop-down broken

### DIFF
--- a/old/bin/ir.pl
+++ b/old/bin/ir.pl
@@ -311,19 +311,6 @@ sub form_header {
     $transdate = $form->datetonum( \%myconfig, $form->{transdate} );
     $closedto  = $form->datetonum( \%myconfig, $form->{closedto} );
 
-    # set option selected
-    for (qw(AP currency)) {
-        $form->{"select$_"} =~ s/ selected="selected"//;
-        $form->{"select$_"} =~
-          s/(option value="\Q$form->{$_}\E")/$1 selected="selected"/;
-    }
-
-    for (qw(vendor department)) {
-        $form->{"select$_"} = $form->unescape( $form->{"select$_"} );
-        $form->{"select$_"} =~ s/ selected="selected"//;
-        $form->{"select$_"} =~ s/(<option value="\Q$form->{$_}\E")/$1 selected/;
-    }
-
     $form->{exchangerate} =
       $form->format_amount( \%myconfig, $form->{exchangerate} );
 
@@ -349,9 +336,7 @@ sub form_header {
 |;
 
     if ( $form->{selectvendor} ) {
-        $vendor = qq|<select data-dojo-type="dijit/form/Select" id=vendor name=vendor>$form->{selectvendor}</select>
-                 <input type=hidden name="selectvendor" value="|
-          . $form->escape( $form->{selectvendor}, 1 ) . qq|">|;
+        $vendor = qq|<select data-dojo-type="dijit/form/Select" id=vendor name=vendor>$form->{selectvendor}</select>|;
     }
     else {
         $vendor = qq|<input data-dojo-type="dijit/form/TextBox" name=vendor value="$form->{vendor}" size=35>

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -1104,7 +1104,7 @@ qq|<td align="center"><input data-dojo-type="dijit/form/TextBox" name="memo_$i" 
 }
 
 sub update {
-
+    $form->{ARAP} = 'AR';
     delete $form->{"partnumber_$form->{delete_line}"} if $form->{delete_line};
 
 


### PR DESCRIPTION
The vendor invoice's dropdown was broken and this commit fixes that. The sales invoice's
dropdown would disappear after hitting 'Update' without changes three times. This commit
fixes that too.
