### PR TITLE
Use Starlet in order to allow faster responses from the application server

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,7 @@ commands:
               --with-feature=xls \
               --with-feature=edi \
               --installdeps .
+            cpanm --notest Starlet
             if [ "x$COVERAGE" == "x1" ]
             then
               cpanm --quiet --notest \
@@ -105,7 +106,7 @@ commands:
             echo $PERL5OPT
             echo $PERL5LIB
             plackup -I$HOME/project/lib -I$HOME/project/old/lib \
-                    --port 5001 \
+                    -s Starlet --max-workers 2 --port 5001 \
                     $HOME/project/bin/ledgersmb-server.psgi
             echo "Plackup done!"
             touch plackup-done


### PR DESCRIPTION
Using Starlet, we have 2 workers, which means that the http server hosting
the application will be more responsive to requests being issued in quick
succession.
This both speeds up testing as well as reduces the chances of requests being
sent, but not timely handled because they get stuck in limbo (or in the
socket queue).

Thank you for working on the LedgerSMB code base and wanting to create
a pull request.

For the easiest processing and the best maintenance of the series of
commits ('line of history'), we ask you to take a few things into
consideration.