### PR TITLE
Fix failure to post invoice with COGS error

### DIFF
--- a/sql/modules/COGS.sql
+++ b/sql/modules/COGS.sql
@@ -111,7 +111,7 @@ LOOP
        RAISE EXCEPTION 'TOO MANY ALLOCATED';
    ELSIF t_alloc = in_qty THEN
        return ARRAY[t_alloc, t_cogs];
-   ELSIF (in_qty + t_alloc) <= t_avail THEN
+   ELSIF (in_qty - t_alloc) <= t_avail THEN
        UPDATE invoice SET allocated = allocated + (in_qty - t_alloc)
         WHERE id = t_inv.id;
        t_cogs := t_cogs + (in_qty - t_alloc) * t_inv.sellprice;


### PR DESCRIPTION
In some cases, the COGS calculation (on posting an AR invoice)
triggers a database constraint, failing to post the invoice.

The cause of the failure is the fact that the 'available amount'
on each given AP invoice is checked, but with an incorrect
'amount remaining to be allocated'.
