### PR TITLE
Reduce use of deprecated LedgerSMB::App_State::Locale

### DIFF
--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -396,8 +396,7 @@ sub error {
 sub dberror{
    my $self = shift @_;
    my $state_error = {};
-   my $locale = $LedgerSMB::App_State::Locale;
-   if(! $locale){$locale=$self->{_locale};}#tshvr4
+   my $locale = $self->{_locale};
    my $dbh = $LedgerSMB::App_State::DBH;
    $state_error = {
             '42883' => $locale->text('Internal Database Error'),

--- a/lib/LedgerSMB/Scripts/budgets.pm
+++ b/lib/LedgerSMB/Scripts/budgets.pm
@@ -136,6 +136,7 @@ sub _render_screen {
            rowcount => $budget->{rowcount},
                  id => $budget->{id},
     };
+    $budget->{_locale} = $locale;
     my $template = LedgerSMB::Template::UI->new_UI;
     return $template->render($budget, 'budgetting/budget_entry', $budget);
 }

--- a/lib/LedgerSMB/Template/UI.pm
+++ b/lib/LedgerSMB/Template/UI.pm
@@ -88,16 +88,6 @@ sub new_UI {
                 dojo_theme =>
                     ($LedgerSMB::App_State::Company_Config->{dojo_theme}
                      || LedgerSMB::Sysconfig::dojo_theme()),
-                PRINTERS => [
-                    ( map { { text => $_, value => $_ } }
-                      keys %LedgerSMB::Sysconfig::printers,
-                      {
-                          text => ($LedgerSMB::App_State::Locale ?
-                                   $LedgerSMB::App_State::Locale->text('Screen')
-                                   : 'Screen' ),
-                          value => 'screen'
-                      } )
-                    ],
                 LIST_FORMATS => sub {
                     return LedgerSMB::Template::available_formats();
                 },
@@ -139,6 +129,14 @@ sub render_string {
                 $vars,
                 \&LedgerSMB::Template::HTML::escape)},
           %{$self->{standard_vars}},
+          PRINTERS => [
+              ( map { { text => $_, value => $_ } }
+                keys %LedgerSMB::Sysconfig::printers,
+                {
+                    text  => $request->{_locale}->text('Screen'),
+                    value => 'screen'
+                } )
+          ],
           text => sub {
               if ($vars->{locale}) {
                   return LedgerSMB::Locale->get_handle($vars->{locale})


### PR DESCRIPTION
In case of LedgerSMB.pm, the required value is already available in
$self->{_locale}. In the case of the templates, translation depends on
the session and therefor can't be part of the singleton which is cached
between sessions.