### PR TITLE
Implement CSV import for goods and services

### DIFF
--- a/sql/changes/1.8/parts-imports.sql
+++ b/sql/changes/1.8/parts-imports.sql
@@ -1,0 +1,67 @@
+
+
+CREATE OR REPLACE FUNCTION
+pg_temp.menu_insert(in_parent_id int, in_position int, in_label text)
+returns int
+AS $$
+DECLARE
+        new_id int;
+BEGIN
+        UPDATE menu_node
+            -- prevent duplicates by setting negative as a first step
+           SET position = -1 * (position + 1)
+         WHERE parent = in_parent_id
+               AND position >= in_position;
+
+        UPDATE menu_node
+            -- negate again now that all numbers are final
+           SET position = -1 * position
+         WHERE parent = in_parent_id
+               AND position < 0;
+
+        INSERT INTO menu_node (parent, position, label)
+        VALUES (in_parent_id, in_position, in_label);
+
+        RETURN currval('menu_node_id_seq');
+END;
+$$ language plpgsql;
+
+
+DO $$
+DECLARE
+  menu_id int;
+  parent_menu_id int;
+BEGIN
+  SELECT pg_temp.menu_insert(
+     (select id from menu_node where label = 'Goods and Services'),
+     (select position from menu_node where label = 'Import Inventory'),
+     'Import'
+  ) INTO parent_menu_id;
+  UPDATE menu_node
+     SET menu = true
+   WHERE id = parent_menu_id;
+
+  SELECT pg_temp.menu_insert(parent_menu_id, 1, 'Goods') INTO menu_id;
+  UPDATE menu_node
+     SET url = 'import_csv.pl?action=begin_import&type=parts'
+   WHERE id = menu_id;
+
+  SELECT pg_temp.menu_insert(parent_menu_id, 2, 'Services') INTO menu_id;
+  UPDATE menu_node
+     SET url = 'import_csv.pl?action=begin_import&type=services'
+   WHERE id = menu_id;
+
+  SELECT pg_temp.menu_insert(parent_menu_id, 3, 'Overhead') INTO menu_id;
+  UPDATE menu_node
+     SET url = 'import_csv.pl?action=begin_import&type=overhead'
+   WHERE id = menu_id;
+
+
+  UPDATE menu_node
+     SET label = 'Inventory',
+         position = 4,
+         parent = parent_menu_id
+   WHERE id = (select id from menu_node where label = 'Import Inventory');
+
+END;
+$$ language plpgsql;

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -118,3 +118,4 @@ mc/delete-migration-validation-data.sql
 1.8/remove-custom-field-sprocs.sql
 1.8/remove-unused-sprocs.sql
 1.8/remove-unused-groups-admin.sql
+1.8/parts-imports.sql

--- a/sql/modules/Menu.sql
+++ b/sql/modules/Menu.sql
@@ -99,9 +99,16 @@ DECLARE
         new_id int;
 BEGIN
         UPDATE menu_node
-        SET position = position + 1
-        WHERE parent = in_parent_id
-                AND position >= in_position;
+            -- prevent duplicates by setting negative as a first step
+           SET position = -1 * (position + 1)
+         WHERE parent = in_parent_id
+               AND position >= in_position;
+
+        UPDATE menu_node
+            -- negate again now that all numbers are final
+           SET position = -1 * position
+         WHERE parent = in_parent_id
+               AND position < 0;
 
         INSERT INTO menu_node (parent, position, label)
         VALUES (in_parent_id, in_position, in_label);

--- a/sql/modules/Roles.sql
+++ b/sql/modules/Roles.sql
@@ -751,7 +751,7 @@ SELECT lsmb__grant_role('cash_all', rname)
 SELECT lsmb__create_role('part_create');
 SELECT lsmb__grant_role('part_create', 'contact_read');
 SELECT lsmb__grant_menu('part_create', node_id, 'allow')
-  FROM unnest(array[78,79,80,81,82]) node_id;
+  FROM unnest(array[78,79,80,81,82,259,260,261]) node_id;
 
 SELECT lsmb__grant_perms('part_create', obj, 'ALL')
   FROM unnest(array['partsvendor'::text, 'partscustomer', 'parts_id_seq',

--- a/xt/66-cucumber/01-basic/menu.feature
+++ b/xt/66-cucumber/01-basic/menu.feature
@@ -101,7 +101,10 @@ Scenario Outline: Navigate to menu and open screen
 #   | Goods and Services > Add Pricegroup        |                          |
     | Goods and Services > Add Service           | service entry            |
 #   | Goods and Services > Enter Inventory       | Enter Inventory          |
-#   | Goods and Services > Import Inventory      |                          |
+#   | Goods and Services > Import > Goods        |                          |
+#   | Goods and Services > Import > Services     |                          |
+#   | Goods and Services > Import > Overhead     |                          |
+#   | Goods and Services > Import > Inventory    |                          |
 #   | Goods and Services > Reports               |                          |
 #   | Goods and Services > Reports > Inventory Activity |                   |
 #   | Goods and Services > Search                | search for goods & services |


### PR DESCRIPTION
This commit adds 3 menu items to the Goods & Services menu,
grouped together with the 'Import Inventory' menu under an
'Import' submenu.

Note that this commit also fixes a bug in menu_insert() where
primary key conflicts can occur when a new menu item added
before the last item in the (sub)menu.
