### PR TITLE
Fix error claiming incorrect currency setup upon 'Update' in part screen

### DIFF
--- a/old/bin/ic.pl
+++ b/old/bin/ic.pl
@@ -1444,6 +1444,7 @@ qq|$form->{script}?action=edit&id=$form->{"id_$i"}&login=$form->{login}&sessioni
 }
 
 sub update {
+    &link_part;
     if ( $form->{item} eq "assembly" ) {
 
         $i = $form->{assembly_rows};


### PR DESCRIPTION
Make sure the correct data is loaded from the database, including
the currency information which silences this warning.
