### PR TITLE
Close database connection when rejecting a user session

### DIFF
--- a/lib/LedgerSMB/Middleware/AuthenticateSession.pm
+++ b/lib/LedgerSMB/Middleware/AuthenticateSession.pm
@@ -171,8 +171,12 @@ sub call {
         $extended_cookie = _verify_session($env->{'lsmb.db'},
                                            $env->{'lsmb.company'},
                                            $session_cookie);
-        return LedgerSMB::PSGI::Util::session_timed_out()
-            if ! $extended_cookie;
+        if (! $extended_cookie) {
+            $dbh->commit;  # potentially log something
+            $dbh->disconnect;
+
+            return LedgerSMB::PSGI::Util::session_timed_out();
+        }
 
         # create a session invalidation callback here.
         $env->{'lsmb.invalidate_session_cb'} = sub {


### PR DESCRIPTION
After rejecting a user session due to time-out, the database connection
was left open. Because the check modifies the session table (it deletes
the session record all together), the transaction takes out a lock on
the session table. When that transaction isn't committed (or rolled back),
the exclusive lock remains in place, locking up further login attempts.

Fixes #4356
