### PR TITLE
Correct reported version name to 1.8.0-dev

### DIFF
--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -156,7 +156,7 @@ use LedgerSMB::Company_Config;
 use LedgerSMB::Setting;
 use LedgerSMB::Template;
 
-our $VERSION = '1.8.0';
+our $VERSION = '1.8.0-dev';
 
 my $logger = Log::Log4perl->get_logger('LedgerSMB');
 my $json = JSON::MaybeXS->new( pretty => 1,

--- a/locale/LedgerSMB.pot
+++ b/locale/LedgerSMB.pot
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Project-Id-Version: LedgerSMB 1.8.0\n"
+"Project-Id-Version: LedgerSMB 1.8.0-dev\n"
 "Report-Msgid-Bugs-To: devel@lists.ledgersmb.org\n"
 "POT-Creation-Date: 2019-07-01 10:14+0000\n"
 "MIME-Version: 1.0\n"

--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -180,8 +180,8 @@ sub new {
             split(/:/, $self->{cookie});
     }
 
-    $self->{version}   = "1.8.0";
-    $self->{dbversion} = "1.8.0";
+    $self->{version}   = "1.8.0-dev";
+    $self->{dbversion} = "1.8.0-dev";
 
     bless $self, $type;
 

--- a/sql/Pg-database.sql
+++ b/sql/Pg-database.sql
@@ -1358,7 +1358,7 @@ sinumber|1
 sonumber|1
 yearend|1
 businessnumber|1
-version|1.8.0
+version|1.8.0-dev
 closedto|\N
 revtrans|1
 ponumber|1

--- a/t/data/Is_LSMB_running.html
+++ b/t/data/Is_LSMB_running.html
@@ -53,7 +53,7 @@
                         alt="LedgerSMB Logo" />
                 </a>
                 <h2 align="center" style="margin-top: 0">
-                    LedgerSMB 1.8.0
+                    LedgerSMB 1.8.0-dev
                 </h2>
                 <div class="listtop">
                     Database administrator credentials


### PR DESCRIPTION
Note that we currently report 1.8.0, which implies GA. We're definitely
nowhere near GA yet. Indicate correctly our dev status.
