### PR TITLE
Fix exchange rate type deletion

### DIFF
--- a/lib/LedgerSMB/Scripts/currency.pm
+++ b/lib/LedgerSMB/Scripts/currency.pm
@@ -256,6 +256,7 @@ sub _list_exchangerates {
         },
         {
             col_id => 'drop',
+            type   => 'href',
             href_base => $base_url,
         },
         ];


### PR DESCRIPTION
Link text was displayed, but dynatable column wasn't set to be a
href, so no clickable link was generated.