### PR TITLE
Load the template from the database when posting and printing receipts

### DIFF
--- a/lib/LedgerSMB/Scripts/payment.pm
+++ b/lib/LedgerSMB/Scripts/payment.pm
@@ -1402,11 +1402,10 @@ sub print_payment {
       rows          => \@rows,
       format_amount => sub {LedgerSMB::PGNumber->from_input(@_)->to_output()}
   };
-  $Payment->{templates_path} = 'templates/'.$request->setting->get('templates').'/';
   my $template = LedgerSMB::Template->new( # printed document
       user     => $Payment->{_user},
       locale   => $Payment->{_locale},
-      path     => $Payment->{templates_path},
+      path     => 'DB',
       template => 'printPayment',
       format => 'HTML' );
   return $template->render($select); ###TODO: psgi-render-to-attachment

--- a/templates/demo/printPayment.html
+++ b/templates/demo/printPayment.html
@@ -12,25 +12,20 @@
   <meta name="robots" content="noindex,nofollow" />
 </head>
 <body id="printPayment">
- <?lsmb PROCESS elements.html  # Include form elements helper. ?>
- <?lsmb accountclass.type = 'hidden';
-        INCLUDE input element_data=accountclass ?>
- <?lsmb login.type = 'hidden' ; INCLUDE input element_data=login ?>
- <?lsmb #WE NEED TO KNOW HOW MANY COLUMNS WE ARE USING, PLEASE DO NOT MOVE THE NEXT LINE -?>
  <?lsmb column_count = 0 -?>
  <table width="100%" id="header_table">
    <tr id="header_bar">
       <th id="top_bar_header" colspan="2" width="30%" align="left">
-		<h5>
-		LOGO AREA
-		<br/><?lsmb text('Address: [_1]', company.address) ?>
-		<br/><?lsmb text('Tel: [_1]', company.telephone) ?>
-		</h5>
+                <h5>
+                LOGO AREA
+                <br/><?lsmb text('Address: [_1]', company.address) ?>
+                <br/><?lsmb text('Tel: [_1]', company.telephone) ?>
+                </h5>
       </th>
       <th align="left">
-     		 <h1 style="text-transform:uppercase">
-     		 <?lsmb text('Payment Order Number [_1]', header.payment_reference) ?>
-     		 </h1>
+                 <h1 style="text-transform:uppercase">
+                 <?lsmb text('Payment Order Number [_1]', header.payment_reference) ?>
+                 </h1>
       </th>
    </tr>
  </table>
@@ -38,19 +33,19 @@
  <table class="datarow" width="100%" cellspacing="0" cellpadding="0" border="1" bordercolor="000000">
    <tr>
        <th class="titledatarow" align=center width=7%>
-       			<font color=000000><?lsmb text('Invoice') ?>&nbsp;<?lsmb text('Number')?></font>
+                        <font color=000000><?lsmb text('Invoice') ?>&nbsp;<?lsmb text('Number')?></font>
        </th>
        <th class="titledatarow" align=center width=11%>
-       			<font  color=000000><?lsmb text('Account') ?></font>
+                        <font  color=000000><?lsmb text('Account') ?></font>
        </th>
        <th class="titledatarow" align=center width=68%>
-		       <font color=000000><?lsmb text('Description') ?></font>
+                       <font color=000000><?lsmb text('Description') ?></font>
        </th>
        <th class="titledatarow" align=center width=14%>
-       			<font color=000000><?lsmb text('Source') ?></font>
+                        <font color=000000><?lsmb text('Source') ?></font>
        </th>
        <th class="titledatarow" align=center width=14%>
-       			<font color=000000><?lsmb text('Amount') ?></font>
+                        <font color=000000><?lsmb text('Amount') ?></font>
        </th>
    </tr>
       <?lsmb FOREACH row IN rows -?>
@@ -62,9 +57,9 @@
                  <td align="center"> <?lsmb row.amount ?>            </td>
            </tr>
       <?lsmb END -?>
-	  <tr valign="top">
-          	<th align="right" colspan="4"> &nbsp; <?lsmb text('TOTAL') ?></th>
-          	<td align="center"> <?lsmb header.amount ?>     </td>
+          <tr valign="top">
+                <th align="right" colspan="4"> &nbsp; <?lsmb text('TOTAL') ?></th>
+                <td align="center"> <?lsmb header.amount ?>     </td>
           </tr>
  </table>
  
@@ -72,10 +67,10 @@
  <table width=100%>
    <tr>
        <th class="titledatarow" align="left" >
-		<font color=000000><?lsmb text('Currency') ?>: <?lsmb header.currency ?></font>
+                <font color=000000><?lsmb text('Currency') ?>: <?lsmb header.currency ?></font>
        </th>
        <th class="titledatarow" align="left">
-       		<font  color=000000><?lsmb text('Date') ?>: <?lsmb header.payment_date ?></font>
+                <font  color=000000><?lsmb text('Date') ?>: <?lsmb header.payment_date ?></font>
        </th>
        <th rowspan="5" width="30%" align="left">
        <font size=3 style="text-transform:uppercase">
