### PR TITLE
Follow-up to #4246 which didn't address all auth instantiations

### DIFF
--- a/lib/LedgerSMB/Auth/DB.pm
+++ b/lib/LedgerSMB/Auth/DB.pm
@@ -66,18 +66,22 @@ sub _build_credentials {
     return \%rv;
 }
 
-=item get_credentials(domain, company)
+=item get_credentials([domain, company])
 
 Gets credentials from the 'HTTP_AUTHORIZATION' environment variable which must
 be passed in as per the standards of HTTP basic authentication.
 
 Returns a hashref with the keys of login and password.
 
+Note that the object needs to cache the domain and company values supplied
+on the first invocation. Further invocations to this method may return a
+cached response from the first invocation.
+
 =cut
 
 sub get_credentials {
     my ($self, $domain, $company) = @_;
-    # We ignore domain, but other auth providers may choose to use it
+    # We ignore domain and company, but other auth providers may use it
 
     return $self->credentials;
 }

--- a/lib/LedgerSMB/PSGI.pm
+++ b/lib/LedgerSMB/PSGI.pm
@@ -99,11 +99,8 @@ in LedgerSMB::Scripts::*.
 
 sub psgi_app {
     my $env = shift;
-
-    my $auth = LedgerSMB::Auth::factory($env);
-
     my $psgi_req = Plack::Request::WithEncoding->new($env);
-    my $request = LedgerSMB->new($psgi_req, $auth);
+    my $request = LedgerSMB->new($psgi_req, $env->{'lsmb.auth'});
 
     $request->{action} = $env->{'lsmb.action_name'};
     my $res;

--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -209,6 +209,8 @@ sub new {
     }
 
     $self->{_auth} = LedgerSMB::Auth::factory(\%ENV);
+    # initialize domain and company (values will be cached)
+    $self->{_auth}->get_credentials(undef, $self->{company});
     $self;
 }
 


### PR DESCRIPTION
With this commit, only two instantiations remain. One for old code
and one for 'the rest'. The domain doesn't matter for old code,
which makes the instantiation doable.
