### PR TITLE
Restrict migration selects

### DIFF
--- a/lib/LedgerSMB/Upgrade_Tests.pm
+++ b/lib/LedgerSMB/Upgrade_Tests.pm
@@ -1064,15 +1064,15 @@ push @tests, __PACKAGE__->new(
 
 
 push @tests, __PACKAGE__->new(
-    test_query => 'select parts_id, credit_id, pricegroup_id
+    test_query => 'select parts_id, customer_id, pricegroup_id
                      from partscustomer
                     where not exists (select 1
                                         from pricegroup
                                        where id = pricegroup_id)
-                                        and pricegroup_id <> 0',
+                      and pricegroup_id <> 0',
     display_name => marktext('Non-existing customer pricegroups in partscustomer'),
     name => 'partscustomer_pricegroups_exist',
-    display_cols => ['parts_id', 'credit_id', 'pricegroup_id'],
+    display_cols => ['parts_id', 'customer_id', 'pricegroup_id'],
  instructions => marktext(
                    'Please fix the pricegroup data in your partscustomer table (no UI available)'),
     table => 'partscustomer',
@@ -1243,7 +1243,7 @@ Void the clearing date in the dialog shown or go back to SQL-Ledger if you feel 
 
 ### On the vendor side, SL doesn't use pricegroups
 # push @tests, __PACKAGE__->new(
-#     test_query => "select parts_id, credit_id, pricegroup_id
+#     test_query => "select *
 #                      from partsvendor
 #                     where not exists (select 1
 #                                         from pricegroup

--- a/lib/LedgerSMB/Upgrade_Tests.pm
+++ b/lib/LedgerSMB/Upgrade_Tests.pm
@@ -344,7 +344,7 @@ push @tests, __PACKAGE__->new(
 );
 
 push @tests, __PACKAGE__->new(
-   test_query => q{SELECT * FROM employee
+   test_query => q{SELECT login, name, employeenumber FROM employee
                    WHERE not name ~ '[[:alnum:]_]'::text},
          name => 'minimal_employee_name_requirements',
  display_name => marktext('Employee name doesn\'t meet minimal requirements (e.g. non-empty, alphanumeric)'),
@@ -359,7 +359,7 @@ push @tests, __PACKAGE__->new(
 );
 
 push @tests, __PACKAGE__->new(
-   test_query => 'SELECT * FROM employee
+   test_query => 'SELECT login, name, employeenumber FROM employee
                    WHERE employeenumber IN
                          (SELECT employeenumber FROM employee
                         GROUP BY employeenumber
@@ -377,7 +377,8 @@ push @tests, __PACKAGE__->new(
 );
 
 push @tests, __PACKAGE__->new(
-   test_query => 'select * from parts where obsolete is not true
+   test_query => 'select partnumber, description, sellprice
+                  from parts where obsolete is not true
                   and partnumber in
                   (select partnumber from parts
                   WHERE obsolete is not true
@@ -396,7 +397,8 @@ push @tests, __PACKAGE__->new(
 );
 
 push @tests, __PACKAGE__->new(
-   test_query => 'SELECT * from ar where invnumber in (
+   test_query => 'SELECT invnumber, transdate, amount, netamount, paid
+                   from ar where invnumber in (
                    select invnumber from ar
                    group by invnumber having count(*) > 1)',
  display_name => marktext('Unique AR Invoice numbers'),
@@ -414,7 +416,8 @@ push @tests, __PACKAGE__->new(
 # New tests in 1.4
 
 push @tests, __PACKAGE__->new(
-   test_query => 'select * from acc_trans WHERE amount IS NULL',
+   test_query => 'select trans_id, chart_id, transdate
+                  from acc_trans WHERE amount IS NULL',
  display_name => marktext('No NULL Amounts'),
          name => 'no_null_ac_amounts',
  display_cols => ['trans_id', 'chart_id', 'transdate'],
@@ -429,7 +432,8 @@ database, or delete the offending rows through PgAdmin III or psql'),
 );
 
 push @tests, __PACKAGE__->new(
-   test_query => 'select *, eca.id as id  from entity_credit_account eca
+   test_query => 'select meta_number, class, description, name, eca.id as id
+                     from entity_credit_account eca
                      join entity_class ec on eca.entity_class = ec.id
                      join entity e on eca.entity_id = e.id
                    where meta_number in
@@ -546,7 +550,8 @@ push @tests, __PACKAGE__->new(
 );
 
 push @tests, __PACKAGE__->new(
-   test_query => q{select * from from cr_coa_to_account ccta
+   test_query => q{select chart_id, account
+                   from from cr_coa_to_account ccta
                    where chart_id in (select crcoa.chart_id
                                         from cr_coa_to_account crcoa
                                        where ccta.chart_id = crcoa.chart_id
@@ -563,7 +568,8 @@ push @tests, __PACKAGE__->new(
 );
 
 push @tests, __PACKAGE__->new(
-   test_query => q{select * from from cr_coa_to_account ccta
+   test_query => q{select chart_id, account
+                   from from cr_coa_to_account ccta
                    where not exists (select 1
                                        from account
                                       where account.id = ccta.chart_id)},
@@ -607,7 +613,7 @@ push @tests, __PACKAGE__->new(
 
 
 push @tests,__PACKAGE__->new(
-    test_query => q{select *
+    test_query => q{select category
                     from chart
                    where charttype = 'A'
                      and category not in ('A', 'L', 'Q', 'I', 'E')},
@@ -625,7 +631,7 @@ push @tests,__PACKAGE__->new(
     );
 
 push @tests,__PACKAGE__->new(
-    test_query => q{select *
+    test_query => q{select accno, description, link
                     from chart
                    where charttype = 'A'
                      and link ~ '(^|:)(AR|AP|IC)(:|\$)'
@@ -645,7 +651,7 @@ number of "AR_*", "AP_*" and/or "IC_*" links concatenated by colons (:).'),
     );
 
 push @tests,__PACKAGE__->new(
-    test_query => q{select *
+    test_query => q{select accno, description, link
                     from chart c
                    where charttype = 'A'
                      and 0 = (select count(*)
@@ -665,7 +671,7 @@ heading which sorts alphanumerically before the first account by accno'),
     );
 
 push @tests,__PACKAGE__->new(
-    test_query => 'select *
+    test_query => 'select id, customernumber, name
                     from customer
                    where customernumber is null',
     display_name => marktext('Empty customernumbers'),
@@ -811,7 +817,7 @@ selectable_values => { business_id => q{SELECT concat(description,' -- ',discoun
     );
 
 push @tests,__PACKAGE__->new(
-    test_query => q{ select *
+    test_query => q{ select category, accno, description
                     from chart
                    where charttype = 'A'
                      and category not in ('A', 'L', 'Q', 'I', 'E')},
@@ -829,7 +835,7 @@ push @tests,__PACKAGE__->new(
     );
 
 # push @tests,__PACKAGE__->new(
-#     test_query => "select *
+#     test_query => "select accno, description, link
 #                     from chart
 #                    where charttype = 'A'
 #                      and link ~ ':?\\(AR|AP|IC\\)\\(:|$\\)'",
@@ -848,7 +854,7 @@ push @tests,__PACKAGE__->new(
 #     );
 
 push @tests,__PACKAGE__->new(
-    test_query => q{select *
+    test_query => q{select accno, description, link
                     from chart c
                    where charttype = 'A'
                      and 0 = (select count(*)
@@ -868,7 +874,7 @@ heading which sorts alphanumerically before the first account by accno'),
     );
 
 push @tests,__PACKAGE__->new(
-    test_query => 'select *
+    test_query => 'select id, customernumber, name
                     from customer
                    where customernumber in (select customernumber
                                               from customer
@@ -888,7 +894,7 @@ push @tests,__PACKAGE__->new(
     );
 
 push @tests,__PACKAGE__->new(
-    test_query => 'select *
+    test_query => 'select id, vendornumber, name
                     from vendor
                    where vendornumber is null',
     display_name => marktext('Empty vendornumbers'),
@@ -904,7 +910,7 @@ push @tests,__PACKAGE__->new(
     );
 
 push @tests,__PACKAGE__->new(
-    test_query => 'select *
+    test_query => 'select id, vendornumber, name
                     from vendor
                    where vendornumber in (select vendornumber
                                               from vendor
@@ -923,7 +929,7 @@ push @tests,__PACKAGE__->new(
     );
 
 push @tests, __PACKAGE__->new(
-    test_query => 'select *
+    test_query => 'select id, login, name, employeenumber
                      from employee
                     where employeenumber is null',
     display_name => marktext('Null employee numbers'),
@@ -939,7 +945,7 @@ push @tests, __PACKAGE__->new(
     );
 
 push @tests, __PACKAGE__->new(
-    test_query => 'select *
+    test_query => 'select id, login, name, employeenumber
                      from employee
                     where employeenumber in (select employeenumber
                                                from employee
@@ -958,7 +964,8 @@ push @tests, __PACKAGE__->new(
     );
 
 push @tests, __PACKAGE__->new(
-    test_query => 'select *
+    test_query => 'select id, invnumber, transdate, duedate, datepaid,
+                     ordnumber, quonumber, approved
                      from ar
                     where invnumber in (select invnumber
                                           from ar
@@ -1002,7 +1009,8 @@ push @tests, __PACKAGE__->new(
     );
 
 push @tests, __PACKAGE__->new(
-   test_query => 'select * from parts where obsolete is not true
+   test_query => 'select partnumber, description, sellprice
+                  from parts where obsolete is not true
                   and partnumber in
                   (select partnumber from parts
                   WHERE obsolete is not true
@@ -1022,7 +1030,7 @@ push @tests, __PACKAGE__->new(
 
 
 push @tests, __PACKAGE__->new(
-    test_query => 'select *
+    test_query => 'select parts_id, make, model
                      from makemodel
                     where model is null',
     display_name => marktext('Null model numbers'),
@@ -1039,7 +1047,7 @@ push @tests, __PACKAGE__->new(
 
 
 push @tests, __PACKAGE__->new(
-    test_query => 'select *
+    test_query => 'select parts_id, make, model
                      from makemodel
                     where make is null',
     display_name => marktext('Null make numbers'),
@@ -1056,7 +1064,7 @@ push @tests, __PACKAGE__->new(
 
 
 push @tests, __PACKAGE__->new(
-    test_query => 'select *
+    test_query => 'select parts_id, credit_id, pricegroup_id
                      from partscustomer
                     where not exists (select 1
                                         from pricegroup
@@ -1074,7 +1082,7 @@ push @tests, __PACKAGE__->new(
     );
 
 push @tests, __PACKAGE__->new(
-    test_query => q{select *
+    test_query => q{select accno, charttype, description
                      from chart
                     where not charttype in ('H', 'A')},
     display_name => marktext('Unknown charttype; should be H(eader)/A(ccount)'),
@@ -1091,7 +1099,7 @@ push @tests, __PACKAGE__->new(
 
 
 push @tests, __PACKAGE__->new(
-    test_query => q{select *
+    test_query => q{select accno, category, description
                      from chart
                     where charttype = 'A'
                           and category not in ('A','L','E','I','Q')},
@@ -1126,7 +1134,7 @@ push @tests, __PACKAGE__->new(
 
 
 push @tests, __PACKAGE__->new(
-    test_query => q{select *
+    test_query => q{select accno, description
                      from chart
                     where charttype = 'A'
                           and accno < (select min(accno)
@@ -1145,7 +1153,7 @@ push @tests, __PACKAGE__->new(
 
 
 push @tests, __PACKAGE__->new(
-    test_query => 'select *
+    test_query => 'select accno, description, validto, rate
                      from tax t
                      join chart c on t.chart_id = c.id
                     where c.id in (select chart_id
@@ -1235,7 +1243,7 @@ Void the clearing date in the dialog shown or go back to SQL-Ledger if you feel 
 
 ### On the vendor side, SL doesn't use pricegroups
 # push @tests, __PACKAGE__->new(
-#     test_query => "select *
+#     test_query => "select parts_id, credit_id, pricegroup_id
 #                      from partsvendor
 #                     where not exists (select 1
 #                                         from pricegroup


### PR DESCRIPTION
Make sure that migration queries explicitly refer to the required fields, in order to validate their availability and prevent requiring needless information.