### PR TITLE
Move handling of downloaded documents out of mainline code path

### DIFF
--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -600,7 +600,30 @@ sub report_renderer_doc {
             },
             );
 
-        return $template->render($vars, $cvars);
+        $template->render($vars, $cvars);
+
+        my $charset = '';
+        $charset = '; charset=utf-8'
+                          if $template->{mimetype} =~ m!^text/!;
+
+        # $request->{mimetype} set by format
+        my $headers = [
+            'Content-Type' => "$template->{mimetype}$charset",
+            ];
+
+        # Use the same Content-Disposition criteria as _http_output()
+        my $name = $template->{output_options}->{filename};
+        if ($name) {
+            $name =~ s#^.*/##;
+            push @$headers,
+                ( 'Content-Disposition' =>
+                  qq{attachment; filename="$name"} );
+        }
+
+        my $body = $template->{output};
+        utf8::encode($body) if utf8::is_utf8($body); ## no critic
+
+        return [ HTTP_OK, $headers, [ $body ] ];
     };
 }
 

--- a/lib/LedgerSMB/PSGI.pm
+++ b/lib/LedgerSMB/PSGI.pm
@@ -117,11 +117,6 @@ sub psgi_app {
             }
 
             $res = $env->{'lsmb.action'}->($request);
-
-            if (ref $res && ref $res eq 'LedgerSMB::Template') {
-                # We got an evaluated template instead of a PSGI triplet...
-                $res = LedgerSMB::PSGI::Util::template_to_psgi($res);
-            }
         }, DBH     => $env->{'lsmb.db'},
            Locale  => $request->{_locale};
 

--- a/lib/LedgerSMB/PSGI/Util.pm
+++ b/lib/LedgerSMB/PSGI/Util.pm
@@ -106,50 +106,6 @@ sub incompatible_database {
 }
 
 
-=head2 template_to_psgi($template, %args)
-
-Returns a PSGI return value triplet (status, headers and body).
-
-Note that the only guarantee here is that the triplet can
-be used as a PSGI return value which means that the body
-is *not* restricted to being an array of strings.
-
-When C<extra_headers> is specified in the C<%args> hash, these are
-included in the headers part of returned triplet.
-
-=cut
-
-
-sub template_to_psgi {
-    my $self = shift @_;
-    my %args = ( @_ );
-
-    my $charset = '';
-    $charset = '; charset=utf-8'
-        if $self->{mimetype} =~ m!^text/!;
-
-    # $self->{mimetype} set by format
-    my $headers = [
-        'Content-Type' => "$self->{mimetype}$charset",
-        (@{$args{extra_headers} // []})
-        ];
-
-    # Use the same Content-Disposition criteria as _http_output()
-    my $name = $self->{output_options}{filename};
-    if ($name) {
-        $name =~ s#^.*/##;
-        push @$headers,
-            ( 'Content-Disposition' =>
-              qq{attachment; filename="$name"} );
-    }
-
-    my $body = $self->{output};
-    utf8::encode($body) if utf8::is_utf8($body); ## no critic
-
-    return [ HTTP_OK, $headers, [ $body ] ];
-}
-
-
 =head1 LICENSE AND COPYRIGHT
 
 Copyright (C) 2017 The LedgerSMB Core Team


### PR DESCRIPTION
This commit moves the handling of downloaded documents (returned
as template objects) out of the main code path into the now-available
special case code path for handling document creation.

This also allows cleaning up LedgerSMB::PSGI::Util.
