### PR TITLE
* Make welcome.html 'maindiv' compliant

### DIFF
--- a/UI/welcome.html
+++ b/UI/welcome.html
@@ -1,7 +1,6 @@
 <html>
-  <head><title>Welcome</title></head>
 <body>
-  <div style="width:100%">
+  <div id="welcome" style="width:100%">
     <h1 style="margin-bottom: 3em">Welcome to LedgerSMB</h1>
     <div style="float:left; width:calc(33.3% - 1em); padding: 1em; margin: 0.5em; border: 1px solid black; border-radius: 0.5em; min-width: 300px; box-sizing: border-box">
       <h2>What is LedgerSMB</h2>


### PR DESCRIPTION
The 'title' tag is included in the maindiv, together with the
div that's in the body, resulting in a 2-element match when
matching children of #maindiv. This commit fixes the expectation.