### PR TITLE
Add back checkmarks to mark account AR/AP 'tax applicable'

### DIFF
--- a/UI/accounts/edit.html
+++ b/UI/accounts/edit.html
@@ -281,6 +281,16 @@
      } ?>
    </div>
    <div class="inputgroup">
+      <?lsmb IF form.AR_tax; AR_tax = 'CHECKED'; END;
+          INCLUDE input element_data={
+              name = 'AR_tax',
+              type = 'checkbox',
+             label = text('Tax'),
+           checked = AR_tax,
+             value = 'AR_tax'
+     } ?>
+   </div>
+   <div class="inputgroup">
       <?lsmb IF form.AR_overpayment; AR_overpayment = 'CHECKED'; END;
          INCLUDE input element_data={
               name = 'AR_overpayment',
@@ -322,6 +332,16 @@
              value = 'AP_paid'} ?>
    </div>
    <div class="inputgroup">
+      <?lsmb IF form.AP_tax; AP_tax = 'CHECKED'; END;
+          INCLUDE input element_data={
+              name = 'AP_tax',
+              type = 'checkbox',
+             label = text('Tax'),
+           checked = AP_tax,
+             value = 'AP_tax'
+     } ?>
+   </div>
+   <div class="inputgroup">
       <?lsmb IF form.AP_overpayment; AP_overpayment= 'CHECKED'; END;
          INCLUDE input element_data={
               name = 'AP_overpayment',
@@ -361,15 +381,6 @@
              value = 'IC_cogs'} ?>
    </div>
    <div class="inputgroup">
-      <?lsmb IF form.IC_returns;IC_returns= 'CHECKED'; END;
-         INCLUDE input element_data={
-              name = 'IC_returns',
-              type = 'checkbox',
-             label = text('Returns'),
-           checked = IC_returns,
-             value = 'IC_returns'} ?>
-   </div>
-   <div class="inputgroup">
       <?lsmb IF form.IC_taxpart; IC_taxpart= 'CHECKED'; END;
          INCLUDE input element_data={
               name = 'IC_taxpart',
@@ -377,6 +388,15 @@
              label = text('Tax'),
            checked = IC_taxpart,
              value = 'IC_taxpart'} ?>
+   </div>
+   <div class="inputgroup">
+      <?lsmb IF form.IC_returns;IC_returns= 'CHECKED'; END;
+         INCLUDE input element_data={
+              name = 'IC_returns',
+              type = 'checkbox',
+             label = text('Returns'),
+           checked = IC_returns,
+             value = 'IC_returns'} ?>
    </div>
 </div>
 <div class="inputline" id="services-line">


### PR DESCRIPTION
These checkmarks were lost on the 1.2->1.3 rewrite with the effect
that accounts without this checkmark will show on the AR/AP
screen, but associated amounts will not show up when viewing
(=loading from the database) a posted transaction.

Also sort the 'Tax' checkmark for each of the checkmark rows into
the same column.
