### PR TITLE
Don't migrate zero or null exchange rates as defaults

### DIFF
--- a/sql/changes/mc/currency-migration.sql
+++ b/sql/changes/mc/currency-migration.sql
@@ -25,7 +25,7 @@ BEGIN
          AND curr IS NOT NULL;
 
   -- Migrate 'exchangerate' content / BUY field
-  PERFORM DISTINCT 1 FROM exchangerate WHERE buy IS NOT NULL;
+  PERFORM DISTINCT 1 FROM exchangerate WHERE buy IS NOT NULL AND buy != 0;
   IF FOUND THEN
     DECLARE
       v_rate_type int;
@@ -37,12 +37,14 @@ BEGIN
       INSERT INTO exchangerate_default
            (rate_type, curr, valid_from, valid_to, rate)
       SELECT v_rate_type, curr, transdate, transdate, buy
-        FROM exchangerate;
+        FROM exchangerate
+        WHERE buy IS NOT NULL
+        AND buy != 0;
     END;
   END IF;
 
   -- Migrate 'exchangerate' content / SELL field
-  PERFORM DISTINCT 1 FROM exchangerate WHERE sell IS NOT NULL;
+  PERFORM DISTINCT 1 FROM exchangerate WHERE sell IS NOT NULL AND sell != 0;
   IF FOUND THEN
     DECLARE
       v_rate_type int;
@@ -54,7 +56,9 @@ BEGIN
       INSERT INTO exchangerate_default
            (rate_type, curr, valid_from, valid_to, rate)
       SELECT v_rate_type, curr, transdate, transdate, sell
-        FROM exchangerate;
+        FROM exchangerate
+        WHERE sell IS NOT NULL
+        AND sell != 0;
     END;
   END IF;
 END;


### PR DESCRIPTION
In lsmb 1.6 and earlier, exchange rates were stored on a per-day
basis, always as a buy and sell rate pair.

In legacy databases, often only one of the buy or sell fields is
populated for a given day. In this situation, the unpopulated field
may be set to `0` or `NULL`.

For lsmb 1.7, we migrate these exchange rates into an `exchangerate_default`
table. This patch ensures that we do not migrate the unpopulated `0` or
`NULL` values.

Note that the `exchangerate_default` table is only used to provide default
exchange rates for convenience when entering a new transaction. It has no
impact on accounting data.