### PR TITLE
 Fix #4002 Don't display delete currency option if currency is used

### DIFF
--- a/lib/LedgerSMB/Currency.pm
+++ b/lib/LedgerSMB/Currency.pm
@@ -38,6 +38,14 @@ This is the description of the currency.
 
 has 'description' => (is => 'rw', isa => 'Str');
 
+=item 'is_used'
+
+True if currency has been used. Currencies that have been used within
+the accounts cannot be deleted.
+
+=cut
+
+has 'is_used' => (is => 'ro', isa => 'Bool');
 
 =back
 

--- a/lib/LedgerSMB/Scripts/currency.pm
+++ b/lib/LedgerSMB/Scripts/currency.pm
@@ -66,6 +66,11 @@ sub list_currencies {
             $s->{drop_NOHREF} = 1;
             $s->{drop} = '(' . $request->{_locale}->text('default') . ')';
         }
+        elsif ($s->{is_used}) {
+            # Cannot delete a currency that's already being used
+            $s->{drop_NOHREF} = 1;
+            $s->{drop} = '';
+        }
         else {
             $s->{drop} = '[' . $request->{_locale}->text('delete') . ']';
         }

--- a/sql/modules/BLACKLIST
+++ b/sql/modules/BLACKLIST
@@ -145,6 +145,7 @@ cr_report_block_changing_approved
 credit_limit__used
 currency__delete
 currency__get
+currency__is_used
 currency__list
 currency__save
 customer_location_save


### PR DESCRIPTION
This PR ensures that the currency 'delete' button is not shown if clicking it would
trigger a database error.

There are two parts:
1) adding the necessary database functionality
2) extending LedgerSMB::Currency and adjusting the UI