### PR TITLE
* Fix #3933: Saving orders deletes unrelated invoice shipping info

### DIFF
--- a/old/lib/LedgerSMB/OE.pm
+++ b/old/lib/LedgerSMB/OE.pm
@@ -167,7 +167,7 @@ sub save {
             $sth   = $dbh->prepare($query);
             $sth->execute( $form->{id} ) || $form->dberror($query);
 
-            $query = qq|DELETE FROM new_shipto WHERE trans_id = ?|;
+            $query = qq|DELETE FROM new_shipto WHERE oe_id = ?|;
             $sth   = $dbh->prepare($query);
             $sth->execute( $form->{id} ) || $form->dberror($query);
 
@@ -549,7 +549,7 @@ sub delete {
     $query = qq|DELETE FROM orderitems WHERE trans_id = ?|;
     $sth->finish;
 
-    $query = qq|DELETE FROM new_shipto WHERE trans_id = ?|;
+    $query = qq|DELETE FROM new_shipto WHERE oe_id = ?|;
     $sth   = $dbh->prepare($query);
     $sth->execute( $form->{id} ) || $form->dberror($query);
     $sth->finish;
@@ -623,7 +623,7 @@ sub retrieve {
         for ( keys %$ref ) { $form->{$_} = $ref->{$_} }
         $sth->finish;
 
-        $query = qq|SELECT * FROM new_shipto WHERE trans_id = ?|;
+        $query = qq|SELECT * FROM new_shipto WHERE oe_id = ?|;
         $sth   = $dbh->prepare($query);
         $sth->execute( $form->{id} ) || $form->dberror($query);
 


### PR DESCRIPTION
The orders should be using the 'oe_id' column, but are in fact
using the 'trans_id' column to store shipping information,
even for deletion. However, the 'trans_id' is used for AR/AP
invoices and thus deletion removes shipping info from invoices...

This commit addresses the orders part of #3899 as well,
although through a very different pattern.
