### PR TITLE
Fix first reconciliation failing to be displayed

### DIFF
--- a/lib/LedgerSMB/Scripts/recon.pm
+++ b/lib/LedgerSMB/Scripts/recon.pm
@@ -282,7 +282,7 @@ sub _display_report {
                                     ($recon->{their_total}
                                     + $recon->{outstanding_total}
                                     + $recon->{mismatch_our_total});
-    $recon->{out_of_balance} = $recon->{their_total} - $recon->{our_total};
+    $recon->{out_of_balance} = ($recon->{their_total} // 0) - ($recon->{our_total} // 0);
     $recon->{out_of_balance}->bfround(
         LedgerSMB::Setting->get('decimal_places') * -1
     );


### PR DESCRIPTION
Under some circumstances, the first reconciliation for an account fails
to be correctly displayed with an error from the BigFloat module saying
that 'is_zero' can't be called on an undefined value.

The cause seems to be that the first reconciliation on an account
doesn't have a defined 'our_total' -- as there's no prior recon.

When there's no defined value, default to zero (0).
