### PR TITLE
* Fix #3889: Sales person not correctly showing on AR Invoice screen

### DIFF
--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -1112,6 +1112,8 @@ sub update {
     $form->{exchangerate} =
       $form->parse_amount( \%myconfig, $form->{exchangerate} );
 
+    ( $form->{employee}, $form->{employee_id} ) = split /--/, $form->{employee}
+        if $form->{employee} && ! $form->{employee_id};
     if ( $newname = &check_name(customer) ) {
         rebuild_vc('customer', $form->{transdate}, 1);
     }

--- a/old/lib/LedgerSMB/IS.pm
+++ b/old/lib/LedgerSMB/IS.pm
@@ -1488,7 +1488,7 @@ sub retrieve_invoice {
                       a.shippingpoint, a.shipvia, a.terms, a.notes,
                       a.intnotes,
                       a.duedate, a.taxincluded, a.curr AS currency,
-                      a.person_id, e.name AS employee, a.till,
+                      a.person_id as employee_id, e.name AS employee, a.till,
                       a.reverse, a.entity_credit_account as customer_id,
                       a.language_code, a.ponumber, a.crdate,
                       a.on_hold, a.description, a.setting_sequence


### PR DESCRIPTION
Found as part of testing for the report on AR/AP orders in #3889,
the sales person turned out not to be correctly retained through
out 'Update's on the invoice.
Also, saving and retrieving the invoice, doesn't correctly show
the stored sales person.
Both issues are fixed in this commit.
