### PR TITLE
Fix failure to post AR reversal with COGS

### DIFF
--- a/sql/modules/COGS.sql
+++ b/sql/modules/COGS.sql
@@ -41,7 +41,7 @@ FOR t_inv IN
      WHERE allocated + qty > 0 and a.approved and parts_id = in_parts_id
    ORDER BY a.transdate ASC, a.id ASC, i.id ASC
 LOOP
-   t_reallocated := greatest(in_qty - t_alloc, t_inv.qty + t_inv.allocated);
+   t_reallocated := least(t_alloc - in_qty, t_inv.qty + t_inv.allocated);
    UPDATE invoice
       SET allocated = allocated - t_reallocated
     WHERE id = t_inv.id;


### PR DESCRIPTION
In some cases the number of items to be reversed is calculated
incorrectly, leading to an error to be throw when the draft document
is posted (ERROR TOO MANY ALLOCATED).

This commit fixes the calculation of the number of items to be
allocated, removing the error.
