### PR TITLE
Move HTML /un/escaping to the UI template processor

### DIFF
--- a/lib/LedgerSMB/Template.pm
+++ b/lib/LedgerSMB/Template.pm
@@ -167,12 +167,6 @@ the target document, showing the exact content of the string.
 E.g. for HTML encoding, this means that ampersand is encoded into C<&amp;>
 and that newline characters in LaTeX are encoded into double backslashes.
 
-=item UNESCAPE($string) [optional]
-
-This function reverses the string-escaping as might have been applied by
-the C<escape> function. This function is not guaranteed to be available
-(currently only supported for HTML templates).
-
 =item text($string, @args)
 
 This function looks up the translation of C<$string> in the language lexicon,
@@ -477,11 +471,8 @@ sub _render {
 
     my $format = "LedgerSMB::Template::$self->{format}";
     my $escape = $format->can('escape');
-    my $unescape = $format->can('unescape');
     my $cleanvars = {
         ( %{preprocess($vars, $escape)},
-          UNESCAPE => ($unescape ? sub { return $unescape->(@_); }
-                       : sub { return @_; }),
           escape => sub { return $escape->(@_); },
           text => sub { return $self->_maketext($escape, @_); },
           %{$self->{additional_vars} // {}},

--- a/lib/LedgerSMB/Template/HTML.pm
+++ b/lib/LedgerSMB/Template/HTML.pm
@@ -18,7 +18,6 @@ Implements C<LedgerSMB::Template>'s FORMATTER protocol for HTML output.
 use strict;
 use warnings;
 
-use HTML::Entities;
 use HTML::Escape;
 use LedgerSMB::Sysconfig;
 
@@ -36,16 +35,6 @@ sub escape {
     return undef unless defined $vars;
     $vars = escape_html($vars);
     return $vars;
-}
-
-=item unescape($string)
-
-Apply the reverse transformation of C<escape> to <$string>.
-
-=cut
-
-sub unescape {
-    return decode_entities(shift @_);
 }
 
 =item setup($parent, $cleanvars, $output)

--- a/lib/LedgerSMB/Template/UI.pm
+++ b/lib/LedgerSMB/Template/UI.pm
@@ -24,6 +24,7 @@ use LedgerSMB::Template::HTML;
 
 use Carp;
 use File::Spec;
+use HTML::Entities;
 use Template;
 
 our $engine;
@@ -87,21 +88,21 @@ sub new_UI {
                 COMPILE_DIR =>
                    File::Spec->rel2abs( $LedgerSMB::Sysconfig::templates_cache,
                                         File::Spec->tmpdir ),
+                VARIABLES => {
+                    escape => \&LedgerSMB::Template::HTML::escape,
+                    LIST_FORMATS => sub {
+                        return _available_formats();
+                    },
+                    UNESCAPE => sub {
+                        return decode_entities(shift @_);
+                    },
+                }
                 )
                 or die Template->error;
         }
 
-        my $escape = \&LedgerSMB::Template::HTML::escape;
-        my $unescape = \&LedgerSMB::Template::HTML::unescape;
         $singleton = bless {
             standard_vars => {
-                UNESCAPE => ($unescape ? sub { return $unescape->(@_); }
-                             : sub { return @_; }),
-                escape => $escape,
-
-                LIST_FORMATS => sub {
-                    return _available_formats();
-                },
             },
         }, __PACKAGE__;
     }


### PR DESCRIPTION
Unescaping has to do with escaping values which should have
remained unescaped in order to insert them as-is into the
HTML output stream. Printed documents should not require
unescaping.
