### PR TITLE
Allow running LedgerSMB in another schema than 'public'

### DIFF
--- a/lib/LedgerSMB/PGObject.pm
+++ b/lib/LedgerSMB/PGObject.pm
@@ -29,6 +29,7 @@ use namespace::autoclean;
 with 'PGObject::Simple::Role' => { -excludes => [qw(_get_dbh _get_schema _get_prefix)], };
 
 use LedgerSMB::App_State;
+use LedgerSMB::Sysconfig;
 
 # nulls come back from the db as undefs.
 # we have not put this in the main PGObject module because
@@ -49,7 +50,7 @@ around BUILDARGS => sub {
 };
 
 sub _get_dbh { return LedgerSMB::App_State::DBH() }
-sub _get_schema { return 'public' } # can be overridden
+sub _get_schema { return LedgerSMB::Sysconfig::db_namespace() }
 sub _get_prefix { return '' } # can be overridden
 
 

--- a/old/lib/LedgerSMB/PGOld.pm
+++ b/old/lib/LedgerSMB/PGOld.pm
@@ -22,6 +22,7 @@ use warnings;
 
 use base 'PGObject::Simple';
 use LedgerSMB::App_State;
+use LedgerSMB::Sysconfig;
 
 =head1 METHODS
 
@@ -85,6 +86,19 @@ sub is_allowed_role {
     );
     return $access->{lsmb__is_allowed_role};
 }
+
+=item $self->funcschema()
+
+
+
+=cut
+
+sub funcschema {
+    my ($self) = @_;
+
+    return LedgerSMB::Sysconfig::db_namespace();
+}
+
 
 =back
 

--- a/sql/changes/1.5/abstract_tables.sql
+++ b/sql/changes/1.5/abstract_tables.sql
@@ -1,10 +1,10 @@
 
 
-ALTER TABLE IF EXISTS ONLY public.note
+ALTER TABLE IF EXISTS ONLY note
     ADD CHECK (false) NO INHERIT;
 
-ALTER TABLE IF EXISTS ONLY public.file_base
+ALTER TABLE IF EXISTS ONLY file_base
     ADD CHECK (false) NO INHERIT;
 
-ALTER TABLE IF EXISTS ONLY public.file_secondary_attachment
+ALTER TABLE IF EXISTS ONLY file_secondary_attachment
     ADD CHECK (false) NO INHERIT;

--- a/sql/changes/1.5/abstract_tables.sql@1
+++ b/sql/changes/1.5/abstract_tables.sql@1
@@ -1,0 +1,10 @@
+
+
+ALTER TABLE IF EXISTS ONLY public.note
+    ADD CHECK (false) NO INHERIT;
+
+ALTER TABLE IF EXISTS ONLY public.file_base
+    ADD CHECK (false) NO INHERIT;
+
+ALTER TABLE IF EXISTS ONLY public.file_secondary_attachment
+    ADD CHECK (false) NO INHERIT;

--- a/sql/changes/1.5/open_forms_callers.sql
+++ b/sql/changes/1.5/open_forms_callers.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
-ALTER TABLE public.open_forms ALTER COLUMN id SET DEFAULT floor(random()*(1000000))+1;
-ALTER TABLE public.open_forms ADD COLUMN form_name character varying(100);
-ALTER TABLE public.open_forms ADD COLUMN last_used timestamp without time zone;
+ALTER TABLE open_forms ALTER COLUMN id SET DEFAULT floor(random()*(1000000))+1;
+ALTER TABLE open_forms ADD COLUMN form_name character varying(100);
+ALTER TABLE open_forms ADD COLUMN last_used timestamp without time zone;
 
 COMMIT;

--- a/sql/changes/1.5/open_forms_callers.sql@1
+++ b/sql/changes/1.5/open_forms_callers.sql@1
@@ -1,0 +1,7 @@
+BEGIN;
+
+ALTER TABLE public.open_forms ALTER COLUMN id SET DEFAULT floor(random()*(1000000))+1;
+ALTER TABLE public.open_forms ADD COLUMN form_name character varying(100);
+ALTER TABLE public.open_forms ADD COLUMN last_used timestamp without time zone;
+
+COMMIT;

--- a/sql/modules/Roles.sql
+++ b/sql/modules/Roles.sql
@@ -119,8 +119,6 @@ BEGIN
 END;
 $$;
 
-GRANT ALL ON SCHEMA public TO public;
-
 GRANT SELECT ON periods TO public; -- 'periods' is a view in Pg-database
 GRANT SELECT ON location_class_to_entity_class TO PUBLIC;
 

--- a/utils/devel/sql-change-sha
+++ b/utils/devel/sql-change-sha
@@ -1,0 +1,27 @@
+#!/usr/bin/perl
+
+use strict;
+use warnings;
+
+use lib 'lib';
+use LedgerSMB::Database::Change;
+
+=head1 SYNOPSIS
+
+   utils/devel/sql-change-sha sql/changes/1.5/open_forms_callers.sql
+   # prints:
+   #   sql/changes/1.5/open_forms_callers.sql -> ke63Vj9L87jBNBhn3SgzIAtT2WQ3GBjowM24pRtt4H1a13PmUd3hW9T+VQCsPUF2UDXWs9pMIPbOEE/l7kNROA
+
+=head1 DESCRIPTION
+
+This is a utility to print (from the command-line) the SHA that will be
+generated for a schema change file; the value returned is the same as
+what would have been stored in the 'sha' column of the 'db_patches' table.
+
+=cut
+
+for my $path (@ARGV) {
+    my $change = LedgerSMB::Database::Change->new($path);
+
+    print $path . ' -> ' . $change->sha . "\n";
+}

--- a/xt/40-dbsetup.t
+++ b/xt/40-dbsetup.t
@@ -23,6 +23,7 @@ my $temp = $ENV{TEMP} || '/tmp/';
 
 plan tests => 22;
 $ENV{PGDATABASE} = $ENV{LSMB_NEW_DB};
+$LedgerSMB::Sysconfig::db_namespace = 'altschema';
 
 my $db = LedgerSMB::Database->new({
          dbname       => $ENV{LSMB_NEW_DB},


### PR DESCRIPTION
Reported by Nicolas Couchoud on the users mailing list,
this use-case was broken when we moved from DBObject to
PGObject.