### PR TITLE
Follow up to elimination 'no strict "refs"' (3187cb7c)

### DIFF
--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -656,7 +656,7 @@ sub _redirect {
     require "old/bin/$script";
 
     my $ref = qualify_to_ref $form->{action}, 'lsmb_legacy';
-    &{ $ref };
+    &{ *{$ref} };
 
 }
 


### PR DESCRIPTION
Found while using the csv upload module, the symbolref misses a
cast-to-glob before it can be used as a coderef.
