### PR TITLE
* Fix errors when restoring backups

### DIFF
--- a/sql/modules/BLACKLIST
+++ b/sql/modules/BLACKLIST
@@ -140,7 +140,6 @@ file_links_vrebuild
 form_check
 form_close
 form_open
-full_ilike_match
 get_default_lang
 get_link_descriptions
 gifi__list

--- a/sql/modules/Employee.sql
+++ b/sql/modules/Employee.sql
@@ -225,8 +225,8 @@ $$
                                 coalesce(in_enddateto, 'infinity'::timestamp)
                         AND coalesce(enddate, 'infinity'::timestamp) >=
                                 coalesce(in_enddatefrom, '-infinity'::timestamp)
-                        AND (name ~*~ in_name
-                            OR note ~*~ in_notes)
+                        AND (name ilike '%' || in_name || '%'
+                            OR note ilike '%' || in_notes || '%')
                         AND (sales = 't' OR coalesce(in_sales, 'f') = 'f')
 $$ language sql;
 

--- a/sql/modules/Util.sql
+++ b/sql/modules/Util.sql
@@ -124,32 +124,7 @@ AS $$
    SELECT $2[array_upper($2,1)]=$1;
 $$ IMMUTABLE;
 
-CREATE OR REPLACE FUNCTION full_ilike_match(seek text, source text)
-   RETURNS BOOL
-   LANGUAGE SQL
-AS $$
-select seek ilike '%' || source || '%';
-$$;
-
-DO $$
-
-BEGIN
-
-PERFORM * FROM pg_operator where oprname = '~*~';
-
-IF NOT FOUND THEN
-
-CREATE OPERATOR ~*~ (
-    procedure = full_ilike_match,
-    leftarg = 'text',
-    rightarg = 'text'
-);
-
-END IF;
-
-END;
-
-$$ LANGUAGE PLPGSQL;
+DROP OPERATOR IF EXISTS ~*~ (text, text);
 
 CREATE OR REPLACE FUNCTION lsmb__min_date() RETURNS date
 LANGUAGE SQL AS

--- a/xt/42-util.pg
+++ b/xt/42-util.pg
@@ -4,7 +4,7 @@ BEGIN;
 
     -- Plan the tests.
 
-    SELECT plan(13);
+    SELECT plan(12);
 
     -- Add data
 
@@ -19,7 +19,6 @@ BEGIN;
     SELECT has_function('array_endswith',ARRAY['anyelement','anyarray']);
     SELECT has_function('array_splice_from',ARRAY['anyelement','anyarray']);
     SELECT has_function('array_splice_to',ARRAY['anyelement','anyarray']);
-    SELECT has_function('full_ilike_match',ARRAY['text','text']);
     SELECT has_function('get_default_lang','{}'::text[]);
     SELECT has_function('in_tree',ARRAY['integer','tree_record[]']);
     SELECT has_function('in_tree',ARRAY['integer[]','tree_record[]']);


### PR DESCRIPTION
pg_dump includes the ~*~ custom operator later in the dump stream
than its use in the employee_search function. This throws an ERROR
and fails to create the function.

Because the operator is used only in 1 function, lets not make things
complicated and simply remove it in favor of expanding the wrapper
it really is.