### PR TITLE
Skip COGS calculation when posting a service

### DIFF
--- a/sql/modules/COGS.sql
+++ b/sql/modules/COGS.sql
@@ -362,6 +362,15 @@ IF t_inv.qty + t_inv.allocated = 0 THEN
    return 0;
 END IF;
 
+PERFORM 1 FROM parts
+         WHERE t_inv.parts_id = parts.id
+               AND parts.inventory_accno_id IS NOT NULL;
+
+IF NOT FOUND THEN
+   -- the part doesn't have an associated inventory account: it's a service.
+   return 0;
+END IF;
+
 SELECT * INTO t_ap FROM ap WHERE id = t_inv.trans_id;
 
 IF t_inv.qty < 0 THEN -- normal COGS


### PR DESCRIPTION
Before this change, on reversal (negative quantity), code gets executed
which assumes an inventory account to be available. Obviously, a service
isn't kept in inventory, meaning that there's no inventory account and
the code fails hard.

Exiting early when there's no inventory account prevents this scenario
(and all the others which require an inventory account).
