### PR TITLE
Fix authentication domain to separate app from setup app auth

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -51,6 +51,7 @@ requires 'Plack::Middleware::ReverseProxy';
 requires 'Plack::Request';
 requires 'Plack::Request::WithEncoding';
 requires 'Plack::Util';
+requires 'Plack::Util::Accessor';
 requires 'Template', '2.14';
 requires 'Text::CSV';
 requires 'Template::Parser';

--- a/lib/LedgerSMB/Auth/DB.pm
+++ b/lib/LedgerSMB/Auth/DB.pm
@@ -66,7 +66,7 @@ sub _build_credentials {
     return \%rv;
 }
 
-=item get_credentials
+=item get_credentials(domain, company)
 
 Gets credentials from the 'HTTP_AUTHORIZATION' environment variable which must
 be passed in as per the standards of HTTP basic authentication.
@@ -76,7 +76,7 @@ Returns a hashref with the keys of login and password.
 =cut
 
 sub get_credentials {
-    my ($self, $domain) = @_;
+    my ($self, $domain, $company) = @_;
     # We ignore domain, but other auth providers may choose to use it
 
     return $self->credentials;

--- a/lib/LedgerSMB/Middleware/AuthenticateSession.pm
+++ b/lib/LedgerSMB/Middleware/AuthenticateSession.pm
@@ -73,6 +73,7 @@ use parent qw ( Plack::Middleware );
 use DBI;
 use Plack::Request;
 use Plack::Util;
+use Plack::Util::Accessor qw( domain );
 
 use LedgerSMB;
 use LedgerSMB::Auth;
@@ -132,7 +133,9 @@ sub call {
     return LedgerSMB::PSGI::Util::unauthorized()
         unless $env->{'lsmb.company'};
 
-    my $creds = LedgerSMB::Auth::factory($env)->get_credentials;
+    my $creds = LedgerSMB::Auth::factory($env)->get_credentials(
+        $self->domain,
+        $env->{'lsmb.company'});
     return LedgerSMB::PSGI::Util::unauthorized()
         unless $creds->{login} && $creds->{password};
     my $dbh = $env->{'lsmb.db'} =

--- a/lib/LedgerSMB/PSGI.pm
+++ b/lib/LedgerSMB/PSGI.pm
@@ -221,7 +221,20 @@ sub setup_url_space {
             enable '+LedgerSMB::Middleware::ClearDownloadCookie';
             $psgi_app;
         }
-        for  (@LedgerSMB::Sysconfig::newscripts);
+        for  (grep { $_ ne 'setup.pl' } @LedgerSMB::Sysconfig::newscripts);
+
+        mount '/setup.pl' => builder {
+            enable '+LedgerSMB::Middleware::RequestID';
+            enable 'AccessLog',
+                format => 'Req:%{Request-Id}i %h %l %u %t "%r" %>s %b "%{Referer}i" "%{User-agent}i"';
+            enable '+LedgerSMB::Middleware::DynamicLoadWorkflow';
+            enable '+LedgerSMB::Middleware::Log4perl';
+            enable '+LedgerSMB::Middleware::AuthenticateSession',
+                domain => 'setup';
+            enable '+LedgerSMB::Middleware::DisableBackButton';
+            enable '+LedgerSMB::Middleware::ClearDownloadCookie';
+            $psgi_app;
+        };
 
         mount '/stop.pl' => sub { exit; }
             if $coverage;


### PR DESCRIPTION
Note that LedgerSMB::Auth::DB (the prototype Auth module) takes
a domain argument, yet the middleware doesn't supply it. Note also
that the name of the database to log into may be a criterion when
generating an auth response -- add it as an argument.

This PR fixes the (supported!) use-case of custom Auth plugins. 1.7
was supposed to be improved by letting the plugin know whether or
not authentication is going on against 'setup' or against the regular
app.
