### PR TITLE
Show custom account links

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -5,6 +5,7 @@ Forthcoming
 New functionalities
 * Deletion of template transactions (Nick P)
 * Transaction date now part of purchase history report (Chris T)
+* UI allows addition and removal of custom `account_link` flags (Nick P)
 
 Quality Assurance
 * Expanded checks and resolutions for schema changes (Erik H)

--- a/UI/accounts/edit.html
+++ b/UI/accounts/edit.html
@@ -257,6 +257,22 @@
               value = '1'} ?>
    </div>
 </div>
+<?lsmb IF form.custom_link_descriptions.size ?>
+<div class="inputline" id="acc-custom-flags-line">
+    <label class="line"><?lsmb text('Custom Flags') ?></label>
+    <?lsmb FOREACH link IN form.custom_link_descriptions ?>
+    <div class="inputgroup">
+        <?lsmb INCLUDE input element_data={
+              name = link.description,
+              type = 'checkbox',
+             label = link.description,
+           checked = form.${link.description} ? 'CHECKED' : '',
+             value = link.description
+        } ?>
+    </div>
+    <?lsmb END ?>
+</div>
+<?lsmb END ?>
 <div class="inputline" id="summary-line">
    <label class="line" for="summary-a"><?lsmb text('Summary account for') ?></label>
    <div class="inputgroup">

--- a/old/lib/LedgerSMB/DBObject/Account.pm
+++ b/old/lib/LedgerSMB/DBObject/Account.pm
@@ -178,6 +178,7 @@ The following object properties are set:
   * tax
   * link
   * translations
+  * custom_link_descriptions
 
 =cut
 

--- a/sql/Pg-database.sql
+++ b/sql/Pg-database.sql
@@ -134,8 +134,7 @@ COMMENT ON TABLE account_link_description IS
 $$ This is a lookup table which provide basic information as to categories and
 dropdowns of accounts.  In general summary accounts cannot belong to more than
 one category (an AR summary account cannot appear in other dropdowns for
-example).  Custom fields are not overwritten when the account is edited from
-the front-end.$$;
+example).$$;
 
 INSERT INTO account_link_description (description, summary, custom)
 VALUES

--- a/sql/modules/Account.sql
+++ b/sql/modules/Account.sql
@@ -439,12 +439,9 @@ BEGIN
                 t_heading_id := in_heading;
         END IF;
 
-    -- don't remove custom links.
+        -- Remove all links. Later we'll (re-)insert the ones we want.
         DELETE FROM account_link
-        WHERE account_id = in_id
-              and description in ( select description
-                                    from  account_link_description
-                                    where custom = 'f');
+        WHERE account_id = in_id;
 
         UPDATE account
         SET accno = in_accno,

--- a/sql/modules/Account.sql
+++ b/sql/modules/Account.sql
@@ -614,14 +614,18 @@ COMMENT ON FUNCTION account__get_by_link_desc(in_description text) IS
 $$ Gets a list of accounts with a specific link description set.  For example,
 for a dropdown list.$$;
 
-CREATE OR REPLACE FUNCTION get_link_descriptions()
+DROP FUNCTION IF EXISTS get_link_descriptions();
+CREATE OR REPLACE FUNCTION get_link_descriptions(in_summary BOOLEAN, in_custom BOOLEAN)
 RETURNS SETOF account_link_description AS
 $$
-    SELECT * FROM account_link_description;
+    SELECT * FROM account_link_description
+    WHERE (in_custom IS NULL OR custom = in_custom)
+    AND (in_summary IS NULL OR summary = in_summary);
 $$ LANGUAGE SQL;
 
-COMMENT ON FUNCTION get_link_descriptions() IS
-$$ Gets a set of all valid account_link descriptions.$$;
+COMMENT ON FUNCTION get_link_descriptions(BOOLEAN, BOOLEAN) IS
+$$ Gets the set of possible account_link descriptions, optionally filtered by
+their `custom` or `summary` attributes.$$;
 
 CREATE OR REPLACE FUNCTION account_heading__list()
 RETURNS SETOF account_heading AS

--- a/sql/modules/Roles.sql
+++ b/sql/modules/Roles.sql
@@ -1028,6 +1028,9 @@ SELECT lsmb__grant_perms('account_delete', obj, 'DELETE')
                     'account_translation', 'account_heading_translation',
                     'cr_coa_to_account', 'tax']) obj;
 
