### PR TITLE
Follow-up to fixing #2587 (9faef0ad2a61d9cd1c771bf7a20a3979c747366c)

### DIFF
--- a/old/bin/ir.pl
+++ b/old/bin/ir.pl
@@ -575,6 +575,9 @@ sub form_header {
             elsif ($closedto) {
                 %buttons = ();
             }
+            else {
+                for ( keys %button ) { delete $button{$_} unless $_ eq 'update' };
+            }
         }
 
         for ( sort { $button{$a}->{ndx} <=> $button{$b}->{ndx} } keys %button )

--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -606,7 +606,7 @@ sub form_header {
         if ($form->{separate_duties} or $form->{batch_id}){
            $button{'post'}->{value} = $locale->text('Save');
         }
-       delete $button{void} if $form->{invnumber} =~ /-VOID/;
+        delete $button{void} if $form->{invnumber} =~ /-VOID/;
 
         if ( $form->{id} ) {
 
@@ -640,7 +640,6 @@ sub form_header {
 
         }
         else {
-
             if ( $transdate > $closedto ) {
                 # Added on_hold, by Aurynn.
                 for ( "update", "ship_to", "post",
@@ -652,9 +651,11 @@ sub form_header {
 
                 for ( keys %button ) { delete $button{$_} if !$allowed{$_} }
             }
-
             elsif ($closedto) {
                 %button = ();
+            }
+            else {
+                for ( keys %button ) { delete $button{$_} unless $_ eq 'update' };
             }
         }
         for ( sort { $button{$a}->{ndx} <=> $button{$b}->{ndx} } keys %button )


### PR DESCRIPTION
Fixes the fact that all buttons show, instead of only the applicable ones.

Note that this commit causes only 1 button (Update) to show on the initial
screen, which is completely correct: without a vendor having been selected,
the data on the screen can't save and therefor the button shouldn't show.

(Also, the system can't calculate whether or not the transaction will be
posted in an "open" period, due to the missing 'transdate' which the
browser must provide.)
