### PR TITLE
* The initial screen is the welcome screen

### DIFF
--- a/xt/lib/PageObject/App/Initial.pm
+++ b/xt/lib/PageObject/App/Initial.pm
@@ -13,10 +13,10 @@ extends 'PageObject';
 
 __PACKAGE__->self_register(
               'app-main-initial',
-              './/div[@id="flicker-container"]',
+              './/div[@id="welcome"]',
               tag_name => 'div',
               attributes => {
-                  id => 'flicker-container',
+                  id => 'welcome',
               });
 
 


### PR DESCRIPTION
The initial screen has long been the welcome screen. Somehow, tests never failed on it, but today we're making sure they won't by declaring a specific weasel widget for it.