### PR TITLE
Manage custom ci images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,13 +141,16 @@ executors:
       coverage:
         type: integer
         default: 1
+      CIRCLE_PROJECT_USERNAME:
+        type: string
+        default: ${CIRCLE_PROJECT_USERNAME:-ledgersmb}
     docker:
-      - image: ledgersmb/ledgersmb_circleci-perl:<< parameters.perl >>
-      - image: ledgersmb/ledgersmb_circleci-postgres:<< parameters.postgres >>
-      - image: ledgersmb/ledgersmb_circleci-<< parameters.browser >>
+      - image: << parameters.CIRCLE_PROJECT_USERNAME >>/ledgersmb_circleci-perl:<< parameters.perl >>
+      - image: << parameters.CIRCLE_PROJECT_USERNAME >>/ledgersmb_circleci-postgres:<< parameters.postgres >>
+      - image: << parameters.CIRCLE_PROJECT_USERNAME >>/ledgersmb_circleci-<< parameters.browser >>
     environment:
       COVERAGE: << parameters.coverage >>
-#      DEVEL_COVER_OPTIONS: 
+#      DEVEL_COVER_OPTIONS:
       RELEASE_TESTING: 1
       PGHOST: localhost
       PGUSER: postgres
@@ -160,6 +163,25 @@ executors:
 
 # Define jobs
 jobs:
+  ci_images:
+    <<: *defaults
+    docker:
+      - image: circleci/node:6.17.1-stretch
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Log into Docker Hub
+          command: |
+            echo "$DOCKER_HUB_PWD" | docker login -u "$DOCKER_HUB_USER_ID" --password-stdin;
+      - run:
+          name: Freshen up circleci custom images if the PR altered them
+          command: |
+            for image in $( git log --name-only --oneline -1 | grep -e '^\.circleci\/images' | cut -d "/" -f3 | sort -u ); do
+              pushd .circleci/images/$image;
+              ./build.sh;
+              popd;
+            done
   test_nodojo:
     <<: *defaults
     executor:
@@ -178,4 +200,8 @@ jobs:
 workflows:
   workflow:
     jobs:
-      - test_nodojo
+      - ci_images
+
+      - test_nodojo:
+          requires:
+            - ci_images

--- a/.circleci/images/chrome/build.sh
+++ b/.circleci/images/chrome/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -x
+
+REPO=${CIRCLE_PROJECT_USERNAME:-$USER}
+
+docker build -t $REPO/ledgersmb_circleci-chrome .
+docker push $REPO/ledgersmb_circleci-chrome

--- a/.circleci/images/firefox/build.sh
+++ b/.circleci/images/firefox/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -x
+
+REPO=${CIRCLE_PROJECT_USERNAME:-$USER}
+
+docker build -t $REPO/ledgersmb_circleci-firefox .
+docker push $REPO/ledgersmb_circleci-firefox

--- a/.circleci/images/perl/Dockerfile
+++ b/.circleci/images/perl/Dockerfile
@@ -3,13 +3,14 @@ MAINTAINER  ylavoie@yveslavoie.com
 
 # Perl version
 ARG perl=5.28.0
