### PR TITLE
Constrain account_links: account can be summary for at most one descriptor

### DIFF
--- a/UI/lib/dynatable.html
+++ b/UI/lib/dynatable.html
@@ -150,14 +150,21 @@ END; ?>
                                          class=COL.class
                                          value=ROW.row_id
                 checked=CHECKED } ?>
-         <?lsmb- ELSIF TYPE == 'select' ?>
-         <?lsmb PROCESS select element_data = {
+         <?lsmb- ELSIF TYPE == 'select';
+                # ROW is passed as an argument if COL.options is a callback
+                # function, which allows dropdown options to be dynamically
+                # customised to each row. The ROW argument is harmlessly
+                # ignored by Template Toolkit if COL.options is a static
+                # arrayref common to every row.
+                OPTION_LIST = COL.options(ROW);
+
+                PROCESS select element_data = {
                 text_attr='text'
                 value_attr='value'
                 id=COL.col_id _ '-' _ ROWCOUNT
                 name=PFX _ COL.col_id _ '_' _ ROW.row_id
                 class=COL.class
-                options=COL.options
+                options=OPTION_LIST
                 default_blank=COL.default_blank
                 default_values=[ROW.row_id] } ?>
          <?lsmb- ELSIF TYPE == 'href';

--- a/lib/LedgerSMB/Setup/SchemaChecks.pm
+++ b/lib/LedgerSMB/Setup/SchemaChecks.pm
@@ -167,8 +167,13 @@ sub _format_grid {
         elsif ($cols->{$dropdown}->{type} eq 'input_text') {
             $cols->{$dropdown}->{type} = 'select';
             $cols->{$dropdown}->{default_blank} = 1;
-            $cols->{$dropdown}->{options} =
-                [ map { { value => $_, text => $map->{$_} } } keys %$map ];
+            if (ref $map eq 'CODE') {
+                $cols->{$dropdown}->{options} = $map;
+            }
+            else {
+                $cols->{$dropdown}->{options} =
+                    [ map { { value => $_, text => $map->{$_} } } keys %$map ];
+            }
         }
         else {
             # FAIL!

--- a/sql/changes/1.7/limit_summary_account_links.sql
+++ b/sql/changes/1.7/limit_summary_account_links.sql
@@ -1,0 +1,52 @@
+-- Chart of Account accounts can be tagged as a 'Summary Account' if linked to
+-- a summary descriptor via the account_link table. An account can only be linked
+-- with a single summary descriptor. This change introduces a trigger constraint
+-- to enforce that.
+
+-- This is implemented as a change file, rather than as a module under sql/modules
+-- because it represents a change to the schema rather than application logic.
+
+CREATE OR REPLACE FUNCTION limit_summary_account_links()
+RETURNS TRIGGER AS
+$$
+BEGIN
+    -- Is the account_link we're assigning a Summary descriptor?
+    PERFORM 1
+    FROM account_link_description
+    WHERE description = NEW.description
+    AND summary IS TRUE;
+
+    -- There can only be one Summary descriptor assigned to an account.
+    IF FOUND THEN
+        IF (
+            SELECT COUNT(*) > 1
+            FROM account_link
+            JOIN account_link_description ON (
+                account_link.description = account_link_description.description
+            )
+            WHERE account_id = NEW.account_id
+            AND account_link_description.summary IS TRUE
+         )
+         THEN
+            RAISE EXCEPTION 'Account already has a summary account_link - cannot add another';
+        END IF;
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE PLPGSQL;
+
+COMMENT ON FUNCTION limit_summary_account_links() IS
+$$Called as a constraint trigger function on the account_link table. Raises an
+exception if the operation would create more than one Summary account_link
+descriptors for the relevant account.$$;
+
+DROP TRIGGER IF EXISTS prohibit_multiple_summary_account_links ON account_link;
+
+CREATE CONSTRAINT TRIGGER prohibit_multiple_summary_account_links
+AFTER UPDATE OR INSERT ON account_link
+FOR EACH ROW EXECUTE PROCEDURE limit_summary_account_links();
+
+COMMENT ON TRIGGER prohibit_multiple_summary_account_links ON account_link IS
+$$Accounts can be linked with only one Summary account_link descriptor. This trigger
+enforces that constraint.$$

--- a/sql/changes/1.7/limit_summary_account_links.sql.checks.pl
+++ b/sql/changes/1.7/limit_summary_account_links.sql.checks.pl
@@ -10,8 +10,7 @@ check(
         SELECT account.accno AS "Account",
                account.id AS account_id,
                account.description AS "Description",
-               string_agg(account_link.description, ', ') AS "Currently Summary For",
-'' AS "New Summary For"
+               string_agg(account_link.description, ', ') AS "Currently Summary For"
         FROM account
         JOIN account_link ON (
             account.id = account_link.account_id

--- a/sql/changes/1.7/limit_summary_account_links.sql.checks.pl
+++ b/sql/changes/1.7/limit_summary_account_links.sql.checks.pl
@@ -1,0 +1,109 @@
+
+package migration_checks;
+
+use LedgerSMB::Database::ChangeChecks;
+
+
+check(
+    q|Check that each account is a summary for no more than one transaction type|,
+    query => q{
+        SELECT account.accno AS "Account",
+               account.id AS account_id,
+               account.description AS "Description",
+               string_agg(account_link.description, ', ') AS "Currently Summary For",
+'' AS "New Summary For"
+        FROM account
+        JOIN account_link ON (
+            account.id = account_link.account_id
+        )
+        JOIN account_link_description ON (
+            account_link.description = account_link_description.description
+        )
+        WHERE account_link_description.summary IS TRUE
+        GROUP BY account.accno, account.id, account.description
+        HAVING COUNT(*) > 1
+    },
+    description => q{
+The migration check found that at least one of your accounts is linked as
+a summary account for multiple transaction types.
+
+An account may only be a summary for a single transaction type, but this
+was not enforced in earlier versions of LedgerSMB.
+
+To continue with the upgrade, the listed accounts must be altered so that
+they are a summary account for only a single transaction type, or changed
+so that they are no longer a summary account.
+
+For each account row below, please select which transaction type it should be
+a summary accout for, or leave the selection blank if the account
+should no longer be considered as a summary accout.
+
+These choices will not alter accounting data, but will affect which
+accounts appear in certain selection menus. After the upgrade, you may review
+your Chart of Accounts to consider whether any additional summary accounts
+should be configured.
+},
+    tables => {
+        'account_link' => {
+            prim_key => ['account_id', 'Description' ]
+        }
+    },
+    on_failure => sub {
+        my ($dbh, $rows) = @_;
+
+        describe;
+        grid(
+           $rows,
+           name => 'account_link',
+           columns => ['Account', 'Description', 'Currently Summary For', 'New Summary For'],
+           edit_columns => ['New Summary For', 'Description'],
+           dropdowns => {
+               'New Summary For' => sub {
+                   my ($row) = @_;
+                   my $q = $dbh->prepare("
+                       SELECT description AS value, description AS text
+                       FROM account_link
+                       WHERE account_id = ?
+                       ORDER BY description
+                   ");
+                   $q->execute($row->{account_id});
+                   return $q->fetchall_arrayref({});
+               },
+           },
+        );
+
+        confirm proceed => 'Proceed';
+    },
+    on_submit => sub {
+        my ($dbh, $rows) = @_;
+        my $confirm = provided 'confirm';
+
+        if ($confirm eq 'proceed') {
+            # Query to remove 'extra' summary links
+            my $q = $dbh->prepare("
+                DELETE FROM account_link
+                WHERE account_id = ?
+                AND (? IS NULL OR ? != description)
+            ");
+
+            my $provided_data = provided 'account_link';
+
+            foreach my $row(@{$rows}) {
+                $data = shift @{$provided_data};
+   
+                $q->execute(
+                    $row->{'account_id'},
+                    $data->{'New Summary For'},
+                    $data->{'New Summary For'},
+                ) or die 'Failed to clear unwanted account link summary descriptors: ' . $dbh->errstr;
+            }
+        }
+        else {
+          die "Unexpected confirmation value found: $confirm";
+        }
+    },
+);
+
+
+
+1;

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -83,3 +83,4 @@
 1.7/drop-duplicate-gifi-index.sql
 1.7/drop-menu-add-accounts.sql
 1.7/drop-max_ac_id.sql
+1.7/limit_summary_account_links.sql


### PR DESCRIPTION
This PR adds a database trigger constraint and companion schema change tests to
ensure that accounts can only be a Summary account for a single
account_link_description.
    
This constraint is assumed by the lsmb UI but was not previously enforced.

To provide a user-friendly schema change check interface, this PR extends the
select dropdown HTML template to accept a callback function to define the option
list on a per-row basis, without affecting existing behaviour.