### PR TITLE
* Filter the list of variables and values round-tripped via browser

### DIFF
--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -391,7 +391,10 @@ sub hide_form {
     else {
         delete $self->{header};
 
-        for ( sort keys %$self ) {
+        for ( grep { ! ref $self->{$_} } # no use serializing references
+              grep { ! m/^all_/ }
+              grep { ! m/^_/ }
+              sort keys %$self ) {
             print qq|<input type="hidden" name="$_" value="|
               . $self->quote( $self->{$_} )
               . qq|" />\n|;


### PR DESCRIPTION
* Don't round-trip private variables (prefixed with an '_')
* Don't round-trip variables whose values are reference (because their round-trips aren't adding value: it'll just show the name of the referred type)
* Don't round-trip variables which are actually database caches, indentified by the prefix 'all_'.
