### PR TITLE
Fix #1194: Insufficient visual difference between columns

### DIFF
--- a/old/bin/aa.pl
+++ b/old/bin/aa.pl
@@ -668,7 +668,8 @@ $form->open_status_div($status_div_id) . qq|
 |;
 
     print qq|
-    <tr>
+    <thead>
+    <tr class="listheading">
       <th>| . $locale->text('Amount') . qq|</th>
      <th>| . (($form->{currency} ne $form->{defaultcurrency}) ? $form->{defaultcurrency} : '') . qq|</th>
       <th>| . $locale->text('Account') . qq|</th>
@@ -680,7 +681,8 @@ $form->open_status_div($status_div_id) . qq|
         }
     }
     print qq|
-    </tr>
+    </th>
+    </thead>
 |;
 
 


### PR DESCRIPTION
By setting the row to 'listheading' class, the background of the
cells will be turned navy/dark blue. There's a bit of margin between
the cells, meaning that a (white) line shows between the cells in
the heading. Voila, there's the visual support.
