### PR TITLE
* Reduce a warning when active business units not set

### DIFF
--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -2298,7 +2298,9 @@ sub create_links {
             $self->db_parse_numeric(sth=>$sth, hashref=>$ref);#tshvr
 
             for my $aref (@{$ref->{bu_lines}}){
-                $ref->{"b_unit_$aref->[0]"} = $aref->[1];
+                if ($aref && $aref->[0]) {
+                    $ref->{"b_unit_$aref->[0]"} = $aref->[1];
+                }
             }
 
             if ($self->{reverse}){


### PR DESCRIPTION
When the business unit active but hasn't been set, an 'undef' value
is being returned which causes the string concatenation to warn.
