### PR TITLE
Add not null constraints to exchangerate_type table

### DIFF
--- a/sql/changes/1.8/constrain-exchangerate-type.sql
+++ b/sql/changes/1.8/constrain-exchangerate-type.sql
@@ -1,0 +1,4 @@
+ALTER TABLE exchangerate_type ALTER COLUMN builtin SET DEFAULT FALSE;
+ALTER TABLE exchangerate_type ALTER COLUMN builtin SET NOT NULL;
+ALTER TABLE exchangerate_type ALTER COLUMN description SET DEFAULT '';
+ALTER TABLE exchangerate_type ALTER COLUMN description SET NOT NULL;

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -126,3 +126,4 @@ mc/delete-migration-validation-data.sql
 1.8/drop-payment_map.sql
 1.8/explicit-reconciliation.sql
 1.8/constrain-default-exchange-rates.sql
+1.8/constrain-exchangerate-type.sql


### PR DESCRIPTION
Sets defaults and add not null constraints to exchangerate_type
`inbuilt` and `description` fields.
