### PR TITLE
Close #3203: Make invoice/order/rfq (internal) notes scrollable

### DIFF
--- a/UI/css/system/global.css
+++ b/UI/css/system/global.css
@@ -1,3 +1,9 @@
+textarea#intnotes,
+textarea#notes {
+    /* Prevent notes fields taking up endless screen estate */
+    max-height: 15em;
+}
+
 div.input {
     float: left;
 }


### PR DESCRIPTION
When the notes or internal notes fields exceed 15 lines, make them
scrollable and limit their height to prevent the lower part of the
screen from moving away too far down.
