### PR TITLE
Make sure a hash is used to compare SQL-Ledger versions

### DIFF
--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -1248,7 +1248,7 @@ sub process_and_run_upgrade_script {
         format_options => {extension => 'sql'},
         format => 'TXT' );
 
-    $dbtemplate->render($request, VERSION_COMPARE => \&Version::Compare::version_compare);
+    $dbtemplate->render($request, { VERSION_COMPARE => \&Version::Compare::version_compare } );
 
     my $tempfile = File::Temp->new();
     print $tempfile $dbtemplate->{output}


### PR DESCRIPTION
Fix a SL migration error by making sure that the renderer is called with the proper parameters.