### PR TITLE
Use the full available viewport height in Contacts & Account screens

### DIFF
--- a/UI/Contact/contact.html
+++ b/UI/Contact/contact.html
@@ -30,7 +30,9 @@ PROCESS "dynatable.html"  ?>
 <?lsmb text("Edit Employee") ?>
 -->
 </div>
-<div id="contact_tabs" data-dojo-type="dijit/layout/TabContainer" style="height:500px;">
+    <div id="contact_tabs"
+         data-dojo-type="dijit/layout/TabContainer"
+         data-dojo-props="doLayout:false">
   <?lsmb FOREACH ITEM IN DIVS;
       INCLUDEDIV = "Contact/divs/" _ ITEM _ ".html";
       INCLUDE $INCLUDEDIV;

--- a/UI/accounts/edit.html
+++ b/UI/accounts/edit.html
@@ -13,7 +13,8 @@
 ?>
 <body class="lsmb <?lsmb dojo_theme ?>">
 <div id="account-tabs"
-     data-dojo-type="dijit/layout/TabContainer">
+     data-dojo-type="dijit/layout/TabContainer"
+     data-dojo-props="doLayout:false">
 <?lsmb IF form.charttype == 'H'; ?>
 <div data-dojo-type="dijit/layout/ContentPane"
      data-dojo-props="selected:true"


### PR DESCRIPTION
When viewing a contact, currently all tabs are limited to 500px height.
However, not all tabs are only 500px in height (notably, the tab with the
role assignments is much "higher").
