### PR TITLE
* Move role grants to Roles.sql

### DIFF
--- a/sql/Pg-database.sql
+++ b/sql/Pg-database.sql
@@ -662,8 +662,6 @@ create table location_class_to_entity_class (
   entity_class int not null references entity_class(id)
 );
 
-GRANT SELECT ON location_class_to_entity_class TO PUBLIC;
-
 COMMENT ON TABLE location_class_to_entity_class IS
 $$This determines which location classes go with which entity classes$$;
 
@@ -3717,8 +3715,6 @@ SELECT 'last_year', 'Last Year',
        ((extract('YEAR' from now()) - 1)::text || '-01-01')::date as date_from
 ;
 
-GRANT SELECT ON periods TO public;
-
 CREATE TABLE asset_unit_class (
         id int not null unique,
         class text primary key
@@ -4896,8 +4892,6 @@ select c.id, c.accno, coalesce(at.description, c.description),
          ON c.id = at.trans_id
 group by c.id, c.accno, coalesce(at.description, c.description), c.category,
          c.heading, c.gifi_accno, c.contra, c.tax;
-
-GRANT SELECT ON chart TO public;
 
 COMMENT ON VIEW chart IS $$Compatibility chart for 1.2 and earlier.$$;
 

--- a/sql/modules/Roles.sql
+++ b/sql/modules/Roles.sql
@@ -121,6 +121,10 @@ $$;
 
 GRANT ALL ON SCHEMA public TO public;
 
+GRANT SELECT ON periods TO public; -- 'periods' is a view in Pg-database
+GRANT SELECT ON location_class_to_entity_class TO PUBLIC;
+
+
 \echo BASE ROLES
 SELECT lsmb__create_role('base_user');
 


### PR DESCRIPTION
While loading some database to be repaired while helping a user,
the fact that some GRANTs are in Pg-database.sql means they don't
get applied upon reloading the modules -- with resulting in access
problems.
This may be a problem with restores across PG clusters too, when the
user elects not to load the roles file.

Note that the 'chart' view exists in Pg-database, but gets dropped
during "schema change updates", meaning the grant on it can't be
executed in Roles.sql: by the time it gets there, the view doesn't
exist anymore.