### PR TITLE
Improve waiting for new page content

### DIFF
--- a/xt/lib/PageObject.pm
+++ b/xt/lib/PageObject.pm
@@ -35,7 +35,7 @@ sub self_register {
 sub open {
     my ($class, $session) = @_;
 
-    my $body = shift @{$session->page->find_all('body')};
+    my $body = shift @{$session->page->find_all('//body')};
     $session->get($class->url);
 
     $session->page->wait_for_body(replaces => $body);


### PR DESCRIPTION
The XPath used to find an existing BODY tag - which is then used
to wait for that tag to go out of scope - was incorrect, so that
no tag was ever found.