### PR TITLE
* Fix DisableBackbutton middleware

### DIFF
--- a/lib/LedgerSMB/PSGI.pm
+++ b/lib/LedgerSMB/PSGI.pm
@@ -128,7 +128,9 @@ sub psgi_app {
         $request->{dbh}->commit if defined $request->{dbh};
     }
     catch {
-        # The database setup middleware will roll back before disconnecting
+        # Explicitly roll back, because middleware may require the
+        # database connection to be in a working state (e.g. DisableBackbutton)
+        $request->{dbh}->rollback;
         my $error = $_;
         if ($error !~ /^Died at/) {
             $env->{'psgix.logger'}->({


### PR DESCRIPTION
Note that the DisableBackbutton middleware needs the database connection
to be in an operative state (no failed queries) in order to execute its
own query.
The 'try' block makes sure this happens by calling 'commit' at the end;
regardless of whether the commit cases a rollback or an actual commit,
the result will be a new transaction to work with.
The 'catch' block assumed the outer handler would clean up. While that's
true, it doesn't allow the intermediate middleware to operate on the
connection.

This commit fixes the above situation by making sure the 'catch' block
leaves the database in a fresh (non-failed) transaction.
