### PR TITLE
Migrate sl32

### DIFF
--- a/UI/setup/upgrade_info.html
+++ b/UI/setup/upgrade_info.html
@@ -23,6 +23,11 @@ INCLUDE input element_data = {
     name = 'lsmbversion'
     type = 'hidden'
    value = lsmbversion
+};
+INCLUDE input element_data = {
+  name = 'slversion'
+  type = 'hidden'
+ value = slversion
 } ?>
 <div class="form">
 <p>

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -193,6 +193,14 @@ sub get_dispatch_table {
         operation => $migratemsg,
         next_action => 'upgrade' },
       { appname => 'sql-ledger',
+        version => '3.2',
+        slschema => 'sl32',
+        message => $request->{_locale}->text(
+                     'SQL-Ledger 3.2 database detected.'
+                   ),
+        operation => $migratemsg,
+        next_action => 'upgrade' },
+      { appname => 'sql-ledger',
         version => undef,
         message => $request->{_locale}->text(
                       'Unsupported SQL-Ledger version detected.'
@@ -587,12 +595,12 @@ sub _get_linked_accounts {
 
 my %info_applicable_for_upgrade = (
     'default_ar' => [ 'ledgersmb/1.2',
-                      'sql-ledger/2.7', 'sql-ledger/2.8', 'sql-ledger/3.0' ],
+                      'sql-ledger/2.7', 'sql-ledger/2.8', 'sql-ledger/3.0', 'sql-ledger/3.2' ],
     'default_ap' => [ 'ledgersmb/1.2',
-                      'sql-ledger/2.7', 'sql-ledger/2.8', 'sql-ledger/3.0' ],
+                      'sql-ledger/2.7', 'sql-ledger/2.8', 'sql-ledger/3.0', 'sql-ledger/3.2' ],
     'default_country' => [ 'ledgersmb/1.2',
-                           'sql-ledger/2.7', 'sql-ledger/2.8', 'sql-ledger/3.0' ],
-    'slschema' => [ 'sql-ledger/2.7', 'sql-ledger/2.8', 'sql-ledger/3.0' ]
+                           'sql-ledger/2.7', 'sql-ledger/2.8', 'sql-ledger/3.0', 'sql-ledger/3.2' ],
+    'slschema' => [ 'sql-ledger/2.7', 'sql-ledger/2.8', 'sql-ledger/3.0', 'sql-ledger/3.2' ]
     );
 
 =item applicable_for_upgrade
@@ -690,6 +698,7 @@ my %upgrade_run_step = (
     'sql-ledger/2.7' => 'run_sl28_migration',
     'sql-ledger/2.8' => 'run_sl28_migration',
     'sql-ledger/3.0' => 'run_sl30_migration',
+    'sql-ledger/3.2' => 'run_sl32_migration',
     'ledgersmb/1.2' => 'run_upgrade',
     'ledgersmb/1.3' => 'run_upgrade'
     );
@@ -1333,6 +1342,26 @@ sub run_sl30_migration {
     $dbh->commit;
 
     process_and_run_upgrade_script($request, $database, 'sl30', 'sl3.0');
+
+    return create_initial_user($request);
+}
+
+
+=item run_sl32_migration
+
+
+=cut
+
+sub run_sl32_migration {
+    my ($request) = @_;
+    my ($reauth, $database) = _init_db($request);
+    return $reauth if $reauth;
+
+    my $dbh = $request->{dbh};
+    $dbh->do('ALTER SCHEMA public RENAME TO sl32');
+    $dbh->commit;
+
+    process_and_run_upgrade_script($request, $database, 'sl32', 'sl3.0');
 
     return create_initial_user($request);
 }

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -686,6 +686,7 @@ sub upgrade_info {
         $request->{slschema} =~ s/\.//;
     }
     $request->{lsmbversion} = $CURRENT_MINOR_VERSION;
+    $request->{slversion} = $dbinfo->{version};
     return $retval;
 }
 

--- a/lib/LedgerSMB/Upgrade_Preparation.pm
+++ b/lib/LedgerSMB/Upgrade_Preparation.pm
@@ -109,7 +109,7 @@ sub _get_migration_preparations {
         name => 'add_unique_acc_trans_key',
            appname => 'sql-ledger',
        min_version => '2.7',
-       max_version => '3.0'
+       max_version => '3.2'
     );
 
     return @preparations;

