### PR TITLE
Set stricter policy on authentication cookie

### DIFF
--- a/lib/LedgerSMB/Middleware/AuthenticateSession.pm
+++ b/lib/LedgerSMB/Middleware/AuthenticateSession.pm
@@ -216,7 +216,7 @@ sub call {
             # Set the new cookie (with the extended life-time on response
             Plack::Util::header_push(
                 $res->[1], 'Set-Cookie',
-                qq|$cookie_name=$extended_cookie; path=$path$secure|)
+                qq|$cookie_name=$extended_cookie; SameSite=Strict; HttpOnly; path=$path$secure|)
                 if $extended_cookie;
         });
 }

--- a/old/bin/old-handler.pl
+++ b/old/bin/old-handler.pl
@@ -115,7 +115,7 @@ try {
     my $path = LedgerSMB::PSGI::Util::cookie_path($ENV{SCRIPT_NAME});
     print 'Set-Cookie: '
         . LedgerSMB::Sysconfig::cookie_name . '='
-        . $form->{_new_session_cookie_value} . "; path=$path\n"
+        . $form->{_new_session_cookie_value} . "; SameSite=Strict; HttpOnly; path=$path\n"
         if $form->{_new_session_cookie_value};
 
     # we get rid of myconfig and use User as a real object


### PR DESCRIPTION
Note that the web app truely doesn't require access to the session
cookie and that the session cookie doesn't need to be supplied to
any other sites than the one that set the cookie. Indicate both.
