### PR TITLE
Independent scenarios

### DIFF
--- a/xt/66-cucumber/10-gl/account-add-delete.feature
+++ b/xt/66-cucumber/10-gl/account-add-delete.feature
@@ -18,8 +18,17 @@ Scenario: Add a new account
    And I enter "New Account" into "Description"
    And I press "Save"
   Then I should see the Account screen
+  When I navigate the menu and select the item at "General Journal > Chart of Accounts"
+  Then I should see the Chart of Accounts screen
+   And I expect the report to contain 79 rows
 
 Scenario: Delete the account from the chart of accounts
+ Given a gl account with these properties:
+    | Property       | Value                |
+    | Account Number | T0001                |
+    | Description    | New Account          |
+    | Category       | A                    |
+    | Heading        | 1000--CURRENT ASSETS |
   When I navigate the menu and select the item at "General Journal > Chart of Accounts"
   Then I should see the Chart of Accounts screen
    And I expect the report to contain 79 rows

--- a/xt/66-cucumber/10-gl/account-heading-add-delete.feature
+++ b/xt/66-cucumber/10-gl/account-heading-add-delete.feature
@@ -8,7 +8,7 @@ Background:
   Given a standard test company
     And a logged in admin user
 
-Scenario: Add a new account
+Scenario: Add a new account heading
   When I navigate the menu and select the item at "General Journal > Chart of Accounts"
   Then I should see the Chart of Accounts screen
    And I expect the report to contain 78 rows
@@ -19,7 +19,11 @@ Scenario: Add a new account
    And I press "Save"
   Then I should see the Account screen
 
-Scenario: Delete the account from the chart of accounts
+Scenario: Delete the account heading from the chart of accounts
+ Given a gl account heading with these properties:
+    | Property       | Value       |
+    | Account Number | H0001       |
+    | Description    | New Heading |
   When I navigate the menu and select the item at "General Journal > Chart of Accounts"
   Then I should see the Chart of Accounts screen
    And I expect the report to contain 79 rows

--- a/xt/66-cucumber/10-gl/chart-of-accounts.feature
+++ b/xt/66-cucumber/10-gl/chart-of-accounts.feature
@@ -97,7 +97,7 @@ Scenario: Create a new account based on an existing account
 Scenario: Create a new heading based on an existing heading
   When I navigate the menu and select the item at "General Journal > Chart of Accounts"
   Then I should see the Chart of Accounts screen
-   And I expect the report to contain 79 rows
+   And I expect the report to contain 78 rows
   When I click Account Number "1000"
   Then I should see the Account screen
   When I select the "Heading" tab
@@ -107,6 +107,6 @@ Scenario: Create a new heading based on an existing heading
   Then I should see the Account screen
   When I navigate the menu and select the item at "General Journal > Chart of Accounts"
   Then I should see the Chart of Accounts screen
-   And I expect the report to contain 80 rows
+   And I expect the report to contain 79 rows
    And I expect the 'Description' report column to contain 'New Heading' for Account Number 'TEST-2'
 

--- a/xt/66-cucumber/13-cash/reconciliation-search.feature
+++ b/xt/66-cucumber/13-cash/reconciliation-search.feature
@@ -6,14 +6,14 @@ Feature: Reconciliation Report Search
 Background:
   Given a standard test company named "standard-recon-test"
     And a logged in admin user
-
-Scenario: Default search with no filter
- Given reconciliation reports with these properties:
+    And reconciliation reports with these properties:
        | Account Number | Statement Date | Statement Balance | Approved | Submitted |
        | 1060           | 2018-01-01     | 1000.00           | no       | no        |
        | 1060           | 2018-02-01     | 1000.01           | no       | yes       |
        | 1060           | 2018-03-01     | 1000.02           | yes      | yes       |
        | 1065           | 2018-01-01     | 100.00            | no       | no        |
+
+Scenario: Default search with no filter
  When I navigate the menu and select the item at "Cash > Reports > Reconciliation"
   Then I should see the Search Reconciliation Reports screen
   When I press "Search"

