### PR TITLE
Fix manual tax lines being posted on 'today' instead of transdate

### DIFF
--- a/old/lib/LedgerSMB/IR.pm
+++ b/old/lib/LedgerSMB/IR.pm
@@ -549,9 +549,10 @@ sub post_invoice {
     }
     if ($form->{manual_tax}){
         my $ac_sth = $dbh->prepare(
-              "INSERT INTO acc_trans (chart_id, trans_id, amount, source, memo)
+              "INSERT INTO acc_trans
+                    (chart_id, trans_id, transdate, amount, source, memo)
                     VALUES ((select id from account where accno = ?),
-                            ?, ?, ?, ?)"
+                            ?, ?, ?, ?, ?)"
         );
         my $tax_sth = $dbh->prepare(
               "INSERT INTO tax_extended (entry_id, tax_basis, rate)
@@ -571,7 +572,8 @@ sub post_invoice {
             my $fx_taxbasis = $taxbasis * $fx;
             $form->{payables} += $fx_taxamount;
             $invamount += $fx_taxamount;
-            $ac_sth->execute($taccno, $form->{id}, $fx_taxamount * -1,
+            $ac_sth->execute($taccno, $form->{id}, $form->{transdate},
+                             $fx_taxamount * -1,
                              $form->{"mt_ref_$taccno"},
                              $form->{"mt_desc_$taccno"});
             $tax_sth->execute($fx_taxbasis * -1, $taxrate);

--- a/old/lib/LedgerSMB/IS.pm
+++ b/old/lib/LedgerSMB/IS.pm
@@ -1151,7 +1151,8 @@ sub post_invoice {
 
     if ($form->{manual_tax}){
         my $ac_sth = $dbh->prepare(
-              "INSERT INTO acc_trans (chart_id, trans_id, amount, source, memo)
+              "INSERT INTO acc_trans (chart_id, trans_id, transdate,
+                                      amount, source, memo)
                     VALUES ((select id from account where accno = ?),
                             ?, ?, ?, ?)"
         );
@@ -1174,7 +1175,8 @@ sub post_invoice {
             my $fx_taxbasis = $taxbasis * $fx;
             $form->{receivables} -= $fx_taxamount;
             $invamount += $fx_taxamount;
-            $ac_sth->execute($taccno, $form->{id}, $fx_taxamount,
+            $ac_sth->execute($taccno, $form->{id}, $form->{transdate},
+                             $fx_taxamount,
                              $form->{"mt_ref_$taccno"},
                              $form->{"mt_desc_$taccno"})
                 || $form->dberror();


### PR DESCRIPTION
Note this is a very old bug: I've traced it back to 1.3 (I've stopped
there).

Manual backport (instead of cherry-pick) of d74854a3e due to IIAA having been
factored out in 1.7(/MC) for the first time.
