### PR TITLE
Report renderer no longer hard-codes mix of document and UI rendering

### DIFF
--- a/lib/LedgerSMB/Report.pm
+++ b/lib/LedgerSMB/Report.pm
@@ -495,10 +495,11 @@ sub _render {
         return [map { +{ %$_, %{shift @newlines} } } @$lines ];
     };
 
-    if (ref $args{renderer}) {
-        my $setting = LedgerSMB::Setting->new({base => $request});
-        return $args{renderer}->($template, $self, {
-            report => $self,
+    my $setting = LedgerSMB::Setting->new({base => $request});
+    return $args{renderer}->(
+        $template, $self,
+        {
+            report          => $self,
             company_name    => $setting->get('company_name'),
             company_address => $setting->get('company_address'),
             request         => $request,
@@ -512,37 +513,7 @@ sub _render {
             rows            => $self->rows,
 
             DBNAME          => $request->{company},
-                           });
-    }
-    else {
-        $template = LedgerSMB::Template->new(
-            user => $LedgerSMB::App_State::User,
-            locale => $self->locale,
-            path => 'UI',
-            output_options => {
-                filename => $self->output_name($request),
-            },
-            template => $template,
-            format => uc($request->{format} || 'HTML'),
-            );
-        my $render = $template->can($args{renderer});
-        return &$render($template,
-                        {report => $self,
-                   company_name => LedgerSMB::Setting->new({base => $request})->get('company_name'),
-                company_address => LedgerSMB::Setting->new({base => $request})->get('company_address'),
-                        request => $request,
-                      new_heads => $replace_hnames,
-                           name => $self->name,
-                         hlines => $self->header_lines,
-                        columns => $columns,
-                      order_url => $self->order_url,
-                        buttons => $self->buttons,
-                        options => $self->options,
-                           rows => $self->rows,
-
-                         DBNAME => $request->{company},
-                        });
-    }
+        });
 }
 
 =head2 show_cols

--- a/lib/LedgerSMB/Report.pm
+++ b/lib/LedgerSMB/Report.pm
@@ -330,9 +330,14 @@ sub _exclude_from_totals {
 }
 
 
-=head2 render
+=head2 render(renderer => \&renderer($template_name, $report, $vars, $clean_vars) )
 
 This takes no arguments and simply renders the report as is.
+
+C<&renderer> is a function of 4 arguments. The difference between C<$vars> and
+C<$clean_vars> is that the latter are already HTML-safely encoded whereas
+the former are not (and therefor will be encoded before being inserted into
+the template).
 
 =cut
 
@@ -340,18 +345,17 @@ sub render {
     my $self = shift;
     my $request = shift;
 
-    return $self->_render($request, renderer => 'render');
+    return $self->_render($request, renderer => 'render', @_);
 }
 
 
-# PRIVATE METHODS
+=head2 output_name($request)
 
-# _output_name
-#
-# Returns a base file name (without extension) for the current report.
-# Used where output is to a file or attachment.
+Returns the suggested file name to be used to store the report.
 
