### PR TITLE
* Suppress warnings in Travis CI output

### DIFF
--- a/old/lib/LedgerSMB/IR.pm
+++ b/old/lib/LedgerSMB/IR.pm
@@ -197,7 +197,7 @@ sub post_invoice {
             }
             $pth->finish;
 
-            if ( $form->{"projectnumber_$i"} ne "" ) {
+            if ( ($form->{"projectnumber_$i"} // "") ne "" ) {
                 ( $null, $project_id ) =
                   split /--/, $form->{"projectnumber_$i"};
             }


### PR DESCRIPTION
Suppress uninitialized variable warnings by either not executing the
scope in which the variable is referenced, or by using a default value
when the variable isn't defined.
