### PR TITLE
Rename menu option s/Search and GL/Search/

### DIFF
--- a/sql/changes/1.7/rename-menu-option-gl-search.sql
+++ b/sql/changes/1.7/rename-menu-option-gl-search.sql
@@ -1,0 +1,4 @@
+UPDATE menu_node
+SET label='Search'
+WHERE id=76
+AND label='Search and GL';

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -84,3 +84,4 @@
 1.7/drop-menu-add-accounts.sql
 1.7/drop-max_ac_id.sql
 1.7/limit_summary_account_links.sql
+1.7/rename-menu-option-gl-search.sql


### PR DESCRIPTION
Following discussion in chatroom and for consistency with other
menu options renames the General Journal child menu option
from 'Search and GL' to plain, simple 'Search'.