### PR TITLE
Hide and mark the uncompleted wage screen as 'experimental'

### DIFF
--- a/UI/Contact/divs/wage.html
+++ b/UI/Contact/divs/wage.html
@@ -78,4 +78,9 @@ PROCESS dynatable
 </form>
 </tr>
 </table>
+<div>
+  The project is looking to partner with subject matter experts to
+  expand the functionality on these screens.
+</div>
+
 </div>

--- a/lib/LedgerSMB/Scripts/configuration.pm
+++ b/lib/LedgerSMB/Scripts/configuration.pm
@@ -152,6 +152,11 @@ sub _default_settings {
                          'Please review the terms and conditions for the $1 before use.']
                 },
               ] },
+        { title => $locale->text('Experimental features'),
+          items => [
+              { name => 'enable_wage_screen', type => 'YES_NO',
+                label => $locale->text('Employee wage screen') },
+              ] },
         );
     return @default_settings;
 }

--- a/lib/LedgerSMB/Scripts/contact.pm
+++ b/lib/LedgerSMB/Scripts/contact.pm
@@ -149,7 +149,10 @@ sub _main_screen {
        if ($person->{entity_id} && $person->{entity_class}
                 && $person->{entity_class} == EC_EMPLOYEE ){
           shift @DIVS;
-          unshift @DIVS, 'employee', 'user', 'wage';
+          if ($request->setting->get('enable_wage_screen')) {
+              unshift @DIVS, 'wage';
+          }
+          unshift @DIVS, 'employee', 'user';
        }
        @entity_files = LedgerSMB::File->list(
                {ref_key => $entity_id, file_class => '4'}


### PR DESCRIPTION
Note that the issue marks the wage screen as non-functional, while
the UI doesn't provide any indication to that effect. Moving the
screen into hidden state by default; allowing it to be enabled
through the settings screen.

Re #907

