### PR TITLE
Fix Add Currency 'Action not defined: save_currency' error

### DIFF
--- a/UI/Configuration/currency.html
+++ b/UI/Configuration/currency.html
@@ -14,7 +14,7 @@
 
     <form data-dojo-type="lsmb/Form"
           method="post"
-          action="<?lsmb form.script ?>">
+          action="<?lsmb request.script ?>">
       <?lsmb FOREACH hidden IN hiddens.keys;
              PROCESS input element_data={
                         type => 'hidden',


### PR DESCRIPTION
On System->Currency->Edit Currencies screen, clicking 'Add'
produced an error because the form action was not correctly
defined.