### PR TITLE
Stop meddling with TeX::Encode's internals

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -81,7 +81,9 @@ feature 'latex-pdf-ps', "PDF and PostScript output" =>
         requires 'LaTeX::Driver', '0.300.2';
         requires 'Template::Latex', '3.08';
         requires 'Template::Plugin::Latex', '3.08';
-        requires 'TeX::Encode';
+        # 2.007 contains a fix for two characters we used to have
+        # a work-around for in our code base.
+        requires 'TeX::Encode', '2.007';
 };
 
 feature 'openoffice', "OpenOffice.org output" =>

--- a/lib/LedgerSMB/Template/LaTeX.pm
+++ b/lib/LedgerSMB/Template/LaTeX.pm
@@ -30,25 +30,6 @@ use Template::Plugin::Latex;
 use TeX::Encode::charmap;
 use TeX::Encode;
 
-BEGIN {
-    delete $TeX::Encode::charmap::ACCENTED_CHARS{
-        "\N{LATIN CAPITAL LETTER A WITH RING ABOVE}"};
-    delete $TeX::Encode::charmap::ACCENTED_CHARS{
-        "\N{LATIN SMALL LETTER A WITH RING ABOVE}"};
-    %TeX::Encode::charmap::CHAR_MAP = (
-        %TeX::Encode::charmap::CHARS,
-        %TeX::Encode::charmap::ACCENTED_CHARS,
-        %TeX::Encode::charmap::GREEK);
-    for(keys %TeX::Encode::charmap::MATH)
-    {
-        $TeX::Encode::charmap::CHAR_MAP{$_} ||= '$' . $TeX::Encode::charmap::MATH{$_} . '$';
-    }
-    for(keys %TeX::Encode::charmap::MATH_CHARS)
-    {
-        $TeX::Encode::charmap::CHAR_MAP{$TeX::Encode::charmap::MATH_CHARS{$_}} ||= '$' . $_ . '$';
-    }
-    $TeX::Encode::charmap::CHAR_MAP_RE = '[' . join('', map { quotemeta($_) } sort { length($b) <=> length($a) } keys %TeX::Encode::charmap::CHAR_MAP) . ']';
-}
 
 my $binmode = ':raw';
 my $extension = 'tex';


### PR DESCRIPTION
v2.007 fixed the bug we were working around. Require that new version
to keep delivering the same user experience, but remove the work-around.

Re #1852.
Thanks to athreef/TeX-Encode#7 for the quick response.
