### PR TITLE
Add back checkmarks to mark account AR/AP 'tax applicable'

### DIFF
--- a/UI/accounts/edit.html
+++ b/UI/accounts/edit.html
@@ -333,6 +333,16 @@
      } ?>
    </div>
    <div class="inputgroup">
+      <?lsmb IF form.AR_tax; AR_tax = 'CHECKED'; END;
+          INCLUDE input element_data={
+              name = 'AR_tax',
+              type = 'checkbox',
+             label = text('Tax'),
+           checked = AR_tax,
+             value = 'AR_tax'
+     } ?>
+   </div>
+   <div class="inputgroup">
       <?lsmb IF form.AR_overpayment; AR_overpayment = 'CHECKED'; END;
          INCLUDE input element_data={
               name = 'AR_overpayment',
@@ -374,6 +384,16 @@
              value = 'AP_paid'} ?>
    </div>
    <div class="inputgroup">
+      <?lsmb IF form.AP_tax; AP_tax = 'CHECKED'; END;
+          INCLUDE input element_data={
+              name = 'AP_tax',
+              type = 'checkbox',
+             label = text('Tax'),
+           checked = AP_tax,
+             value = 'AP_tax'
+     } ?>
+   </div>
+   <div class="inputgroup">
       <?lsmb IF form.AP_overpayment; AP_overpayment= 'CHECKED'; END;
          INCLUDE input element_data={
               name = 'AP_overpayment',
@@ -413,15 +433,6 @@
              value = 'IC_cogs'} ?>
    </div>
    <div class="inputgroup">
-      <?lsmb IF form.IC_returns;IC_returns= 'CHECKED'; END;
-         INCLUDE input element_data={
-              name = 'IC_returns',
-              type = 'checkbox',
-             label = text('Returns'),
-           checked = IC_returns,
-             value = 'IC_returns'} ?>
-   </div>
-   <div class="inputgroup">
       <?lsmb IF form.IC_taxpart; IC_taxpart= 'CHECKED'; END;
          INCLUDE input element_data={
               name = 'IC_taxpart',
@@ -429,6 +440,15 @@
              label = text('Tax'),
            checked = IC_taxpart,
              value = 'IC_taxpart'} ?>
+   </div>
+   <div class="inputgroup">
+      <?lsmb IF form.IC_returns;IC_returns= 'CHECKED'; END;
+         INCLUDE input element_data={
+              name = 'IC_returns',
+              type = 'checkbox',
+             label = text('Returns'),
+           checked = IC_returns,
+             value = 'IC_returns'} ?>
    </div>
 </div>
 <div class="inputline" id="services-line">

--- a/xt/66-cucumber/10-gl/chart-of-accounts.feature
+++ b/xt/66-cucumber/10-gl/chart-of-accounts.feature
@@ -46,7 +46,7 @@ Scenario: View the chart of accounts and change every property of an account
    And I expect "Equity" to be selected for "Account Type"
    And I expect to see 3 selected checkboxes in "Options"
    And I expect to see 2 selected checkboxes in "Custom Flags"
-   And I expect to see 20 selected checkboxes in "Include in drop-down menus"
+   And I expect to see 22 selected checkboxes in "Include in drop-down menus"
   When I select "Custom Summary" from the drop down "Summary account for"
    And I deselect every checkbox in "Custom Flags"
    And I deselect every checkbox in "Include in drop-down menus"


### PR DESCRIPTION
These checkmarks were lost on the 1.2->1.3 rewrite with the effect
that accounts without this checkmark will show on the AR/AP
screen, but associated amounts will not show up when viewing
(=loading from the database) a posted transaction.

Also sort the 'Tax' checkmark for each of the checkmark rows into
the same column.