### PR TITLE
Fix bug preventing first transaction on account appearing in recon report

### DIFF
--- a/sql/modules/Reconciliation.sql
+++ b/sql/modules/Reconciliation.sql
@@ -494,8 +494,6 @@ $$
                 AND ac.approved IS TRUE
                 AND ac.chart_id = t_chart_id
                 AND ac.transdate <= t_end_date
-                AND (ac.entry_id > (select min(entry_id) from acc_trans
-                                     where acc_trans.chart_id = r.chart_id))
         GROUP BY gl.ref, ac.source, ac.transdate,
                 ac.memo, ac.voucher_id, gl.table
         HAVING count(rl.id) = 0;


### PR DESCRIPTION
The `reconciliation__pending_transactions` function tries to be smart
and efficient by excluding all transaction preceeding the first one
which was posted on the account to be reconciled. However, in the
process, it also excluded the first transaction itself.  
Moreover, the exclusion of the preceeding transactions is largely
irrelevant, because over the lifespan of the database, the number of
*succeeding* transactions will be an order of magnitude bigger than
the excluded ones. Yet the succeeding transactions will mostly have
been reconciled, so be considered spurriously too.