@@ -121,7 +116,7 @@
    </tr>
    <tr>
        <td align="left" colspan="3">
-	      <font size="3"><b><?lsmb text('Notes') ?>:</b> <?lsmb header.notes ?></font> 
+              <font size="3"><b><?lsmb text('Notes') ?>:</b> <?lsmb header.notes ?></font> 
        </td>
    </tr>
  </table>

--- a/templates/demo_with_images/printPayment.html
+++ b/templates/demo_with_images/printPayment.html
@@ -12,25 +12,20 @@
   <meta name="robots" content="noindex,nofollow" />
 </head>
 <body id="printPayment">
- <?lsmb PROCESS elements.html  # Include form elements helper. ?>
- <?lsmb accountclass.type = 'hidden';
-        INCLUDE input element_data=accountclass ?>
- <?lsmb login.type = 'hidden' ; INCLUDE input element_data=login ?>
- <?lsmb #WE NEED TO KNOW HOW MANY COLUMNS WE ARE USING, PLEASE DO NOT MOVE THE NEXT LINE -?>
  <?lsmb column_count = 0 -?>
  <table width="100%" id="header_table">
    <tr id="header_bar">
       <th id="top_bar_header" colspan="2" width="30%" align="left">
-		<h5>
-		LOGO AREA
-		<br/><?lsmb text('Address: [_1]', company.address) ?>
-		<br/><?lsmb text('Tel: [_1]', company.telephone) ?>
-		</h5>
+                <h5>
+                LOGO AREA
+                <br/><?lsmb text('Address: [_1]', company.address) ?>
+                <br/><?lsmb text('Tel: [_1]', company.telephone) ?>
+                </h5>
       </th>
       <th align="left">
-     		 <h1 style="text-transform:uppercase">
-     		 <?lsmb text('Payment Order Number [_1]', header.payment_reference) ?>
-     		 </h1>
+                 <h1 style="text-transform:uppercase">
+                 <?lsmb text('Payment Order Number [_1]', header.payment_reference) ?>
+                 </h1>
       </th>
    </tr>
  </table>
@@ -38,19 +33,19 @@
  <table class="datarow" width="100%" cellspacing="0" cellpadding="0" border="1" bordercolor="000000">
    <tr>
        <th class="titledatarow" align=center width=7%>
-       			<font color=000000><?lsmb text('Invoice') ?>&nbsp;<?lsmb text('Number')?></font>
+                        <font color=000000><?lsmb text('Invoice') ?>&nbsp;<?lsmb text('Number')?></font>
        </th>
        <th class="titledatarow" align=center width=11%>
-       			<font  color=000000><?lsmb text('Account') ?></font>
+                        <font  color=000000><?lsmb text('Account') ?></font>
        </th>
        <th class="titledatarow" align=center width=68%>
-		       <font color=000000><?lsmb text('Description') ?></font>
+                       <font color=000000><?lsmb text('Description') ?></font>
        </th>
        <th class="titledatarow" align=center width=14%>
-       			<font color=000000><?lsmb text('Source') ?></font>
+                        <font color=000000><?lsmb text('Source') ?></font>
        </th>
        <th class="titledatarow" align=center width=14%>
-       			<font color=000000><?lsmb text('Amount') ?></font>
+                        <font color=000000><?lsmb text('Amount') ?></font>
        </th>
    </tr>
       <?lsmb FOREACH row IN rows -?>
@@ -62,9 +57,9 @@
                  <td align="center"> <?lsmb row.amount ?>            </td>
            </tr>
       <?lsmb END -?>
-	  <tr valign="top">
-          	<th align="right" colspan="4"> &nbsp; <?lsmb text('TOTAL') ?></th>
-          	<td align="center"> <?lsmb header.amount ?>     </td>
+          <tr valign="top">
+                <th align="right" colspan="4"> &nbsp; <?lsmb text('TOTAL') ?></th>
+                <td align="center"> <?lsmb header.amount ?>     </td>
           </tr>
  </table>
  
@@ -72,10 +67,10 @@
  <table width=100%>
    <tr>
        <th class="titledatarow" align="left" >
-		<font color=000000><?lsmb text('Currency') ?>: <?lsmb header.currency ?></font>
+                <font color=000000><?lsmb text('Currency') ?>: <?lsmb header.currency ?></font>
        </th>
        <th class="titledatarow" align="left">
-       		<font  color=000000><?lsmb text('Date') ?>: <?lsmb header.payment_date ?></font>
+                <font  color=000000><?lsmb text('Date') ?>: <?lsmb header.payment_date ?></font>
        </th>
        <th rowspan="5" width="30%" align="left">
        <font size=3 style="text-transform:uppercase">
@@ -121,7 +116,7 @@
    </tr>
    <tr>
        <td align="left" colspan="3">
