### PR TITLE
Fix error adding exchange rate

### DIFF
--- a/UI/Configuration/rate.html
+++ b/UI/Configuration/rate.html
@@ -14,7 +14,7 @@
 
     <form data-dojo-type="lsmb/Form"
           method="post"
-          action="<?lsmb form.script ?>"
+          action="<?lsmb request.script ?>"
           enctype="multipart/form-data">
       <?lsmb FOREACH hidden IN hiddens.keys;
              PROCESS input element_data={


### PR DESCRIPTION
Trying to add an exchange rate type resulted in an
`Action Not Defined` error. Fixed by this patch.