### PR TITLE
Fix 'pricelist' link on contacts screen

### DIFF
--- a/UI/Contact/pricelist.html
+++ b/UI/Contact/pricelist.html
@@ -125,6 +125,8 @@ IF FORMATS.grep('ODS').size()
      ?>">[<?lsmb text('CSV') ?>]</a>
 <?lsmb IF pricematrix_pricegroup;
      PROCESS dynatable
+       attributes = { id = 'pricematrixgroup'
+                      input_prefix = 'grp_' }
          tbody = { rows = pricematrix_pricegroup };
        END ?>
 </form>

--- a/UI/lib/dynatable.html
+++ b/UI/lib/dynatable.html
@@ -108,7 +108,7 @@ END; ?>
           <?lsmb- IF TYPE == 'input_text' -?>
           <?lsmb
                  PROCESS input element_data = {
-                                          id=COL.col_id _ '-' _ ROWCOUNT
+                                          id=PFX _ COL.col_id _ '-' _ ROWCOUNT
                                           type="text"
                                           "data-dojo-type" = COL.data_dojo_type
                                           class=COL.class
@@ -116,7 +116,7 @@ END; ?>
                                           value=ROW.${COL.col_id} } ?>
          <?lsmb- ELSIF TYPE == 'password';
                  PROCESS input element_data = {
-                                          id=COL.col_id _ '-' _ ROWCOUNT
+                                          id=PFX _ COL.col_id _ '-' _ ROWCOUNT
                                           type="password"
                                           "data-dojo-type" = COL.data_dojo_type
                                           class=COL.class
@@ -130,7 +130,7 @@ END; ?>
                    END;
                    ?>
          <?lsmb PROCESS input element_data = {
-                          id=COL.col_id _ '-' _ ROWCOUNT
+                          id=PFX _ COL.col_id _ '-' _ ROWCOUNT
                           type="checkbox"
                           name=PFX _ COL.col_id _ '_' _ ROWCOUNT
                           class=COL.class
@@ -144,7 +144,7 @@ END; ?>
 
                ELSIF TYPE == 'radio' ?>
          <?lsmb PROCESS input element_data = {
-                                         id=COL.col_id _ '-' _ ROWCOUNT
+                                         id=PFX _ COL.col_id _ '-' _ ROWCOUNT
                                          type="radio"
                                          name=PFX _ COL.col_id
                                          class=COL.class
@@ -161,7 +161,7 @@ END; ?>
                 PROCESS select element_data = {
                 text_attr='text'
                 value_attr='value'
-                id=COL.col_id _ '-' _ ROWCOUNT
+                id=PFX _ COL.col_id _ '-' _ ROWCOUNT
                 name=PFX _ COL.col_id _ '_' _ ROW.row_id
                 class=COL.class
                 options=OPTION_LIST
@@ -225,7 +225,7 @@ END; ?>
        <?lsmb
           IF TYPE == 'input_text' -?>
        <?lsmb PROCESS input element_data = {
-                                  id=COL.col_id _ '-' _ ROWCOUNT
+                                  id=PFX _ COL.col_id _ '-' _ ROWCOUNT
                                   type="text"
                                   class=COL.class
                                   "data-dojo-type"=DOJO
@@ -240,7 +240,7 @@ END; ?>
                    END;
                    ?>
           <?lsmb PROCESS input element_data = {
-                                          id=COL.col_id _ '-' _ ROWCOUNT
+                                          id=PFX _ COL.col_id _ '-' _ ROWCOUNT
                                           type="checkbox"
                                           name=PFX _ COL.col_id _ '_' _ ROWCOUNT
                                           class=COL.class
@@ -248,7 +248,7 @@ END; ?>
                                           checked=CHECKED } ?>
          <?lsmb- ELSIF TYPE == 'radio' ?>
          <?lsmb PROCESS input element_data = {
-                                         id=COL.col_id _ '-' _ ROWCOUNT
+                                         id=PFX _ COL.col_id _ '-' _ ROWCOUNT
                                          type="radio"
                                          name=PFX _ COL.col_id
                                          class=COL.class

--- a/t/16-schema-upgrade-html.t
+++ b/t/16-schema-upgrade-html.t
@@ -579,7 +579,7 @@ is join("\n", @$out), q{<!DOCTYPE html>
    </th>   </tr>
 </thead><tbody>   <tr class=" 0">
       <input id="grid-row-1" type="hidden" name="grid_row_1" value="0" />
-      <input id="grid---pk-0" type="hidden" name="grid_--pk_0" value="Y29sMQ== Y29sMg==" />      <td class="a  text">            col1      </td>      <td class="b  text">            col2      </td>      <td class="c  input_text">          <input id="c-1" type="text" name="grid_c_0" size="60" value="col3" data-dojo-type="dijit/form/ValidationTextBox" maxlength="255" />      </td>   </tr>
+      <input id="grid---pk-0" type="hidden" name="grid_--pk_0" value="Y29sMQ== Y29sMg==" />      <td class="a  text">            col1      </td>      <td class="b  text">            col2      </td>      <td class="c  input_text">          <input id="grid_c-1" type="text" name="grid_c_0" size="60" value="col3" data-dojo-type="dijit/form/ValidationTextBox" maxlength="255" />      </td>   </tr>
 </tbody><input id="rowcount-grid" type="hidden" name="rowcount_grid" value="1" />
 </table>
 </form>


### PR DESCRIPTION
When clicking the link, the server response is said to be faulty,
which is caused by the fact that the HTML being returned includes
2 'dynatable' results, both of which contain a price matrix; one for
the customer and one for the price group the customer is part of.

Unfortunately, the 2 dynatables use the same 'id' attribute values.
This changes adds the prefix to be used for the 'name' attribute
to the 'id' attribute values as well.