-sub _output_name {
+=cut
+
+sub output_name {
     my $self = shift;
     my $request = shift;
 
@@ -375,6 +379,8 @@ sub _output_name {
 
     return $name;
 }
+
+# PRIVATE METHODS
 
 # _render
 #
@@ -488,33 +494,55 @@ sub _render {
         my @newlines = map { { name => $_->{name} } } @{$self->header_lines};
         return [map { +{ %$_, %{shift @newlines} } } @$lines ];
     };
-    $template = LedgerSMB::Template->new(
-        user => $LedgerSMB::App_State::User,
-        locale => $self->locale,
-        path => 'UI',
-        output_options => {
-            filename => $self->_output_name($request),
-        },
-        template => $template,
-        format => uc($request->{format} || 'HTML'),
-    );
-    my $render = $template->can($args{renderer});
-    return &$render($template,
-                      {report => $self,
-                 company_name => LedgerSMB::Setting->new({base => $request})->get('company_name'),
-              company_address => LedgerSMB::Setting->new({base => $request})->get('company_address'),
-                      request => $request,
-                    new_heads => $replace_hnames,
-                         name => $self->name,
-                       hlines => $self->header_lines,
-                      columns => $columns,
-                    order_url => $self->order_url,
-                      buttons => $self->buttons,
-                      options => $self->options,
-                         rows => $self->rows,
 
-                       DBNAME => $request->{company},
-                      });
+    if (ref $args{renderer}) {
+        my $setting = LedgerSMB::Setting->new({base => $request});
+        return $args{renderer}->($template, $self, {
+            report => $self,
+            company_name    => $setting->get('company_name'),
+            company_address => $setting->get('company_address'),
+            request         => $request,
+            new_heads       => $replace_hnames,
+            name            => $self->name,
+            hlines          => $self->header_lines,
+            columns         => $columns,
+            order_url       => $self->order_url,
+            buttons         => $self->buttons,
+            options         => $self->options,
+            rows            => $self->rows,
+
+            DBNAME          => $request->{company},
+                           });
+    }
+    else {
+        $template = LedgerSMB::Template->new(
+            user => $LedgerSMB::App_State::User,
+            locale => $self->locale,
+            path => 'UI',
+            output_options => {
+                filename => $self->output_name($request),
+            },
+            template => $template,
+            format => uc($request->{format} || 'HTML'),
+            );
+        my $render = $template->can($args{renderer});
+        return &$render($template,
+                        {report => $self,
+                   company_name => LedgerSMB::Setting->new({base => $request})->get('company_name'),
+                company_address => LedgerSMB::Setting->new({base => $request})->get('company_address'),
+                        request => $request,
+                      new_heads => $replace_hnames,
+                           name => $self->name,
+                         hlines => $self->header_lines,
+                        columns => $columns,
+                      order_url => $self->order_url,
+                        buttons => $self->buttons,
+                        options => $self->options,
+                           rows => $self->rows,
+
+                         DBNAME => $request->{company},
+                        });
+    }
 }
 
 =head2 show_cols

--- a/lib/LedgerSMB/Scripts/asset.pm
+++ b/lib/LedgerSMB/Scripts/asset.pm
@@ -146,8 +146,9 @@ Displays a list of all asset classes.  No inputs required.
 
 sub asset_category_results {
     my ($request) = @_;
-    return LedgerSMB::Report::Listings::Asset_Class->new(%$request)
-        ->render($request);
+    return $request->render_report(
+        LedgerSMB::Report::Listings::Asset_Class->new(%$request)
+        );
 }
 
 =item edit_asset_class
@@ -236,8 +237,9 @@ be set.
 
 sub asset_results {
     my ($request) = @_;
-    return LedgerSMB::Report::Listings::Asset->new(%$request)
-        ->render($request);
+    return $request->render_report(
+        LedgerSMB::Report::Listings::Asset->new(%$request)
+        );
 }
 
 =item asset_save
@@ -984,8 +986,9 @@ No inputs required or used.
 
 sub display_nbv {
     my ($request) = @_;
-    my $report = LedgerSMB::Report::Assets::Net_Book_Value->new(%$request);
-    return $report->render($request);
+    return $request->render_report(
+        LedgerSMB::Report::Assets::Net_Book_Value->new(%$request)
+        );
 }
 
 =item begin_import

--- a/lib/LedgerSMB/Scripts/budget_reports.pm
+++ b/lib/LedgerSMB/Scripts/budget_reports.pm
@@ -33,9 +33,9 @@ more.
 sub search {
     my ($request) = @_;
     LedgerSMB::Report::Budget::Search->prepare_criteria($request);
-    my $report = LedgerSMB::Report::Budget::Search->new(%$request);
-    $report->run_report;
-    return $report->render($request);
+    return $request->render_report(
+        LedgerSMB::Report::Budget::Search->new(%$request)
+        );
 }
 
 =item variance_report
@@ -48,9 +48,9 @@ vs amounts used.
 sub variance_report {
     my ($request) = @_;
     my $id = $request->{id};
-    my $report = LedgerSMB::Report::Budget::Variance->for_budget_id($id);
-    $report->run_report;
-    return $report->render($request);
+    return $request->render_report(
+        LedgerSMB::Report::Budget::Variance->for_budget_id($id)
+        );
 }
 
 =back

--- a/lib/LedgerSMB/Scripts/business_unit.pm
+++ b/lib/LedgerSMB/Scripts/business_unit.pm
@@ -130,8 +130,9 @@ If set, excludes those which are not associated with customers/vendors.
 
 sub list {
     my ($request) = @_;
-    return LedgerSMB::Report::Listings::Business_Unit->new(%$request)
-        ->render($request);
+    return $request->render_report(
+        LedgerSMB::Report::Listings::Business_Unit->new(%$request)
+        );
 }
 
 =item delete

--- a/lib/LedgerSMB/Scripts/contact_reports.pm
+++ b/lib/LedgerSMB/Scripts/contact_reports.pm
@@ -32,9 +32,9 @@ Runs the search report and displays it
 sub search{
     my ($request) = @_;
 
-    my $report = LedgerSMB::Report::Contact::Search->new(%$request);
-    $report->run_report;
-    return $report->render($request);
+    return $request->render_report(
+        LedgerSMB::Report::Contact::Search->new(%$request)
+        );
 }
 
 =item history
@@ -46,9 +46,9 @@ Runs the purchase history report and displays it
 sub history {
     my ($request) = @_;
 
-    my $report = LedgerSMB::Report::Contact::History->new(%$request);
-    $report->run_report;
-    return $report->render($request);
+    return $request->render_report(
+        LedgerSMB::Report::Contact::History->new(%$request)
+        );
 }
 
 =back

--- a/lib/LedgerSMB/Scripts/drafts.pm
+++ b/lib/LedgerSMB/Scripts/drafts.pm
@@ -18,10 +18,12 @@ which have not been approved yet.
 
 =cut
 
-use LedgerSMB::DBObject::Draft;
-use LedgerSMB::Template;
 use strict;
 use warnings;
+
+use LedgerSMB::DBObject::Draft;
+use LedgerSMB::Report::Unapproved::Drafts;
+use LedgerSMB::Template;
 
 our $VERSION = '0.1';
 
@@ -136,11 +138,11 @@ amount_ge: total greater than or equal to
 
 sub list_drafts {
     my ($request) = @_;
-    use LedgerSMB::Report::Unapproved::Drafts;
-    my $report = LedgerSMB::Report::Unapproved::Drafts->new(%$request);
+
     $request->open_form;
-    $report->run_report;
-    return $report->render($request);
+    return $request->render_report(
+        LedgerSMB::Report::Unapproved::Drafts->new(%$request)
+        );
 }
 
 

--- a/lib/LedgerSMB/Scripts/goods.pm
+++ b/lib/LedgerSMB/Scripts/goods.pm
@@ -53,12 +53,14 @@ sub search {
     my ($request) = @_;
     for (qw(so po is ir quo rfq)){
        $request->{col_ordnumber} = 1;
-       return LedgerSMB::Report::Inventory::History->new(%$request)
-              ->render($request)
-               if ($request->{"inc_$_"});
+       return $request->render_report(
+           LedgerSMB::Report::Inventory::History->new(%$request)
+           )
+           if ($request->{"inc_$_"});
     }
-    my $report = LedgerSMB::Report::Inventory::Search->new(%$request);
-    return $report->render($request);
+    return $request->render_report(
+        LedgerSMB::Report::Inventory::Search->new(%$request)
+        );
 }
 
 =item search_partsgroups
@@ -70,8 +72,9 @@ for a prefix search
 
 sub search_partsgroups {
     my ($request) = @_;
-    my $report = LedgerSMB::Report::Inventory::Partsgroups->new(%$request);
-    return $report->render($request);
+    return $request->render_report(
+        LedgerSMB::Report::Inventory::Partsgroups->new(%$request)
+        );
 }
 
 =item search_pricegroups
@@ -83,8 +86,9 @@ for a prefix search
 
 sub search_pricegroups {
     my ($request) = @_;
-    my $report = LedgerSMB::Report::Inventory::Pricegroups->new(%$request);
-    return $report->render($request);
+    return $request->render_report(
+        LedgerSMB::Report::Inventory::Pricegroups->new(%$request)
+        );
 }
 
 =item inventory_activity
@@ -95,8 +99,9 @@ This routine runs the inventory activity report/
 
 sub inventory_activity {
     my ($request) = @_;
-    my $report = LedgerSMB::Report::Inventory::Activity->new(%$request);
-    return $report->render($request);
+    return $request->render_report(
+        LedgerSMB::Report::Inventory::Activity->new(%$request)
+        );
 }
 
 =item cogs_lines
@@ -107,8 +112,9 @@ Runs the cogs lines report.
 
 sub cogs_lines {
     my ($request) = shift;
-    return LedgerSMB::Report::Invoices::COGS->new(%$request)
-        ->render($request);
+    return $request->render_report(
+        LedgerSMB::Report::Invoices::COGS->new(%$request)
+        );
 }
 
 =back

--- a/lib/LedgerSMB/Scripts/inv_reports.pm
+++ b/lib/LedgerSMB/Scripts/inv_reports.pm
@@ -36,9 +36,9 @@ use LedgerSMB::Scripts::reports;
 
 sub search_adj{
     my ($request) = @_;
-    my $rpt = LedgerSMB::Report::Inventory::Search_Adj->new(%$request);
-    $rpt->run_report;
-    return $rpt->render($request);
+    return $request->render_report(
+        LedgerSMB::Report::Inventory::Search_Adj->new(%$request)
+        );
 }
 
 =item adj_detail
@@ -50,9 +50,9 @@ Shows adjustment details
 sub adj_detail {
     my ($request) = @_;
     $request->{hiddens} = { id => $request->{id}};
-    my $rpt = LedgerSMB::Report::Inventory::Adj_Details->new(%$request);
-    $rpt->run_report;
-    return $rpt->render($request);
+    return $request->render_report(
+        LedgerSMB::Report::Inventory::Adj_Details->new(%$request)
+        );
 }
 
 =item approve

--- a/lib/LedgerSMB/Scripts/inventory.pm
+++ b/lib/LedgerSMB/Scripts/inventory.pm
@@ -19,7 +19,6 @@ use warnings;
 use LedgerSMB::Inventory::Adjust;
 use LedgerSMB::Inventory::Adjust_Line;
 use LedgerSMB::Report::Inventory::Search_Adj;
-use LedgerSMB::Report::Inventory::Adj_Details;
 use LedgerSMB::Scripts::reports;
 use LedgerSMB::Template::UI;
 
@@ -118,8 +117,10 @@ sub adjustment_save {
 
 sub adjustment_list {
     my ($request) = @_;
-    my $report = LedgerSMB::Report::Inventory::Search_Adj->new(%$request);
-    return $report->render($request);
+
+    return $request->render_report(
+        LedgerSMB::Report::Inventory::Search_Adj->new(%$request)
+        );
 }
 
 =item adjustment_approve

--- a/lib/LedgerSMB/Scripts/invoice.pm
+++ b/lib/LedgerSMB/Scripts/invoice.pm
@@ -75,8 +75,9 @@ sub invoices_outstanding {
     # the line below is needed because we are using trinary boolean logic
     # which does not work well with Moose
     delete $request->{on_hold} if $request->{on_hold} eq 'on';
-    my $report = LedgerSMB::Report::Invoices::Outstanding->new(%$request);
-    return $report->render($request);
+    return $request->render_report(
+        LedgerSMB::Report::Invoices::Outstanding->new(%$request)
+        );
 }
 
 =item invoice_search
@@ -92,8 +93,9 @@ sub  invoice_search{
     # the line below is needed because we are using trinary boolean logic
     # which does not work well with Moose
     delete $request->{on_hold} if $request->{on_hold} eq 'on';
-    my $report = LedgerSMB::Report::Invoices::Transactions->new(%$request);
-    return $report->render($request);
+    return $request->render_report(
+        LedgerSMB::Report::Invoices::Transactions->new(%$request)
+        );
 }
 
 =back

--- a/lib/LedgerSMB/Scripts/lreports_co.pm
+++ b/lib/LedgerSMB/Scripts/lreports_co.pm
@@ -58,9 +58,9 @@ Runs a Caja Diaria and displays results.
 
 sub run_caja_diaria {
     my ($request) = @_;
-    my $report = LedgerSMB::Report::co::Caja_Diaria->new(%$request);
-    $report->run_report;
-    return $report->render($request);
+    return $request->render_report(
+        LedgerSMB::Report::co::Caja_Diaria->new(%$request)
+        );
 }
 
 =item run_bm
@@ -71,9 +71,9 @@ Runs Balance y Mayor and displays results.
 
 sub run_bm {
     my ($request) = @_;
-    my $report = LedgerSMB::Report::co::Balance_y_Mayor->new(%$request);
-    $report->run_report;
-    return $report->render($request);
+    return $request->render_report(
+        LedgerSMB::Report::co::Balance_y_Mayor->new(%$request)
+        );
 }
 
 

--- a/lib/LedgerSMB/Scripts/order.pm
+++ b/lib/LedgerSMB/Scripts/order.pm
@@ -128,7 +128,7 @@ sub search {
            value => 'generate',
         }]);
     }
