### PR TITLE
Add the printer listing back to the document templates

### DIFF
--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -520,6 +520,14 @@ sub _render {
     my $unescape = $format->can('unescape');
     my $cleanvars = {
         ( %{preprocess($vars, $escape)},
+          PRINTERS => [
+              ( ( map { { text => $_, value => $_ } }
+                  keys %LedgerSMB::Sysconfig::printers ),
+                {
+                    text  => 'Screen',
+                    value => 'screen'
+                } )
+          ],
           LIST_FORMATS => sub { return available_formats(); },
           UNESCAPE => ($unescape ? sub { return $unescape->(@_); }
                        : sub { return @_; }),


### PR DESCRIPTION
Unfortunately, reports are rendered as documents, causing the UI
elements such as printer lists to be unavailable.

Adding this back on 1.7 only, because on master, we'll need to create
infrastructure allowing reports to render either as document or as
UI component (probably based on different document templates).
