### PR TITLE
Remove tt_url() function from HTML template processors

### DIFF
--- a/UI/Contact/divs/bank_act.html
+++ b/UI/Contact/divs/bank_act.html
@@ -9,8 +9,9 @@
 href_base = request.script _ '?&amp;entity_id=' _ entity_id _ '&amp;target_div=bank_act_div' _
             '&amp;form_id=' _ form_id _ '&amp;credit_id=' _ credit_id _ '&amp;id=';
 FOREACH ba IN bank_account;
-    ba.iban_href_suffix = '&amp;bic=' _ tt_url(ba.bic) _ '&amp;iban='
-         _ tt_url(ba.iban) _ '&amp;action=edit' _ '&amp;id=' _ ba.id;
+  # Note that the href will be URL encoded when inserted in the template
+    ba.iban_href_suffix = '&amp;bic=' _ ba.bic _ '&amp;iban='
+         _ ba.iban _ '&amp;action=edit' _ '&amp;id=' _ ba.id;
     ba.delete_href_suffix=ba.id _ '&amp;action=delete_bank_account';
     ba.delete = '[' _ text('Delete') _ ']';
 END;

--- a/UI/Contact/divs/contact_info.html
+++ b/UI/Contact/divs/contact_info.html
@@ -12,9 +12,9 @@ FOREACH ROW IN contacts;
     ROW.delete = '[' _ text('Delete') _ ']';
     base_suffix =
                "$request.script?entity_id=$entity_id&amp;" _
-               "contact=" _ tt_url(ROW.contact) _
+               "contact=" _ ROW.contact _
                "&amp;class_id=$ROW.class_id&amp;" _
-               "description=" _ tt_url(ROW.description) _
+               "description=" _ ROW.description _
                "&amp;credit_id=$credit_act.id&amp;for_credit=$ROW.credit_id&amp;target_div=contact_info_div";
     ROW.edit_href_suffix = base_suffix _ '&amp;action=edit';
     ROW.delete_href_suffix = base_suffix _ '&amp;action=delete_contact';

--- a/UI/Contact/divs/employee.html
+++ b/UI/Contact/divs/employee.html
@@ -211,11 +211,11 @@ IF manage_users and entity_id;
        <a href="admin.pl?action=edit_user&amp;user_id=<?lsmb user_id ?>"
        >[<?lsmb text('Edit User') ?>]</a><?lsmb
    ELSE ?>
-       <a href="admin.pl?action=new_user&amp;first_name=<?lsmb tt_url(first_name)
-                ?>&amp;last_name=<?lsmb tt_url(last_name)
-                ?>&amp;employeenumber=<?lsmb tt_url(employeenumber)
-                ?>&amp;country_id=<?lsmb tt_url(country_id)
-                ?>&amp;entity_id=<?lsmb tt_url(entity_id) ?>"
+       <a href="admin.pl?action=new_user&amp;first_name=<?lsmb first_name | uri
+                ?>&amp;last_name=<?lsmb last_name | uri
+                ?>&amp;employeenumber=<?lsmb employeenumber | uri
+                ?>&amp;country_id=<?lsmb country_id | uri
+                ?>&amp;entity_id=<?lsmb entity_id | uri ?>"
        >[<?lsmb text('Add User') ?>]</a><?lsmb
    END;
 END ?>

--- a/UI/Contact/divs/files.html
+++ b/UI/Contact/divs/files.html
@@ -51,11 +51,11 @@ INCLUDE dynatable
 END;
 ?>
 <a href="file.pl?action=show_attachment_screen&amp;ref_key=<?lsmb entity_id
-         ?>&amp;file_class=4&amp;callback=<?lsmb tt_url(callback) ?>"
+         ?>&amp;file_class=4&amp;callback=<?lsmb callback | uri ?>"
 >[<?lsmb text('Attach to Entity') ?>]</a>
 <?lsmb IF credit_act.id ?>
 <a href="file.pl?action=show_attachment_screen&amp;ref_key=<?lsmb credit_act.id
-    ?>&amp;file_class=5&amp;callback=<?lsmb tt_url(callback) ?>"
+    ?>&amp;file_class=5&amp;callback=<?lsmb callback | uri ?>"
 >[<?lsmb text('Attach to Credit Account') ?>]</a>
 <?lsmb END ?>
 </div>

--- a/UI/journal/journal_entry.html
+++ b/UI/journal/journal_entry.html
@@ -395,7 +395,7 @@ FOREACH link IN form.file_links;
 </table>
 <?lsmb callback = "gl.pl?action=edit&amp;id=" _ form.id -?>
 <a href="file.pl?action=show_attachment_screen&amp;ref_key=<?lsmb form.id
