### PR TITLE
Make use new option to keep Weasel sessions between scenarios

### DIFF
--- a/xt/66-cucumber/01-basic/menu.feature
+++ b/xt/66-cucumber/01-basic/menu.feature
@@ -1,4 +1,4 @@
-@one-db @weasel
+@one-db @weasel @weasel-one-session
 Feature: correct operation of the menu and immediate linked pages
   As an end-user, I want to be able to navigate the menu and open
   the screens from the available links. If my authorizations


### PR DESCRIPTION
Using the Pherkin::Extension::Weasel version which was released today, the tag 'weasel-one-session' has received extra meaning: it signals that the Weasel session should not be reinitialized but instead should be reused.