### PR TITLE
* Revert 2381122dfd977d15cb8b8551c45d9ba7f5deac1d (PR #4037)

### DIFF
--- a/sql/changes/mc/aa-migration.sql.checks.pl
+++ b/sql/changes/mc/aa-migration.sql.checks.pl
@@ -114,7 +114,7 @@ Please add a foreign currency code to each transaction.
 
 check q|Assert all required AP exchange rates are available|,
     query => q|SELECT * FROM exchangerate e
-                WHERE coalesce(buy,0) = 0
+                WHERE coalesce(sell,0) = 0
                   AND EXISTS (select 1 from ap
                                where ap.transdate = e.transdate
                                  and ap.curr = e.curr)|,
@@ -158,7 +158,7 @@ useful.
 
 check q|Assert all required AR exchange rates are available|,
     query => q|SELECT * FROM exchangerate e
-                WHERE coalesce(sell,0) = 0
+                WHERE coalesce(buy,0) = 0
                   AND EXISTS (select 1 from ar
                                where ar.transdate = e.transdate
                                  and ar.curr = e.curr)|,


### PR DESCRIPTION
As found in IS.pm, AR rates *are* associated with
'buy' rates. So, the idea to reverse them must be
wrong. When migrating a LedgerSMB database, this
point was tested and proven because nearly *all*
rates were problematic without this reversal and
only 1 was *with* this reversal.