### PR TITLE
Fix warning from test xt/41-coaload.t

### DIFF
--- a/xt/41-coaload.t
+++ b/xt/41-coaload.t
@@ -28,8 +28,11 @@ my @files = sort $rule->name("*.sql")->file->in("sql/coa");
 
 for my $sqlfile (@files) {
     tests $sqlfile => { async => 1 }, sub {
-        my ($unused,$dir,$type,$name) = $sqlfile =~ qr(sql\/coa\/(([a-z]{2})\/)?(.+\/)?([^\/\.]+)\.sql$);
-        my $db = "lsmb_test_coa_${dir}_${name}";
+        # Generate test database name based on sql file name
+        my ($db) = $sqlfile =~ m|^sql/(coa/.+)\.sql$|
+            or die "failed to extract test_name from filename $sqlfile";
+        $db =~ s|\W|_|g; # replace non-word characters with underscores
+        $db = "lsmb_test_$db";
 
         my ($stdout, $stderr, $rv) = capture {
             system('dropdb', $db);


### PR DESCRIPTION
When running xt/41-coaload.t as part of our development test suite,
a warning was produced:

`Use of uninitialized value $dir in concatenation (.) or string at xt/41-coaload.t line 32`

The root cause of this is a regex used to parse the input sql file names
to generate temporary test database names.

This patch changes the way temporary test database names are derived from
the file names, such that a warning is no longer generated.