### PR TITLE
Drop unused payment_map table

### DIFF
--- a/sql/Pg-database.sql
+++ b/sql/Pg-database.sql
@@ -1607,21 +1607,6 @@ ALTER TABLE invoice_note ADD FOREIGN KEY (ref_key) REFERENCES invoice(id);
 
 --
 
-CREATE TABLE payment_map (
-    line_id int references journal_line(id),
-    pays int references eca_invoice(journal_id) not null,
-    primary key(line_id)
-);
-
-COMMENT ON TABLE payment_map IS $$ This maps the payment journal entry to the
-invoices it pays.  A couple notes here:
-1)  There is no requirement tht the payment "invoice" be linked to the same
-entity_credit_account as the paid invoice.  People can pay eachothers invoices
-if LedgerSMB supports this at an app level.
-2)  This now means that payments are first class transactions.$$;
---
-
-
 CREATE TABLE journal_note (
    internal_only bool not null default false,
    primary key (id),

--- a/sql/changes/1.8/drop-payment_map.sql
+++ b/sql/changes/1.8/drop-payment_map.sql
@@ -1,0 +1,4 @@
+
+-- The `payment_map` table isn't used, nor has it ever been.
+
+drop table if exists payment_map;

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -123,3 +123,4 @@ mc/delete-migration-validation-data.sql
 1.8/add-system-files-menu.sql
 1.8/initialize-payments-from-vouchers.sql
 1.8/payments-reversing.sql
+1.8/drop-payment_map.sql

--- a/xt/42-payment.pg
+++ b/xt/42-payment.pg
@@ -5,7 +5,7 @@ BEGIN;
 
     -- Plan the tests.
 
-    SELECT plan(43);
+    SELECT plan(42);
 
     -- Add data
 
@@ -16,7 +16,6 @@ BEGIN;
     SELECT has_table('ap');
     SELECT has_table('payment');
     SELECT has_table('payment_links');
-    SELECT has_table('payment_map');
     SELECT has_table('payment_type');
 
     -- Validate required functions


### PR DESCRIPTION
Note that the same information is available through payment_links
(which links to acc_trans lines which link to invoices in ar/ap).