### PR TITLE
Add explicit tracking of reconciliation line details

### DIFF
--- a/sql/changes/1.8/explicit-reconciliation.sql
+++ b/sql/changes/1.8/explicit-reconciliation.sql
@@ -1,0 +1,43 @@
+
+
+create table cr_report_line_links (
+    report_line_id int references cr_report_line(id),
+    entry_id int references acc_trans(entry_id),
+    primary key (report_line_id, entry_id)
+);
+
+
+comment on table cr_report_line_links is
+$$This table expresses the explicit relationship between the
+lines on the reconciliation report and the lines in acc_trans which
+constitute the ledger lines aggregated into the reconciliation line.$$;
+
+
+with recon_items as (
+      SELECT ac.chart_id, gl.ref as reference, ac.source as source,
+             ac.voucher_id, array_agg(ac.entry_id) as entries, ac.transdate
+        FROM acc_trans ac
+        JOIN transactions t on (ac.trans_id = t.id)
+        JOIN (select id, entity_credit_account::text as ref, curr,
+                     transdate, 'ar' as table
+                FROM ar where approved
+                UNION
+              select id, entity_credit_account::text, curr,
+                     transdate, 'ap' as table
+                FROM ap WHERE approved
+                UNION
+              select id, reference, '',
+                     transdate, 'gl' as table
+                FROM gl WHERE approved) gl
+                ON (gl.table = t.table_name AND gl.id = t.id)
+        WHERE  ac.approved IS TRUE
+        GROUP BY ac.chart_id, gl.ref, ac.source, ac.transdate,
+                 ac.memo, ac.voucher_id, gl.table
+)
+insert into cr_report_line_links (report_line_id, entry_id)
+     select cl.id, unnest(ri.entries)
+       from cr_report r
+       join cr_report_line cl on r.id = cl.report_id
+       join recon_items ri on (ri.voucher_id = cl.voucher_id
+                               or cl.ledger_id = any(ri.entries))
+                              and r.chart_id = ri.chart_id;

--- a/sql/changes/1.8/explicit-reconciliation.sql.checks.pl
+++ b/sql/changes/1.8/explicit-reconciliation.sql.checks.pl
@@ -1,0 +1,61 @@
+
+package _18_uprade_checks;
+
+use LedgerSMB::Database::ChangeChecks;
+
+check q|Ensure that the database doesn't contain unapproved reconciliations|,
+    query => q|select id, accno, description, end_date, their_total
+                 from cr_report r
+                 join account a on a.id = r.chart_id
+                where not (deleted or approved)
+                order by accno, end_date|,
+    description => q|
+The migration procedure found un-approved reconciliations in your database.
+
+After upgrading, the procedure to determine reconcilable lines will be
+different from the procedure used before the upgrade. Because of this
+difference in treatment, it's not possible to migrate unapproved
+reconcilitiations (*approved* reconciliations __will__ be migrated).
+
+Please delete the unapproved reconciliations listed in the table below
+by clicking the 'Delete Unapproved Reconciliations' button.
+
+|,
+    tables => {
+        add_curr => {
+            prim_key => 'id',
+        },
+    },
+    on_failure => sub {
+        my ($dbh, $rows) = @_;
+
+        describe;
+
+        grid $rows,
+            name => 'reconciliations',
+            columns => [ qw( accno description end_date their_total ) ];
+
+        confirm delete => 'Delete Unapproved Reconciliations';
+    },
+    on_submit => sub {
+        my ($dbh, $rows) = @_;
+        my $confirm = provided 'confirm';
+
+        if ($confirm eq 'delete') {
+            my $ids = [ map { $_->{id} } @$rows ];
+            $dbh->do('DELETE FROM cr_report_line WHERE report_id IN ?',
+                     {}, $ids)
+                or die 'Failed to remove unapproved report: ' . $dbh->errstr;
+            $dbh->do('DELETE FROM cr_report WHERE id IN ?',
+                     {}, $ids)
+                or die 'Failed to remove unapproved report: ' . $dbh->errstr;
+        }
+        else {
+          die "Unexpected confirmation value found: $confirm";
+        }
+    }
+;
+
+
+
+1;

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -124,3 +124,4 @@ mc/delete-migration-validation-data.sql
 1.8/initialize-payments-from-vouchers.sql
 1.8/payments-reversing.sql
 1.8/drop-payment_map.sql
+1.8/explicit-reconciliation.sql

