### PR TITLE
Fewer warnings

### DIFF
--- a/lib/LedgerSMB/Report/Dates.pm
+++ b/lib/LedgerSMB/Report/Dates.pm
@@ -213,7 +213,7 @@ sub _get_from_date {
 
 sub _get_to_date {
     my ($self) = @_;
-    if (! defined $self->interval
+    if (not defined $self->interval
         or $self->interval eq 'none'
         or not defined $self->from_date){
         return LedgerSMB::PGDate->from_db();

--- a/lib/LedgerSMB/Report/Dates.pm
+++ b/lib/LedgerSMB/Report/Dates.pm
@@ -213,7 +213,9 @@ sub _get_from_date {
 
 sub _get_to_date {
     my ($self) = @_;
-    if ($self->interval eq 'none' or not defined $self->from_date){
+    if (! defined $self->interval
+        or $self->interval eq 'none'
+        or not defined $self->from_date){
         return LedgerSMB::PGDate->from_db();
     }
     my $dateobj = $self->from_date;

--- a/old/bin/aa.pl
+++ b/old/bin/aa.pl
@@ -221,14 +221,14 @@ sub create_links {
 
     my $vc = $form->{vc};
     AA->get_name( \%myconfig, \%$form )
-            unless $form->{"old$vc"} eq $form->{$vc}
+            unless ($from->{"old$vc"} and $form->{$vc} and $form->{"old$vc"} eq $form->{$vc})
                     or $form->{"old$vc"} =~ /^\Q$form->{$vc}\E--/;
 
-    $form->{currency} =~ s/ //g;
+    $form->{currency} =~ s/ //g if $form->{currency};
     $form->{duedate}     = $duedate     if $duedate;
     $form->{crdate}      = $crdate      if $crdate;
 
-    if ($form->{"$form->{vc}"} !~ /--/){
+    if ($form->{"$form->{vc}"} && $form->{"$form->{vc}"} !~ /--/){
         $form->{"old$form->{vc}"} = $form->{$form->{vc}} . '--' . $form->{"$form->{vc}_id"};
     } else {
         $form->{"old$form->{vc}"} = $form->{$form->{vc}};
@@ -253,6 +253,7 @@ sub create_links {
 
 
         # if there is a value we have an old entry
+        if ($form->{acc_trans}{$key}) {
         foreach my $i ( 1 .. scalar @{ $form->{acc_trans}{$key} } ) {
 
 
@@ -330,6 +331,7 @@ sub create_links {
                 }
             }
         }
+        }
     }
 
     $form->{paidaccounts} = 1 if not defined $form->{paidaccounts};
@@ -357,7 +359,7 @@ sub create_links {
     # readonly
     if ( !$form->{readonly} ) {
         $form->{readonly} = 1
-          if $myconfig{acs} =~ /$form->{ARAP}--Add Transaction/;
+          if $myconfig{acs} && $myconfig{acs} =~ /$form->{ARAP}--Add Transaction/;
     }
     delete $form->{selectcurrency};
     #$form->generate_selects(\%myconfig);
@@ -449,8 +451,10 @@ sub form_header {
     if ( ( $rows = $form->numtextrows( $form->{notes}, 50 ) - 1 ) < 2 ) {
         $rows = 2;
     }
+    $form->{notes} //= '';
     $notes =
 qq|<textarea data-dojo-type="dijit/form/Textarea" name=notes rows=$rows cols=50 wrap=soft>$form->{notes}</textarea>|;
+    $form->{intnotes} //= '';
     $intnotes =
 qq|<textarea data-dojo-type="dijit/form/Textarea" name=intnotes rows=$rows cols=35 wrap=soft>$form->{intnotes}</textarea>|;
 
@@ -464,7 +468,7 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" name=intnotes rows=$rows cols=
           </tr>
 | if $form->{selectdepartment};
 
-    $n = ( $form->{creditremaining} < 0 ) ? "0" : "1";
+    $n = ( ($form->{creditremaining} // 0) < 0 ) ? "0" : "1";
 
     $name =
       ( $form->{"select$form->{vc}"} )

--- a/old/bin/aa.pl
+++ b/old/bin/aa.pl
@@ -222,7 +222,7 @@ sub create_links {
     my $vc = $form->{vc};
     AA->get_name( \%myconfig, \%$form )
             unless ($from->{"old$vc"} and $form->{$vc} and $form->{"old$vc"} eq $form->{$vc})
-                    or $form->{"old$vc"} =~ /^\Q$form->{$vc}\E--/;
+                    or ($form->{"old$vc"} and $form->{"old$vc"} =~ /^\Q$form->{$vc}\E--/);
 
     $form->{currency} =~ s/ //g if $form->{currency};
     $form->{duedate}     = $duedate     if $duedate;
@@ -366,7 +366,7 @@ sub create_links {
 }
 
 sub form_header {
-     my $min_lines = $LedgerSMB::Company_Config::settings->{min_empty};
+     my $min_lines = $LedgerSMB::Company_Config::settings->{min_empty} // 0;
 
     $title = $form->{title};
     $form->all_business_units($form->{transdate},
@@ -466,7 +466,8 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" name=intnotes rows=$rows cols=
       . $form->escape( $form->{selectdepartment}, 1 ) . qq|">
         </td>
           </tr>
-| if $form->{selectdepartment};
+        | if $form->{selectdepartment};
+     $department //= '';
 
     $n = ( ($form->{creditremaining} // 0) < 0 ) ? "0" : "1";
 
@@ -693,8 +694,10 @@ $form->open_status_div($status_div_id) . qq|
 
         $project = qq|
       <td align=right><select data-dojo-type="dijit/form/Select" id="projectnumber_$i" name="projectnumber_$i">$form->{"selectprojectnumber_$i"}</select></td>
-| if $form->{selectprojectnumber};
+            | if $form->{selectprojectnumber};
+        $project //= '';
 
+        $form->{"description_$i"} //= '';
         if ( ( $rows = $form->numtextrows( $form->{"description_$i"}, 40 ) ) >
             1 )
         {
@@ -844,8 +847,10 @@ qq|<td><input data-dojo-type="dijit/form/TextBox" name="description_$i" size=40 
 ";
 
     $form->{paidaccounts}++ if ( $form->{"paid_$form->{paidaccounts}"} );
-    $form->{"select$form->{ARAP}_paid"} =~ /($form->{cash_accno}--[^<]*)/;
-    $form->{"$form->{ARAP}_paid_$form->{paidaccounts}"} = $1;
+    if (defined $form->{cash_accno}) {
+        $form->{"select$form->{ARAP}_paid"} =~ /($form->{cash_accno}--[^<]*)/;
+        $form->{"$form->{ARAP}_paid_$form->{paidaccounts}"} = $1;
+    }
     foreach my $i ( 1 .. $form->{paidaccounts} ) {
 
         $form->hide_form("cleared_$i");
@@ -862,7 +867,7 @@ qq|<td><input data-dojo-type="dijit/form/TextBox" name="description_$i" size=40 
         # format amounts
         $form->{"paidfx_$i"} = $form->format_amount(
             \%myconfig,
-            $form->{"paid_$i"} * $form->{"exchangerate_$i"} , 2 );
+            ($form->{"paid_$i"} // 0) * ($form->{"exchangerate_$i"} // 1) , 2 );
         $form->{"paid_$i"} =
           $form->format_amount( \%myconfig, $form->{"paid_$i"}, 2 );
         $form->{"exchangerate_$i"} =
@@ -882,6 +887,9 @@ qq|<input data-dojo-type="dijit/form/TextBox" name="exchangerate_$i" size=10 val
 
         $form->hide_form("forex_$i");
 
+        $form->{"datepaid_$i"} //= '';
+        $form->{"source_$i"} //= '';
+        $form->{"memo_$i"} //= '';
         $column_data{paid} =
 qq|<td align=center><input data-dojo-type="dijit/form/TextBox" name="paid_$i" id="paid_$i" size=11 value=$form->{"paid_$i"}></td>|;
         $column_data{ARAP_paid} =
@@ -1000,7 +1008,7 @@ sub form_footer {
                 delete $button{$_};
             }
 
-            if ( $transdate && ($transdate <= $closedto) ) {
+            if ( $closedto && $transdate && ($transdate <= $closedto) ) {
                 for ( "post","save_info") {
                     delete $button{$_};
                 }

--- a/old/bin/aa.pl
+++ b/old/bin/aa.pl
@@ -121,14 +121,15 @@ sub new_screen {
 sub add {
     $form->{title} = "Add";
 
-    $form->{callback} =
-"$form->{script}?action=add&login=$form->{login}&sessionid=$form->{sessionid}"
+    $form->{callback} = "$form->{script}?action=add"
       unless $form->{callback};
-    if ($form->{type} eq "credit_note"){
+    if (defined $form->{type}
+        and $form->{type} eq "credit_note"){
         $form->{reverse} = 1;
         $form->{subtype} = 'credit_note';
         $form->{type} = 'transaction';
-    } elsif ($form->{type} eq 'debit_note'){
+    } elsif (defined $form->{type}
+             and $form->{type} eq 'debit_note'){
         $form->{reverse} = 1;
         $form->{subtype} = 'debit_note';
         $form->{type} = 'transaction';
@@ -852,7 +853,7 @@ qq|<td><input data-dojo-type="dijit/form/TextBox" name="description_$i" size=40 
         $form->{"select$form->{ARAP}_paid_$i"} =
           $form->{"select$form->{ARAP}_paid"};
         $form->{"select$form->{ARAP}_paid_$i"} =~
-          s/(value="\Q$form->{"$form->{ARAP}_paid_$i"}\E")/\1 selected="selected"/;
+          s/(value="\Q$form->{"$form->{ARAP}_paid_$i"}\E")/$1 selected="selected"/;
 
         # format amounts
         $form->{"paidfx_$i"} = $form->format_amount(
@@ -1131,7 +1132,7 @@ sub save_temp {
              push @{$lsmb->{journal_lines}},
                   {accno => $acc_id,
                    amount => $amount,
-                   cleared => false,
+                   cleared => 'false',
                   };
         }
     }

--- a/old/bin/arap.pl
+++ b/old/bin/arap.pl
@@ -286,7 +286,7 @@ sub name_selected {
 
     # delete all the new_ variables
     foreach my $i ( 1 .. $form->{lastndx} ) {
-        for (qw(id, name)) { delete $form->{"new_${_}_$i"} }
+        for (qw(id name)) { delete $form->{"new_${_}_$i"} }
     }
 
     for (qw(ndx lastndx nextsub)) { delete $form->{$_} }
@@ -803,10 +803,10 @@ sub continue        { &{ $form->{nextsub} }; }
 sub continuenew     {$form->{rowcount}--; &setlocation_id;  &{ $form->{nextsub} }; }
 sub updatenew       {&createlocations;}
 sub gl_transaction  { &add }
-sub ar_transaction  { &add_transaction(ar) }
-sub ap_transaction  { &add_transaction(ap) }
-sub sales_invoice_  { &add_transaction(is) }
-sub vendor_invoice_ { &add_transaction(ir) }
+sub ar_transaction  { &add_transaction('ar') }
+sub ap_transaction  { &add_transaction('ap') }
+sub sales_invoice_  { &add_transaction('is') }
+sub vendor_invoice_ { &add_transaction('ir') }
 
 
 1;

--- a/old/bin/io.pl
+++ b/old/bin/io.pl
@@ -1234,7 +1234,6 @@ sub print_form {
 
     if ($form->test_should_get_images){
         my $file = LedgerSMB::File->new();
-        my @files;
         my $fc;
         if ($inv eq 'inv') {
            $fc = 1;

--- a/old/bin/ir.pl
+++ b/old/bin/ir.pl
@@ -116,8 +116,7 @@ sub add {
         $form->{reverse} = 0;
     }
 
-    $form->{callback} =
-"$form->{script}?action=add&type=$form->{type}&login=$form->{login}&sessionid=$form->{sessionid}"
+    $form->{callback} = "$form->{script}?action=add&type=$form->{type}"
       unless $form->{callback};
     &invoice_links;
     &prepare_invoice;
@@ -165,7 +164,7 @@ sub invoice_links {
 
     for (@curr) { $form->{selectcurrency} .= "<option>$_\n" }
 
-    if ( @{ $form->{all_vendor} } ) {
+    if ( $form->{all_vendor} && @{ $form->{all_vendor} } ) {
         unless ( $form->{vendor_id} ) {
             $form->{vendor_id} = $form->{all_vendor}->[0]->{id};
         }
@@ -186,6 +185,8 @@ sub invoice_links {
           if $form->{department_id};
      }
 
+    $form->{vendor} //= '';
+    $form->{vendor_id} //= '';
     $form->{oldvendor}    = "$form->{vendor}--$form->{vendor_id}";
     $form->{oldtransdate} = $form->{transdate};
 
@@ -202,6 +203,7 @@ sub invoice_links {
         }
 
         if ( $key eq "AP_paid" ) {
+            if ( $form->{acc_trans}{$key} ) {
             foreach my $i ( 1 .. scalar @{ $form->{acc_trans}{$key} } ) {
                 $form->{"AP_paid_$i"} =
 "$form->{acc_trans}{$key}->[$i-1]->{accno}--$form->{acc_trans}{$key}->[$i-1]->{description}";
@@ -221,6 +223,7 @@ sub invoice_links {
                   $form->{acc_trans}{$key}->[ $i - 1 ]->{cleared};
 
                 $form->{paidaccounts} = $i;
+            }
             }
         }
         else {
@@ -242,7 +245,7 @@ sub invoice_links {
           $form->datetonum( \%myconfig, $form->{closedto} ) );
 
     if ( !$form->{readonly} ) {
-        $form->{readonly} = 1 if $myconfig{acs} =~ /AP--Vendor Invoice/;
+        $form->{readonly} = 1 if $myconfig{acs} && $myconfig{acs} =~ /AP--Vendor Invoice/;
     }
 
      $form->generate_selects(\%myconfig);
@@ -1239,7 +1242,7 @@ sub post {
     $form->isblank( "vendor",    $locale->text('Vendor missing!') );
 
     # if the vendor changed get new values
-    if ( &check_name(vendor) ) {
+    if ( &check_name('vendor') ) {
         &update;
         $form->finalize_request();
     }

--- a/old/bin/ir.pl
+++ b/old/bin/ir.pl
@@ -1023,7 +1023,7 @@ sub update {
     $form->{$_} = LedgerSMB::PGDate->from_input($form->{$_})->to_output()
        for qw(transdate duedate crdate);
 
-    if ( $newname = &check_name(vendor) ) {
+    if ( $newname = &check_name('vendor') ) {
         $form->rebuild_vc('vendor', $form->{transdate}, 1);
     }
     if ( $form->{transdate} ne $form->{oldtransdate} ) {

--- a/old/bin/old-handler.pl
+++ b/old/bin/old-handler.pl
@@ -92,7 +92,7 @@ print 'Set-Cookie: '
     if $form->{"request.download-cookie"};
 
 
-$locale = LedgerSMB::Locale->get_handle( ${LedgerSMB::Sysconfig::language} )
+$locale = LedgerSMB::Locale->get_handle( LedgerSMB::Sysconfig::language() )
   or $form->error( __FILE__ . ':' . __LINE__ . ": Locale not loaded: $!\n" );
 
 
@@ -150,10 +150,7 @@ try {
         binmode STDOUT, ':utf8';
         binmode STDERR, ':utf8';
         # window title bar, user info
-        $form->{titlebar} =
-            "LedgerSMB "
-            . $locale->text('Version')
-            . " $form->{version} - $myconfig{name} - $myconfig{dbname}";
+        $form->{titlebar} = ''; # Not needed anymore: the SPA already has a title(bar)
 
         &{ $form->{action} };
         LedgerSMB::App_State::cleanup();

--- a/old/bin/printer.pl
+++ b/old/bin/printer.pl
@@ -45,23 +45,23 @@ sub print_options {
         };
 
     # SC: Option values extracted from other old/bin/ scripts
-    if ($form->{type} eq 'invoice') {
+    if ($form->{type} && $form->{type} eq 'invoice') {
     push @{$options{formname}{options}}, {
         text => $locale->text('Invoice'),
         value => 'invoice',
         };
     }
-    if ($form->{type} eq 'sales_quotation') {
+    if ($form->{type} && $form->{type} eq 'sales_quotation') {
         push @{$options{formname}{options}}, {
             text => $locale->text('Quotation'),
             value => 'sales_quotation',
             };
-    } elsif ($form->{type} eq 'request_quotation') {
+    } elsif ($form->{type} && $form->{type} eq 'request_quotation') {
         push @{$options{formname}{options}}, {
             text => $locale->text('RFQ'),
             value => 'request_quotation',
             };
-    } elsif ($form->{type} eq 'sales_order') {
+    } elsif ($form->{type} && $form->{type} eq 'sales_order') {
         push @{$options{formname}{options}}, {
             text => $locale->text('Sales Order'),
             value => 'sales_order',
@@ -78,7 +78,7 @@ sub print_options {
             text => $locale->text('Packing List'),
             value => 'packing_list',
             };
-    } elsif ($form->{type} eq 'purchase_order') {
+    } elsif ($form->{type} && $form->{type} eq 'purchase_order') {
         push @{$options{formname}{options}}, {
             text => $locale->text('Purchase Order'),
             value => 'purchase_order',
@@ -87,7 +87,7 @@ sub print_options {
             text => $locale->text('Bin List'),
             value => 'bin_list',
             };
-    } elsif ($form->{type} eq 'ship_order') {
+    } elsif ($form->{type} && $form->{type} eq 'ship_order') {
         push @{$options{formname}{options}}, {
             text => $locale->text('Pick List'),
             value => 'pick_list',
@@ -96,7 +96,7 @@ sub print_options {
             text => $locale->text('Packing List'),
             value => 'packing_list',
             };
-    } elsif ($form->{type} eq 'receive_order') {
+    } elsif ($form->{type} && $form->{type} eq 'receive_order') {
         push @{$options{formname}{options}}, {
             text => $locale->text('Bin List'),
             value => 'bin_list',
@@ -111,7 +111,7 @@ sub print_options {
             value => 'shipping_label',
             };
 
-    if ( $form->{media} eq 'email' ) {
+    if ( $form->{media} && $form->{media} eq 'email' ) {
         $options{media} = {
             name => 'sendmode',
             options => [{
@@ -155,7 +155,7 @@ sub print_options {
             value => 'pdf',
             };
     }
-    if ($form->{type} eq 'invoice'){
+    if ($form->{type} && $form->{type} eq 'invoice'){
        push @{$options{format}{options}}, {
             text => '894.EDI',
             value => '894.edi',
@@ -173,11 +173,11 @@ sub print_options {
     # $locale->text('E-mailed')
     # $locale->text('Scheduled')
 
-    $options{status} = (
+    $options{status} = {
         printed   => 'Printed',
         emailed   => 'E-mailed',
         recurring => 'Scheduled'
-    );
+    };
 
     $options{groupby} = {};
     $options{groupby}{groupprojectnumber} = "checked" if $form->{groupprojectnumber};
@@ -185,7 +185,7 @@ sub print_options {
 
     $options{sortby} = {};
     for (qw(runningnumber partnumber description bin)) {
-        $options{sortby}{$_} = "checked" if $form->{sortby} eq $_;
+        $options{sortby}{$_} = "checked" if $form->{sortby} && $_ && $form->{sortby} eq $_;
     }
 
     \%options;

--- a/old/lib/LedgerSMB/AA.pm
+++ b/old/lib/LedgerSMB/AA.pm
@@ -607,6 +607,7 @@ sub get_name {
             + c.terms"
       : "current_date + c.terms";
 
+    $form->{"$form->{vc}_id"} //= 0;
     $form->{"$form->{vc}_id"} *= 1;
 
 

--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -217,7 +217,7 @@ sub open_form {
     my ($self) = @_;
     my @results ;
 
-    if ($self->{form_id} =~ '^\s*$'){
+    if ($self->{form_id} && $self->{form_id} =~ '^\s*$'){
         delete $self->{form_id};
     }
 
@@ -253,7 +253,7 @@ sub check_form {
 
 sub close_form {
     my ($self) = @_;
-    if ($self->{form_id} =~ '^\s*$'){
+    if ($self->{form_id} && $self->{form_id} =~ '^\s*$'){
         delete $self->{form_id};
     }
 
@@ -478,6 +478,8 @@ sub numtextrows {
     my ( $self, $str, $cols, $maxrows ) = @_;
 
     my $rows = 0;
+
+    return 0 if ! defined $str;
 
     for ( split /\n/, $str ) {
         $rows += int( ( (length) - 2 ) / $cols ) + 1;
@@ -1184,7 +1186,7 @@ sub generate_selects {
         $form->{selectlanguage} = "<option></option>\n";
         for ( @{ $form->{all_language} } ) {
                 my $value = $_->{code};
-                my $selected = ($form->{language} eq $value) ?
+                my $selected = ($form->{language} && $form->{language} eq $value) ?
                      ' selected="selected"' : "";
             $form->{selectlanguage} .=
               qq|<option value="$value"$selected>$_->{description}</option>\n|;
@@ -1714,7 +1716,7 @@ sub all_vc {
 
     $sth->finish;
 
-    if ( $count < $myconfig->{vclimit} ) {
+    if ( $count < ($myconfig->{vclimit} // 0) ) {
 
         $self->{"${vc}_id"} *= 1;
 
@@ -1746,8 +1748,8 @@ sub all_vc {
 
     # get self
     if ( !$self->{employee_id} ) {
-        ( $self->{employee}, $self->{employee_id} ) = split /--/,
-          $self->{employee};
+        $self->{employee} //= '';
+        ( $self->{employee}, $self->{employee_id} ) = split /--/, $self->{employee};
         ( $self->{employee}, $self->{employee_id} ) = $self->get_employee
           unless $self->{employee_id};
     }
@@ -2120,7 +2122,7 @@ sub create_links {
               ORDER BY accno|;
 
     $sth = $dbh->prepare($query);
-    $self->{id} = undef if $self->{id} eq '';
+    $self->{id} = undef if $self->{id} && $self->{id} eq '';
     $sth->execute( "%" . "$module%", $self->{id}) || $self->dberror($query);
 
     $self->{accounts} = "";

--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -384,6 +384,8 @@ sub hide_form {
     if (@_) {
 
         for (@_) {
+            next if not defined $self->{$_};
+
             print qq|<input type="hidden" name="$_" value="|
               . $self->quote( $self->{$_} )
               . qq|" />\n|;
@@ -2576,25 +2578,27 @@ sub get_partsgroup {
                      FROM partsgroup pg
                      JOIN parts p ON (p.partsgroup_id = pg.id)|;
 
-    my $where;
+    my $where = '';
     my $sortorder = "partsgroup";
 
-    if ( $p->{searchitems} eq 'part' ) {
-        $where = qq| WHERE (p.inventory_accno_id > 0
-                       AND p.income_accno_id > 0)|;
-    }
-    elsif ($p->{searchitems} eq 'service') {
-        $where = qq| WHERE p.inventory_accno_id IS NULL|;
-    }
-    elsif ($p->{searchitems} eq 'assembly') {
-        $where = qq| WHERE p.assembly = '1'|;
-    }
-    elsif ($p->{searchitems} eq 'labor') {
-        $where =
-          qq| WHERE p.inventory_accno_id > 0 AND p.income_accno_id IS NULL|;
-    }
-    elsif ($p->{searchitems} eq 'nolabor') {
-        $where = qq| WHERE p.income_accno_id > 0|;
+    if ( $p->{searchitems} ) {
+        if ( $p->{searchitems} eq 'part' ) {
+            $where = qq| WHERE (p.inventory_accno_id > 0
+                                AND p.income_accno_id > 0)|;
+        }
+        elsif ($p->{searchitems} eq 'service') {
+            $where = qq| WHERE p.inventory_accno_id IS NULL|;
+        }
+        elsif ($p->{searchitems} eq 'assembly') {
+            $where = qq| WHERE p.assembly = '1'|;
+        }
+        elsif ($p->{searchitems} eq 'labor') {
+            $where =
+                qq| WHERE p.inventory_accno_id > 0 AND p.income_accno_id IS NULL|;
+        }
+        elsif ($p->{searchitems} eq 'nolabor') {
+            $where = qq| WHERE p.income_accno_id > 0|;
+        }
     }
 
     if ( $p->{all} ) {

--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -294,9 +294,10 @@ Note that recurring transaction support depends on this function escaping ','.
 sub escape {
     my ( $self, $str, $beenthere ) = @_;
 
+    return if not defined $str;
     # for Apache 2 we escape strings twice
-    if (
-        ( $ENV{SERVER_SIGNATURE} =~ /Apache\/2\.(\d+)\.(\d+)/ )
+    if ($ENV{SERVER_SIGNATURE}
+        && ( $ENV{SERVER_SIGNATURE} =~ /Apache\/2\.(\d+)\.(\d+)/ )
         && !$beenthere
     ) {
         $str = $self->escape( $str, 1 ) if $1 == 0 && $2 < 44;  ## no critic (ProhibitMagicNumbers) sniff

--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -318,6 +318,8 @@ Returns the unencoded form of the URI-encoded $str.
 sub unescape {
     my ( $self, $str ) = @_;
 
+    return if ! defined $str;
+
     $str =~ tr/+/ /;
     $str =~ s/\\$//;
 
@@ -327,7 +329,6 @@ sub unescape {
     $str =~ s/\r?\n/\n/g;
 
     $str;
-
 }
 
 =item $form->quote($str);
@@ -2400,17 +2401,18 @@ sub lastname_used {
     }
 
     my $sth;
-    if ( $self->{type} =~ /_order/ ) {
+    if ($self->{type} && $self->{type} =~ /_order/ ) {
         $arap  = 'oe';
         $where = "quotation = '0'";
     }
 
-    if ( $self->{type} =~ /_quotation/ ) {
+    if ($self->{type} && $self->{type} =~ /_quotation/ ) {
         $arap  = 'oe';
         $where = "quotation = '1'";
     }
 
     $where = "AND $where " if $where;
+    $where //= '';
     my $query = qq|
         SELECT entity.name, ct.curr AS currency, entity_id AS ${vc}_id,
             current_date + ct.terms AS duedate,


### PR DESCRIPTION
By adding variable checks in a few targetted places, we can greatly reduce the warning noise found in our plackup-error.log on TravisCI (and therefore, I presume, on production systems).

Not having to wade through these errors might help find true errors faster (and it just *looks* a whole lot better).

Note that this is a current-progress checkpoint and more work *can* be done.