### PR TITLE
Use inheritance to define the template of the various PNL reports

### DIFF
--- a/lib/LedgerSMB/Report/PNL/ECA.pm
+++ b/lib/LedgerSMB/Report/PNL/ECA.pm
@@ -70,12 +70,6 @@ has 'control_code' => (is => 'rw', isa =>'Str');
 
 =over
 
-=item template
-
-=cut
-
-sub template { return 'Reports/PNL' }
-
 =item name
 
 =cut

--- a/lib/LedgerSMB/Report/PNL/Income_Statement.pm
+++ b/lib/LedgerSMB/Report/PNL/Income_Statement.pm
@@ -48,12 +48,6 @@ has ignore_yearend => (is => 'ro', 'isa' =>'Str', required =>1);
 
 =over
 
-=item template
-
-=cut
-
-sub template { return 'Reports/PNL' }
-
 =item name
 
 =cut

--- a/lib/LedgerSMB/Report/PNL/Invoice.pm
+++ b/lib/LedgerSMB/Report/PNL/Invoice.pm
@@ -65,12 +65,6 @@ has invnumber => (is => 'rw', isa =>'Str');
 
 =over
 
-=item template
-
-=cut
-
-sub template { return 'Reports/PNL' }
-
 =item name
 
 =cut

--- a/lib/LedgerSMB/Report/PNL/Product.pm
+++ b/lib/LedgerSMB/Report/PNL/Product.pm
@@ -59,12 +59,6 @@ has description  => (is => 'rw', isa =>'Str');
 
 =over
 
-=item template
-
-=cut
-
-sub template { return 'Reports/PNL' }
-
 =item name
 
 =cut


### PR DESCRIPTION
The issue came up due to the fact that the templates have moved to the
database. These reports all intentionally use the same report, now
define the same source for its name.
