### PR TITLE
Add error checking to DBI calls in the code path for logging in

### DIFF
--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -273,19 +273,22 @@ sub initialize_with_db {
 
     my $sth = $self->{dbh}->prepare(q{
             SELECT value FROM defaults
-             WHERE setting_key = 'role_prefix'});
-    $sth->execute;
+             WHERE setting_key = 'role_prefix'})
+        or die $self->{dbh}->errstr;;
+    $sth->execute or die $sth->errstr;
 
 
     ($self->{_role_prefix}) = $sth->fetchrow_array;
 
-    $sth = $self->{dbh}->prepare('SELECT check_expiration()');
-    $sth->execute;
+    $sth = $self->{dbh}->prepare('SELECT check_expiration()')
+        or die $self->{dbh}->errstr;
+    $sth->execute or die $sth->errstr;
     ($self->{warn_expire}) = $sth->fetchrow_array;
 
     if ($self->{warn_expire}){
-        $sth = $self->{dbh}->prepare('SELECT user__check_my_expiration()');
-        $sth->execute;
+        $sth = $self->{dbh}->prepare('SELECT user__check_my_expiration()')
+            or die $self->{dbh}->errstr;
+        $sth->execute or die $sth->errstr;
         ($self->{pw_expires})  = $sth->fetchrow_array;
     }
 


### PR DESCRIPTION
Through fiddling with database permissions in recent days, these
DBI statements popped up as being unchecked. By having them fixed,
we now report a true error instead of 'transaction has been cancelled
due to a previous error' which is pretty hard to debug.