### PR TITLE
Fix #2822: Contact notes have empty Author and Entered At heading

### DIFF
--- a/lib/LedgerSMB/Entity/Note.pm
+++ b/lib/LedgerSMB/Entity/Note.pm
@@ -58,6 +58,14 @@ If set this indicates this has been saved to the db.
 
 has 'id' => (is =>'ro', isa => 'Int', required => 0);
 
+=item created
+
+Timestamp of creation of the note.
+
+=cut
+
+has 'created' => (is => 'ro', required => 0);
+
 =item created_by
 
 If set this indicates the username (login) of the user who created


### PR DESCRIPTION
Note that the empty author has been fixed since 1.5.8, meaning that
only the empty 'Entered At' was still left to be addressed.
