### PR TITLE
Fix #4236: Rate entry allowed for default currency

### DIFF
--- a/UI/Configuration/rate.html
+++ b/UI/Configuration/rate.html
@@ -30,10 +30,10 @@
              options=currencies
              text_attr='curr'
              value_attr='curr'
-             default_values=[form.curr] } ?>
+             default_blank=1 } ?>
       <?lsmb PROCESS select element_data={
              name='rate_type'
-             label=text('Currency')
+             label=text('Rate type')
              options=exchangerate_types
              text_attr='description'
              value_attr='id'

--- a/lib/LedgerSMB/Scripts/currency.pm
+++ b/lib/LedgerSMB/Scripts/currency.pm
@@ -223,6 +223,7 @@ sub _list_exchangerates {
     my ($request, $exchangerates) = @_;
     my @exchangerate_types = LedgerSMB::Exchangerate_Type->list();
     my @currencies = LedgerSMB::Currency->list();
+    shift @currencies; # Remove the default currency
     my %rate_types = map { $_->{id} => $_->{description} } @exchangerate_types;
     my $base_url = 'currency.pl?action=delete_exchangerate';
     my $columns = [


### PR DESCRIPTION
Incidentally fix a label on the rate entry screen as well.