--- a/xt/66-cucumber/13-cash/reconciliation.feature
+++ b/xt/66-cucumber/13-cash/reconciliation.feature
@@ -41,6 +41,9 @@ Scenario: Create new reconciliation report, update and save.
   Then I should see the Search Reconciliation Reports screen
 
 Scenario: Search for reconciliation report and delete it,
+ Given reconciliation reports with these properties:
+       | Account Number | Statement Date | Statement Balance | Approved | Submitted |
+       | 1060           | 2018-01-01     | 101.00            | no       | no        |
   When I navigate the menu and select the item at "Cash > Reports > Reconciliation"
   Then I should see the Search Reconciliation Reports screen
   When I press "Search"

--- a/xt/66-cucumber/13-cash/vouchers-payment.feature
+++ b/xt/66-cucumber/13-cash/vouchers-payment.feature
@@ -50,6 +50,11 @@ Scenario: Add payments to an existing batch
    And an unpaid AP transaction with these values:
        | Vendor   | Date       | Invoice Number | Amount |
        | Vendor B | 2017-01-02 | INV101         | 25.00  |
+   And a payment batch with these properties:
+       | Property     | Value      |
+       | Description  | Test Batch |
+       | Batch Date   | 2018-01-01 |
+       | Batch Number | B-1001     |
   When I navigate the menu and select the item at "Cash > Vouchers > Payments"
   Then I should see the Create New Batch screen
    And I should see a Batch with these values:
@@ -79,6 +84,11 @@ Scenario: Add partial payment to an existing batch
    And an unpaid AP transaction with these values:
        | Vendor   | Date       | Invoice Number | Amount |
        | Vendor C | 2017-03-01 | INV103         | 250.00 |
+   And a payment batch with these properties:
+       | Property     | Value      |
+       | Description  | Test Batch |
+       | Batch Date   | 2018-01-01 |
+       | Batch Number | B-1001     |
   When I navigate the menu and select the item at "Cash > Vouchers > Payments"
   Then I should see the Create New Batch screen
    And I should see a Batch with these values:
@@ -110,12 +120,16 @@ Scenario: Add partial payment to an existing batch
   When I press "Save Batch"
   Then I should see the Filtering Payments screen
 
-Scenario: Review the contents of an existing batch
-  When I navigate the menu and select the item at "Transaction Approval > Batches"
-  Then I should see the Search Batches screen
-  When I enter "Test Batch" into "Description"
-   And I press "Search"
-  Then I should see the Batch Search Report screen
-   And I expect the report to contain 1 row
-   And I expect the 'Payment Amount' report column to contain '126.00' for Batch Number 'B-1001'
+###TODO: This test was dependent on the previous one
+# Also, there's an important underlying question: should we test
+# transaction approval as part of the original functionality or is it
+# a separate functionality to be tested?
+# Scenario: Review the contents of an existing batch
+#   When I navigate the menu and select the item at "Transaction Approval > Batches"
+#   Then I should see the Search Batches screen
+#   When I enter "Test Batch" into "Description"
+#    And I press "Search"
+#   Then I should see the Batch Search Report screen
+#    And I expect the report to contain 1 row
+#    And I expect the 'Payment Amount' report column to contain '126.00' for Batch Number 'B-1001'
 

--- a/xt/66-cucumber/14-transaction_approval/search-batches.feature
+++ b/xt/66-cucumber/14-transaction_approval/search-batches.feature
@@ -6,15 +6,15 @@ Feature: Search Batches
 
 Background:
   Given a standard test company named "standard-batch-test"
-    And a logged in admin user
-
-Scenario: Search for all unapproved batches
- Given batches with these properties:
+    And batches with these properties:
        | Type    | Date       | Batch Number | Description | Approved |
        | ap      | 2018-01-01 | B-1001       | Batch-1     | no       |
        | ar      | 2018-02-01 | B-1002       | Batch-ABC-2 | no       |
        | payment | 2018-03-01 | B-1003       | Batch-3     | no       |
        | payment | 2018-04-01 | B-1004       | Batch-4     | yes      |
