### PR TITLE
* Fix invoication arguments of all_business_units

### DIFF
--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -1966,7 +1966,7 @@ sub get_regular_metadata {
     $transdate = $transdate->to_db if eval { $transdate->can('to_db') };
 
     $self->all_employees( $myconfig, $dbh, $transdate, 1 );
-    $self->all_business_units( $myconfig, $dbh, $transdate, $job );
+    $self->all_business_units( $transdate, $vc );
     $self->all_taxaccounts( $myconfig, $dbh, $transdate );
     $self->all_languages();
 }


### PR DESCRIPTION
On the MC branch, during shipping, this incorrect argument list manifests
itself as an error "Can't bind reference" being thrown.

Fixes #3978
