### PR TITLE
Show custom summary account_link descriptors in UI

### DIFF
--- a/UI/accounts/edit.html
+++ b/UI/accounts/edit.html
@@ -274,27 +274,36 @@
 </div>
 <?lsmb END ?>
 <div class="inputline" id="summary-line">
-   <label class="line" for="summary-a"><?lsmb text('Summary account for') ?></label>
-   <div class="inputgroup">
-   <?lsmb # fixed_asset may eventually go in here too depending on future
-          # directions in development.
-      summary = [];
-      IF form.AR; summary = 'AR'; END;
-      IF form.AP; summary = 'AP'; END;
-      IF form.IC; summary = 'IC'; END;
-      s_accts = [
-        {}
-        {text = 'AR',        value = 'AR'}
-        {text = 'AP',        value = 'AP'}
-        {text = 'Inventory', value = 'IC'}
-      ];
-      INCLUDE select element_data = {
-               name = "summary"
-            options = s_accts
-     default_values = [summary]
-                 id = 'summary-a'
-      }; ?>
-   </div>
+    <label class="line" for="summary-a"><?lsmb text('Summary account for') ?></label>
+    <div class="inputgroup">
+    <?lsmb
+        summary = [];
+
+        # Localize summary account_link descriptions
+        FOREACH account_link IN form.summary_link_descriptions;
+            IF account_link.description == 'IC';
+                # Retain historic override for Inventory
+                account_link.text = text('Inventory');
+            ELSE;
+                account_link.text = text(account_link.description);
+            END;
+
+            IF form.${account_link.description};
+                summary = account_link.description;
+            END;
+        END;
+
+        INCLUDE select element_data = {
+                   name = "summary"
+                options = form.summary_link_descriptions
+         default_values = summary
+          default_blank = 'true'
+              text_attr = 'text',
+             value_attr = 'description'
+                     id = 'summary-a'
+        };
+    ?>
+    </div>
 </div>
 </div> <!-- account details div -->
 <div id="dropdowns">

--- a/xt/66-cucumber/10-gl/chart-of-accounts.feature
+++ b/xt/66-cucumber/10-gl/chart-of-accounts.feature
@@ -14,9 +14,10 @@ Scenario: View the chart of accounts and change every property of an account
        | 1234  | Test GIFI   |
        | 1235  | Test GIFI 2 |
    And Custom Flags with these properties:
-       | Description   |
-       | Custom-Flag 1 |
-       | Custom-Flag 2 |
+       | Description    | Summary |
+       | Custom-Flag 1  | no      |
+       | Custom-Flag 2  | no      |
+       | Custom Summary | yes     |
   When I navigate the menu and select the item at "General Journal > Chart of Accounts"
   Then I should see the Chart of Accounts screen
    And I expect the report to contain 78 rows
@@ -47,14 +48,18 @@ Scenario: View the chart of accounts and change every property of an account
    And I expect to see 3 selected checkboxes in "Options"
    And I expect to see 2 selected checkboxes in "Custom Flags"
    And I expect to see 20 selected checkboxes in "Include in drop-down menus"
-  When I select "Inventory" from the drop down "Summary account for"
+  When I select "Custom Summary" from the drop down "Summary account for"
    And I deselect every checkbox in "Custom Flags"
    And I deselect every checkbox in "Include in drop-down menus"
    And I press "Save"
    And I wait for the page to load
   Then I expect to see 0 selected checkboxes in "Include in drop-down menus"
   Then I expect to see 0 selected checkboxes in "Custom Flags"
-   And I expect "Inventory" to be selected for "Summary account for"
+   And I expect "Custom Summary" to be selected for "Summary account for"
+  When I select "Inventory" from the drop down "Summary account for"
+   And I press "Save"
+   And I wait for the page to load
+  Then I expect "Inventory" to be selected for "Summary account for"
   When I navigate the menu and select the item at "General Journal > Chart of Accounts"
   Then I should see the Chart of Accounts screen
    And I expect the report to contain 78 rows

--- a/xt/lib/Pherkin/Extension/ledgersmb_steps/common_steps.pl
+++ b/xt/lib/Pherkin/Extension/ledgersmb_steps/common_steps.pl
@@ -367,12 +367,14 @@ Given qr/^Custom Flags with these properties:$/, sub {
     my $dbh = S->{ext_lsmb}->admin_dbh;
     my $q = $dbh->prepare("
         INSERT INTO account_link_description (description, summary, custom)
-        VALUES (?, FALSE, TRUE)
+        VALUES (?, ?, TRUE)
     ");
 
     foreach my $row (@{C->data}) {
+        my $is_summary = (lc $row->{Summary} eq 'yes' ? 1 : 0);
         $q->execute(
             $row->{Description},
+            $is_summary,
         ) or die "failed to insert account_link_description (Custom Flag) with description $row->{Description}";
     }
 };


### PR DESCRIPTION
This commit extends the Chart of Accounts edit screen to include
custom summary account_link descriptors in the 'Summary Account For'
dropdown.
    
This dropdown is now populated from the database
`account_link_description` table, rather than being hard-coded (but
required to correspond).
    
Checks in the perl code to limit the number of summary account_link
descriptors linked to an account have been removed. The UI prevents
this and the database now has a constraint to enforce this. The
perl checks are therefore unnecessary.