### PR TITLE
1.6 Respect tempdir when rendering ODS template

### DIFF
--- a/lib/LedgerSMB/Template/ODS.pm
+++ b/lib/LedgerSMB/Template/ODS.pm
@@ -740,6 +740,15 @@ sub _format_cleanup_handler {
     return shift @style_stack;
 }
 
+
+# _ods_process($output, $template)
+#
+# If $output is a scalar, it is interpreted as a filename into which
+# the rendered template will be written.
+#
+# If $output is a scalar reference, the rendered template will be written
+# into the referenced scalar and no file will be rendered to disk.
+
 sub _ods_process {
     my ($output, $template) = @_;
     my $workdir = File::Temp->newdir;
@@ -753,9 +762,12 @@ sub _ods_process {
     else {
         $fn = $output;
     }
-    $ods = ooDocument(file => $fn,
-                      create => 'spreadsheet',
-                      work_dir => $workdir );
+
+    odfWorkingDirectory($workdir->dirname);
+    $ods = ooDocument(
+        file => $fn,
+        create => 'spreadsheet',
+    );
 
     my $parser = XML::Twig->new(
         start_tag_handlers => {


### PR DESCRIPTION
Rendering an ODS document using `OpenOffice::OODoc` requires a
working directory for temporary files.

We use File::Temp to create and destroy this temporary directory,
but it was not being properly configured for the OpenOffice::OODoc
module.

As a result, OpenOffice::OODoc was falling back to its default of
using the current directory. If this was not writeable, template
rendering would fail.

This patch correctly configures the module to use a writeable
temporary directory which is cleaned-up afterwards.