### PR TITLE
Update apache-vhost.conf. Add timeout settings, closes #4416

### DIFF
--- a/doc/conf/apache-vhost.conf
+++ b/doc/conf/apache-vhost.conf
@@ -48,7 +48,13 @@ NameVirtualHost *:443
   RewriteCond "%{REQUEST_FILENAME}" !-d
   RewriteRule "^/(.*)" "http://localhost:5762/$1" [P]
   ProxyPassReverse "/" "http://localhost:5762/"
-
+  
+  # Timeout settings, if you receive reverse proxy 
+  # timeout or 50x errors, especially during company 
+  # database creation, try to raise these setting.
+  Timeout 300
+  ProxyTimeout 300
+  
 </VirtualHost>
 
 


### PR DESCRIPTION
Timeout 300 and ProxyTimeout 300
Fix for reverse proxy error, as where apache was only waiting 60 sec to timeout, even if global is set to 300