+SELECT lsmb__create_role('account_link_description_create');
+SELECT lsmb__grant_perms('account_link_description_create', 'account_link_description', 'INSERT');
+
 SELECT lsmb__create_role('auditor');
 SELECT lsmb__grant_perms('auditor', 'audittrail', 'SELECT');
 

--- a/xt/42-account.pg
+++ b/xt/42-account.pg
@@ -3,8 +3,7 @@ BEGIN;
     CREATE EXTENSION pgtap;
 
     -- Plan the tests.
-
-    SELECT plan(51);
+    SELECT plan(58);
 
     -- Add data
 
@@ -52,7 +51,7 @@ BEGIN;
     SELECT has_function('chart_list_overpayment',ARRAY['integer']);
     SELECT has_function('chart_list_search',ARRAY['text','text']);
     SELECT has_function('cr_coa_to_account_save',ARRAY['text','text']);
-    SELECT has_function('get_link_descriptions',ARRAY['']);
+    SELECT has_function('get_link_descriptions',ARRAY['boolean','boolean']);
     SELECT has_function('gifi__list',ARRAY['']);
     SELECT has_function('report__coa',ARRAY['']);
     SELECT has_function('report_trial_balance',ARRAY['date','date','integer','integer','boolean']);
@@ -75,6 +74,7 @@ BEGIN;
 --       DEALLOCATE test;
        RETURN ret;
     END $$ LANGUAGE plpgsql;
+
 
     SELECT test_account_link_description('AR_paid1', false, true);
     SELECT test_account_link_description('AP_paid1', false, true);
@@ -178,6 +178,74 @@ BEGIN;
                     WHERE accno LIKE '0%' AND description LIKE 'TEST%';
     SELECT results_eq('test',ARRAY[true],'Test AR Accounts Are Found');
     DEALLOCATE test;
+
+
+    -- Tests for get_link_descriptions function
+    DELETE FROM account_link;
+    DELETE FROM account_link_description;
+    INSERT INTO account_link_description(description, summary, custom) VALUES
+        ('Plain', false, false),
+        ('Summary', true, false),
+        ('Custom', false, true),
+        ('CustomSummary', true, true);
+
+
+    PREPARE test AS SELECT description FROM get_link_descriptions(NULL, NULL);
+    SELECT set_eq(
+        'test',
+        ARRAY['Plain', 'Summary', 'CustomSummary', 'Custom'],
+        $$get_link_descriptions (no filter) returns expected records$$
+    );
+    DEALLOCATE test;
+
+    PREPARE test AS SELECT description FROM get_link_descriptions(TRUE, NULL);
+    SELECT set_eq(
+        'test',
+        ARRAY['Summary', 'CustomSummary'],
+        $$get_link_descriptions (Summary) returns expected records$$
+    );
+    DEALLOCATE test;
+
+    PREPARE test AS SELECT description FROM get_link_descriptions(TRUE, FALSE);
+    SELECT set_eq(
+        'test',
+        ARRAY['Summary'],
+        $$get_link_descriptions (Summary, not Custom) returns expected records$$
+    );
+    DEALLOCATE test;
+
+    PREPARE test AS SELECT description FROM get_link_descriptions(TRUE, TRUE);
+    SELECT set_eq(
+        'test',
+        ARRAY['CustomSummary'],
+        $$get_link_descriptions (Summary + Custom) returns expected records$$
+    );
+    DEALLOCATE test;
+
+    PREPARE test AS SELECT description FROM get_link_descriptions(NULL, TRUE);
+    SELECT set_eq(
+        'test',
+        ARRAY['CustomSummary', 'Custom'],
+        $$get_link_descriptions (Custom) returns expected records$$
+    );
+    DEALLOCATE test;
+
+    PREPARE test AS SELECT description FROM get_link_descriptions(FALSE, TRUE);
+    SELECT set_eq(
+        'test',
+        ARRAY['Custom'],
+        $$get_link_descriptions (Custom, not Summary) returns expected records$$
+    );
+    DEALLOCATE test;
+
+    PREPARE test AS SELECT description FROM get_link_descriptions(FALSE, FALSE);
+    SELECT set_eq(
+        'test',
+        ARRAY['Plain'],
+        $$get_link_descriptions (Neither Custom nor Summary) returns expected records$$
+    );
+    DEALLOCATE test;
+
 
     -- Finish the tests and clean up.
     SELECT * FROM finish();