--- a/sql/modules/Roles.sql
+++ b/sql/modules/Roles.sql
@@ -694,13 +694,14 @@ SELECT lsmb__grant_perms('reconciliation_enter', obj, 'SELECT')
              ]) obj;
 
 SELECT lsmb__grant_perms('reconciliation_enter', obj, 'ALL')
-  FROM unnest(array['cr_report_line'::text, 'cr_report_line_id_seq',
-                    'cr_report_id_seq']) obj;
+  FROM unnest(array['cr_report_line'::text, 'cr_report_line_links',
+                    'cr_report_line_id_seq', 'cr_report_id_seq']) obj;
 
 SELECT lsmb__grant_menu('reconciliation_enter', 45, 'allow');
 
 SELECT lsmb__create_role('reconciliation_approve');
-SELECT lsmb__grant_perms('reconciliation_approve', 'cr_report_line', 'DELETE');
+SELECT lsmb__grant_perms('reconciliation_approve', obj, 'DELETE')
+  FROM unnest(array['cr_report_line'::text, 'cr_report_line_links']) obj;
 SELECT lsmb__grant_perms('reconciliation_approve', 'cr_report', 'UPDATE');
 SELECT lsmb__grant_perms('reconciliation_approve', obj, 'SELECT')
   FROM unnest(array['recon_payee'::text, 'acc_trans', 'account_checkpoint']) obj;

--- a/t/16-prechecks/1.8/explicit-reconciliation.precheck
+++ b/t/16-prechecks/1.8/explicit-reconciliation.precheck
@@ -1,0 +1,32 @@
+{
+    q|Ensure that the database doesn't contain unapproved reconciliations| =>
+        [
+         {
+             failure_data => [
+                 [ qw( id accno description end_date their_total ) ],
+                 [ 22, '1510', 'Petty cash', '2018-01-01', 25.03 ],
+                 ],
+             submit_session =>
+                 [
+                  {
+                      statement => q{DELETE FROM cr_report_line WHERE report_id IN ?},
+                      # bound_params => [ [ 22 ] ], can't check bound arrays..
+                      results => [],
+                  },
+                  {
+                      statement => q{DELETE FROM cr_report WHERE id IN ?},
+                      # bound_params => [ [ 22 ] ], can't check bound arrays..
+                      results => [],
+                  },
+                 ],
+             response => {
+                 confirm => 'delete',
+                 'reconciliation' => [
+                     {
+                         '__pk' => 'MjI=',
+                     },
+                     ],
+             },
+         },
+        ],
+}

--- a/xt/42-reconciliation.pg
+++ b/xt/42-reconciliation.pg
@@ -94,23 +94,26 @@ BEGIN;
     SELECT results_eq('test',ARRAY[true],'Pending Transactions Ran');
     DEALLOCATE test;
 
-    PREPARE test AS SELECT count(*)::int
-                      FROM cr_report_line
+    PREPARE test AS SELECT count(distinct ac.trans_id)::int
+                      FROM acc_trans ac
+                      JOIN cr_report_line_links rll on ac.entry_id = rll.entry_id
+                      JOIN cr_report_line rl ON rll.report_line_id = rl.id
                       WHERE report_id = currval('cr_report_id_seq')::int;
-    SELECT results_eq('test',Array[10],'Correct number of transactions 1');
+    SELECT results_eq('test',Array[12],'Correct number of transactions 1');
     DEALLOCATE test;
 
     PREPARE test AS SELECT count(*)::int
                       FROM cr_report_line
                       WHERE scn LIKE '% gl %'
                       AND report_id = currval('cr_report_id_seq')::int;
-    SELECT results_eq('test', ARRAY[3], 'Correct number of GL groups');
+    SELECT results_eq('test', ARRAY[2], 'Correct number of GL groups');
     DEALLOCATE test;
 
     PREPARE test AS SELECT count(*)::int
                       FROM cr_report_line
                       WHERE report_id = currval('cr_report_id_seq')::int;
-    SELECT results_eq('test',ARRAY[10],'Correct number of report lines');
+    -- "3 sources (1,2,t gl 1) x 2 dates" == 6 transactions
+    SELECT results_eq('test',ARRAY[6],'Correct number of report lines');
     DEALLOCATE test;
 
     PREPARE test AS SELECT reconciliation__submit_set(currval('cr_report_id_seq')::int, (select as_array(id::int) from cr_report_line where report_id = currval('cr_report_id_seq')::int));
@@ -137,6 +140,7 @@ BEGIN;
     SELECT results_eq('test',ARRAY[2],'1 Transactions closed');
     DEALLOCATE test;
 
