### PR TITLE
Simplify waiter pattern

### DIFF
--- a/xt/lib/PageObject.pm
+++ b/xt/lib/PageObject.pm
@@ -54,13 +54,11 @@ sub wait_for_page {
         sub {
 
             if ($ref) {
-                local $@;
-                # if there's a reference element,
-                # wait for it to go stale (raise an exception)
-                eval {
+                # In case of an exception, eval returns 'undef'
+                $ref = eval {
                     $ref->tag_name;
+                    $ref;
                 };
-                $ref = undef if !defined $@;
                 return 0;
             }
             else {

--- a/xt/lib/PageObject/App/Main.pm
+++ b/xt/lib/PageObject/App/Main.pm
@@ -84,15 +84,13 @@ sub wait_for_content {
     $self->session->wait_for(
         # removed content
         sub {
-            my $gone = 1;
-            try {
-                my $tagname = $old_content->tag_name;
-                # When successfully accessing the tag
-                #  it's not out of scope yet...
-                $gone = 0 if defined $tagname;
+            # In case of an exception, eval returns 'undef'
+            $old_content = eval {
+                $old_content->tag_name;
+                $old_content;
             };
 
-            return $gone;
+            return not defined $old_content;
         });
     $self->_wait_for_valid_content;
 


### PR DESCRIPTION
The old pattern(s) were both inconsistent and hard to reason
about, as demonstrated by the fact that 'wait_for_page'
checked the wrong condition to clear the reference.