### PR TITLE
Fix 1.7 regression, reports missing report download links

### DIFF
--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -520,6 +520,7 @@ sub _render {
     my $unescape = $format->can('unescape');
     my $cleanvars = {
         ( %{preprocess($vars, $escape)},
+          LIST_FORMATS => sub { return available_formats(); },
           UNESCAPE => ($unescape ? sub { return $unescape->(@_); }
                        : sub { return @_; }),
           escape => sub { return $escape->(@_); },


### PR DESCRIPTION
As found by @freelock, the reports in 1.7 are missing their
download links. This turns out to be an unintended side effect
from the achitectural improvement to separate the concerns of
being a report and being a UI element. Meaning that reports
should really not be used as part of the UI, instead being
stand alone documents.

The stand alone document generator isn't supposed to know
which *other* output formats are available in the server (as
they wouldn't be stand alone documents if they did).

For now, let the generator know about other formats until
we complete the separation of concerns.