### PR TITLE
Reduce the dependency on LedgerSMB::App_State::DBH

### DIFF
--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -371,7 +371,7 @@ sub call_procedure {
     my %args = @_;
     $args{funcschema} ||= $LedgerSMB::Sysconfig::db_namespace;
     $args{funcname} ||= $args{procname};
-    $args{dbh} = LedgerSMB::App_State::DBH();
+    $args{dbh} = $self->{dbh};
     $args{args} ||= [];
     return PGObject->call_procedure(%args);
 }
@@ -397,7 +397,7 @@ sub dberror{
    my $self = shift @_;
    my $state_error = {};
    my $locale = $self->{_locale};
-   my $dbh = $LedgerSMB::App_State::DBH;
+   my $dbh = $self->{_dbh};
    $state_error = {
             '42883' => $locale->text('Internal Database Error'),
             '42501' => $locale->text('Access Denied'),

--- a/lib/LedgerSMB/DBH.pm
+++ b/lib/LedgerSMB/DBH.pm
@@ -59,32 +59,6 @@ sub connect {
     return $dbh;
 }
 
-=head2 set_datestyle
-
-This is used for old code, to set the datetyle for input.  It is not needed
-for new code because of PGDate support to/from the db.  For this reason, once
-order entry is removed, we should probably remove support for it.
-
-=cut
-
-sub set_datestyle {
-    my $dbh = LedgerSMB::App_State::DBH;
-    my $datequery = 'select dateformat from user_preference join users using(id)
-                      where username = CURRENT_USER';
-    my $date_sth = $dbh->prepare($datequery);
-    $date_sth->execute;
-    my ($datestyle) = $date_sth->fetchrow_array;
-    my %date_query = (
-        'mm/dd/yyyy' => 'set DateStyle to \'SQL, US\'',
-        'mm-dd-yyyy' => 'set DateStyle to \'POSTGRES, US\'',
-        'dd/mm/yyyy' => 'set DateStyle to \'SQL, EUROPEAN\'',
-        'dd-mm-yyyy' => 'set DateStyle to \'POSTGRES, EUROPEAN\'',
-        'dd.mm.yyyy' => 'set DateStyle to \'GERMAN\''
-    );
-    $dbh->do( $date_query{ $datestyle } ) if $date_query{ $datestyle };
-    return;
-}
-
 =head2 require_version($version)
 
 Checks for a setting called 'ignore_version' and returns immediately if this is

--- a/lib/LedgerSMB/Scripts/account.pm
+++ b/lib/LedgerSMB/Scripts/account.pm
@@ -162,7 +162,7 @@ sub _display_account_screen {
         $account->{$item} = 1;
     }
 
-    my @languages = LedgerSMB->call_procedure(
+    my @languages = $form->call_procedure(
         funcname => 'person__list_languages'
     );
 

--- a/lib/LedgerSMB/Scripts/budgets.pm
+++ b/lib/LedgerSMB/Scripts/budgets.pm
@@ -180,7 +180,7 @@ sub view_budget {
         } else {
             $row->{credit} = $line->{amount};
         }
-        my ($account) = $budget->call_procedure(
+        my ($account) = $request->call_procedure(
                           funcname => 'account_get',
                               args => [$line->{account_id}]
         );

--- a/lib/LedgerSMB/Scripts/contact.pm
+++ b/lib/LedgerSMB/Scripts/contact.pm
@@ -168,7 +168,7 @@ sub _main_screen {
     $request->{target_div} ||= 'person_div' if defined $person;
     $request->{target_div} ||= 'company_div';
 
-    my @all_years =  LedgerSMB->call_procedure(
+    my @all_years =  $request->call_procedure(
               funcname => 'date_get_all_years'
     );
 
@@ -191,7 +191,7 @@ sub _main_screen {
     # DIVS contents
     my $entity_id = $company->{entity_id};
     $entity_id ||= $person->{entity_id};
-    my @pricegroups = LedgerSMB->call_procedure(
+    my @pricegroups = $request->call_procedure(
         funcname => 'pricegroups__list'
     );
     my @credit_list =
@@ -236,21 +236,21 @@ sub _main_screen {
                                                  $credit_act->{id});
 
     # Globals for the template
-    my @salutations = LedgerSMB->call_procedure(
+    my @salutations = $request->call_procedure(
                 funcname => 'person__list_salutations'
     );
-    my @all_taxes = LedgerSMB->call_procedure(funcname => 'account__get_taxes');
+    my @all_taxes = $request->call_procedure(funcname => 'account__get_taxes');
 
     my $arap_class = $entity_class || '0';
     $arap_class = 2 unless $arap_class == 1;
-    my @ar_ap_acc_list = LedgerSMB->call_procedure(funcname => 'chart_get_ar_ap',
+    my @ar_ap_acc_list = $request->call_procedure(funcname => 'chart_get_ar_ap',
                                            args => [$arap_class]);
 
-    my @cash_acc_list = LedgerSMB->call_procedure(funcname => 'chart_list_cash',
+    my @cash_acc_list = $request->call_procedure(funcname => 'chart_list_cash',
                                            args => [$entity_class]);
 
     my @discount_acc_list =
-         LedgerSMB->call_procedure(funcname => 'chart_list_discount',
+         $request->call_procedure(funcname => 'chart_list_discount',
                                      args => [$entity_class]);
 
     for my $var (\@ar_ap_acc_list, \@cash_acc_list, \@discount_acc_list){
@@ -262,7 +262,7 @@ sub _main_screen {
 
 #
     my @language_code_list =
-             LedgerSMB->call_procedure(funcname => 'person__list_languages');
+             $request->call_procedure(funcname => 'person__list_languages');
 
     for my $ref (@language_code_list){
         $ref->{text} = "$ref->{description}";
@@ -270,10 +270,10 @@ sub _main_screen {
 
     my @location_class_list =
        grep { $_->{class} =~ m/^(?:Billing|Sales|Shipping)$/ }
-            LedgerSMB->call_procedure(funcname => 'location_list_class');
+            $request->call_procedure(funcname => 'location_list_class');
 
     my @business_types =
-               LedgerSMB->call_procedure(funcname => 'business_type__list');
+               $request->call_procedure(funcname => 'business_type__list');
 
     my @all_currencies =
         map { { curr => $_ } }
@@ -297,10 +297,10 @@ sub _main_screen {
     my @plugins = grep { /^[^.]/ && -f "UI/Contact/plugins/$_" } readdir($dh2);
     closedir $dh2;
 
-    my @country_list = LedgerSMB->call_procedure(
+    my @country_list = $request->call_procedure(
                      funcname => 'location_list_country'
       );
-    my @entity_classes = LedgerSMB->call_procedure(
+    my @entity_classes = $request->call_procedure(
                       funcname => 'entity__list_classes'
     );
 

--- a/lib/LedgerSMB/Scripts/template.pm
+++ b/lib/LedgerSMB/Scripts/template.pm
@@ -63,7 +63,7 @@ sub display {
     $dbtemp->{content} = $dbtemp->template if defined $dbtemp;
     $dbtemp = $request unless $dbtemp->{format};
     $dbtemp->{languages} =
-        [ LedgerSMB->call_procedure(funcname => 'person__list_languages') ];
+        [ $request->call_procedure(funcname => 'person__list_languages') ];
     return LedgerSMB::Template::UI->new_UI
         ->render($request, 'templates/preview', { request => $request,
                                                   template => $dbtemp,
@@ -92,7 +92,7 @@ sub edit {
     $dbtemp->{content} = $dbtemp->template;
     $dbtemp = $request unless $dbtemp->{format};
     $dbtemp->{languages} =
-        [ LedgerSMB->call_procedure(funcname => 'person__list_languages') ];
+        [ $request->call_procedure(funcname => 'person__list_languages') ];
 
     return LedgerSMB::Template::UI->new_UI
         ->render($request, 'templates/edit', { request => $request,

--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -513,7 +513,7 @@ sub _render {
     $vars->{DBNAME} = $LedgerSMB::App_State::DBName;
     $vars->{SETTINGS} = {
         %$LedgerSMB::App_State::Company_Config,
-    } if $vars->{DBNAME} && LedgerSMB::App_State::DBH;
+    } if $vars->{DBNAME} && $LedgerSMB::App_State::Company_Config;
 
     my $format = "LedgerSMB::Template::$self->{format}";
     my $escape = $format->can('escape');

--- a/lib/LedgerSMB/Template/UI.pm
+++ b/lib/LedgerSMB/Template/UI.pm
@@ -39,7 +39,7 @@ our @pre_render_cbs = (
         $vars->{locale} = $vars->{language} // $vars->{locale}
                           // $request->{_locale};
         $cvars->{locale} = $cvars->{language} // $cvars->{locale};
-        if ($vars->{DBNAME} && LedgerSMB::App_State::DBH()) {
+        if ($vars->{DBNAME} && $LedgerSMB::App_State::Company_Config) {
             $vars->{SETTINGS} = {
                 (%$LedgerSMB::App_State::Company_Config,)
             };


### PR DESCRIPTION
This commit moves `set_datestyle` to Form.pm because Form.pm
is the only user *and* it's deprecated old-code. This way the
routine will be automatically cleaned up when we remove Form.pm.

Instead of jumping through hoops trying to estimate whether
$LedgerSMB::App_State::Company_Config might have a value,
check the value directly. At least this reduces the dependency
on LedgerSMB::App_State::DBH...