### PR TITLE
* Annotate 'use English' about Perl 5.20

### DIFF
--- a/lib/LedgerSMB/PSGI.pm
+++ b/lib/LedgerSMB/PSGI.pm
@@ -46,6 +46,10 @@ use Plack::Builder::Conditionals;
 use Plack::Util;
 
 
+# After Perl 5.20 is the minimum required version,
+# we can drop the restriction on the match vars
+# because 5.20 doesn't copy the data (but uses       
+# string slices)
 use English qw(-no_match_vars);
 if ($EUID == 0) {
     die join("\n",

--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -21,6 +21,10 @@ use warnings;
 use Config;
 use Config::IniFiles;
 use DBI qw(:sql_types);
+# After Perl 5.20 is the minimum required version,
+# we can drop the restriction on the match vars
+# because 5.20 doesn't copy the data (but uses
+# string slices)
 use English qw(-no_match_vars);
 
 


### PR DESCRIPTION
On #perl in Freenode, I just learned that the
negative performance impact from the match
variables has been resolved by using 'string
slices' as of Perl 5.20.

[skip ci]