### PR TITLE
Add dynatable spec parser generator

### DIFF
--- a/UI/lib/dynatable.html
+++ b/UI/lib/dynatable.html
@@ -13,7 +13,7 @@
    #   - rowcount_<attributes.id>: total number of rows in body and footer
    #   - row_<rownum>            : the row_id belonging to row <rownum>
    # Other fields are mapped to their fieldnames:
-   #   [<attributes.input_prefix>_]<col_id>_<rownum>
+   #   [<attributes.input_prefix>]<col_id>_<rownum>
 
    # Note that URLs computed from href_base and XX_href_suffix as well as
    # order_url will be URL encoded by this block


### PR DESCRIPTION
By using the spec generator, we eliminate the need to understand the
structure of the parameters posted by dynatable when developing against
it.

(Includes a documentation fix for dynatable.)