### PR TITLE
Remove list of available formats and permalinks from printed documents

### DIFF
--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -91,27 +91,6 @@ template to get debugging messages is to be surrounded by
 =back
 
 
-=item available_formats()
-
-Returns a list of format names, any of the following (in order) as applicable:
-
-=over
-
-=item HTML (always available)
-
-=item TXT (includes CSV, always available))
-
-=item PDF
-
-=item PS
-
-=item XLS
-
-=item XLSX
-
-=item ODS
-
-=back
 
 
 =item render($variables, $raw_variables)
@@ -154,7 +133,7 @@ subroutine.
 
 =head1 PROPERTIES
 
-=over 
+=over
 
 =item output
 
@@ -325,24 +304,6 @@ use parent qw( Exporter );
 our @EXPORT_OK = qw( preprocess );
 
 my $logger = Log::Log4perl->get_logger('LedgerSMB::Template');
-
-sub available_formats {
-    my @retval = ('HTML', 'TXT');
-
-    if ($LedgerSMB::Sysconfig::template_latex){
-        push @retval, 'PDF', 'PS';
-    }
-    if ($LedgerSMB::Sysconfig::template_xls){
-        push @retval, 'XLS';
-    }
-    if ($LedgerSMB::Sysconfig::template_xlsx){
-        push @retval, 'XLSX';
-    }
-    if ($LedgerSMB::Sysconfig::template_ods){
-        push @retval, 'ODS';
-    }
-    return \@retval;
-}
 
 sub new {
     my $class = shift;
@@ -530,7 +491,6 @@ sub _render {
     my $unescape = $format->can('unescape');
     my $cleanvars = {
         ( %{preprocess($vars, $escape)},
-          LIST_FORMATS => sub { return available_formats(); },
           UNESCAPE => ($unescape ? sub { return $unescape->(@_); }
                        : sub { return @_; }),
           escape => sub { return $escape->(@_); },

--- a/lib/LedgerSMB/Template/UI.pm
+++ b/lib/LedgerSMB/Template/UI.pm
@@ -17,8 +17,6 @@ This module instantiates a singleton UI template rendering engine
 use strict;
 use warnings;
 
-#use parent qw(LedgerSMB::Template);
-
 use LedgerSMB::Locale;
 use LedgerSMB::Sysconfig;
 use LedgerSMB::Template;
@@ -44,6 +42,25 @@ our @pre_render_cbs = (
         }
     },
     );
+
+
+sub _available_formats {
+    my @retval = ('HTML', 'TXT');
+
+    if ($LedgerSMB::Sysconfig::template_latex){
+        push @retval, 'PDF', 'PS';
+    }
+    if ($LedgerSMB::Sysconfig::template_xls){
+        push @retval, 'XLS';
+    }
+    if ($LedgerSMB::Sysconfig::template_xlsx){
+        push @retval, 'XLSX';
+    }
+    if ($LedgerSMB::Sysconfig::template_ods){
+        push @retval, 'ODS';
+    }
+    return \@retval;
+}
 
 =head2 new_UI()
 
@@ -84,7 +101,7 @@ sub new_UI {
                 tt_url => \&LedgerSMB::Template::tt_url,
 
                 LIST_FORMATS => sub {
-                    return LedgerSMB::Template::available_formats();
+                    return _available_formats();
                 },
             },
         }, __PACKAGE__;

--- a/templates/demo/PNL.html
+++ b/templates/demo/PNL.html
@@ -1,9 +1,6 @@
 <?lsmb INCLUDE 'ui-header.html';
 account_data = report.account_data;
 
-FORMATS = LIST_FORMATS();
-LINK = request.script _ '?' _ request.query_string _ '&amp;company=' _ DBNAME;
-LINK = LINK.replace('\&amp;\&amp;', '&amp;');
 DRILLBASE = 'journal.pl?sort=transdate&amp;&amp;category=X'
        _ '&amp;col_transdate=Y&amp;col_reference=Y&amp;col_description=Y'
        _ '&amp;col_debits=Y&amp;col_credits=Y&amp;col_source=Y'
@@ -94,14 +91,7 @@ END ;
 <?lsmb END ?>
 </tbody>
 </table>
-<?lsmb IF FORMATS.grep('PDF').size() ?>
-<div class="export-links">
-<div class="export-link"><a target="_blank"
-           href="<?lsmb LINK ?>&amp;format=PDF">[<?lsmb text('PDF') ?>]</a>
-<div class="export-link"><a target="_blank"
-       href="<?lsmb LINK ?>&amp;format=CSV">[<?lsmb text('CSV') ?>]</a></div>
-</div>
-<?lsmb END ?>
+
 </div>
 </body>
 </html>

--- a/templates/demo/balance_sheet.html
+++ b/templates/demo/balance_sheet.html
@@ -1,8 +1,5 @@
 <?lsmb INCLUDE 'ui-header.html';
 
-FORMATS = LIST_FORMATS();
-LINK = request.script _ '?' _ request.query_string _ '&amp;company=' _ DBNAME;
-LINK = LINK.replace('\&amp;\&amp;', '&amp;');
 DRILLBASE = 'journal.pl?sort=transdate&amp;&amp;category=X'
        _ '&amp;col_transdate=Y&amp;col_reference=Y&amp;col_description=Y'
        _ '&amp;col_debits=Y&amp;col_credits=Y&amp;col_source=Y'
@@ -109,14 +106,6 @@ END ;
 </tbody>
 </table>
 
-<?lsmb IF FORMATS.grep('PDF').size() ?>
-<div class="export-links">
-<div class="export-link"><a target="_blank"
-           href="<?lsmb LINK ?>&amp;format=PDF">[<?lsmb text('PDF') ?>]</a></div>
-<div class="export-link"><a target="_blank"
-       href="<?lsmb LINK ?>&amp;format=CSV">[<?lsmb text('CSV') ?>]</a></div>
-</div>
-<?lsmb END ?>
 </div>
 
 </body>

--- a/templates/demo/display_report.html
+++ b/templates/demo/display_report.html
@@ -7,17 +7,6 @@ PROCESS "elements.html";
 
 PROCESS "dynatable.html";
 
-FORMATS = LIST_FORMATS();
-QSTRING = request.query_string;
-
-IF NOT QSTRING.match('company=');
-   ESCAPED_COMPANY = request.company FILTER uri;
-   QSTRING = QSTRING _ '&amp;company=' _ ESCAPED_COMPANY;
-END;
-
-LINK = request.script _ '?' _ QSTRING;
-
-
 ?>
 <body class="lsmb <?lsmb dojo_theme ?>">
 <form data-dojo-type="lsmb/Form"
@@ -69,27 +58,6 @@ END; ?>
 FOREACH BUTTON IN buttons;
   PROCESS button element_data = BUTTON;
 END; ?><br />
-<a href="<?lsmb LINK ?>">[<?lsmb text('permalink') ?>]</a>&nbsp;
-<?lsmb IF FORMATS.grep('PDF').size() ?>
-<a target="_blank"
-   href="<?lsmb LINK _ '&amp;format=PDF' ?>">[<?lsmb text('PDF') ?>]</a>&nbsp;
-<?lsmb END;
-IF FORMATS.grep('TXT').size(); ?>
-<a target="_blank"
-   href="<?lsmb LINK _ '&amp;format=CSV' ?>">[<?lsmb text('CSV') ?>]</a>&nbsp;
-<?lsmb END;
-IF FORMATS.grep('ODS').size() ?>
-<a target="_blank"
-   href="<?lsmb LINK _ '&amp;format=ODS' ?>">[<?lsmb text('ODS') ?>]</a>&nbsp;
-<?lsmb END;
-IF FORMATS.grep('XLS').size(); ?>
-<a target="_blank"
-   href="<?lsmb LINK _ '&amp;format=XLS' ?>">[<?lsmb text('XLS') ?>]</a>&nbsp;
-<?lsmb END;
-IF FORMATS.grep('XLSX').size(); ?>
-<a target="_blank"
-   href="<?lsmb LINK _ '&amp;format=XLSX' ?>">[<?lsmb text('XLSX') ?>]</a>&nbsp;
-<?lsmb END; ?>
 </form>
 </body>
 <?lsmb PROCESS end_html ?>

--- a/templates/demo_with_images/PNL.html
+++ b/templates/demo_with_images/PNL.html
@@ -1,9 +1,6 @@
 <?lsmb INCLUDE 'ui-header.html';
 account_data = report.account_data;
 
-FORMATS = LIST_FORMATS();
-LINK = request.script _ '?' _ request.query_string _ '&amp;company=' _ DBNAME;
-LINK = LINK.replace('\&amp;\&amp;', '&amp;');
 DRILLBASE = 'journal.pl?sort=transdate&amp;&amp;category=X'
        _ '&amp;col_transdate=Y&amp;col_reference=Y&amp;col_description=Y'
        _ '&amp;col_debits=Y&amp;col_credits=Y&amp;col_source=Y'
@@ -94,14 +91,7 @@ END ;
 <?lsmb END ?>
 </tbody>
 </table>
-<?lsmb IF FORMATS.grep('PDF').size() ?>
-<div class="export-links">
-<div class="export-link"><a target="_blank"
-           href="<?lsmb LINK ?>&amp;format=PDF">[<?lsmb text('PDF') ?>]</a>
-<div class="export-link"><a target="_blank"
-       href="<?lsmb LINK ?>&amp;format=CSV">[<?lsmb text('CSV') ?>]</a></div>
-</div>
-<?lsmb END ?>
+
 </div>
 </body>
 </html>

--- a/templates/demo_with_images/balance_sheet.html
+++ b/templates/demo_with_images/balance_sheet.html
@@ -1,8 +1,5 @@
 <?lsmb INCLUDE 'ui-header.html';
 
-FORMATS = LIST_FORMATS();
-LINK = request.script _ '?' _ request.query_string _ '&amp;company=' _ DBNAME;
-LINK = LINK.replace('\&amp;\&amp;', '&amp;');
 DRILLBASE = 'journal.pl?sort=transdate&amp;&amp;category=X'
        _ '&amp;col_transdate=Y&amp;col_reference=Y&amp;col_description=Y'
        _ '&amp;col_debits=Y&amp;col_credits=Y&amp;col_source=Y'
@@ -109,14 +106,6 @@ END ;
 </tbody>
 </table>
 
-<?lsmb IF FORMATS.grep('PDF').size() ?>
-<div class="export-links">
-<div class="export-link"><a target="_blank"
-           href="<?lsmb LINK ?>&amp;format=PDF">[<?lsmb text('PDF') ?>]</a></div>
-<div class="export-link"><a target="_blank"
-       href="<?lsmb LINK ?>&amp;format=CSV">[<?lsmb text('CSV') ?>]</a></div>
-</div>
-<?lsmb END ?>
 </div>
 
 </body>

--- a/templates/demo_with_images/display_report.html
+++ b/templates/demo_with_images/display_report.html
@@ -7,17 +7,6 @@ PROCESS "elements.html";
 
 PROCESS "dynatable.html";
 
-FORMATS = LIST_FORMATS();
-QSTRING = request.query_string;
-
-IF NOT QSTRING.match('company=');
-   ESCAPED_COMPANY = request.company FILTER uri;
-   QSTRING = QSTRING _ '&amp;company=' _ ESCAPED_COMPANY;
-END;
-
-LINK = request.script _ '?' _ QSTRING;
-
-
 ?>
 <body class="lsmb <?lsmb dojo_theme ?>">
 <form data-dojo-type="lsmb/Form"
@@ -69,27 +58,6 @@ END; ?>
 FOREACH BUTTON IN buttons;
   PROCESS button element_data = BUTTON;
 END; ?><br />
-<a href="<?lsmb LINK ?>">[<?lsmb text('permalink') ?>]</a>&nbsp;
-<?lsmb IF FORMATS.grep('PDF').size() ?>
-<a target="_blank"
-   href="<?lsmb LINK _ '&amp;format=PDF' ?>">[<?lsmb text('PDF') ?>]</a>&nbsp;
-<?lsmb END;
-IF FORMATS.grep('TXT').size(); ?>
-<a target="_blank"
-   href="<?lsmb LINK _ '&amp;format=CSV' ?>">[<?lsmb text('CSV') ?>]</a>&nbsp;
-<?lsmb END;
-IF FORMATS.grep('ODS').size() ?>
-<a target="_blank"
-   href="<?lsmb LINK _ '&amp;format=ODS' ?>">[<?lsmb text('ODS') ?>]</a>&nbsp;
-<?lsmb END;
-IF FORMATS.grep('XLS').size(); ?>
-<a target="_blank"
-   href="<?lsmb LINK _ '&amp;format=XLS' ?>">[<?lsmb text('XLS') ?>]</a>&nbsp;
-<?lsmb END;
-IF FORMATS.grep('XLSX').size(); ?>
-<a target="_blank"
-   href="<?lsmb LINK _ '&amp;format=XLSX' ?>">[<?lsmb text('XLSX') ?>]</a>&nbsp;
-<?lsmb END; ?>
 </form>
 </body>
 <?lsmb PROCESS end_html ?>

--- a/templates/xedemo/PNL.html
+++ b/templates/xedemo/PNL.html
@@ -1,9 +1,6 @@
 <?lsmb INCLUDE 'ui-header.html';
 account_data = report.account_data;
 
-FORMATS = LIST_FORMATS();
-LINK = request.script _ '?' _ request.query_string _ '&amp;company=' _ DBNAME;
-LINK = LINK.replace('\&amp;\&amp;', '&amp;');
 DRILLBASE = 'journal.pl?sort=transdate&amp;&amp;category=X'
        _ '&amp;col_transdate=Y&amp;col_reference=Y&amp;col_description=Y'
        _ '&amp;col_debits=Y&amp;col_credits=Y&amp;col_source=Y'
@@ -94,14 +91,7 @@ END ;
 <?lsmb END ?>
 </tbody>
 </table>
-<?lsmb IF FORMATS.grep('PDF').size() ?>
-<div class="export-links">
-<div class="export-link"><a target="_blank"
-           href="<?lsmb LINK ?>&amp;format=PDF">[<?lsmb text('PDF') ?>]</a>
-<div class="export-link"><a target="_blank"
-       href="<?lsmb LINK ?>&amp;format=CSV">[<?lsmb text('CSV') ?>]</a></div>
-</div>
-<?lsmb END ?>
+
 </div>
 </body>
 </html>

--- a/templates/xedemo/balance_sheet.html
+++ b/templates/xedemo/balance_sheet.html
@@ -1,8 +1,5 @@
 <?lsmb INCLUDE 'ui-header.html';
 
-FORMATS = LIST_FORMATS();
-LINK = request.script _ '?' _ request.query_string _ '&amp;company=' _ DBNAME;
-LINK = LINK.replace('\&amp;\&amp;', '&amp;');
 DRILLBASE = 'journal.pl?sort=transdate&amp;&amp;category=X'
        _ '&amp;col_transdate=Y&amp;col_reference=Y&amp;col_description=Y'
        _ '&amp;col_debits=Y&amp;col_credits=Y&amp;col_source=Y'
@@ -109,14 +106,6 @@ END ;
 </tbody>
 </table>
 
-<?lsmb IF FORMATS.grep('PDF').size() ?>
-<div class="export-links">
-<div class="export-link"><a target="_blank"
-           href="<?lsmb LINK ?>&amp;format=PDF">[<?lsmb text('PDF') ?>]</a></div>
-<div class="export-link"><a target="_blank"
-       href="<?lsmb LINK ?>&amp;format=CSV">[<?lsmb text('CSV') ?>]</a></div>
-</div>
-<?lsmb END ?>
 </div>
 
 </body>

--- a/templates/xedemo/display_report.html
+++ b/templates/xedemo/display_report.html
@@ -7,17 +7,6 @@ PROCESS "elements.html";
 
 PROCESS "dynatable.html";
 
-FORMATS = LIST_FORMATS();
-QSTRING = request.query_string;
-
-IF NOT QSTRING.match('company=');
-   ESCAPED_COMPANY = request.company FILTER uri;
-   QSTRING = QSTRING _ '&amp;company=' _ ESCAPED_COMPANY;
-END;
-
-LINK = request.script _ '?' _ QSTRING;
-
-
 ?>
 <body class="lsmb <?lsmb dojo_theme ?>">
 <form data-dojo-type="lsmb/Form"
@@ -69,27 +58,6 @@ END; ?>
 FOREACH BUTTON IN buttons;
   PROCESS button element_data = BUTTON;
 END; ?><br />
-<a href="<?lsmb LINK ?>">[<?lsmb text('permalink') ?>]</a>&nbsp;
-<?lsmb IF FORMATS.grep('PDF').size() ?>
-<a target="_blank"
-   href="<?lsmb LINK _ '&amp;format=PDF' ?>">[<?lsmb text('PDF') ?>]</a>&nbsp;
-<?lsmb END;
-IF FORMATS.grep('TXT').size(); ?>
-<a target="_blank"
-   href="<?lsmb LINK _ '&amp;format=CSV' ?>">[<?lsmb text('CSV') ?>]</a>&nbsp;
-<?lsmb END;
-IF FORMATS.grep('ODS').size() ?>
-<a target="_blank"
-   href="<?lsmb LINK _ '&amp;format=ODS' ?>">[<?lsmb text('ODS') ?>]</a>&nbsp;
-<?lsmb END;
-IF FORMATS.grep('XLS').size(); ?>
-<a target="_blank"
-   href="<?lsmb LINK _ '&amp;format=XLS' ?>">[<?lsmb text('XLS') ?>]</a>&nbsp;
-<?lsmb END;
-IF FORMATS.grep('XLSX').size(); ?>
-<a target="_blank"
-   href="<?lsmb LINK _ '&amp;format=XLSX' ?>">[<?lsmb text('XLSX') ?>]</a>&nbsp;
-<?lsmb END; ?>
 </form>
 </body>
 <?lsmb PROCESS end_html ?>


### PR DESCRIPTION
While doing so, move the 'available_formats' generator to the UI
template processor: it's not used by printed documents anymore.
