### PR TITLE
* Fix #3907: 'Save' and 'Post' buttons on copy-to-new transaction

### DIFF
--- a/bin/aa.pl
+++ b/bin/aa.pl
@@ -98,6 +98,7 @@ my $is_update;
 sub copy_to_new{
     delete $form->{id};
     delete $form->{invnumber};
+    delete $form->{approved};
     $form->{paidaccounts} = 1;
     if ($form->{paid_1}){
         delete $form->{paid_1};

--- a/bin/gl.pl
+++ b/bin/gl.pl
@@ -139,6 +139,7 @@ sub new {
 sub copy_to_new {
      delete $form->{reference};
      delete $form->{id};
+     delete $form->{approved};
      update();
 }
 


### PR DESCRIPTION
Since the entire form is being re-used and the approval state wasn't
explicitly removed, the old state was left dangling from the transaction
from which the current one was copied. Stop it from dangling.
