### PR TITLE
Fix recon reports for mc

### DIFF
--- a/sql/changes/mc/aa-migration.sql.checks.pl
+++ b/sql/changes/mc/aa-migration.sql.checks.pl
@@ -114,7 +114,7 @@ Please add a foreign currency code to each transaction.
 
 check q|Assert all required AP exchange rates are available|,
     query => q|SELECT * FROM exchangerate e
-                WHERE coalesce(sell,0) = 0
+                WHERE coalesce(buy,0) = 0
                   AND EXISTS (select 1 from ap
                                where ap.transdate = e.transdate
                                  and ap.curr = e.curr)|,
@@ -158,7 +158,7 @@ useful.
 
 check q|Assert all required AR exchange rates are available|,
     query => q|SELECT * FROM exchangerate e
-                WHERE coalesce(buy,0) = 0
+                WHERE coalesce(sell,0) = 0
                   AND EXISTS (select 1 from ar
                                where ar.transdate = e.transdate
                                  and ar.curr = e.curr)|,

--- a/sql/changes/mc/acc-trans-migration.sql
+++ b/sql/changes/mc/acc-trans-migration.sql
@@ -134,13 +134,13 @@ BEGIN
                           where ltd.id = crl.ledger_id);
   UPDATE cr_report_line crl
      SET our_balance = our_balance
-                     + (select our_balance from cr_report_line cl
+                     + (select sum(our_balance) from cr_report_line cl
                            join lines_to_delete ltd on cl.ledger_id = ltd.id
-                          where ltd.id = crl.ledger_id or ltd.assoc = crl.ledger_id),
+                          where ltd.assoc = crl.ledger_id),
          their_balance = their_balance
-                       + (select their_balance from cr_report_line cl
+                       + (select sum(their_balance) from cr_report_line cl
                            join lines_to_delete ltd on cl.ledger_id = ltd.id
-                          where ltd.id = crl.ledger_id or ltd.assoc = crl.ledger_id)
+                          where ltd.assoc = crl.ledger_id)
    WHERE EXISTS (select 1 from lines_to_delete ltd where ltd.assoc = crl.ledger_id);
   DELETE FROM cr_report_line crl
    WHERE EXISTS (select 1 from lines_to_delete ltd

--- a/sql/changes/mc/acc-trans-migration.sql
+++ b/sql/changes/mc/acc-trans-migration.sql
@@ -132,6 +132,16 @@ BEGIN
          AND NOT EXISTS (select 1 from cr_report_line cl
                            join lines_to_delete ltd on cl.ledger_id = ltd.assoc
                           where ltd.id = crl.ledger_id);
+  UPDATE cr_report_line crl
+     SET our_balance = our_balance
+                     + (select our_balance from cr_report_line cl
+                           join lines_to_delete ltd on cl.ledger_id = ltd.id
+                          where ltd.id = crl.ledger_id or ltd.assoc = crl.ledger_id),
+         their_balance = their_balance
+                       + (select their_balance from cr_report_line cl
+                           join lines_to_delete ltd on cl.ledger_id = ltd.id
+                          where ltd.id = crl.ledger_id or ltd.assoc = crl.ledger_id)
+   WHERE EXISTS (select 1 from lines_to_delete ltd where ltd.assoc = crl.ledger_id);
   DELETE FROM cr_report_line crl
    WHERE EXISTS (select 1 from lines_to_delete ltd
                   where ltd.id = crl.ledger_id);
@@ -250,4 +260,3 @@ BEGIN
 
 END;
 $migrate$;
-


### PR DESCRIPTION
1- Fix the foreign currency validation check to use buy rate for AP and sell for AR
2- Sum the transation and its FX part in the reconciliation records before removing the FX.