### PR TITLE
Fix error adding exchange rate type

### DIFF
--- a/UI/Configuration/ratetype.html
+++ b/UI/Configuration/ratetype.html
@@ -12,7 +12,7 @@
 
     <form data-dojo-type="lsmb/Form"
           method="post"
-          action="<?lsmb form.script ?>">
+          action="<?lsmb request.script ?>">
       <?lsmb FOREACH hidden IN hiddens.keys;
              PROCESS input element_data={
                      type => 'hidden',


### PR DESCRIPTION
Trying to add an exchange rate type resulted in the following error:

    Action Not Defined: save_exchangerate_type

Fixed by this patch.