### PR TITLE
Add NOT NULL constraint to exchange rate defaults table

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -25,6 +25,7 @@ Changed functionalities
 * Employee 'Wages & Deductions' (experimental) page now hidden until enabled
 * Templates for printed documents need to escape inserted data (was automatic)
 * Search checkmarks 'Open/Closed' replaced by radio button 'Open/Closed/All'
+* Default exchange rates cannot be NULL
 
 Bugs fixed
 * Default dates sometimes off by a day (before or after the current day) (#2587)

--- a/sql/changes/1.8/constrain-default-exchange-rates.sql
+++ b/sql/changes/1.8/constrain-default-exchange-rates.sql
@@ -1,0 +1,4 @@
+ALTER TABLE exchangerate_default
+ALTER COLUMN rate
+SET NOT NULL;
+

--- a/sql/changes/1.8/constrain-default-exchange-rates.sql.checks.pl
+++ b/sql/changes/1.8/constrain-default-exchange-rates.sql.checks.pl
@@ -1,0 +1,75 @@
+package _18_uprade_checks;
+
+use LedgerSMB::Database::ChangeChecks;
+
+check q|Ensure that the database doesn't contain NULL default exchange rates|,
+    query => q|
+        SELECT exchangerate_type.description,
+               r.rate_type,
+               r.curr,
+               r.valid_from,
+               r.valid_to,
+               r.rate
+        FROM exchangerate_default r
+        JOIN exchangerate_type ON exchangerate_type.id = r.rate_type
+        WHERE r.rate IS NULL
+        ORDER BY valid_from
+    |,
+    description => q|
+The upgrade process found exchange rate defaults with NULL values, which
+are invalid.
+
+These defaults must be removed as they are prohibited by stricter data
+integrity rules enforced by the update.
+
+Removal of these entries will not affect accounting data. They are used
+only to pre-populate the exchange rate field when entering a new transaction.
+
+Please delete the invalid values listed in the table below by clicking
+the 'Delete null exchange rate defaults' button.
+|,
+    tables => {
+        exchangerate_default => {
+            prim_key => [qw(rate_type curr valid_from)]
+        },
+    },
+    on_failure => sub {
+        my ($dbh, $rows) = @_;
+
+        describe;
+
+        grid $rows,
+            name => 'exchange rate defaults',
+            table => 'exchangerate_default',
+            columns => [qw(description curr valid_from valid_to rate)];
+
+        confirm delete => 'Delete null exchange rate defaults';
+    },
+    on_submit => sub {
+        my ($dbh, $rows) = @_;
+        my $confirm = provided 'confirm';
+
+        if ($confirm eq 'delete') {
+            my $delete = $dbh->prepare('
+                DELETE FROM exchangerate_default
+                WHERE rate_type = ?
+                AND curr = ?
+                AND valid_from = ?
+            ') or die 'ERROR preparing sql to remove default exchange rate ' . $dbh->errstr;
+
+            foreach my $row(@$rows) {
+                $delete->execute(
+                    $row->{rate_type},
+                    $row->{curr},
+                    $row->{valid_from},
+                ) or die 'Failed to remove default exchange rate: ' . $dbh->errstr;
+            }
+        }
+        else {
+          die "Unexpected confirmation value found: $confirm";
+        }
+    }
+;
+
+
+1;

--- a/sql/changes/1.8/constrain-default-exchange-rates.sql.checks.pl
+++ b/sql/changes/1.8/constrain-default-exchange-rates.sql.checks.pl
@@ -50,12 +50,12 @@ the 'Delete null exchange rate defaults' button.
         my $confirm = provided 'confirm';
 
         if ($confirm eq 'delete') {
-            my $delete = $dbh->prepare('
-                DELETE FROM exchangerate_default
-                WHERE rate_type = ?
-                AND curr = ?
-                AND valid_from = ?
-            ') or die 'ERROR preparing sql to remove default exchange rate ' . $dbh->errstr;
+            my $delete = $dbh->prepare(
+                'DELETE FROM exchangerate_default '.
+                'WHERE rate_type = ? '.
+                'AND curr = ? '.
+                'AND valid_from = ?'
+            ) or die 'ERROR preparing sql to remove default exchange rate ' . $dbh->errstr;
 
             foreach my $row(@$rows) {
                 $delete->execute(

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -125,3 +125,4 @@ mc/delete-migration-validation-data.sql
 1.8/payments-reversing.sql
 1.8/drop-payment_map.sql
 1.8/explicit-reconciliation.sql
+1.8/constrain-default-exchange-rates.sql

--- a/t/16-prechecks/1.8/constrain-default-exchange-rates.precheck
+++ b/t/16-prechecks/1.8/constrain-default-exchange-rates.precheck
@@ -1,0 +1,29 @@
+{
+    q|Ensure that the database doesn't contain NULL default exchange rates| =>
+        [
+         {
+             failure_data => [
+                 [ qw(description rate_type curr valid_from valid_to rate) ],
+                 [ 'Migrated BUY rates', 3, 'SEK', '2019-01-01', '2020-01-02', undef ],
+             ],
+             submit_session => [
+                  {
+                      statement => 'DELETE FROM exchangerate_default '.
+                                   'WHERE rate_type = ? '.
+                                   'AND curr = ? '.
+                                   'AND valid_from = ?',
+                      bound_params => [3, 'SEK', '2019-01-01'],
+                      results => [],
+                  },
+             ],
+             response => {
+                 confirm => 'delete',
+                 'reconciliation' => [
+                     {
+                         '__pk' => 'MjI=',
+                     },
+                 ],
+             },
+         },
+        ],
+}


### PR DESCRIPTION
This patch ensures that the exchangerate_default.rate field cannot
be `NULL` as that is an invalid value, which causes errors in other
parts of the code that tries to use it (such as the Edit rates screen).

During the upgrade, migration checks are used to identify any existing
NULL exchange rate defaults and the upgrader is asked to accept their
deletion.