### PR TITLE
* In tests which depend on it, use known company names

### DIFF
--- a/xt/66-cucumber/11-ar/customer_history_report.feature
+++ b/xt/66-cucumber/11-ar/customer_history_report.feature
@@ -4,7 +4,7 @@ Feature: Customer History Report
   of customers to generate a report, filtering by various parameters.
 
 Background:
-  Given a standard test company
+  Given a standard test company named "standard-customer-history"
     And a logged in admin user
 
 Scenario: 
@@ -16,5 +16,5 @@ Scenario:
    And I should see these headings:
        | Heading             | Contents         |
        | Report Name         | Purchase History |
-       | Company             | standard-0   |
+       | Company             | standard-customer-history   |
 

--- a/xt/66-cucumber/13-cash/reconciliation-search.feature
+++ b/xt/66-cucumber/13-cash/reconciliation-search.feature
@@ -4,7 +4,7 @@ Feature: Reconciliation Report Search
   reports according to various attributes.
 
 Background:
-  Given a standard test company
+  Given a standard test company named "standard-recon-test"
     And a logged in admin user
 
 Scenario: Default search with no filter
@@ -41,7 +41,7 @@ Scenario: Filter by "Statement Date From"
    And I should see these headings:
        | Heading             | Contents               |
        | Report Name         | Reconciliation Reports |
-       | Company             | standard-0             |
+       | Company             | standard-recon-test             |
        | From Date           | 2018-02-01             |
        | To Date             |                        |
        | From Amount         |                        |
@@ -59,7 +59,7 @@ Scenario: Filter by "Statement Date To"
    And I should see these headings:
        | Heading             | Contents               |
        | Report Name         | Reconciliation Reports |
-       | Company             | standard-0             |
+       | Company             | standard-recon-test             |
        | From Date           |                        |
        | To Date             | 2018-02-01             |
        | From Amount         |                        |
@@ -75,7 +75,7 @@ Scenario: Filter by "Amount From"
   Then I should see the Reconciliation Search Report screen
        | Heading             | Contents               |
        | Report Name         | Reconciliation Reports |
-       | Company             | standard-0             |
+       | Company             | standard-recon-test             |
        | From Date           |                        |
        | To Date             |                        |
        | From Amount         | 1000.01                |
@@ -92,7 +92,7 @@ Scenario: Filter by "Amount To"
   Then I should see the Reconciliation Search Report screen
        | Heading             | Contents               |
        | Report Name         | Reconciliation Reports |
-       | Company             | standard-0             |
+       | Company             | standard-recon-test             |
        | From Date           |                        |
        | To Date             |                        |
        | From Amount         |                        |

--- a/xt/66-cucumber/14-transaction_approval/search-batches.feature
+++ b/xt/66-cucumber/14-transaction_approval/search-batches.feature
@@ -5,7 +5,7 @@ Feature: Search Batches
   presented as a list.
 
 Background:
-  Given a standard test company
+  Given a standard test company named "standard-batch-test"
     And a logged in admin user
 
 Scenario: Search for all unapproved batches
@@ -22,7 +22,7 @@ Scenario: Search for all unapproved batches
    And I should see these headings:
        | Heading             | Contents     |
        | Report Name         | Batch Search |
-       | Company             | standard-0   |
+       | Company             | standard-batch-test   |
        | Transaction Type    |              |
        | Description         |              |
        | Amount Greater Than |              |
@@ -43,7 +43,7 @@ Scenario: Search for batches, filtering by batch type
    And I should see these headings:
        | Heading             | Contents     |
        | Report Name         | Batch Search |
-       | Company             | standard-0   |
+       | Company             | standard-batch-test   |
        | Transaction Type    | payment      |
        | Description         |              |
        | Amount Greater Than |              |
@@ -60,7 +60,7 @@ Scenario: Search for batches, filtering by batch type
    And I should see these headings:
        | Heading             | Contents     |
        | Report Name         | Batch Search |
-       | Company             | standard-0   |
+       | Company             | standard-batch-test   |
        | Transaction Type    |              |
        | Description         | ABC          |
        | Amount Greater Than |              |
@@ -77,7 +77,7 @@ Scenario: Search for all approved batches
    And I should see these headings:
        | Heading             | Contents     |
        | Report Name         | Batch Search |
-       | Company             | standard-0   |
+       | Company             | standard-batch-test   |
        | Transaction Type    |              |
        | Description         |              |
        | Amount Greater Than |              |

--- a/xt/lib/Pherkin/Extension/ledgersmb_steps/common_steps.pl
+++ b/xt/lib/Pherkin/Extension/ledgersmb_steps/common_steps.pl
@@ -19,13 +19,14 @@ use Test::BDD::Cucumber::StepFile;
 
 my $company_seq = 0;
 
-Given qr/a (fresh )?standard test company/, sub {
+Given qr/a (fresh )?standard test company(?: named "(.*)")?/, sub {
     my $fresh_required = $1;
+    my $company = $2;
 
     S->{ext_lsmb}->ensure_template;
 
     if (! S->{"the company"} || $fresh_required) {
-        my $company = "standard-" . $company_seq++;
+        $company //= "standard-" . $company_seq++;
         S->{ext_lsmb}->create_from_template($company);
     }
 };


### PR DESCRIPTION
The standard companies are sequence-numbered,  which means that those names
aren't suitable for use when the tests depend on the name being known.
While the names might have been constant on Travis CI and under certain
local testing conditions, they certainly aren't always 'standard-0' during
(my) local testing.