### PR TITLE
Remove test noise

### DIFF
--- a/sql/modules/COGS.sql
+++ b/sql/modules/COGS.sql
@@ -162,12 +162,12 @@ LOOP
    ELSIF t_alloc = in_qty THEN
        return ARRAY[t_alloc, t_cogs];
    ELSIF (in_qty - t_alloc) <= -1 * (t_inv.qty + t_inv.allocated) THEN
-       raise notice 'partial reversal';
+       -- 'partial reversal';
        UPDATE invoice SET allocated = allocated + (in_qty - t_alloc)
         WHERE id = t_inv.id;
        return ARRAY[in_qty * -1, t_cogs + (in_qty - t_alloc) * t_inv.sellprice];
    ELSE
-       raise notice 'total reversal';
+       -- 'total reversal';
        UPDATE invoice SET allocated = qty * -1
         WHERE id = t_inv.id;
        t_alloc := t_alloc - (t_inv.qty + t_inv.allocated);
@@ -426,7 +426,6 @@ ELSE -- reversal
      FROM parts p
     WHERE id = t_inv.parts_id;
    retval := r_cogs[1];
-   raise notice 'cogs reversal returned %', r_cogs;
 
 END IF;
 

--- a/xt/42-account.pg
+++ b/xt/42-account.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
     SELECT plan(58);

--- a/xt/42-admin.pg
+++ b/xt/42-admin.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-app-module.pg
+++ b/xt/42-app-module.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-arap.pg
+++ b/xt/42-arap.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-assets.pg
+++ b/xt/42-assets.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-backup.pg
+++ b/xt/42-backup.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-budget.pg
+++ b/xt/42-budget.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-business-dates.pg
+++ b/xt/42-business-dates.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-business-type.pg
+++ b/xt/42-business-type.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-business-unit.pg
+++ b/xt/42-business-unit.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-cogs-fifo.pg
+++ b/xt/42-cogs-fifo.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-company.pg
+++ b/xt/42-company.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-customer.pg
+++ b/xt/42-customer.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-date.pg
+++ b/xt/42-date.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-draft.pg
+++ b/xt/42-draft.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-employee.pg
+++ b/xt/42-employee.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-endofyear.pg
+++ b/xt/42-endofyear.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-entity.pg
+++ b/xt/42-entity.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-files.pg
+++ b/xt/42-files.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-goods.pg
+++ b/xt/42-goods.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-inventory.pg
+++ b/xt/42-inventory.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-invoice.pg
+++ b/xt/42-invoice.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-journal.pg
+++ b/xt/42-journal.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-location.pg
+++ b/xt/42-location.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-menu.pg
+++ b/xt/42-menu.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-orderentry.pg
+++ b/xt/42-orderentry.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-parts.pg
+++ b/xt/42-parts.pg
@@ -2,6 +2,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 
@@ -68,4 +69,3 @@ BEGIN;
     SELECT * FROM finish();
 
 ROLLBACK;
-

--- a/xt/42-payment-fx.pg
+++ b/xt/42-payment-fx.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-payment.pg
+++ b/xt/42-payment.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-payroll.pg
+++ b/xt/42-payroll.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-person.pg
+++ b/xt/42-person.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-pnl.pg
+++ b/xt/42-pnl.pg
@@ -5,6 +5,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-pricematrix.pg
+++ b/xt/42-pricematrix.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-reconciliation.pg
+++ b/xt/42-reconciliation.pg
@@ -2,6 +2,7 @@ BEGIN;
 
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-report.pg
+++ b/xt/42-report.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-robot.pg
+++ b/xt/42-robot.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-roles.pg
+++ b/xt/42-roles.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-session.pg
+++ b/xt/42-session.pg
@@ -2,6 +2,7 @@ BEGIN;
 
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-system.pg
+++ b/xt/42-system.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-taxform.pg
+++ b/xt/42-taxform.pg
@@ -37,6 +37,7 @@ $500 currnet year, $500 in future year
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-templates.pg
+++ b/xt/42-templates.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-timecards.pg
+++ b/xt/42-timecards.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-transaction_templates.pg
+++ b/xt/42-transaction_templates.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-trial_balance.pg
+++ b/xt/42-trial_balance.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-util.pg
+++ b/xt/42-util.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 

--- a/xt/42-voucher.pg
+++ b/xt/42-voucher.pg
@@ -1,6 +1,7 @@
 BEGIN;
     -- Load the TAP functions.
     CREATE EXTENSION pgtap;
+    SET client_min_messages TO warning;
 
     -- Plan the tests.
 


### PR DESCRIPTION
1- Remove notices in COGS to remove test noise.
2- Set PostgreSQL minimum messages in pgTAG test files to prevent notices coming from PostgreSQL code about text-search queries which don't contain lexemes searched.