### PR TITLE
Reduce dependency on LedgerSMB::App_State::User

### DIFF
--- a/lib/LedgerSMB/Scripts/contact.pm
+++ b/lib/LedgerSMB/Scripts/contact.pm
@@ -462,6 +462,7 @@ sub dispatch_legacy {
     my $entry = $dispatch->{$request->{action}};
     return dispatch($entry->{script},
                     'add',
+                    $request->{_user},
                     { %{$entry->{data}},
                       script => $entry->{script},
                       action => 'add',

--- a/lib/LedgerSMB/Scripts/order.pm
+++ b/lib/LedgerSMB/Scripts/order.pm
@@ -159,7 +159,8 @@ callback.
 sub generate {
     my ($request) = @_;
 
-    return dispatch('oe.pl', 'generate_purchase_orders', $request);
+    return dispatch('oe.pl', 'generate_purchase_orders',
+                    $request->{_user}, $request);
 }
 
 =back

--- a/lib/LedgerSMB/Scripts/transtemplate.pm
+++ b/lib/LedgerSMB/Scripts/transtemplate.pm
@@ -69,6 +69,7 @@ sub view {
         unless $script;
 
     return dispatch($script, $entry->{function},
+                    $request->{_user},
                     { %$request, script => $script },
                     # $entry->{function}'s arguments:
                     $transtemplate, $journal_type);

--- a/lib/LedgerSMB/Scripts/vouchers.pm
+++ b/lib/LedgerSMB/Scripts/vouchers.pm
@@ -150,6 +150,7 @@ sub _add_vouchers_old {
 
     return dispatch($entry->{script},
                     $entry->{function},
+                    $request->{_user},
                     $request);
 }
 
@@ -528,6 +529,7 @@ sub print_batch {
                 dispatch(
                     $entry->{script},
                     $entry->{entrypoint},
+                    $request->{_user},
                     { %$request },
                     # entrypoint's arguments:
                     $_,

--- a/old/lib/LedgerSMB/old_code.pm
+++ b/old/lib/LedgerSMB/old_code.pm
@@ -57,6 +57,7 @@ Wraps a "call" to old code, returning a PSGI triplet for the response.
 sub dispatch {
     my $script = shift;
     my $entrypoint = shift;
+    my $user = shift;
     my $form_args = shift;
     my @entrypoint_args = @_;
 
@@ -77,7 +78,7 @@ sub dispatch {
             local *STDOUT = $stdout;
             $lsmb_legacy::form = Form->new();
             $lsmb_legacy::form->{$_} = $form_args->{$_} for (keys %$form_args);
-            %lsmb_legacy::myconfig = %$LedgerSMB::App_State::User;
+            %lsmb_legacy::myconfig = %$user;
 
             # This is a forked process, but we're using the parent's
             # database handle. Don't destroy the database handle when


### PR DESCRIPTION
The fact that we carry around lots of global state hampers
speed of development. So we decided long ago that the global
state carried in LedgerSMB::App_State is to be reduced as much
as possible. This is another one of those steps.