+    And a logged in admin user
+
+Scenario: Search for all unapproved batches
   When I navigate the menu and select the item at "Transaction Approval > Batches"
   Then I should see the Search Batches screen
   When I press "Search"

--- a/xt/66-cucumber/README.md
+++ b/xt/66-cucumber/README.md
@@ -66,6 +66,65 @@ The code consists of the following components:
    * self-registering Weasel::WidgetHandler-s and Weasel::FindExpander-s,
      keeping DOM-tree knowledge local to the PageObject
 
+## Structure of feature files
+
+The general structure of feature files is well documented elsewhere on
+the web ((See https://cucumber.io/docs/gherkin/reference/)[https://cucumber.io/docs/gherkin/reference/]).
+The general structure consists of N sections:
+
+ * Feature (only one section allowed)
+ * Background (optional; only a single background allowed)
+ * Scenario (at least one, but potentially many)
+
+The `Feature` section describes the feature being tested. There's no need
+to be terse: this is for documentation purposes and sets the boundaries
+of what will be tested in the scenarios.
+
+The `Background` section (when available) specifies steps to be prepended
+to every scenario in the feature file.
+
+The `Scenario` sections test the various behaviours of the feature. There
+are several best practices for writing scenarios:
+
+ * Each scenario tests one behaviour
+ * Each scenario is independent from others
+   which means that scenarios can be run without requiring
+   the others to run as well, in any specific sequence
+
+To achieve independence, each scenario runs in its own copy of the
+test database.
+
+### Tagging features and scenarios
+
+Tags can be used to classify scenarios. By tagging a feature, all
+scenarios within that feature will be applied the given tag. Tags
+are at-sign prefixed words on the line before the `Feature:` or
+`Scenario:` keyword. E.g.:
+
+```plain
+@weasel
+Feature: Bulk payments
+
+@wip
+Scenario: Add payments to a new batch
+```
+
+The following tags are available:
+
+ * `@weasel`  
+   This tag signals to the Weasel plugin to expect browser-based
+   tests (and thus to initialize the browser environment)
+ * `@wip`  
+   This tag signals to the test framework that the test isn't done
+   and should be skipped during Continuous Integration test runs
+ * `@one-db`  
+   This tag signals to the LedgerSMB plugin that all the scenarios
+   in this feature should run against the same database. This is a
+   performance optimization which should *only* be applied when the
+   tests don't modify the database they're running againsts. That way
+   independence of scenarios within the feature is maintained.
+
+
 # DOM tree mapping
 
 The DOM tree's root element (`html`), maps to PageObject::Root, by

--- a/xt/lib/Pherkin/Extension/LedgerSMB.pm
+++ b/xt/lib/Pherkin/Extension/LedgerSMB.pm
@@ -236,8 +236,8 @@ sub create_from_template {
 sub ensure_nonexisting_company {
     my ($self, $company) = @_;
 
-    $self->super_dbh->do(qq(DROP DATABASE IF EXISTS "$company"));
     $self->_clear_admin_dbh;
+    $self->super_dbh->do(qq(DROP DATABASE IF EXISTS "$company"));
 }
 
 sub ensure_nonexisting_user {

--- a/xt/lib/Pherkin/Extension/LedgerSMB.pm
+++ b/xt/lib/Pherkin/Extension/LedgerSMB.pm
@@ -19,6 +19,7 @@ use LedgerSMB::PGDate;
 use LedgerSMB::Entity::Person::Employee;
 use LedgerSMB::Entity::User;
 use Test::BDD::Cucumber::Extension;
+use List::Util qw(any);
 
 use Moose;
 use namespace::autoclean;
@@ -105,8 +106,11 @@ sub pre_scenario {
     $stash->{ext_lsmb} = $self;
     $stash->{"the admin"} = $self->admin_user_name;
     $stash->{"the admin password"} = $self->admin_user_password;
-    $stash->{"the company"} = $self->last_feature_stash->{"the company"}
-        if $self->last_feature_stash->{"the company"};
+
+    if ($self->last_feature_stash->{"the company"}
+        && any { $_ eq 'one-db' } @{$scenario->tags}) {
+        $stash->{"the company"} = $self->last_feature_stash->{"the company"};
+    }
 }
 
 

--- a/xt/lib/Pherkin/Extension/ledgersmb_steps/common_steps.pl
+++ b/xt/lib/Pherkin/Extension/ledgersmb_steps/common_steps.pl
@@ -596,5 +596,57 @@ INSERT INTO parts (partnumber, description, unit, listprice, sellprice,
     $sth->execute($part, $part);
 };
 
+Given qr/a gl account with these properties:$/, sub {
+    my %map = (
+        'Account Number' => 'accno',
+        'Description' => 'description',
+        'Category' => 'category',
+        'Heading' => 'heading',
+        );
+
+    my $dbh = S->{ext_lsmb}->admin_dbh;
+    for my $row (@{C->data}) {
+        if ($row->{Property} eq 'Heading') {
+            my ($headno) = split(/--/, $row->{Value});
+            my ($heading) = $dbh->selectall_array(
+                q{select id from account_heading where accno = ?},
+                { Slice => {} }, $headno);
+            $row->{Value} = $heading->{id};
+        }
+    }
+
+    my $placeholders = join(', ', map { '?' } @{C->data});
+    my $fieldnames = join(', ', map { $map{$_->{Property}} } @{C->data});
+    $dbh->do(qq{insert into account ($fieldnames) values ($placeholders)},
+             undef, map { $_->{Value} } @{C->data})
+        or die $dbh->errstr;
+};
+
+
+Given qr/a gl account heading with these properties:$/, sub {
+    my %map = (
+        'Account Number' => 'accno',
+        'Description' => 'description',
+        'Heading' => 'heading',
+        );
+
+    my $dbh = S->{ext_lsmb}->admin_dbh;
+    for my $row (@{C->data}) {
+        if ($row->{Property} eq 'Heading') {
+            my ($headno) = split(/--/, $row->{Value});
+            my ($heading) = $dbh->selectall_array(
+                q{select id from account_heading where accno = ?},
+                { Slice => {} }, $headno);
+            $row->{Value} = $heading->{id};
+        }
+    }
+
+    my $placeholders = join(', ', map { '?' } @{C->data});
+    my $fieldnames = join(', ', map { $map{$_->{Property}} } @{C->data});
+    $dbh->do(qq{insert into account_heading ($fieldnames) values ($placeholders)},
+             undef, map { $_->{Value} } @{C->data})
+        or die $dbh->errstr;
+};
+
 
 1;

--- a/xt/lib/Pherkin/Extension/ledgersmb_steps/common_steps.pl
+++ b/xt/lib/Pherkin/Extension/ledgersmb_steps/common_steps.pl
@@ -192,6 +192,25 @@ Given qr/a (vendor|customer) "(.*)"$/, sub {
         )->save;
 };
 
+
+Given qr/a (\w+) batch with these properties:$/, sub {
+    my $batch_class = $1;
+    my %map = (
+        'Batch Date' => 'batch_date',
+        'Batch Number' => 'batch_number',
+        'Description' => 'description',
+        );
+
+    my $batch_data = {
+        dbh => S->{ext_lsmb}->admin_dbh,
+        batch_class => $batch_class,
+        map { $map{$_->{Property}} => $_->{Value} } @{C->data},
+    };
+    my $batch = LedgerSMB::Batch->new({base => $batch_data});
+    $batch->create;
+};
+
+
 Given qr/an unpaid AP transaction with these values:$/, sub {
     # Expects data in the following form:
     # | Vendor   | Date       | Invoice Number | Amount |


### PR DESCRIPTION
Have all scenarios run against separate databases, unless explicitly instructed so.

As it turns out, this change shows that scenarios haven't been coded to be independent of each other. Add that best practice/requirement to the README in the cucumber tests. Also adjust tests to comply with this best practice.