### PR TITLE
Include line total in tax base amount, even on 0% tax rates

### DIFF
--- a/old/bin/io.pl
+++ b/old/bin/io.pl
@@ -127,9 +127,7 @@ sub _calc_taxes {
             $form->{tax_obj}{$_->account} = $_;
             $form->{taxes}{$_->account} = 0 if ! $form->{taxes}{$_->account};
             $form->{taxes}{$_->account} += $_->value;
-            if ($_->value){
-               $form->{taxbasis}{$_->account} += $linetotal;
-            }
+            $form->{taxbasis}{$_->account} += $linetotal;
         }
     }
 }


### PR DESCRIPTION
A 0% rate is a valid rate. And there are valid use-cases to
want to record the taxable amount (base amount), such as
import/export reporting.