-    return $report->render($request);
+    return $request->render_report($report);
 }
 
 =item combine

--- a/lib/LedgerSMB/Scripts/payment.pm
+++ b/lib/LedgerSMB/Scripts/payment.pm
@@ -316,7 +316,7 @@ inputs currently expected include
 
 sub get_search_results {
     my ($request) = @_;
-    my $report = LedgerSMB::Report::Invoices::Payments->new(%$request);
+
     $request->{hiddens} = {
         batch_id => $request->{batch_id},
       cash_accno => $request->{cash_accno},
@@ -325,7 +325,9 @@ sub get_search_results {
    date_reversed => $request->{date_reversed},
    account_class => $request->{account_class},
     };
-    return $report->render($request);
+    return $request->render_report(
+        LedgerSMB::Report::Invoices::Payments->new(%$request)
+        );
 }
 
 =item reverse_payments

--- a/lib/LedgerSMB/Scripts/payroll.pm
+++ b/lib/LedgerSMB/Scripts/payroll.pm
@@ -21,6 +21,7 @@ use strict;
 use warnings;
 
 use LedgerSMB::Payroll::Income_Type;
+use LedgerSMB::Report::Payroll::Income_Types;
 use LedgerSMB::Template::UI;
 
 =head1 METHODS
@@ -103,9 +104,9 @@ Displays income type search results
 
 sub income_type_results {
     my ($request) = @_;
-    use LedgerSMB::Report::Payroll::Income_Types;
-    return LedgerSMB::Report::Payroll::Income_Types
-        ->new(%$request)->render($request);
+    return $request->render_report(
+        LedgerSMB::Report::Payroll::Income_Types->new(%$request)
+        );
 }
 
 =back

--- a/lib/LedgerSMB/Scripts/pnl.pm
+++ b/lib/LedgerSMB/Scripts/pnl.pm
@@ -71,7 +71,7 @@ sub generate_income_statement {
             $rpt->add_comparison($cmp);
         }
     }
