### PR TITLE
* Fixes #4016: tax doesn't post on AA transaction

### DIFF
--- a/old/bin/aa.pl
+++ b/old/bin/aa.pl
@@ -339,7 +339,7 @@ sub create_links {
     # this works only if all taxes are checked
 
     if ( !$form->{oldinvtotal} ) { # first round loading (or amount was 0)
-        for (@taxaccounts) { $form->{ "calctax_" . $_->account } = 1 }
+        for (@taxaccounts) { $form->{ "calctax_" . $_->{account} } = 1 }
     }
 
     $form->{rowcount}++ if ( $form->{id} || !$form->{rowcount} );
@@ -437,6 +437,9 @@ sub form_header {
         <th align=right>| . $locale->text('Exchange Rate') . qq|</th>
         <td><input data-dojo-type="dijit/form/TextBox" name=exchangerate size=10 value=$form->{exchangerate}></td>
 |;
+    }
+     else {
+         $exchangerate .= q|<input name=exchangerate type=hidden value=1>|;
     }
     $exchangerate .= qq|
 </tr>

--- a/old/lib/LedgerSMB/AA.pm
+++ b/old/lib/LedgerSMB/AA.pm
@@ -129,7 +129,8 @@ sub post_transaction {
         #tshvr HV parse first or problem at aa.pl create_links $form->{"${akey}_$form->{acc_trans}{$key}->[$i-1]->{accno}"}=$form->{acc_trans}{$key}->[ $i - 1 ]->{amount} * $ml; 123,45 * -1  gives 123 !!
         $form->{"tax_$accno"}=$form->parse_amount($myconfig,$form->{"tax_$accno"});
         $form->{"tax_$accno"} *= -1 if $form->{reverse};
-        $fxtax += $tax{fxamount}{$accno} = $form->{"tax_$accno"};
+        $tax{fxamount}{$accno} = $form->{"tax_$accno"};
+        $fxtax += $tax{fxamount}{$accno};
         $tax += $tax{fxamount}{$accno};
         $amount = $tax{fxamount}{$accno} * $form->{exchangerate};
         $tax{amount}{$accno} = $form->round_amount( $amount - $diff, 2 );
@@ -140,7 +141,7 @@ sub post_transaction {
             push @{ $form->{acc_trans}{taxes} },
               {
                 accno          => $accno,
-            amount_bc      => $amount,
+            amount_bc      => $tax{amount}{$accno},
             amount_tc      => $tax{fxamount}{$accno},
             curr           => $form->{currency},
                 project_id     => undef,
@@ -460,15 +461,15 @@ sub post_transaction {
             $query = qq|
                 INSERT INTO acc_trans
                         (trans_id, chart_id, amount_bc, curr, amount_tc,
-                            transdate, fx_transaction)
+                            transdate)
                      VALUES (?, (SELECT id FROM account
                               WHERE accno = ?),
-                        ?, ?, ?, ?, ?)|;
+                        ?, ?, ?, ?)|;
 
             @queryargs = (
                 $form->{id}, $ref->{accno}, $ref->{amount_bc} * $ml,
                 $form->{currency}, $ref->{amount_tc} * $ml,
-                $form->{transdate}, $ref->{fx_transaction}
+                $form->{transdate}
             );
             $dbh->prepare($query)->execute(@queryargs)
               || $form->dberror($query);


### PR DESCRIPTION
Note that in previous code, the (non-fx) amount was made up
of the difference between the fx amount and the total amount
to be posted in the base currency.
In the code that posts AA transactions, this paradigm hadn't
been completely replaced with the new one which posts full
amounts both in the amount_bc as well as in the amount_tc
columns.
Combined with the fact that the "fx adjustment" is guaranteed
to be zero (0) for any base-currency transaction, the adjustment
amount is guaranteed to be zero and hence the criterion for the
posting to be made when the (difference) amount is non-zero,
always fails the test and thereby always fails to post taxes.

