### PR TITLE
* Use the correct index when accessing SchemaChecks dynatable data

### DIFF
--- a/lib/LedgerSMB/Setup/SchemaChecks.pm
+++ b/lib/LedgerSMB/Setup/SchemaChecks.pm
@@ -49,8 +49,9 @@ sub _unpack_grid_data {
 
     my @rows = ();
     for my $rowno (1 .. $rowcount) {
+        my $rowid = $request->{"${prefix}_row_$rowno"};
         push @rows, {
-            map { $_ => $request->{"${prefix}_${_}_$rowno"} }
+            map { $_ => $request->{"${prefix}_${_}_$rowid"} }
                (@$columns, '--pk')
         };
     }

--- a/t/16-schema-upgrade-html.t
+++ b/t/16-schema-upgrade-html.t
@@ -73,10 +73,12 @@ is LedgerSMB::Setup::SchemaChecks::_check_hashid(
 is_deeply( LedgerSMB::Setup::SchemaChecks::_unpack_grid_data(
                {
                    rowcount_pfx => 2,
+                   'pfx_row_1' => 1,
                    'pfx_--pk_1' => '1 2 3',
                    'pfx_a_1' => 1,
                    'pfx_b_1' => 2,
                    'pfx_c_1' => 3,
+                   'pfx_row_2' => 2,
                    'pfx_--pk_2' => '4 5 6',
                    'pfx_a_2' => 4,
                    'pfx_b_2' => 5,


### PR DESCRIPTION
Dynatable row data is keyed on the row's ID number, not on the row number itself.