-    return $rpt->render($request);
+    return $request->render_report($rpt);
 }
 
 =back

--- a/lib/LedgerSMB/Scripts/recon.pm
+++ b/lib/LedgerSMB/Scripts/recon.pm
@@ -143,8 +143,9 @@ Displays the search results
 
 sub get_results {
     my ($request) = @_;
-    my $report = LedgerSMB::Report::Reconciliation::Summary->new(%$request);
-    return $report->render($request);
+    return $request->render_report(
+        LedgerSMB::Report::Reconciliation::Summary->new(%$request)
+        );
 }
 
 =item search($request)

--- a/lib/LedgerSMB/Scripts/report_aging.pm
+++ b/lib/LedgerSMB/Scripts/report_aging.pm
@@ -48,9 +48,9 @@ sub run_report{
          push @{$request->{business_units}}, $request->{"business_unit_$count"}
                if $request->{"business_unit_$count"};
     }
-    my $report = LedgerSMB::Report::Aging->new(%$request);
-    $report->run_report;
-    return $report->render($request);
+    return $request->render_report(
+        LedgerSMB::Report::Aging->new(%$request)
+        );
 }
 
 

--- a/lib/LedgerSMB/Scripts/reports.pm
+++ b/lib/LedgerSMB/Scripts/reports.pm
@@ -121,8 +121,9 @@ Lists the business types.  No inputs expected or used.
 
 sub list_business_types {
     my ($request) = @_;
-    my $report = LedgerSMB::Report::Listings::Business_Type->new(%$request);
-    return $report->render($request);
+    return $request->render_report(
+        LedgerSMB::Report::Listings::Business_Type->new(%$request)
+        );
 }
 
 =item list_gifi