--- a/lib/LedgerSMB/Upgrade_Tests.pm
+++ b/lib/LedgerSMB/Upgrade_Tests.pm
@@ -487,6 +487,27 @@ push @tests, __PACKAGE__->new(
 
 push @tests, __PACKAGE__->new(
         test_query =>
+           q{SELECT COUNT(*)
+             FROM parts p
+             WHERE p.inventory_accno_id IS NULL
+               AND p.income_accno_id IS NULL
+               AND p.expense_accno_id IS NULL
+             HAVING count(*) > 0},
+ display_name => marktext('SQL-Ledger kits are not supported yet'),
+ instructions => marktext(
+                   q(The database is not migrateable because kits
+are not supported yet)),
+         name => 'no_kits',
+ display_cols => [],
+      columns => [],
+        table => 'customer',
+      appname => 'sql-ledger',
+  min_version => '3.2',
+  max_version => '3.9'
+);
+
+push @tests, __PACKAGE__->new(
+        test_query =>
            q{select count(*) as vendor_count
               from vendor
              where (select count(*)

--- a/lib/LedgerSMB/Upgrade_Tests.pm
+++ b/lib/LedgerSMB/Upgrade_Tests.pm
@@ -605,6 +605,43 @@ push @tests, __PACKAGE__->new(
 
 #=cut
 
+push @tests,__PACKAGE__->new(
+    test_query => q{SELECT  ap.id, vendor.name as vendor,
+                            (select name from employee
+                                    WHERE id = ap.employee_id),
+                            invnumber, transdate, amount, exchangerate, ap.curr,
+                            ap.notes, description
+                    FROM ap JOIN vendor ON ap.vendor_id = vendor.id
+                    WHERE exchangerate = 1 AND amount = 0
+                    ORDER BY transdate},
+    display_name => marktext('Invalid AP FX'),
+    name => 'invalid_ap_fx',
+    display_cols => ['transdate', 'id', 'vendor', 'name', 'amount', 'exchangerate', 'curr', 'notes', 'description' ],
+ instructions => marktext('Invalid AP FX transaction. Please fix in SQL-Ledger'),
+    table => 'ap',
+    appname => 'sql-ledger',
+    min_version => '2.7',
+    max_version => '3.2'
+    );
+
+push @tests,__PACKAGE__->new(
+    test_query => q{SELECT  ar.id, customer.name as customer,
+                            (select name from employee
+                                    WHERE id = ar.employee_id),
+                            invnumber, transdate, amount, exchangerate, ar.curr,
+                            ar.notes, description
+                    FROM ar JOIN customer ON ar.vendor_id = customer.id
+                    WHERE exchangerate = 1 AND amount = 0
+                    ORDER BY transdate},
+    display_name => marktext('Invalid ar FX'),
+    name => 'invalid_ar_fx',
+    display_cols => ['transdate', 'id', 'customer', 'name', 'amount', 'exchangerate', 'curr', 'notes', 'description' ],
+ instructions => marktext('Invalid AR FX transaction. Please fix in SQL-Ledger'),
+    table => 'ar',
+    appname => 'sql-ledger',
+    min_version => '2.7',
+    max_version => '3.2'
+    );
 
 push @tests,__PACKAGE__->new(
     test_query => q{select *

--- a/lib/LedgerSMB/Upgrade_Tests.pm
+++ b/lib/LedgerSMB/Upgrade_Tests.pm
@@ -482,7 +482,7 @@ push @tests, __PACKAGE__->new(
         table => 'customer',
       appname => 'sql-ledger',
   min_version => '2.7',
-  max_version => '3.0'
+  max_version => '3.2'
 );
 
 push @tests, __PACKAGE__->new(
@@ -503,7 +503,7 @@ push @tests, __PACKAGE__->new(
         table => 'vendor',
       appname => 'ledgersmb',
   min_version => '2.7',
-  max_version => '3.0'
+  max_version => '3.2'
 );
 
 
@@ -525,7 +525,7 @@ push @tests, __PACKAGE__->new(
  instructions => marktext('Please add the missing GIFI accounts'),
       appname => 'sql-ledger',
   min_version => '2.7',
-  max_version => '3.0'
+  max_version => '3.2'
 );
 
 push @tests, __PACKAGE__->new(
@@ -588,7 +588,7 @@ push @tests, __PACKAGE__->new(
 #   instructions => marktext("Please correct the empty AR accounts"),
 #        appname => 'sql-ledger',
 #    min_version => '2.7',
-#    max_version => '3.0'
+#    max_version => '3.2'
 #     );
 
 #  push @tests, __PACKAGE__->new(
@@ -599,7 +599,7 @@ push @tests, __PACKAGE__->new(
 #   instructions => marktext("Please correct the empty AP accounts"),
 #        appname => 'sql-ledger',
 #    min_version => '2.7',
-#    max_version => '3.0'
+#    max_version => '3.2'
 #     );
 #*/
 
@@ -621,7 +621,7 @@ push @tests,__PACKAGE__->new(
     table => 'chart',
     appname => 'sql-ledger',
     min_version => '2.7',
-    max_version => '3.0'
+    max_version => '3.2'
     );
 
 push @tests,__PACKAGE__->new(
@@ -641,7 +641,7 @@ number of "AR_*", "AP_*" and/or "IC_*" links concatenated by colons (:).'),
     table => 'chart',
     appname => 'sql-ledger',
     min_version => '2.7',
-    max_version => '3.0'
+    max_version => '3.2'
     );
 
 push @tests,__PACKAGE__->new(
@@ -661,7 +661,7 @@ heading which sorts alphanumerically before the first account by accno'),
     table => 'chart',
     appname => 'sql-ledger',
     min_version => '2.7',
-    max_version => '3.0'
+    max_version => '3.2'
     );
 
 push @tests,__PACKAGE__->new(
@@ -677,7 +677,7 @@ push @tests,__PACKAGE__->new(
     table => 'customer',
     appname => 'sql-ledger',
     min_version => '2.7',
-    max_version => '3.0'
+    max_version => '3.2'
     );
 
     push @tests,__PACKAGE__->new(
@@ -702,7 +702,7 @@ Please make sure business used by vendors and constomers are defined.<br>
              table => 'business',
            appname => 'sql-ledger',
        min_version => '2.7',
-       max_version => '3.0',
+       max_version => '3.2',
             insert => 1,
             # They should be constrained
            buttons => ['Save and Retry', 'Cancel', 'Force'],
@@ -738,7 +738,7 @@ selectable_values => { business_id => q{SELECT concat(description,' -- ',discoun
     table => 'vendor',
     appname => 'sql-ledger',
     min_version => '2.7',
-    max_version => '3.0'
+    max_version => '3.2'
     );
 
 push @tests, __PACKAGE__->new(
@@ -761,7 +761,7 @@ selectable_values => { business_id => q{SELECT concat(description,' -- ',discoun
     table => 'customer',
     appname => 'sql-ledger',
     min_version => '2.7',
-    max_version => '3.0'
+    max_version => '3.2'
     );
 
 push @tests, __PACKAGE__->new(
@@ -784,7 +784,7 @@ selectable_values => { business_id => q{SELECT concat(description,' -- ',discoun
     table => 'vendor',
     appname => 'sql-ledger',
     min_version => '2.7',
-    max_version => '3.0'
+    max_version => '3.2'
     );
 
 push @tests, __PACKAGE__->new(
@@ -807,7 +807,7 @@ selectable_values => { business_id => q{SELECT concat(description,' -- ',discoun
     table => 'customer',
     appname => 'sql-ledger',
     min_version => '2.7',
-    max_version => '3.0'
+    max_version => '3.2'
     );
 
 push @tests,__PACKAGE__->new(
@@ -825,7 +825,7 @@ push @tests,__PACKAGE__->new(
     table => 'chart',
     appname => 'sql-ledger',
     min_version => '2.7',
-    max_version => '3.0'
+    max_version => '3.2'
     );
 
 # push @tests,__PACKAGE__->new(
@@ -844,7 +844,7 @@ push @tests,__PACKAGE__->new(
 #     table => 'chart',
 #     appname => 'sql-ledger',
 #     min_version => '2.7',
-#     max_version => '3.0'
+#     max_version => '3.2'
 #     );
 
 push @tests,__PACKAGE__->new(
@@ -864,7 +864,7 @@ heading which sorts alphanumerically before the first account by accno'),
     table => 'chart',
     appname => 'sql-ledger',
     min_version => '2.7',
-    max_version => '3.0'
+    max_version => '3.2'
     );
 
 push @tests,__PACKAGE__->new(
@@ -884,7 +884,7 @@ push @tests,__PACKAGE__->new(
     table => 'customer',
     appname => 'sql-ledger',
     min_version => '2.7',
-    max_version => '3.0'
+    max_version => '3.2'
     );
 
 push @tests,__PACKAGE__->new(
@@ -900,7 +900,7 @@ push @tests,__PACKAGE__->new(
     table => 'vendor',
     appname => 'sql-ledger',
     min_version => '2.7',
-    max_version => '3.0'
+    max_version => '3.2'
     );
 
 push @tests,__PACKAGE__->new(
@@ -919,7 +919,7 @@ push @tests,__PACKAGE__->new(
     table => 'vendor',
     appname => 'sql-ledger',
     min_version => '2.7',
-    max_version => '3.0'
+    max_version => '3.2'
     );
 
 push @tests, __PACKAGE__->new(
@@ -935,7 +935,7 @@ push @tests, __PACKAGE__->new(
     table => 'employee',
     appname => 'sql-ledger',
     min_version => '2.7',
-    max_version => '3.0'
+    max_version => '3.2'
     );
 
 push @tests, __PACKAGE__->new(
@@ -954,7 +954,7 @@ push @tests, __PACKAGE__->new(
     table => 'employee',
     appname => 'sql-ledger',
     min_version => '2.7',
-    max_version => '3.0'
+    max_version => '3.2'
     );
 
 push @tests, __PACKAGE__->new(
@@ -975,7 +975,7 @@ push @tests, __PACKAGE__->new(
     table => 'ar',
     appname => 'sql-ledger',
     min_version => '2.7',
-    max_version => '3.0'
+    max_version => '3.2'
     );
 
 # There's no AP uniqueness requirement?
@@ -998,7 +998,7 @@ push @tests, __PACKAGE__->new(
     table => 'ap',
     appname => 'sql-ledger',
     min_version => '2.7',
-    max_version => '3.0'
+    max_version => '3.2'
     );
 
 push @tests, __PACKAGE__->new(
@@ -1017,7 +1017,7 @@ push @tests, __PACKAGE__->new(
         table => 'parts',
       appname => 'sql-ledger',
   min_version => '2.7',
-  max_version => '3.0'
+  max_version => '3.2'
 );
 
 
@@ -1034,7 +1034,7 @@ push @tests, __PACKAGE__->new(
     table => 'makemodel',
     appname => 'sql-ledger',
     min_version => '2.7',
-    max_version => '3.0'
+    max_version => '3.2'
     );
 
 
@@ -1051,7 +1051,7 @@ push @tests, __PACKAGE__->new(
     table => 'makemodel',
     appname => 'sql-ledger',
     min_version => '2.7',
-    max_version => '3.0'
+    max_version => '3.2'
     );
 
 
@@ -1070,7 +1070,7 @@ push @tests, __PACKAGE__->new(
     table => 'partscustomer',
     appname => 'sql-ledger',
     min_version => '2.7',
-    max_version => '3.0'
+    max_version => '3.2'
     );
 
 push @tests, __PACKAGE__->new(
@@ -1086,7 +1086,7 @@ push @tests, __PACKAGE__->new(
     table => 'chart',
     appname => 'sql-ledger',
     min_version => '2.7',
-    max_version => '3.0'
+    max_version => '3.2'
     );
 
 
@@ -1104,7 +1104,7 @@ push @tests, __PACKAGE__->new(
     table => 'chart',
     appname => 'sql-ledger',
     min_version => '2.7',
-    max_version => '3.0'
+    max_version => '3.2'
     );
 
 
@@ -1121,7 +1121,7 @@ push @tests, __PACKAGE__->new(
     table => 'chart',
     appname => 'sql-ledger',
     min_version => '2.7',
-    max_version => '3.0'
+    max_version => '3.2'
     );
 
 
@@ -1140,7 +1140,7 @@ push @tests, __PACKAGE__->new(
     table => 'chart',
     appname => 'sql-ledger',
     min_version => '2.7',
-    max_version => '3.0'
+    max_version => '3.2'
     );
 
 
@@ -1160,7 +1160,7 @@ push @tests, __PACKAGE__->new(
     table => 'tax',
     appname => 'sql-ledger',
     min_version => '2.7',
-    max_version => '3.0'
+    max_version => '3.2'
     );
 
 push @tests, __PACKAGE__->new(
@@ -1187,7 +1187,7 @@ push @tests, __PACKAGE__->new(
         table => 'ap',
       appname => 'sql-ledger',
   min_version => '2.7',
-  max_version => '3.0'
+  max_version => '3.2'
 );
 
 push @tests, __PACKAGE__->new(
@@ -1229,7 +1229,7 @@ Void the clearing date in the dialog shown or go back to SQL-Ledger if you feel 
              table => 'acc_trans',
            appname => 'sql-ledger',
        min_version => '2.7',
-       max_version => '3.0'
+       max_version => '3.2'
 );
 
 
@@ -1248,7 +1248,7 @@ Void the clearing date in the dialog shown or go back to SQL-Ledger if you feel 
 #     table => 'partsvendor',
 #     appname => 'sql-ledger',
 #     min_version => '2.7',
-#     max_version => '3.0'
+#     max_version => '3.2'
 #     );
 
     return @tests;

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -58,7 +58,7 @@
 # Note: the schema as created up to here, is the one as required by
 #   the migration scripts in sql/upgrade/. Don't insert any change
 #   scripts before this point, because it breaks the migrations from
-#   both LedgerSMB 1.2 & 1.3 as well as from SQL 2.8 and 3.0
+#   both LedgerSMB 1.2 & 1.3 as well as from SQL 2.8, 3.0 and 3.2
 # 1.6 changes
 1.6/drop_chart.sql
 !1.6/drop_arap_cols.sql

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -54,7 +54,6 @@
 1.5/fixed-assets-not-null-constraints.sql
 1.5/template_menu-v2.sql
 1.5/abstract_tables.sql
-#tag: migration-target
 # Note: the schema as created up to here, is the one as required by
 #   the migration scripts in sql/upgrade/. Don't insert any change
 #   scripts before this point, because it breaks the migrations from
@@ -99,6 +98,7 @@ mc/new-constraints.sql
 mc/dropped-objects.sql
 mc/views.sql
 mc/delete-migration-validation-data.sql
+#tag: migration-target
 # 1.7 changes
 1.7/drop-custom-catalog.sql
 1.7/alter-menu-attributes.sql

--- a/sql/upgrade/sl3.0.sql
+++ b/sql/upgrade/sl3.0.sql
@@ -1,8 +1,8 @@
 --Setup
 
 -- With help of a few conditional statements handled by the Template toolkit,
--- this migration file handles migration from all SQL-Ledger version up to 3.0
--- to all Ledgersmb up to 1.6
+-- this migration file handles migration from all SQL-Ledger version up to 3.2
+-- to all Ledgersmb up to 1.8
 
 -- When moved to an interface, these will all be specified and preprocessed.
 \set default_country '''<?lsmb default_country ?>'''
@@ -14,6 +14,7 @@
  */
 \set slschema '<?lsmb slschema ?>'
 \set lsmbversion '<?lsmb lsmbversion ?>'
+\set slversion '<?lsmb slversion ?>'
 
 BEGIN;
 
@@ -432,7 +433,13 @@ delete from account_link where description = 'CT_tax';
 
 -- Business
 
+<?lsmb IF VERSION_COMPARE(slversion,'3.2') >= 0; ?>
+-- TODO: SL3.2+ support multiple discounts per business, as shown by the rn column.
+-- This will fail on primary key violation if there are many in the SL database
+INSERT INTO business SELECT id, description, discount FROM :slschema.business;
+<?lsmb ELSE; ?>
 INSERT INTO business SELECT * FROM :slschema.business;
+<?lsmb END; ?>
 
 --Entity
 
@@ -1269,7 +1276,13 @@ INSERT INTO status SELECT * FROM :slschema.status; -- may need to comment this o
 
 INSERT INTO sic SELECT * FROM :slschema.sic;
 
+<?lsmb IF VERSION_COMPARE(slversion,'3.2') >= 0; ?>
+-- TODO: SL3.2+ support multiple warehouses per id, as shown by the rn column.
+-- This will fail on primary key violation if there are many in the SL database
+INSERT INTO warehouse SELECT id,description FROM :slschema.warehouse;
+<?lsmb ELSE; ?>
 INSERT INTO warehouse SELECT * FROM :slschema.warehouse;
+<?lsmb END; ?>
 
 INSERT INTO warehouse_inventory(entity_id, warehouse_id, parts_id, trans_id,
             orderitems_id, qty, shippingdate)


### PR DESCRIPTION
Migrate SQL-Ledger 3.2.

This PR adds support for 3.2 for everything but kits and payroll. It:
- takes advantage of multi-currency capabilities to stop limiting SL to 1 FX transaction per day;
- pushes the stable migration target to 1.7 instead of 1.6;
- adds tests to prevent migration of kits

