### PR TITLE
Correct default date 2587

### DIFF
--- a/UI/js-src/lsmb/DateTextBox.js
+++ b/UI/js-src/lsmb/DateTextBox.js
@@ -10,6 +10,7 @@ define([
         [DateTextBox],
         {
           _formattedValue: null,
+          defaultIsToday: false,
           constructor: function(params, srcNodeRef) {
             this._formattedValue = srcNodeRef.value;
 
@@ -50,23 +51,31 @@ define([
             }
           },
           postMixInProperties: function() {
-            this.inherited(arguments);
-            if (this._formattedValue &&
-                (! this.value || ! isoDate.test(this.value))) {
-              /* This code purely compensates for the fact that most LedgerSMB
-                 server code sends the date according to the user's selected
-                 preference, instead of in ISO format, which the widget
-                 expects */
-              this.value = this.parse(this._formattedValue, this.constraints);
-            }
+              this.inherited(arguments);
+              if (this._formattedValue &&
+                  (! this.value || ! isoDate.test(this.value))) {
+                  /* This code purely compensates for the fact that most
+                     LedgerSMB server code sends the date according to the
+                     user's selected preference, instead of in ISO format,
+                     which the widget expects */
+                  this.value = this.parse(this._formattedValue,
+                                          this.constraints);
+              }
+              if ((this.value === undefined || isNaN(this.value))
+                  && this.defaultIsToday) {
+                  this.value = new Date();
+              }
           },
-            parse: function(value, constraints) {
-                if (! isoDate.test(value)) {
-                    return this.inherited(arguments);
-                }
-                return locale.parse(value,
-                                    { datePattern: "yyyy-MM-dd", selector: "date" });
-            }
+          parse: function(value, constraints) {
+              if (! isoDate.test(value)) {
+                  return this.inherited(arguments);
+              }
+              return locale.parse(value,
+                                  {
+                                      datePattern: "yyyy-MM-dd",
+                                      selector: "date"
+                                  });
+          }
         });
     }
     );

--- a/old/bin/aa.pl
+++ b/old/bin/aa.pl
@@ -642,11 +642,11 @@ $form->open_status_div($status_div_id) . qq|
           </tr>
               <tr>
                 <th align=right nowrap><label for="crdate">| . $locale->text('Invoice Created') . qq|</label></th>
-                <td><input class="date" data-dojo-type="lsmb/DateTextBox" name=crdate id=crdate size=11 title="($myconfig{'dateformat'})" value=$form->{crdate}></td>
+                <td><input class="date" data-dojo-type="lsmb/DateTextBox" name=crdate id=crdate size=11 title="($myconfig{'dateformat'})" value="$form->{crdate}" data-dojo-props="defaultIsToday:true"></td>
               </tr>
           <tr>
         <th align=right nowrap><label for="transdate">| . $locale->text('Invoice Date') . qq|</label></th>
-        <td><input class="date" data-dojo-type="lsmb/DateTextBox" name=transdate id=transdate size=11 title="($myconfig{'dateformat'})" value=$form->{transdate}></td>
+        <td><input class="date" data-dojo-type="lsmb/DateTextBox" name=transdate id=transdate size=11 title="($myconfig{'dateformat'})" value="$form->{transdate}" data-dojo-props="defaultIsToday:true"></td>
           </tr>
           <tr>
         <th align=right nowrap><label for="duedate">| . $locale->text('Due Date') . qq|</label></th>