@@ -133,8 +134,9 @@ List the gifi entries.  No inputs expected or used.
 
 sub list_gifi {
     my ($request) = @_;
-    return LedgerSMB::Report::Listings::GIFI->new(%$request)
-        ->render($request);
+    return $request->render_report(
+        LedgerSMB::Report::Listings::GIFI->new(%$request)
+        );
 }
 
 =item list_warehouse
@@ -144,8 +146,10 @@ List the warehouse entries.  No inputs expected or used.
 =cut
 
 sub list_warehouse {
-    return LedgerSMB::Report::Listings::Warehouse->new(%{$_[0]})
-        ->render($_[0]);
+    my ($request) = @_;
+    return $request->render_report(
+        LedgerSMB::Report::Listings::Warehouse->new(%$request)
+        );
 }
 
 =item list_language
@@ -156,8 +160,9 @@ List language entries.  No inputs expected or used.
 
 sub list_language {
     my ($request) = @_;
-    return LedgerSMB::Report::Listings::Language->new(%$request)
-        ->render($request);
+    return $request->render_report(
+        LedgerSMB::Report::Listings::Language->new(%$request)
+        );
 }
 
 =item list_sic
@@ -168,8 +173,9 @@ Lists sic codes
 
 sub list_sic {
     my ($request) = @_;
-    return LedgerSMB::Report::Listings::SIC->new(%$request)
-        ->render($request);
+    return $request->render_report(
+        LedgerSMB::Report::Listings::SIC->new(%$request)
+        );
 }
 
 =item generate_balance_sheet
