### PR TITLE
* Fix #3941: Sales tax not included in amount due from purchase invoice

### DIFF
--- a/bin/ir.pl
+++ b/bin/ir.pl
@@ -587,7 +587,7 @@ sub form_header {
 
     }
 
-    $form->hide_form(qw(defaultcurrency)); # taxaccounts));
+    $form->hide_form(qw(defaultcurrency taxaccounts));
 
     for ( split / /, $form->{taxaccounts} ) {
         $form->hide_form( "${_}_rate", "${_}_description" );


### PR DESCRIPTION
This change partially reverts a change made in the early
1.5 release cycle targetted at fixing an exchange rate
issue, but also included the removal of the
'taxaccounts' INPUT element from the invoice -- that
turns out to have this side-effect.
