### PR TITLE
* Orders and quotations fail to save due to employee foreign key

### DIFF
--- a/sql/changes/1.7/fix-oe-person_id-fkey.sql
+++ b/sql/changes/1.7/fix-oe-person_id-fkey.sql
@@ -1,0 +1,12 @@
+
+
+ALTER TABLE oe DROP CONSTRAINT oe_person_id_fkey;
+
+UPDATE oe
+   SET person_id = (SELECT entity_id FROM person
+                     WHERE person.id = oe.person_id)
+ WHERE person_id IS NOT NULL;
+
+
+ALTER TABLE oe ADD FOREIGN KEY (person_id) REFERENCES person (entity_id);
+

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -108,3 +108,4 @@ mc/delete-migration-validation-data.sql
 1.7/limit_summary_account_links.sql
 1.7/rename-menu-option-gl-search.sql
 1.7/to-location-pkeys-optimization.sql
+1.7/fix-oe-person_id-fkey.sql


### PR DESCRIPTION
The foreign key on the AR and AP tables points to person.entity_id;
on the oe table, it points to person.id. However, the code in oe.pl
uses the same logic to compose the value for the person_id field
as does the logic in ir.pl/is.pl. Correct the fkey to align with
ir.pl/is.pl.