### PR TITLE
Decouple setup.pl from login.pl by using its own authentication

### DIFF
--- a/UI/js-src/lsmb/SetupLoginButton.js
+++ b/UI/js-src/lsmb/SetupLoginButton.js
@@ -8,7 +8,7 @@ define([
 ],
        function(declare, event, xhr, dom, style, Button) {
            var authURL =
-               "login.pl?action=authenticate&company=postgres&dbonly=1";
+               "setup.pl?action=authenticate&company=postgres&dbonly=1";
 
            return declare("lsmb/SetupLoginButton",
                           [Button],

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -88,6 +88,7 @@ sub no_db_actions {
     return qw(__default);
 }
 
+
 =item clear_session_actions
 
 Returns an array of actions which should have the session
@@ -97,7 +98,34 @@ dispatched to.
 =cut
 
 sub clear_session_actions {
-    return qw(__default);
+    return qw(__default authenticate);
+}
+
+
+=item authenticate
+
+This routine checks for the authentication information and if successful
+sends either a HTTP_FOUND redirect or a HTTP_OK successful response.
+
+If unsuccessful sends a HTTP_UNAUTHORIZED if the username/password is bad,
+or a HTTP_454 error if the database does not exist.
+
+=cut
+
+sub authenticate {
+    my ($request) = @_;
+
+    $request->{company} ||= $LedgerSMB::Sysconfig::default_db;
+
+
+    if (!$request->{dbonly}
+        && ! $request->{_create_session}->()) {
+        return LedgerSMB::PSGI::Util::unauthorized();
+    }
+
+    return [ HTTP_OK,
+             [ 'Content-Type' => 'text/plain; charset=utf-8' ],
+             [ 'Success' ] ];
 }
 
 


### PR DESCRIPTION
No other parts of setup.pl depend on login.pl (or any other parts of
the main LedgerSMB application, for that matter). Separating the
authentication from login.pl (by copying the code - for now), makes
setup.pl a completely independent application in our stack.
