### PR TITLE
Fix transposed company and dbversion on 500 Error page

### DIFF
--- a/lib/LedgerSMB/PSGI.pm
+++ b/lib/LedgerSMB/PSGI.pm
@@ -133,8 +133,11 @@ sub psgi_app {
                 level => 'error',
                 message => $error });
             $res = LedgerSMB::PSGI::Util::internal_server_error(
-                $error, 'Error!',
-                $request->{dbversion}, $request->{company});
+                $error,
+                'Error!',
+                $request->{company},
+                $request->{dbversion},
+            );
         }
         else {
             $res = [ '500', [ 'Content-Type' => 'text/plain' ], [ $error ]];


### PR DESCRIPTION
The 500 Error response page displays the company name and database
version in its footer, but those values were transposed. Fixed by
this patch.