### PR TITLE
Print checks in numbered order

### DIFF
--- a/lib/LedgerSMB/Scripts/payment.pm
+++ b/lib/LedgerSMB/Scripts/payment.pm
@@ -407,7 +407,8 @@ sub print {
 
         # consider only contacts which have been explicitly selected
         # for inclusion in the bulk payment ($contact->{id} == true-ish)
-        for my $contact (grep { $_->{id} } @{$data->{contacts}}){
+        for my $contact (sort { $a->{source} <=> $b->{source}  }
+                         grep { $_->{id} } @{$data->{contacts}}){
             my ($check) = $payment->call_procedure(
                 funcname => 'company_get_billing_info',
                 args => [ $contact->{id} ]


### PR DESCRIPTION
This is a regression in 1.7 due to the 'parameter parsing' step
introduced after 1.6 which maps the 'flat' argument hash into a
hierarchical structure which processes more easily.

Due to hash randomization the order of the payments (and thus
their source numbering) is non-deterministic. Sort the source
numbers (=check numbers) to make sure they are processed in
source number order.
