### PR TITLE
* Correctly encode db name with &-character

### DIFF
--- a/UI/setup/complete.html
+++ b/UI/setup/complete.html
@@ -10,7 +10,7 @@
 <div class="listtop"><?lsmb text('Database Operation Complete') ?></div>
 <p><?lsmb text('This database operation has completed successfully.  LedgerSMB may now be used.'); ?></p>
 <p><a href="setup.pl?action=login&amp;s_user=<?lsmb login ?>&amp;database="><?lsmb text('Return to setup') ?></a></p>
-<p><a href="login.pl?login=username&amp;company=<?lsmb database ?>"><?lsmb text('Start Using LedgerSMB') ?></a></p><!-- Setting login=username is a kludge to prevent the dbadmin user from being pre-entered. A better solution needs to be found. -->
+<p><a href="login.pl?login=username&amp;company=<?lsmb UNESCAPE(database) | uri ?>"><?lsmb text('Start using LedgerSMB') ?></a></p><!-- Setting login=username is a kludge to prevent the dbadmin user from being pre-entered. A better solution needs to be found. -->
 <?lsmb IF lsmb_info ?>
 <table class='lsmb_info'>
   <thead>


### PR DESCRIPTION
The database name was correctly HTML encoded, but incorrectly URI encoded,
leading to the fact that database names with an '&' character would be
split into separate fields.
