### PR TITLE
Fix migration unapproved recon check

### DIFF
--- a/sql/changes/1.8/explicit-reconciliation.sql.checks.pl
+++ b/sql/changes/1.8/explicit-reconciliation.sql.checks.pl
@@ -42,13 +42,20 @@ by clicking the 'Delete Unapproved Reconciliations' button.
         my $confirm = provided 'confirm';
 
         if ($confirm eq 'delete') {
-            my $ids = [ map { $_->{id} } @$rows ];
-            $dbh->do('DELETE FROM cr_report_line WHERE report_id IN ?',
-                     {}, $ids)
-                or die 'Failed to remove unapproved report: ' . $dbh->errstr;
-            $dbh->do('DELETE FROM cr_report WHERE id IN ?',
-                     {}, $ids)
-                or die 'Failed to remove unapproved report: ' . $dbh->errstr;
+            my $delete_report_lines = $dbh->prepare(
+                'DELETE FROM cr_report_line WHERE report_id = ?'
+            ) or die 'ERROR preparing sql to delete reconciliation report lines';
+
+            my $delete_report = $dbh->prepare(
+                'DELETE FROM cr_report WHERE id = ?'
+            ) or die 'ERROR preparing sql to delete reconciliation report';
+
+            foreach my $row(@$rows) {
+                $delete_report_lines->execute($row->{id})
+                    or die 'Failed to remove unapproved report: ' . $dbh->errstr;
+                $delete_report->execute($row->{id})
+                    or die 'Failed to remove unapproved report: ' . $dbh->errstr;
+            }
         }
         else {
           die "Unexpected confirmation value found: $confirm";

--- a/sql/changes/1.8/explicit-reconciliation.sql.checks.pl
+++ b/sql/changes/1.8/explicit-reconciliation.sql.checks.pl
@@ -4,7 +4,7 @@ package _18_uprade_checks;
 use LedgerSMB::Database::ChangeChecks;
 
 check q|Ensure that the database doesn't contain unapproved reconciliations|,
-    query => q|select id, accno, description, end_date, their_total
+    query => q|select r.id, accno, description, end_date, their_total
                  from cr_report r
                  join account a on a.id = r.chart_id
                 where not (deleted or approved)

--- a/t/16-prechecks/1.8/explicit-reconciliation.precheck
+++ b/t/16-prechecks/1.8/explicit-reconciliation.precheck
@@ -9,13 +9,13 @@
              submit_session =>
                  [
                   {
-                      statement => q{DELETE FROM cr_report_line WHERE report_id IN ?},
-                      # bound_params => [ [ 22 ] ], can't check bound arrays..
+                      statement => q{DELETE FROM cr_report_line WHERE report_id = ?},
+                      bound_params => [ 22 ],
                       results => [],
                   },
                   {
-                      statement => q{DELETE FROM cr_report WHERE id IN ?},
-                      # bound_params => [ [ 22 ] ], can't check bound arrays..
+                      statement => q{DELETE FROM cr_report WHERE id = ?},
+                      bound_params => [ 22 ],
                       results => [],
                   },
                  ],


### PR DESCRIPTION
This PR comprised two commits which fix SQL errors when deleting unapproved
reconciliation reports during a migration to 1.8.

Please see the individual commits for a description of the changes.