### PR TITLE
Fix invoice screens crashing on manual taxes with 0%-tax rate

### DIFF
--- a/old/bin/ir.pl
+++ b/old/bin/ir.pl
@@ -677,7 +677,7 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id=intnotes name=intnotes rows
                    !defined $form->{"mt_amount_$item"}){
                    $form->{"mt_amount_$item"} =
                            $form->{"mt_rate_$item"}
-                           * $form->{"mt_basis_$item"};
+                           * ($form->{"mt_basis_$item"} // 0);
                }
                else
                {

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -780,7 +780,7 @@ qq|<textarea data-dojo-type="dijit/form/Textarea" id="intnotes" name="intnotes" 
                    !defined $form->{"mt_amount_$item"}){
                    $form->{"mt_amount_$item"} =
                            $form->{"mt_rate_$item"}
-                           * $form->{"mt_basis_$item"};
+                           * ($form->{"mt_basis_$item"} // 0);
                }
                $form->{invtotal} += $form->round_amount(
                                          $form->parse_amount( \%myconfig,  $form->{"mt_amount_$item"}), 2);


### PR DESCRIPTION
When a tax rate is set to 0% (which happens with exports, or
tax exempt companies) and the tax is set to "manual", the invoice
screen rendering crashes with a Perl error (undefined value).
