### PR TITLE
Fix #3334: OH column on orders not formatted according to user prefs

### DIFF
--- a/old/bin/io.pl
+++ b/old/bin/io.pl
@@ -437,8 +437,8 @@ qq|<td align=right class="qty"><input data-dojo-type="dijit/form/TextBox" name="
           . $form->format_amount( \%myconfig, $linetotal, 2 )
           . qq|</td>|;
         $column_data{bin}    = qq|<td class="bin">$form->{"bin_$i"}</td>|;
-        $column_data{onhand} = qq|<td class="onhand">$form->{"onhand_$i"}</td>|;
-        $column_data{taxformcheck} = qq|<td class="taxform"><input type="checkbox" data-dojo-type="dijit/form/CheckBox" name="taxformcheck_$i" value="1" $taxchecked></td>|;
+        $column_data{onhand} = qq|<td class="onhand">|. $form->format_amount( \%myconfig, $form->{"onhand_$i"}) . qq|</td>|;
+        $column_data{taxformcheck} = qq|<td class="taxform"><input type="checkbox" data-dojo-type="dijit/form/CheckBox" id="taxformcheck_$i" name="taxformcheck_$i" value="1" $taxchecked></td>|;
         print qq|
 <tbody data-dojo-type="lsmb/InvoiceLine"
  id="line-$i">


### PR DESCRIPTION
Note that this is a short term fix which doesn't take into account
the fact that parts amounts might want to be formatted with different
precision than monetary amounts.

This commit aligns numeric OH formatting with Goods&Services>Search
output as well as formatting on the parts screen itself.