--- a/xt/66-cucumber/10-gl/chart-of-accounts.feature
+++ b/xt/66-cucumber/10-gl/chart-of-accounts.feature
@@ -13,6 +13,10 @@ Scenario: View the chart of accounts and change every property of an account
        | GIFI  | Description |
        | 1234  | Test GIFI   |
        | 1235  | Test GIFI 2 |
+   And Custom Flags with these properties:
+       | Description   |
+       | Custom-Flag 1 |
+       | Custom-Flag 2 |
   When I navigate the menu and select the item at "General Journal > Chart of Accounts"
   Then I should see the Chart of Accounts screen
    And I expect the report to contain 78 rows
@@ -30,6 +34,7 @@ Scenario: View the chart of accounts and change every property of an account
    And I select "1234--Test GIFI" from the drop down "GIFI"
    And I select "Equity" from the drop down "Account Type"
    And I select every checkbox in "Options"
+   And I select every checkbox in "Custom Flags"
    And I select every checkbox in "Include in drop-down menus"
    And I press "Save"
    And I wait for the page to load
@@ -40,12 +45,15 @@ Scenario: View the chart of accounts and change every property of an account
    And I expect "1234--Test GIFI" to be selected for "GIFI"
    And I expect "Equity" to be selected for "Account Type"
    And I expect to see 3 selected checkboxes in "Options"
+   And I expect to see 2 selected checkboxes in "Custom Flags"
    And I expect to see 20 selected checkboxes in "Include in drop-down menus"
   When I select "Inventory" from the drop down "Summary account for"
+   And I deselect every checkbox in "Custom Flags"
    And I deselect every checkbox in "Include in drop-down menus"
    And I press "Save"
    And I wait for the page to load
   Then I expect to see 0 selected checkboxes in "Include in drop-down menus"
+  Then I expect to see 0 selected checkboxes in "Custom Flags"
    And I expect "Inventory" to be selected for "Summary account for"
   When I navigate the menu and select the item at "General Journal > Chart of Accounts"
   Then I should see the Chart of Accounts screen

--- a/xt/66-cucumber/10-gl/step_definitions/pageobject_steps.pl
+++ b/xt/66-cucumber/10-gl/step_definitions/pageobject_steps.pl
@@ -26,6 +26,7 @@ When qr/^I (select|deselect) every checkbox in "(.*)"$/, sub {
     my $page = S->{ext_wsl}->page->body->maindiv->content;
     my %section_ids = (
         'Options' => 'acc-options-line',
+        'Custom Flags' => 'acc-custom-flags-line',
         'Include in drop-down menus' => 'dropdowns',
     );
 
@@ -68,6 +69,7 @@ Then qr/^I expect to see (\d+) selected checkboxes in "(.*)"$/, sub {
     my $section = $2;
     my %section_ids = (
         'Options' => 'acc-options-line',
+        'Custom Flags' => 'acc-custom-flags-line',
         'Include in drop-down menus' => 'dropdowns',
     );
 

--- a/xt/lib/Pherkin/Extension/ledgersmb_steps/common_steps.pl
+++ b/xt/lib/Pherkin/Extension/ledgersmb_steps/common_steps.pl
@@ -363,6 +363,20 @@ Given qr/^GIFI entries with these properties:$/, sub {
     }
 };
 
+Given qr/^Custom Flags with these properties:$/, sub {
+    my $dbh = S->{ext_lsmb}->admin_dbh;
+    my $q = $dbh->prepare("
+        INSERT INTO account_link_description (description, summary, custom)
+        VALUES (?, FALSE, TRUE)
+    ");
+
+    foreach my $row (@{C->data}) {
+        $q->execute(
+            $row->{Description},
+        ) or die "failed to insert account_link_description (Custom Flag) with description $row->{Description}";
+    }
+};
+
 When qr/I wait (\d+) seconds?$/, sub {
     sleep $1
 };


### PR DESCRIPTION
The LedgerSMB schema has the functionality to allow custom account_links - custom flags which can be added to accounts from the Chart of Accounts.

This PR provides an interface to expose this functionality, adding checkboxes to the Edit Account screen so that the custom flags can be added or removed from an account.

BDD and sql tests are extended to cover this functionality.