### PR TITLE
Fix invoice failing to save due to missing exchange rate on payments

### DIFF
--- a/old/bin/ir.pl
+++ b/old/bin/ir.pl
@@ -859,7 +859,7 @@ s/option value="\Q$form->{"AP_paid_$i"}\E"/option value="$form->{"AP_paid_$i"}" 
         $form->{"paidfx_$i"} =
             $form->format_amount(
                 \%myconfig,
-                $form->{"paid_$i"} * $form->{"exchangerate_$i"}, 2 );
+                $form->{"paid_$i"} * ($form->{"exchangerate_$i"} // 1), 2 );
         $form->{"paid_$i"} =
           $form->format_amount( \%myconfig, $form->{"paid_$i"}, 2 );
         $form->{"exchangerate_$i"} =

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -969,7 +969,7 @@ s/option value="\Q$form->{"AR_paid_$i"}\E"/option value="$form->{"AR_paid_$i"}" 
         $form->{"paidfx_$i"} =
             $form->format_amount(
                 \%myconfig,
-                $form->{"paid_$i"} * $form->{"exchangerate_$i"}, 2 );
+                $form->{"paid_$i"} * ($form->{"exchangerate_$i"} // 1), 2 );
         $form->{"paid_$i"} =
           $form->format_amount( \%myconfig, $form->{"paid_$i"}, 2 );
         $form->{"exchangerate_$i"} =


### PR DESCRIPTION

In some circumstances, when an invoice is entered using the default currency, the
exchange rate is missing. The posting procedure trips over this condition. Instead
of crashing, use the standard rate for the default currency: 1.