--- a/old/bin/ir.pl
+++ b/old/bin/ir.pl
@@ -475,11 +475,11 @@ sub form_header {
           </tr>
               <tr>
                 <th align=right nowrap><label for="crdate">| . $locale->text('Invoice Created') . qq|</label></th>
-                <td><input class="date" data-dojo-type="lsmb/DateTextBox" id=crdate name=crdate size=11 title="$myconfig{dateformat}" value=$form->{crdate}></td>
+                <td><input class="date" data-dojo-type="lsmb/DateTextBox" id=crdate name=crdate size=11 title="$myconfig{dateformat}" value=$form->{crdate} data-dojo-props="defaultIsToday:true"></td>
               </tr>
           <tr>
         <th align=right nowrap><label for="transdate">| . $locale->text('Invoice Date') . qq|</label></th>
-        <td><input class="date" data-dojo-type="lsmb/DateTextBox" name=transdate size=11 title="$myconfig{dateformat}" value="$form->{transdate}" id="transdate"></td>
+        <td><input class="date" data-dojo-type="lsmb/DateTextBox" name=transdate size=11 title="$myconfig{dateformat}" value="$form->{transdate}" id="transdate" data-dojo-props="defaultIsToday:true"></td>
           </tr>
           <tr>
         <th align=right nowrap><label for="duedate">| . $locale->text('Due Date') . qq|</label></th>

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -227,8 +227,6 @@ sub invoice_links {
     $form->{paidaccounts} = 1 unless ( exists $form->{paidaccounts} );
 
     $form->{AR} = $form->{AR_1} unless $form->{id};
-    $form->{transdate} = $form->{current_date} if (!$form->{transdate});
-    $form->{crdate} = $form->{current_date} if (!$form->{crdate});
     $form->{locked} =
       ( $form->{revtrans} )
       ? '1'
@@ -528,11 +526,11 @@ sub form_header {
           </tr>
           <tr class="crdate-row">
         <th align=right><label for="crdate">| . $locale->text('Invoice Created') . qq|</label></th>
-        <td><input class="date" data-dojo-type="lsmb/DateTextBox" name="crdate" size="11" title="$myconfig{dateformat}" value="$form->{crdate}" id="crdate"></td>
+        <td><input class="date" data-dojo-type="lsmb/DateTextBox" name="crdate" size="11" title="$myconfig{dateformat}" value="$form->{crdate}" id="crdate" data-dojo-props="defaultIsToday:true"></td>
           </tr>
           <tr class="transdate-row">
         <th align=right><label for="transdate">| . $locale->text('Invoice Date') . qq|</label></th>
-        <td><input class="date" data-dojo-type="lsmb/DateTextBox" name="transdate" id="transdate" size="11" title="$myconfig{dateformat}" value="$form->{transdate}"></td>
+        <td><input class="date" data-dojo-type="lsmb/DateTextBox" name="transdate" id="transdate" size="11" title="$myconfig{dateformat}" value="$form->{transdate}" data-dojo-props="defaultIsToday:true"></td>
           </tr>
           <tr>
         <th align=right><label for="duedate">| . $locale->text('Due Date') . qq|</label></th>

--- a/old/bin/oe.pl
+++ b/old/bin/oe.pl
@@ -403,7 +403,7 @@ sub form_header {
           </tr>
           <tr class="transdate-row">
         <th align=right nowrap>| . $locale->text('Order Date') . qq|</th>
-        <td><input class="date" data-dojo-type="lsmb/DateTextBox"name=transdate size=11 title="$myconfig{dateformat}" value="$form->{transdate}" id="transdate"></td>
+        <td><input class="date" data-dojo-type="lsmb/DateTextBox"name=transdate size=11 title="$myconfig{dateformat}" value="$form->{transdate}" id="transdate" data-dojo-props="defaultIsToday:true"></td>
           </tr>
           <tr class="reqdate-row">
         <th align=right nowrap=true>| . $locale->text('Required by') . qq|</th>
@@ -494,7 +494,7 @@ sub form_header {
         $ordnumber .= qq|
           <tr class="transdate-row">
         <th align=right nowrap>| . $locale->text('Quotation Date') . qq|</th>
-        <td><input class="date" data-dojo-type="lsmb/DateTextBox" name=transdate size=11 title="$myconfig{dateformat}" value="$form->{transdate}" id="transdate"></td>
+        <td><input class="date" data-dojo-type="lsmb/DateTextBox" name=transdate size=11 title="$myconfig{dateformat}" value="$form->{transdate}" id="transdate" data-dojo-props="defaultIsToday:true"></td>
           </tr>
           <tr>
         <th align=right nowrap=true>$reqlabel</th>
@@ -1397,7 +1397,6 @@ sub invoice {
         # check if we need a new exchangerate
         $buysell = ( $form->{type} eq 'sales_order' ) ? "buy" : "sell";
 
-        $orddate = $form->current_date( \%myconfig );
         $exchangerate = "";
 
         if ( !$exchangerate ) {
@@ -1411,7 +1410,6 @@ sub invoice {
 
     OE->save( \%myconfig, \%$form );
 
-    $form->{transdate} = $form->current_date( \%myconfig );
     $form->{duedate} =
       $form->current_date( \%myconfig, $form->{transdate}, $form->{terms} * 1 );
 

--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -2322,7 +2322,7 @@ sub create_links {
         }
     }
 
-    for (qw(separate_duties current_date curr closedto revtrans lock_description)) {
+    for (qw(separate_duties curr closedto revtrans lock_description)) {
         if ($_ eq 'closedto'){
             $query = qq|
                 SELECT value::date FROM defaults

--- a/old/lib/LedgerSMB/IR.pm
+++ b/old/lib/LedgerSMB/IR.pm
@@ -718,8 +718,8 @@ sub retrieve_invoice {
                      WHERE c.id = (SELECT value::int FROM defaults
                                     WHERE setting_key =
                                           'fxloss_accno_id'))
-                   AS fxloss_accno,
-                   current_date AS transdate|;
+                   AS fxloss_accno
+|;
     }
     my $sth = $dbh->prepare($query);
     $sth->execute || $form->dberror($query);

--- a/old/lib/LedgerSMB/IS.pm
+++ b/old/lib/LedgerSMB/IS.pm
@@ -1294,18 +1294,6 @@ sub retrieve_invoice {
 
     my $query;
 
-    if ( ! $form->{id} ) {
-        $query = qq|
-         SELECT current_date AS transdate
-              FROM defaults
-             WHERE setting_key = 'curr'|;
-    my $sth = $dbh->prepare($query);
-    $sth->execute || $form->dberror($query);
-
-    my $ref = $sth->fetchrow_hashref(NAME_lc);
-    for ( keys %$ref ) { $form->{$_} = $ref->{$_} }
-    $sth->finish;
-    }
     @{$form->{currencies}} =
         (LedgerSMB::Setting->new({base => $form}))->get_currencies;
 

--- a/old/lib/LedgerSMB/OE.pm
+++ b/old/lib/LedgerSMB/OE.pm
@@ -562,10 +562,6 @@ sub retrieve {
     my $var;
     my $ref;
 
-    $query = qq|
-      SELECT current_date FROM defaults
-         WHERE setting_key = 'curr'|;
-    ( $form->{transdate} ) = $dbh->selectrow_array($query);
     @{$form->{currencies}} =
         (LedgerSMB::Setting->new({base => $form}))->get_currencies;
     $form->{defaultcurrency} = $form->{currencies}->[0];

--- a/xt/66-cucumber/11-ar/transactions.feature
+++ b/xt/66-cucumber/11-ar/transactions.feature
@@ -16,9 +16,9 @@ Scenario: Creation of a new AR transaction, no taxes
      And I select customer "Customer 1"
     Then I expect to see these transaction header fields and values
        | name            | value    |
-       | Invoice Created |          |
+       | Invoice Created | $$today  |
        | Invoice Date    | $$today  |
-       | Due Date        |          |
+       | Due Date        | $$today  |
        | Currency        | USD      |
        | Description     |          |
        | Invoice Number  |          |

--- a/xt/66-cucumber/12-ap/transactions.feature
+++ b/xt/66-cucumber/12-ap/transactions.feature
@@ -16,9 +16,9 @@ Scenario: Creation of a new AP transaction, no taxes
      And I select vendor "Vendor 1"
     Then I expect to see these transaction header fields and values
        | name            | value    |
-       | Invoice Created |          |
+       | Invoice Created | $$today  |
        | Invoice Date    | $$today  |
-       | Due Date        |          |
+       | Due Date        | $$today  |
        | Currency        | USD      |
        | Description     |          |
        | Invoice Number  |          |


### PR DESCRIPTION
By setting the default date based on the browser date, we prevent
the default date being prevented being off-by-a-day due to
timezone differences (settings in the server versus on the
browser).

Fixes #2587.