+    -- all items on account -11112 are part of the same payment
     PREPARE test AS SELECT reconciliation__new_report_id(test_get_account_id('-11112'), 100, now()::date, false) > 0;
     SELECT results_eq('test',ARRAY[true],'1 Create Recon Report');
     DEALLOCATE test;
@@ -148,7 +152,8 @@ BEGIN;
     PREPARE test AS SELECT count(*)::int
                       FROM cr_report_line
                       WHERE report_id = currval('cr_report_id_seq')::int;
-    SELECT results_eq('test',ARRAY[10],'Correct number of transactions 2');
+    -- 1 payment
+    SELECT results_eq('test',ARRAY[1],'Correct number of transactions 2');
     DEALLOCATE test;
 
     PREPARE test AS SELECT reconciliation__pending_transactions(currval('cr_report_id_seq')::int, 110);
@@ -158,20 +163,23 @@ BEGIN;
     PREPARE test AS SELECT count(*)::int
                       FROM cr_report_line
                       WHERE report_id = currval('cr_report_id_seq')::int;
-    SELECT results_eq('test',ARRAY[10],'Correct number of transactions 3');
+    -- 1 payment
+    SELECT results_eq('test',ARRAY[1],'Correct number of transactions 3');
     DEALLOCATE test;
 
     PREPARE test AS SELECT count(*)::int
                       FROM cr_report_line
                       WHERE scn like '% gl %'
                       AND report_id = currval('cr_report_id_seq')::int;
-    SELECT results_eq('test',ARRAY[3],'1 Correct number of GL groups');
+    -- part of a payment means source doesn't matter in the gl lines
+    SELECT results_eq('test',ARRAY[0],'1 Correct number of GL groups');
     DEALLOCATE test;
 
     PREPARE test AS SELECT count(*)::int
                       FROM cr_report_line
                       WHERE report_id = currval('cr_report_id_seq')::int;
-    SELECT results_eq('test',ARRAY[10],'1 Correct number of report lines');
+    -- 1 payment
+    SELECT results_eq('test',ARRAY[1],'1 Correct number of report lines');
     DEALLOCATE test;
 
     PREPARE test AS SELECT reconciliation__submit_set(currval('cr_report_id_seq')::int, '{}');
@@ -209,7 +217,8 @@ BEGIN;
     PREPARE test AS SELECT count(*)::int
                       FROM cr_report_line
                       WHERE report_id = currval('cr_report_id_seq')::int;
-    SELECT results_eq('test',ARRAY[10],'Correct number of transactions 4');
+    -- 1 payment
+    SELECT results_eq('test',ARRAY[1],'Correct number of transactions 4');
     DEALLOCATE test;
 
     PREPARE test AS SELECT reconciliation__submit_set(currval('cr_report_id_seq')::int, (select as_array(id::int)

--- a/xt/data/42-pg/Reconciliation.sql
+++ b/xt/data/42-pg/Reconciliation.sql
@@ -43,6 +43,9 @@ INSERT INTO ar (id, invnumber, amount_bc, netamount_bc, amount_tc, netamount_tc,
                 entity_credit_account, transdate, curr)
 values (-209, '-2007', '10', '10', 10, 10, -201, '1000-01-03', 'XTS');
 
+insert into payment (id, reference, payment_class, payment_date, entity_credit_id, currency)
+values (-201, 'reference-test', 2, '1000-01-03', -201, 'XTS');
+
 INSERT INTO gl (id, reference, transdate) values (-202, 'Recon gl test 1', '1000-01-01');
 INSERT INTO gl (id, reference, transdate) values (-203, 'Recon gl test 2', '1000-01-01');
 INSERT INTO gl (id, reference, transdate) values (-210, 'Recon gl test 3', '1000-01-03');
@@ -121,3 +124,8 @@ INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc
 values (-214, test_get_account_id('-11111'), '1000-01-03', -10, 'XTS', -10, '1', false);
 INSERT INTO acc_trans (trans_id, chart_id, transdate, amount_bc, curr, amount_tc,  source, approved)
 values (-214, test_get_account_id('-11112'), '1000-01-03', 10, 'XTS', 10, '1', false);
+
+insert into payment_links (payment_id, entry_id, type)
+select -201, entry_id, 1
+  from acc_trans where trans_id < 0 and chart_id = test_get_account_id('-11112');
+


### PR DESCRIPTION
Before this change, the relationship between cr_report_line and
the acc_trans lines from which it was computed, was only implied.

With this change, the relation is tracked explicitly.

Closes #4371
Closes #3969