@@ -199,7 +205,7 @@ sub generate_balance_sheet {
         $cmp->run_report;
         $rpt->add_comparison($cmp);
     }
-    return $rpt->render($request);
+    return $request->render_report($rpt);
 }
 
 =item search_overpayments
@@ -210,12 +216,13 @@ Searches overpayments based on inputs.
 
 sub search_overpayments {
     my ($request) = @_;
-    my $hiddens = {};
-    $hiddens->{$_} = $request->{$_} for qw(batch_id currency exchangerate
-                                        post_date batch_class account_class);
-    $request->{hiddens} = $hiddens;
-    return LedgerSMB::Report::Listings::Overpayments->new(%$request)
-        ->render($request);
+    $request->{hiddens}->{$_} = $request->{$_}
+        for qw(batch_id currency exchangerate
+               post_date batch_class account_class);
+
+    return $request->render_report(
+        LedgerSMB::Report::Listings::Overpayments->new(%$request)
+        );
 }
 
 =item reverse_overpayment

--- a/lib/LedgerSMB/Scripts/taxform.pm
+++ b/lib/LedgerSMB/Scripts/taxform.pm
@@ -119,24 +119,18 @@ package.
 
 =cut
 
-sub _generate_report {
+sub generate_report {
     my ($request) = @_;
+    die $request->{_locale}->text('No tax form selected')
+        unless $request->{tax_form_id};
+
     my $report;
     if ($request->{meta_number}){
         $report = LedgerSMB::Report::Taxform::Details->new(%$request);
     } else {
         $report = LedgerSMB::Report::Taxform::Summary->new(%$request);
     }
-    return $report;
-}
-
-
-sub generate_report {
-    my ($request) = @_;
-    die $request->{_locale}->text('No tax form selected')
-        unless $request->{tax_form_id};
-    my $report = _generate_report($request);
-    return $report->render($request);
+    return $request->render_report($report);
 }
 
 =item save
@@ -199,8 +193,9 @@ Lists all tax forms.
 
 sub list_all {
     my $request= shift;
-    my $report = LedgerSMB::Report::Taxform::List->new(%$request);
-    return $report->render($request);
+    return $request->render_report(
+        LedgerSMB::Report::Taxform::List->new(%$request)
+        );
 }
 
 =back

--- a/lib/LedgerSMB/Scripts/template.pm
+++ b/lib/LedgerSMB/Scripts/template.pm
@@ -44,8 +44,9 @@ Lists the templates.
 
 sub list {
     my ($request) = @_;
-    return LedgerSMB::Report::Listings::Templates->new(%$request)
-        ->render($request);
+    return $request->render_report(
+        LedgerSMB::Report::Listings::Templates->new(%$request)
+        );
 }
 
 =head2 display($request)

--- a/lib/LedgerSMB/Scripts/timecard.pm
+++ b/lib/LedgerSMB/Scripts/timecard.pm
@@ -231,8 +231,9 @@ This generates a report of timecards.
 
 sub timecard_report{
     my ($request) = @_;
-    my $report = LedgerSMB::Report::Timecards->new(%$request);
-    return $report->render($request);
+    return $request->render_report(
+        LedgerSMB::Report::Timecards->new(%$request)
+        );
 }
 
 =item generate_order

--- a/lib/LedgerSMB/Scripts/transtemplate.pm
+++ b/lib/LedgerSMB/Scripts/transtemplate.pm
@@ -128,8 +128,9 @@ Lists all transaction templates
 
 sub list {
     my ($request) = @_;
-    return LedgerSMB::Report::Listings::TemplateTrans->new(%$request)
-        ->render($request);
+    return $request->render_report(
+        LedgerSMB::Report::Listings::TemplateTrans->new(%$request)
+        );
 }
 
 =item delete
@@ -147,8 +148,9 @@ sub delete {
             if $request->{"row_select_$row"};
         delete $request->{"row_select_$row"};
     }
-    return LedgerSMB::Report::Listings::TemplateTrans->new(%$request)
-        ->render($request);
+    return $request->render_report(
+        LedgerSMB::Report::Listings::TemplateTrans->new(%$request)
+        );
 }
 
 =back