-	      <font size="3"><b><?lsmb text('Notes') ?>:</b> <?lsmb header.notes ?></font> 
+              <font size="3"><b><?lsmb text('Notes') ?>:</b> <?lsmb header.notes ?></font> 
        </td>
    </tr>
  </table>

--- a/templates/xedemo/printPayment.html
+++ b/templates/xedemo/printPayment.html
@@ -12,25 +12,20 @@
   <meta name="robots" content="noindex,nofollow" />
 </head>
 <body id="printPayment">
- <?lsmb PROCESS elements.html  # Include form elements helper. ?>
- <?lsmb accountclass.type = 'hidden';
-        INCLUDE input element_data=accountclass ?>
- <?lsmb login.type = 'hidden' ; INCLUDE input element_data=login ?>
- <?lsmb #WE NEED TO KNOW HOW MANY COLUMNS WE ARE USING, PLEASE DO NOT MOVE THE NEXT LINE -?>
  <?lsmb column_count = 0 -?>
  <table width="100%" id="header_table">
    <tr id="header_bar">
       <th id="top_bar_header" colspan="2" width="30%" align="left">
-		<h5>
-		LOGO AREA
-		<br/><?lsmb text('Address: [_1]', company.address) ?>
-		<br/><?lsmb text('Tel: [_1]', company.telephone) ?>
-		</h5>
+                <h5>
+                LOGO AREA
+                <br/><?lsmb text('Address: [_1]', company.address) ?>
+                <br/><?lsmb text('Tel: [_1]', company.telephone) ?>
+                </h5>
       </th>
       <th align="left">
-     		 <h1 style="text-transform:uppercase">
-     		 <?lsmb text('Payment Order Number [_1]', header.payment_reference) ?>
-     		 </h1>
+                 <h1 style="text-transform:uppercase">
+                 <?lsmb text('Payment Order Number [_1]', header.payment_reference) ?>
+                 </h1>
       </th>
    </tr>
  </table>
@@ -38,19 +33,19 @@
  <table class="datarow" width="100%" cellspacing="0" cellpadding="0" border="1" bordercolor="000000">
    <tr>
        <th class="titledatarow" align=center width=7%>
-       			<font color=000000><?lsmb text('Invoice') ?>&nbsp;<?lsmb text('Number')?></font>
+                        <font color=000000><?lsmb text('Invoice') ?>&nbsp;<?lsmb text('Number')?></font>
        </th>
        <th class="titledatarow" align=center width=11%>
-       			<font  color=000000><?lsmb text('Account') ?></font>
+                        <font  color=000000><?lsmb text('Account') ?></font>
        </th>
        <th class="titledatarow" align=center width=68%>
-		       <font color=000000><?lsmb text('Description') ?></font>
+                       <font color=000000><?lsmb text('Description') ?></font>
        </th>
        <th class="titledatarow" align=center width=14%>
-       			<font color=000000><?lsmb text('Source') ?></font>
+                        <font color=000000><?lsmb text('Source') ?></font>
        </th>
        <th class="titledatarow" align=center width=14%>
-       			<font color=000000><?lsmb text('Amount') ?></font>
+                        <font color=000000><?lsmb text('Amount') ?></font>
        </th>
    </tr>
       <?lsmb FOREACH row IN rows -?>
@@ -62,9 +57,9 @@
                  <td align="center"> <?lsmb row.amount ?>            </td>
            </tr>
       <?lsmb END -?>
-	  <tr valign="top">
-          	<th align="right" colspan="4"> &nbsp; <?lsmb text('TOTAL') ?></th>
-          	<td align="center"> <?lsmb header.amount ?>     </td>
+          <tr valign="top">
+                <th align="right" colspan="4"> &nbsp; <?lsmb text('TOTAL') ?></th>
+                <td align="center"> <?lsmb header.amount ?>     </td>
           </tr>
  </table>
  
@@ -72,10 +67,10 @@
  <table width=100%>
    <tr>
        <th class="titledatarow" align="left" >
-		<font color=000000><?lsmb text('Currency') ?>: <?lsmb header.currency ?></font>
+                <font color=000000><?lsmb text('Currency') ?>: <?lsmb header.currency ?></font>
        </th>
        <th class="titledatarow" align="left">
-       		<font  color=000000><?lsmb text('Date') ?>: <?lsmb header.payment_date ?></font>
+                <font  color=000000><?lsmb text('Date') ?>: <?lsmb header.payment_date ?></font>
        </th>
        <th rowspan="5" width="30%" align="left">
        <font size=3 style="text-transform:uppercase">
@@ -121,7 +116,7 @@
    </tr>
    <tr>
        <td align="left" colspan="3">
-	      <font size="3"><b><?lsmb text('Notes') ?>:</b> <?lsmb header.notes ?></font> 
+              <font size="3"><b><?lsmb text('Notes') ?>:</b> <?lsmb header.notes ?></font> 
        </td>
    </tr>
  </table>


### PR DESCRIPTION
This commit can't be applied to 'master' because that has already been restructured
on exactly the point where it loads *all* templates from the database for printable
documents.

Fixes #4358.