+ARG SHA=LATEST
 
 ENV HOME /home/circleci
 SHELL ["/bin/bash", "-c"]
 
 USER root
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
-    DEBIAN_FRONTEND=noninteractive apt-get -qyy install perlbrew && \
+    apt-get -qyy install perlbrew jq && \
     apt-get -qqy autoremove && \
     apt-get -qqy autoclean && \
     rm -rf /var/lib/apt/lists/*
@@ -17,22 +18,21 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
 USER circleci
 WORKDIR $HOME
 
-# Build time variables
-ENV NODE_PATH /usr/lib/node_modules
-
-# Install LedgerSMB
-RUN cd && \
-  git clone -b master https://github.com/ledgersmb/LedgerSMB.git project
-
 # install the standalone perlbrew
-RUN perlbrew init --shell=/bin/bash && \
+RUN cd && \
+    perlbrew init --shell=/bin/bash && \
     source ~/perl5/perlbrew/etc/bashrc && \
     perlbrew install-patchperl && \
-    perlbrew install --notest -j 4 $perl && \
+    perlbrew install --notest --noman -j 4 $perl && \
     perlbrew use perl-$perl && \
     perlbrew install-cpanm && \
     echo "source ~/perl5/perlbrew/etc/bashrc" >> ~/.profile && \
     cpanm inc::Module::Install Starman
+
+# Install LedgerSMB
+RUN cd && \
+    SHA=${SHA} \
+    git clone -b master https://github.com/ledgersmb/LedgerSMB.git project
 
 RUN cd ~/project && \
   source ~/perl5/perlbrew/etc/bashrc && \
@@ -50,26 +50,30 @@ RUN cd ~/project && \
 RUN cd ~/project && \
   source ~/perl5/perlbrew/etc/bashrc && \
   perlbrew use perl-$perl && \
-  cpanm --quiet --notest Dancer2 Dancer2::Session::Cookie Dancer2::Plugin::Auth::Extensible \
-                         URL::Encode URL::Encode::XS \
-                         Pod::ProjectDocs \
-                         Devel::Cover Devel::Cover::Report::Coveralls \
-                         Dist::Zilla \
-                         Locale::Country
+  cpanm --quiet --notest \
+        Dancer2 Dancer2::Session::Cookie Dancer2::Plugin::Auth::Extensible \
+        URL::Encode URL::Encode::XS \
+        Pod::ProjectDocs \
+        Devel::Cover Devel::Cover::Report::Coveralls \
+        Dist::Zilla \
+        Locale::Country
 
-RUN   eval $(perl -I ~/perl5/lib/perl5/ -Mlocal::lib) && \
-  source ~/perl5/perlbrew/etc/bashrc && \
+RUN source ~/perl5/perlbrew/etc/bashrc && \
   perlbrew use perl-$perl && \
-  cd /tmp && git clone git://github.com/pjlsergeant/test-bdd-cucumber-perl.git -b match-mode && \
+  cd /tmp && git clone git://github.com/pherkin/test-bdd-cucumber-perl.git && \
   cd test-bdd-cucumber-perl && ( dzil authordeps --missing | cpanm --notest ) && ( dzil listdeps --missing --author | cpanm --notest ) && \
   dzil install && rm -rf ~/.cpanm && \
   cd ~/ && rm -rf /tmp/test-bdd-cucumber-perl && rm -rf project && mkdir project
+
+RUN source ~/perl5/perlbrew/etc/bashrc && \
+  perlbrew use perl-$perl && \
+  cpanm --quiet --notest Imager
 
 USER root
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
   (wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -) && \
   DEBIAN_FRONTEND=noninteractive apt-get -y update && \
-  DEBIAN_FRONTEND=noninteractive apt-get -y install postgresql-client && \
+  apt-get -y install postgresql-client && \
   apt-get -qqy autoremove && \
   apt-get -qqy autoclean && \
   rm -rf /var/lib/apt/lists/*

--- a/.circleci/images/perl/Dockerfile
+++ b/.circleci/images/perl/Dockerfile
@@ -1,4 +1,5 @@
-FROM        ylavoie/ledgersmb_circleci-primary
+ARG         REPOSITORY=ledgersmb
+FROM        $REPOSITORY/ledgersmb_circleci-primary
 MAINTAINER  ylavoie@yveslavoie.com
 
 # Perl version

--- a/.circleci/images/perl/Dockerfile
+++ b/.circleci/images/perl/Dockerfile
@@ -10,8 +10,8 @@ ENV HOME /home/circleci
 SHELL ["/bin/bash", "-c"]
 
 USER root
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
-    apt-get -qyy install perlbrew jq && \
+RUN apt-get -y update && \
+    DEBIAN_FRONTEND=noninteractive apt-get -qyy install perlbrew jq && \
     apt-get -qqy autoremove && \
     apt-get -qqy autoclean && \
     rm -rf /var/lib/apt/lists/*
@@ -73,8 +73,8 @@ RUN source ~/perl5/perlbrew/etc/bashrc && \
 USER root
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
   (wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -) && \
-  DEBIAN_FRONTEND=noninteractive apt-get -y update && \
-  apt-get -y install postgresql-client && \
+  apt-get -y update && \
+  DEBIAN_FRONTEND=noninteractive apt-get -y install postgresql-client && \
   apt-get -qqy autoremove && \
   apt-get -qqy autoclean && \
   rm -rf /var/lib/apt/lists/*
@@ -110,9 +110,8 @@ RUN mkdir -p /tmp && \
 # Install proxies. They should be in their own image but CircleCI doesn't
 # support bind mounts and proxies need access to UI
 
-RUN DEBIAN_FRONTEND=noninteractive \
-    apt-get update && \
-    apt-get --no-install-recommends --yes install nginx lighttpd && \
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends --yes install nginx lighttpd && \
     apt-get -qqy autoremove && \
     apt-get -qqy autoclean && \
     rm -rf /var/lib/apt/lists/*

--- a/.circleci/images/perl/build.sh
+++ b/.circleci/images/perl/build.sh
@@ -1,8 +1,11 @@
 #!/bin/bash -x
 
+REPO=${CIRCLE_PROJECT_USERNAME:-$USER}
+
 for v in 5.30 5.28 5.26 5.24 5.22 ; do
-  docker build -t ylavoie/ledgersmb_circleci-perl:$v \
+  docker build -t $REPO/ledgersmb_circleci-perl:$v \
     --build-arg perl=$v.0 \
+    --build-arg REPOSITORY=$REPO \
     --build-arg SHA=$(curl -s 'https://api.github.com/repos/ledgersmb/LedgerSMB/branches/master' | jq -r '.commit.sha') .
-  docker push ylavoie/ledgersmb_circleci-perl:$v
+  docker push $REPO/ledgersmb_circleci-perl:$v
 done

--- a/.circleci/images/perl/build.sh
+++ b/.circleci/images/perl/build.sh
@@ -1,6 +1,8 @@
 #!/bin/bash -x
 
-for v in 5.28 5.26 5.24 5.22 5.20 5.18 ; do
-  docker build -t ylavoie/ledgersmb_circleci-perl:$v --build-arg perl=$v.0 .
+for v in 5.30 5.28 5.26 5.24 5.22 ; do
+  docker build -t ylavoie/ledgersmb_circleci-perl:$v \
+    --build-arg perl=$v.0 \
+    --build-arg SHA=$(curl -s 'https://api.github.com/repos/ledgersmb/LedgerSMB/branches/master' | jq -r '.commit.sha') .
   docker push ylavoie/ledgersmb_circleci-perl:$v
 done

--- a/.circleci/images/perl/nginx.conf
+++ b/.circleci/images/perl/nginx.conf
@@ -36,24 +36,17 @@ http {
 
       root /home/circleci/project/UI;
 
-      location @reverseproxy {
-         proxy_pass http://localhost:5762;
-      }
 
       location /css/ {
-         try_files $uri $uri/ =404;
+         try_files $uri =404;
       }
 
       location /images/ {
-         try_files $uri $uri/ =404;
+         try_files $uri =404;
       }
 
-      location /js/(.*) {
-         try_files /js/$1 /js/$1/ /js-src/$1 /js-src/$1/ =404;
-      }
-
-      location /setup {
-         proxy_pass http://localhost:5762;
+      location ~ /js/(.*) {
+         try_files /js/$1 /js-src/$1 =404;
       }
 
       location ~ \.pl$ {
@@ -61,7 +54,7 @@ http {
       }
 
       location / {
-         try_files $uri $uri/ @reverseproxy;
+         try_files $uri $uri/ =404;
       }
    }
 }

--- a/.circleci/images/phantomjs/Dockerfile
+++ b/.circleci/images/phantomjs/Dockerfile
@@ -1,4 +1,5 @@
-FROM ylavoie/ledgersmb_circleci-primary
+ARG REPOSITORY=ledgersmb
+FROM $REPOSITORY/ledgersmb_circleci-primary
 
 ## install phantomjs
 #

--- a/.circleci/images/phantomjs/build.sh
+++ b/.circleci/images/phantomjs/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash -x
+
+REPO=${CIRCLE_PROJECT_USERNAME:-$USER}
+
+docker build -t $REPO/ledgersmb_circleci-phantomjs .
+docker push $REPO/ledgersmb_circleci-phantomjs

--- a/.circleci/images/postgres/build.sh
+++ b/.circleci/images/postgres/build.sh
@@ -1,6 +1,8 @@
-#!/bin/bash
+#!/bin/bash -x
+
+REPO=${CIRCLE_PROJECT_USERNAME:-$USER}
 
 for v in 9.5 9.6 10 11 ; do
-  docker build -t ylavoie/ledgersmb_circleci-postgres:$v --build-arg version=$v .
-  docker push ylavoie/ledgersmb_circleci-postgres:$v
+  docker build -t $REPO/ledgersmb_circleci-postgres:$v --build-arg version=$v .
+  docker push $REPO/ledgersmb_circleci-postgres:$v
 done

--- a/.circleci/images/primary/build.sh
+++ b/.circleci/images/primary/build.sh
@@ -1,4 +1,6 @@
 #!/bin/bash -x
 
-docker build -t ylavoie/ledgersmb_circleci-primary .
-docker push ylavoie/ledgersmb_circleci-primary
+REPO=${CIRCLE_PROJECT_USERNAME:-$USER}
+
+docker build -t $REPO/ledgersmb_circleci-primary .
+docker push $REPO/ledgersmb_circleci-primary


### PR DESCRIPTION
CircleCI advocates having the custom docker images under .circleci/images
Any changes in this subtree has to be checked first to rebuild the involved images before we use them in the regular tests.
This PR also allows the developer to have custom versions without affecting the main repository.