### PR TITLE
Reduce number of screenshots generated by BDD tests

### DIFF
--- a/xt/66-cucumber/11-ar/invoice.feature
+++ b/xt/66-cucumber/11-ar/invoice.feature
@@ -7,7 +7,6 @@ Feature: AR transaction document handling
 
 Background:
    Given a standard test company
-     And a logged in admin
      And a customer "Customer 1"
      And a customer "Customer 2"
      And a part with these properties:
@@ -16,6 +15,7 @@ Background:
        | description | Part 1   |
        | sellprice   | 30       |
        | unit        | ea       |
+     And a logged in admin
 
 
 Scenario: Creation of a new sales invoice, no taxes

--- a/xt/66-cucumber/11-ar/transactions.feature
+++ b/xt/66-cucumber/11-ar/transactions.feature
@@ -7,8 +7,8 @@ Feature: AR transaction document handling
 
 Scenario: Creation of a new AR transaction
    Given a standard test company
-     And a logged in admin
      And a customer named "Customer 1"
+     And a logged in admin
     When I open the AR transaction entry screen
      And I select customer "Customer 1"
 

--- a/xt/66-cucumber/12-ap/invoice.feature
+++ b/xt/66-cucumber/12-ap/invoice.feature
@@ -7,7 +7,6 @@ Feature: AP transaction document handling
 
 Background:
    Given a standard test company
-     And a logged in admin
      And a vendor "Vendor 1"
      And a vendor "Vendor 2"
      And a part with these properties:
@@ -16,6 +15,7 @@ Background:
        | description | Part 1   |
        | sellprice   | 30       |
        | unit        | ea       |
+     And a logged in admin
 
 
 Scenario: Creation of a new sales invoice, no taxes

--- a/xt/66-cucumber/30-inventory/adjustments.feature
+++ b/xt/66-cucumber/30-inventory/adjustments.feature
@@ -10,7 +10,6 @@ Scenario: Adjusting recorded inventory down (to a lower count)
    Given a standard test company
 # Note: we need a way to list inventory; 'part_edit' isn't that role...
 #     And a logged in user with 'part_edit' rights
-     And a logged in admin
      And a vendor "v1"
      And a part with these properties:
        | name       | value          |
@@ -20,6 +19,7 @@ Scenario: Adjusting recorded inventory down (to a lower count)
      And inventory has been built up for 'P001' from these transactions:
        | type     |  amount  | price  | vendor | transdate  |
        | purchase |  10      | 20     | v1     | 2016-11-11 |
+     And a logged in admin
     When I search for part 'P001'
     Then I expect the 'On Hand' report column to contain '10' for Part Number 'P001'
     When I open the parts screen for 'P001'


### PR DESCRIPTION
By logging in as late as possible during the tests,
screenshots will be generated for fewer steps.