### PR TITLE
Replace MIME::Lite with Email::Sender and Email::Stuffer

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -3,6 +3,7 @@
 
 requires 'perl', '5.18.0';
 
+requires 'Authen::SASL';
 requires 'CGI::Emulate::PSGI';
 requires 'CGI::Parse::PSGI';
 requires 'Config::IniFiles';
@@ -11,6 +12,9 @@ requires 'DBI', '1.635';
 requires 'Data::UUID';
 requires 'DateTime';
 requires 'DateTime::Format::Strptime';
+requires 'Email::Sender::Simple';
+requires 'Email::Sender::Transport::SMTP';
+requires 'Email::Stuffer';
 requires 'File::Find::Rule';
 requires 'HTML::Entities';
 requires 'HTML::Escape';
@@ -25,9 +29,10 @@ requires 'Locale::Maketext::Lexicon', '0.62';
 requires 'Log::Log4perl';
 requires 'Log::Log4perl::Layout::PatternLayout';
 requires 'LWP::Simple';
-requires 'MIME::Lite';
 requires 'MIME::Types';
 requires 'Module::Runtime';
+requires 'Moo';                           # for Email::Sender::Transport::SMTP workaround
+requires 'MooX::Types::MooseLike::Base';  # for Email::Sender::Transport::SMTP workaround
 requires 'Moose';
 requires 'Moose::Role';
 requires 'Moose::Util::TypeConstraints';

--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -386,6 +386,11 @@ def 'smtpport',
     default => 25,
     doc => 'Connect to the smtp host using this port.';
 
+def 'smtpsender_hostname',
+    section => 'mail',
+    default => undef,
+    doc => 'Sets the host name used to identify the host when connecting to the mail server (smtphost).';
+
 def 'smtptimeout',
     section => 'mail',
     default => 60,
@@ -400,6 +405,26 @@ def 'smtppass',
     section => 'mail',
     default => undef,
     doc => 'Optional password used when connecting to smtp server.';
+
+def 'smtpauthmech',
+    section => 'mail',
+    default => 'PLAIN',
+    doc => 'SASL mechanism to use for authentication
+
+Note that the default (PLAIN) sends unencrypted passwords. Instead, use
+of more secure mechanisms such as DIGEST-MD5, SRP or PASSDSS is highly
+    recommended if the server supports it.';
+
+def 'smtptls',
+    section => 'mail',
+    default => 'no',
+    doc => q{Whether or not to use TLS to encrypt the connection for mail
+submission; default (no) doesn't use TLS, 'yes' indicates STARTTLS, usually
+used with a regular (25) or submission (587) port. 'tls' indicates "raw"
+TLS, most often used with dedicated port 465.
+
+When using PLAIN or LOGIN authentication, be sure to change this setting to
+prevent publicly visible transmission of credentials.};
 
 def 'backup_email_from',
     section => 'mail',

--- a/old/lib/LedgerSMB/Mailer/TransportSMTP.pm
+++ b/old/lib/LedgerSMB/Mailer/TransportSMTP.pm
@@ -1,0 +1,39 @@
+package LedgerSMB::Mailer::TransportSMTP;
+
+=head1 NAME
+
+LedgerSMB::Mailer::TransportSMTP - Workaround for SASL and Email::Sender
+
+=head1 DESCRIPTION
+
+Email::Sender::Transport::SMTP encapsulates too much of Authen::SASL
+as it hides the possibility to select authentication mechanisms.
+
+This module works around that by allowing C<sasl_username> to be a
+fully configured (including mechanisms) C<Authen::SASL> instance.
+
+=cut
+
+use strict;
+use warnings;
+
+use Moo;
+use MooX::Types::MooseLike::Base qw(:all);
+
+extends 'Email::Sender::Transport::SMTP';
+
+
+has '+sasl_username' => (isa => AnyOf[ Str, InstanceOf['Authen::SASL']]);
+
+=head1 LICENSE AND COPYRIGHT
+
+Copyright (C) 2020 The LedgerSMB Core Team
+
+This file is licensed under the GNU General Public License version 2, or at your
+option any later version.  A copy of the license should have been included with
+your software.
+
+=cut
+
+
+1;

--- a/t/01-load.t
+++ b/t/01-load.t
@@ -102,6 +102,7 @@ my @modules =
           'LedgerSMB::File::Transaction',
           'LedgerSMB::Inventory::Adjust',
           'LedgerSMB::Inventory::Adjust_Line',
+          'LedgerSMB::Mailer::TransportSMTP',
           'LedgerSMB::Middleware::AuthenticateSession',
           'LedgerSMB::Middleware::ClearDownloadCookie',
           'LedgerSMB::Middleware::DisableBackButton',


### PR DESCRIPTION
MIME::Lite is deprecated by its author. This commit separates the
concerns of sending mail and composing mail and uses a different
library to solve each: Email::Sender for smtp submission and
Email::Stuffer to build the mail content (with attachments).

Note that not only did MIME::Lite have been deprecated, it also
had insufficient mail sending capabilities, forcing admins to
resort to the use of mail submission applications such as ssmtp
and bsmtp.

Closes #4378 