### PR TITLE
* Re #3899: Fix selected Ship To address not showing

### DIFF
--- a/old/bin/io.pl
+++ b/old/bin/io.pl
@@ -1642,9 +1642,9 @@ sub ship_to {
                            {
                                my $checked = '';
                                $checked = 'CHECKED="CHECKED"'
-                                   if (defined $form->{location_id}
-                                       and ($form->{location_id} == $form->{"shiptolocationid_$i"}
-                                            or $form->{location_id} == $form->{"locationid_$i"}));
+                                   if ($form->{locationid}
+                                       and ($form->{locationid} == $form->{"shiptolocationid_$i"}
+                                            or $form->{locationid} == $form->{"locationid_$i"}));
 
                                 print qq|
                            <tr>
@@ -1893,7 +1893,7 @@ sub createlocations
 
          &validatelocation;
 
-         $form->{location_id} = IS->createlocation($form);
+         $form->{locationid} = IS->createlocation($form);
 
 
     }


### PR DESCRIPTION
This commit fixes the case where clicking the Ship To
button on an invoice with a selected shipping address,
will show a clean input form with no values selected
(as if no shipping address was selected).
