### PR TITLE
Don't display delete button for in-use exchange rate types

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -26,6 +26,7 @@ Changed functionalities
 * Templates for printed documents need to escape inserted data (was automatic)
 * Search checkmarks 'Open/Closed' replaced by radio button 'Open/Closed/All'
 * Default exchange rates cannot be NULL
+* Don't display delete button for in-use currency or exchange rate types
 
 Bugs fixed
 * Default dates sometimes off by a day (before or after the current day) (#2587)

--- a/lib/LedgerSMB/Exchangerate_Type.pm
+++ b/lib/LedgerSMB/Exchangerate_Type.pm
@@ -48,6 +48,14 @@ value and it thus can't be deleted.
 
 has 'builtin' => (is => 'ro', isa => 'Bool');
 
+=item is_used
+
+This boolean indicates that the rate type is used within the current
+company and therefore cannot be deleted.
+
+=cut
+
+has 'is_used' => (is => 'ro', isa => 'Bool');
 
 =back
 
@@ -123,7 +131,7 @@ sub delete {
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2015 The LedgerSMB Core Team
+Copyright (C) 2015-2020 The LedgerSMB Core Team
 
 This file is licensed under the GNU General Public License version 2, or at your
 option any later version.  A copy of the license should have been included with

--- a/lib/LedgerSMB/Scripts/currency.pm
+++ b/lib/LedgerSMB/Scripts/currency.pm
@@ -64,12 +64,12 @@ sub list_currencies {
         $s->{row_id} = $s->{curr};
         if ($s->{curr} eq $default_curr) {
             $s->{drop_NOHREF} = 1;
-            $s->{drop} = '(' . $request->{_locale}->text('default') . ')';
+            $s->{drop} = $request->{_locale}->text('default');
         }
         elsif ($s->{is_used}) {
             # Cannot delete a currency that's already being used
             $s->{drop_NOHREF} = 1;
-            $s->{drop} = '';
+            $s->{drop} = $request->{_locale}->text('in use');
         }
         else {
             $s->{drop} = '[' . $request->{_locale}->text('delete') . ']';
@@ -147,7 +147,13 @@ sub list_exchangerate_types {
     for my $s (@exchangerate_types) {
         $s->{row_id} = $s->{id};
         if ($s->{builtin}) {
-            $s->{drop_NOHREF} = $s->{builtin};
+            $s->{drop_NOHREF} = 1;
+            $s->{drop} = $request->{_locale}->text('system type');
+        }
+        elsif ($s->{is_used}) {
+            # Cannot delete a currency that's already being used
+            $s->{drop_NOHREF} = 1;
+            $s->{drop} = $request->{_locale}->text('in use');
         }
         else {
             $s->{drop} = '[' . $request->{_locale}->text('delete') . ']';
@@ -369,7 +375,7 @@ sub upload_exchangerates {
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2015 The LedgerSMB Core Team
+Copyright (C) 2015-2020 The LedgerSMB Core Team
 
 This file is licensed under the GNU General Public License version 2, or at your
 option any later version.  A copy of the license should have been included with

--- a/sql/modules/BLACKLIST
+++ b/sql/modules/BLACKLIST
@@ -219,6 +219,7 @@ exchangerate__list
 exchangerate__save
 exchangerate_type__delete
 exchangerate_type__get
+exchangerate_type__is_used
 exchangerate_type__list
 exchangerate_type__save
 file__attach_to_eca

--- a/sql/modules/Currency.sql
+++ b/sql/modules/Currency.sql
@@ -141,15 +141,35 @@ $$ language sql;
 COMMENT ON FUNCTION exchangerate_type__get(numeric) IS
 $$Retrieves an exchangerate type and its description.$$;
 
+CREATE OR REPLACE FUNCTION exchangerate_type__is_used
+(in_id integer)
+RETURNS BOOLEAN AS $$
+BEGIN
+   RETURN EXISTS (SELECT 1 FROM exchangerate_default WHERE rate_type = in_id);
+END;$$ language plpgsql;
+
+COMMENT ON FUNCTION exchangerate_type__is_used(integer) IS
+$$Returns true if exchangerate_type with id 'in_id' is used within the current commpany
+database. Returns false otherwise.$$;
+
+DROP TYPE IF EXISTS exchangerate_type_list CASCADE;
+CREATE TYPE exchangerate_type_list AS (
+  id INTEGER,
+  description TEXT,
+  builtin BOOLEAN,
+  is_used BOOLEAN
+);
+
+DROP FUNCTION IF EXISTS exchangerate_type__list();
 CREATE OR REPLACE FUNCTION exchangerate_type__list()
-RETURNS SETOF exchangerate_type AS
+RETURNS SETOF exchangerate_type_list AS
 $$
-   SELECT * FROM exchangerate_type;
+   SELECT id, description, builtin, exchangerate_type__is_used(id)
+   FROM exchangerate_type;
 $$ language sql;
 
 COMMENT ON FUNCTION exchangerate_type__list() IS
 $$Returns all exchangerate types.$$;
-
 
 
 --- #######   Exchange rates


### PR DESCRIPTION
Exchange rate types which are in-use cannot be deleted, so don't
display the delete link for them.