### PR TITLE
Fix #3703: Removing lines from orders and vendor invoices fails

### DIFF
--- a/old/bin/io.pl
+++ b/old/bin/io.pl
@@ -399,7 +399,7 @@ qq|<option value="$ref->{partsgroup}--$ref->{id}">$ref->{partsgroup}\n|;
         }
 
         $column_data{runningnumber} =
-          qq|<td class="runningnumber"><input data-dojo-type="dijit/form/TextBox" id="runningnumber_$i" name="runningnumber_$i" size=3 value=$i></td>|;
+          qq|<td class="runningnumber"><input data-dojo-attach-point="runningnumber" data-dojo-type="dijit/form/TextBox" id="runningnumber_$i" name="runningnumber_$i" size="3" value="$i"></td>|;
         if ($form->{"partnumber_$i"}){
             $column_data{deleteline} = qq|
 <td rowspan="2" valign="middle">

--- a/old/bin/ir.pl
+++ b/old/bin/ir.pl
@@ -369,7 +369,10 @@ sub form_header {
     print qq|
 <body class="lsmb $form->{dojo_theme}" onLoad="document.forms[0].${focus}.focus()" />
 | . $form->open_status_div($status_div_id) . qq|
-<form method="post" data-dojo-type="lsmb/Form" action="$form->{script}">
+<form method="post"
+      id="invoice"
+      data-dojo-type="lsmb/Invoice"
+      action="$form->{script}" >
 |;
     if ($form->{notice}){
          print qq|$form->{notice}<br/>|;
@@ -1221,7 +1224,9 @@ sub update {
              billing => 1,
              job => 1 );
      $form->generate_selects();
-     $form->{rowcount}--;
+    check_form();
+
+    $form->{rowcount}--;
     display_form();
 }
 

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -1349,6 +1349,8 @@ sub update {
              billing => 1,
              job => 1 );
     $form->generate_selects(\%myconfig);
+    check_form();
+
     $form->{rowcount}--;
     display_form();
 }

--- a/old/bin/oe.pl
+++ b/old/bin/oe.pl
@@ -563,8 +563,10 @@ sub form_header {
     print qq|
 <body class="lsmb $form->{dojo_theme}" onLoad="document.forms[0].${focus}.focus()" />
 | . $form->open_status_div($status_div_id) . qq|
-<form method="post" data-dojo-type="lsmb/Form" action="$form->{script}">
-
+<form method="post"
+      id="invoice"
+      data-dojo-type="lsmb/Invoice"
+      action="$form->{script}" >
 |;
 
     if ($form->{notice}){
@@ -1191,6 +1193,8 @@ sub update {
     }
     $form->all_vc(\%myconfig, $form->{vc}, $form->{transdate}, 1) if ! @{$form->{"all_$form->{vc}"}};
     $form->generate_selects;
+    check_form();
+
     $form->{rowcount}--;
     display_form();
 }


### PR DESCRIPTION
Employ the same mechanism on vendor invoices and orders as used
on sales invoices.