-   ?>&amp;file_class=1&amp;callback=<?lsmb tt_url(callback) ?>">[<?lsmb text('Attach') ?>]</a>
+   ?>&amp;file_class=1&amp;callback=<?lsmb callback | uri ?>">[<?lsmb text('Attach') ?>]</a>
 <?lsmb END # IF for<?lsmb INCLUDE CLOSE_STATUS_DIV id=form.id approved = form.approved ?>
 </form>
 <?lsmb INCLUDE CLOSE_STATUS_DIV ?>

--- a/UI/lib/dynatable.html
+++ b/UI/lib/dynatable.html
@@ -15,6 +15,9 @@
    # Other fields are mapped to their fieldnames:
    #   [<attributes.input_prefix>_]<col_id>_<rownum>
 
+   # Note that URLs computed from href_base and XX_href_suffix as well as
+   # order_url will be URL encoded by this block
+
    # The block takes the following arguments:
 
    #  - attributes   : a hash of attributes (specified below)
@@ -72,7 +75,7 @@
    <th class="<?lsmb COL.col_id _ ' ' _ COL.class _ ' ' _ COL.type ?>"><?lsmb
 
 IF attributes.order_url
-?> <a href="<?lsmb order_url ?>&amp;order_by=<?lsmb COL.col_id ?>"><?lsmb
+?> <a href="<?lsmb order_url | url ?>&amp;order_by=<?lsmb COL.col_id ?>"><?lsmb
 END;
 COL.name;
 IF attributes.order_url
@@ -180,7 +183,7 @@ END; ?>
                    IF COL.href_target;
                       HREF_TGT = ' target="' _ COL.href_target _ '"';
                    END;
-          ?><a href="<?lsmb HREF ?>"<?lsmb HREF_TGT ?>><?lsmb ROW.${COL.col_id} ?></a>
+          ?><a href="<?lsmb HREF | url ?>"<?lsmb HREF_TGT ?>><?lsmb ROW.${COL.col_id} ?></a>
          <?lsmb ELSIF TYPE == 'mirrored';
                                          NAME = PFX _ COL.col_id _ '_' _ ROW.row_id;
                                          ROW.${COL.col_id} ?>
@@ -264,7 +267,7 @@ END; ?>
                    ELSE;
                       HREF = COL.href_base _ ROW.row_id;
                    END
-          ?><a href="<?lsmb HREF ?>"><?lsmb ROW.${COL.col_id} ?></a>
+          ?><a href="<?lsmb HREF | url ?>"><?lsmb ROW.${COL.col_id} ?></a>
          <?lsmb ELSIF TYPE == 'mirrored';
                                          NAME = PFX _ COL.col_id _ '_' _ '_tfoot_' _ ROWCOUNT;
                                          ROW.${COL.col_id} ?>

--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -204,10 +204,6 @@ Note: This string looks up the exact string C<$string>, which makes it
 unsuited for translation of string values passed to the template through
 (escaped) string variable values.
 
-=item tt_url($string)
-
-This function applies basic URL encoding to C<$string>.
-
 =back
 
 =head1 FORMATS
@@ -500,13 +496,6 @@ sub get_template_args {
     return $arghash;
 }
 
-sub tt_url {
-    my $str = shift;
-
-    $str =~ s/([^a-zA-Z0-9_.-])/sprintf("%%%02x", ord($1))/ge;
-    return $str;
-}
-
 sub _maketext {
     my $self = shift;
     my $escape = shift;
@@ -535,7 +524,6 @@ sub _render {
                        : sub { return @_; }),
           escape => sub { return $escape->(@_); },
           text => sub { return $self->_maketext($escape, @_); },
-          tt_url => \&tt_url,
           %{$self->{additional_vars} // {}},
           %$cvars )
     };

--- a/lib/LedgerSMB/Template/UI.pm
+++ b/lib/LedgerSMB/Template/UI.pm
@@ -81,7 +81,6 @@ sub new_UI {
                 UNESCAPE => ($unescape ? sub { return $unescape->(@_); }
                              : sub { return @_; }),
                 escape => $escape,
-                tt_url => \&LedgerSMB::Template::tt_url,
 
                 LIST_FORMATS => sub {
                     return LedgerSMB::Template::available_formats();


### PR DESCRIPTION
This removes a custom function in favor of a standard function
in Template Toolkit (the 'uri' & 'url' filters).
