### PR TITLE
* Fix looping schema checks with multiple failing checks for one change

### DIFF
--- a/lib/LedgerSMB/Database/ChangeChecks.pm
+++ b/lib/LedgerSMB/Database/ChangeChecks.pm
@@ -232,6 +232,10 @@ sub _run_check {
 
         $check->{grids} = { map { $_->{name} => $_ } @grids };
         $check->{on_submit}->($dbh, \@rows);
+        if (! $dbh->{AutoCommit}) {
+            $dbh->commit
+                or die 'Unable to commit ChangeCheck data updates: ' . $dbh->errstr;
+        }
 
         @rows =
             $dbh->selectall_array(


### PR DESCRIPTION
Schema change data modifications get saved, but not committed. Most of
the time this works well enough, because the change script that goes
with it, does get committed. However, if multiple checks fail, the
change script won't always be executed immediately following the data
updates.