### PR TITLE
Fix tax checkmarks sometimes being automatically selected

### DIFF
--- a/UI/Contact/divs/credit.html
+++ b/UI/Contact/divs/credit.html
@@ -288,7 +288,7 @@ PROCESS dynatable
         <div class="inputrow" id="taxrow-<?lsmb tx.chart_id ?>">
         
             <?lsmb checked = "";  
-                   IF credit_act.tax_ids.grep("^${tx.id}$").size == 1;
+                   IF credit_act.tax_ids.grep("^${tx.id}\$").size == 1;
                        checked = "CHECKED";
                    END;
                    INCLUDE input label_pos=1 


### PR DESCRIPTION
Due to an error in the regex (the $-sign is expanded to an empty
string), only prefix matching happened before this change. In a
specific database, one tax account was numbered 21 while another
was numbered 215. Checking the account with id 21 resulted in both
the 21 and 215 account being checked in the UI.