### PR TITLE
.Keep the accounts properties on GIFI in Balance Sheet and Income Statement

### DIFF
--- a/lib/LedgerSMB/Report/Balance_Sheet.pm
+++ b/lib/LedgerSMB/Report/Balance_Sheet.pm
@@ -140,9 +140,9 @@ sub run_report {
         };
     my $row_props = ($self->gifi) ?
         sub { my ($line) = @_;
-              return { account_number => $line->{gifi_accno},
-                       account_desc => $line->{gifi_description},
-              };
+              $line->{account_number} = $line->{gifi_accno};
+              $line->{account_desc} = $line->{gifi_description};
+              return $line;
         } : ($self->legacy_hierarchy) ?
         sub { my ($line) = @_;
               if ($line->{account_type} eq 'A'

--- a/lib/LedgerSMB/Report/PNL.pm
+++ b/lib/LedgerSMB/Report/PNL.pm
@@ -142,9 +142,9 @@ sub run_report {
         };
     my $row_props = ($self->gifi) ?
         sub { my ($line) = @_;
-              return { account_number => $line->{gifi},
-                       account_description => $line->{gifi_description},
-              };
+              $line->{account_number} = $line->{gifi};
+              $line->{account_description} = $line->{gifi_description};
+              return $line;
        } :
        sub { my ($line) = @_; return $line; };
 


### PR DESCRIPTION
GIFI only change the account number and description, in order to standardize reporting to governments. All other account properties have to be preserved when producing Balance Sheet or Income Statement reports