--- a/lib/LedgerSMB/Scripts/trial_balance.pm
+++ b/lib/LedgerSMB/Scripts/trial_balance.pm
@@ -49,9 +49,10 @@ sub run {
                                  grep {$_ =~ /business_/}
                                  keys %$request];
     delete $request->{business_units}
-           unless scalar @{$request->{business_units}};
-    return LedgerSMB::Report::Trial_Balance->new(%$request)
-        ->render($request);
+    unless scalar @{$request->{business_units}};
+    return $request->render_report(
+        LedgerSMB::Report::Trial_Balance->new(%$request)
+        );
 }
 
 =back

--- a/lib/LedgerSMB/Scripts/vouchers.pm
+++ b/lib/LedgerSMB/Scripts/vouchers.pm
@@ -261,8 +261,9 @@ of these parameters.
 sub list_batches {
     my ($request) = @_;
     $request->open_form;
-    return LedgerSMB::Report::Unapproved::Batch_Overview->new(
-                 %$request)->render($request);
+    return $request->render_report(
+        LedgerSMB::Report::Unapproved::Batch_Overview->new(%$request)
+        );
 }
 
 =head2 get_batch
@@ -275,15 +276,16 @@ Displays all vouchers from the batch by type, and includes amount.
 
 sub get_batch {
     my ($request)  = @_;
+    my $setting =  LedgerSMB::Setting->new({base=>$request});
     $request->open_form;
 
     $request->{hiddens} = { batch_id => $request->{batch_id} };
 
-    return LedgerSMB::Report::Unapproved::Batch_Detail->new(
-                 %$request,
-        default_language => LedgerSMB::Setting->new({base=>$request})
-                               ->get('default_language'),
-        )->render($request);
+    return $request->render_report(
+        LedgerSMB::Report::Unapproved::Batch_Detail->new(
+            default_language => $setting->get('default_language'),
+            %$request,
+        ));
 }
 
 =head2 single_batch_approve
@@ -577,7 +579,7 @@ sub print_batch {
         };
     }
     else {
-        return $report->render($request);
+        return $request->render_report($report);
     }
 }
 


### PR DESCRIPTION
Instead, pass the renderer from the caller, which "knows" if we're downloading a document or generating a UI element. Additionally, generalize that decision into a common caller in the `$request`.
