### PR TITLE
Allow running LedgerSMB in another schema than 'public'

### DIFF
--- a/lib/LedgerSMB/PGObject.pm
+++ b/lib/LedgerSMB/PGObject.pm
@@ -30,6 +30,7 @@ use Moose::Role;
 with 'PGObject::Simple::Role' => { -excludes => [qw(_get_dbh _get_schema _get_prefix)], };
 
 use LedgerSMB::App_State;
+use LedgerSMB::Sysconfig;
 
 # nulls come back from the db as undefs.
 # we have not put this in the main PGObject module because
@@ -50,7 +51,7 @@ around BUILDARGS => sub {
 };
 
 sub _get_dbh { LedgerSMB::App_State::DBH() }
-sub _get_schema { 'public' } # can be overridden
+sub _get_schema { return LedgerSMB::Sysconfig::db_namespace() }
 sub _get_prefix { '' } # can be overridden
 
 1;

--- a/lib/LedgerSMB/PGOld.pm
+++ b/lib/LedgerSMB/PGOld.pm
@@ -26,6 +26,7 @@ use warnings;
 
 use base 'PGObject::Simple';
 use LedgerSMB::App_State;
+use LedgerSMB::Sysconfig;
 
 =head1 METHODS
 
@@ -129,6 +130,19 @@ sub is_allowed_role {
     );
     return $access->{lsmb__is_allowed_role};
 }
+
+=item $self->funcschema()
+
+
+
+=cut
+
+sub funcschema {
+    my ($self) = @_;
+
+    return LedgerSMB::Sysconfig::db_namespace();
+}
+
 
 =back
 

--- a/sql/changes/1.5/open_forms_callers.sql
+++ b/sql/changes/1.5/open_forms_callers.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
-ALTER TABLE public.open_forms ALTER COLUMN id SET DEFAULT floor(random()*(1000000))+1;
-ALTER TABLE public.open_forms ADD COLUMN form_name character varying(100);
-ALTER TABLE public.open_forms ADD COLUMN last_used timestamp without time zone;
+ALTER TABLE open_forms ALTER COLUMN id SET DEFAULT floor(random()*(1000000))+1;
+ALTER TABLE open_forms ADD COLUMN form_name character varying(100);
+ALTER TABLE open_forms ADD COLUMN last_used timestamp without time zone;
 
 COMMIT;

--- a/sql/changes/1.5/open_forms_callers.sql@1
+++ b/sql/changes/1.5/open_forms_callers.sql@1
@@ -1,0 +1,7 @@
+BEGIN;
+
+ALTER TABLE public.open_forms ALTER COLUMN id SET DEFAULT floor(random()*(1000000))+1;
+ALTER TABLE public.open_forms ADD COLUMN form_name character varying(100);
+ALTER TABLE public.open_forms ADD COLUMN last_used timestamp without time zone;
+
+COMMIT;

--- a/sql/modules/Roles.sql
+++ b/sql/modules/Roles.sql
@@ -119,7 +119,9 @@ BEGIN
 END;
 $$;
 
-GRANT ALL ON SCHEMA public TO public;
+GRANT SELECT ON periods TO public; -- 'periods' is a view in Pg-database
+GRANT SELECT ON location_class_to_entity_class TO PUBLIC;
+
 
 \echo BASE ROLES
 SELECT lsmb__create_role('base_user');

--- a/xt/40-dbsetup.t
+++ b/xt/40-dbsetup.t
@@ -27,8 +27,8 @@ for my $evar (qw(LSMB_NEW_DB LSMB_TEST_DB)){
 }
 
 if ($run_tests){
-	plan tests => 12;
-	$ENV{PGDATABASE} = $ENV{LSMB_NEW_DB};
+        plan tests => 12;
+        $ENV{PGDATABASE} = $ENV{LSMB_NEW_DB};
 }
 
 my $db = LedgerSMB::Database->new({


### PR DESCRIPTION
Reported by Nicolas Couchoud on the users mailing list,
this use-case was broken when we moved from DBObject to
PGObject.

Note that this commit doesn't actually support *loading*
the schema into another schema than 'public'. When it's
stored there, this commit enables using it.
