### PR TITLE
Add BDD tests for Edit currencies screen

### DIFF
--- a/xt/66-cucumber/05-settings/currency.feature
+++ b/xt/66-cucumber/05-settings/currency.feature
@@ -1,0 +1,43 @@
+@weasel
+Feature: Currency
+  As a LedgerSMB user, I want to be able to view the available currencies,
+  add further currencies, and delete unused currencies. I should not be
+  able to delete the company's default currencies, or those currencies
+  which are being used in the company's accounts.
+
+Background:
+  Given a standard test company
+    And a logged in admin user
+
+Scenario: View the available currencies
+ Given the following exchange rate:
+     | currency | rate type    | valid from | rate |
+     | EUR      | Default rate | 2020-01-01 | 1.1  |
+  When I navigate the menu and select the item at "System > Currency > Edit currencies"
+  Then I should see the Edit currencies screen
+   And I should see the title "Defined currencies"
+   And I expect the report to contain 3 rows
+   And I expect the '' report column to contain 'default' for ID 'USD'
+   And I expect the '' report column to contain 'in use' for ID 'EUR'
+   And I expect the 'Description' report column to contain 'USD' for ID 'USD'
+   And I expect the 'Description' report column to contain 'EUR' for ID 'EUR'
+   And I expect the 'Description' report column to contain 'CAD' for ID 'CAD'
+
+Scenario: Add a currency
+  When I navigate the menu and select the item at "System > Currency > Edit currencies"
+  Then I should see the Edit currencies screen
+  When I enter "SEK" as the id for a new currency
+   And I enter "Swedish Krona" as the description for a new currency
+   And I press "Add"
+  Then I should see the Edit currencies screen
+   And I expect the report to contain 4 rows
+   And I expect the 'Description' report column to contain 'Swedish Krona' for ID 'SEK'
+
+Scenario: Delete a currency
+  When I navigate the menu and select the item at "System > Currency > Edit currencies"
+  Then I should see the Edit currencies screen
+   And I expect the report to contain 3 rows
+  When I click "[delete]" for the row with ID "CAD"
+  Then I should see the Edit currencies screen
+   And I expect the report to contain 2 rows
+

--- a/xt/66-cucumber/05-settings/step_definitions/pageobject_steps.pl
+++ b/xt/66-cucumber/05-settings/step_definitions/pageobject_steps.pl
@@ -1,0 +1,63 @@
+#!perl
+
+use lib 'xt/lib';
+use strict;
+use warnings;
+
+use Test::More;
+use Test::BDD::Cucumber::StepFile;
+
+
+When qr/^I enter "(.*)" as the id for a new currency/, sub {
+    my $data = $1;
+    my $page = S->{ext_wsl}->page->body->maindiv->content;
+
+    my $input = $page->find('//input[@id="curr"]')
+        or die 'failed to find id field for defining a new currency';
+
+    $input->clear;
+    $input->send_keys($data);
+};
+
+
+When qr/^I enter "(.*)" as the description for a new currency/, sub {
+    my $data = $1;
+    my $page = S->{ext_wsl}->page->body->maindiv->content;
+
+    my $input = $page->find('//input[@id="description"]')
+        or die 'failed to find description field for defining a new currency';
+
+    $input->clear;
+    $input->send_keys($data);
+};
+
+
+When qr/^I click "(.*)" for the row with (.*) "(.*)"$/, sub {
+    my $link_text = $1;
+    my $column = $2;
+    my $value = $3;
+    my @rows = S->{ext_wsl}->page->body->maindiv->content->rows;
+
+    foreach my $row(@rows) {
+        if ($row->{$column} eq $value) {
+            my $link = $row->{_element}->find(
+                qq{.//a[.="$1"]}
+            );
+            ok($link, "found $link_text link for $column '$value'");
+            $link->click;
+            last;
+        }
+    }
+};
+
+
+Then qr/I should see the title "(.*)"/, sub {
+    my $page = S->{ext_wsl}->page->body->maindiv->content;
+    my $title = $1;
+
+    my $div = $page->title(title => $title);
+    ok($div, "Found title '$title'");
+};
+
+
+1;

--- a/xt/lib/PageObject/App/System/Currency/EditCurrencies.pm
+++ b/xt/lib/PageObject/App/System/Currency/EditCurrencies.pm
@@ -11,12 +11,63 @@ use namespace::autoclean;
 extends 'PageObject';
 
 __PACKAGE__->self_register(
-              'system-currency',
-              './/div[@id="system-currency"]',
-              tag_name => 'div',
-              attributes => {
-                  id => 'system-currency',
-              });
+    'system-currency',
+    './/div[@id="system-currency"]',
+    tag_name => 'div',
+    attributes => {
+        id => 'system-currency',
+    }
+);
+
+
+
+# title ()
+#
+# Returns the page title div with content matching the specified
+# `title` parameter
+
+sub title {
+    my $self = shift;
+    my %params = @_;
+    my $title = $self->find(sprintf(
+        './div[@class="listtop" and normalize-space(.)="%s"]',
+        $params{title},
+    ));
+    return $title
+}
+
+
+sub _extract_column_headings {
+    my $self = shift;
+
+    my @heading_nodes = $self->find_all('.//table/thead/tr/th
+                                         | .//table/thead/tr/td');
+    return map { $_->get_text } @heading_nodes;;
+}
+
+# rows()
+#
+# Returns an array of hashrefs representing the rows in
+# the table. The hashref contains the text content of each
+# column, keyed by the column heading, plus an additional
+# `_element` key representing the original <tr> element.
+
+sub rows {
+    my $self = shift;
+
+    my @headings = $self->_extract_column_headings;
+    my @rows = $self->find_all('.//table/tbody/tr');
+
+    return map {
+        my @cells = $_->find_all('./td | ./th');
+        my %row_values;
+        @row_values{@headings} = map { $_->get_text } @cells;
+        $row_values{_element} = $_;
+        \%row_values;
+    } @rows;
+}
+
+
 
 sub _verify {
     my ($self) = @_;

--- a/xt/lib/Pherkin/Extension/ledgersmb_steps/common_steps.pl
+++ b/xt/lib/Pherkin/Extension/ledgersmb_steps/common_steps.pl
@@ -683,4 +683,33 @@ Given qr/a gl account heading with these properties:$/, sub {
 };
 
 
+Given qr/the following exchange rates?:$/, sub {
+    # Expects data in the following form:
+    # | currency | rate type    | valid from | rate |
+    # | EUR      | Default rate | 2020-01-01 | 1.1  |
+    my $dbh = S->{ext_lsmb}->admin_dbh;
+
+    my $q = $dbh->prepare('
+        INSERT INTO exchangerate_default (
+            rate_type,
+            curr,
+            valid_from,
+            rate
+        )
+        SELECT id, ?, ?, ?
+        FROM exchangerate_type
+        WHERE description = ?
+        LIMIT 1
+    ');
+
+    foreach my $row (@{C->data}) {
+        $q->execute(
+            $row->{'currency'},
+            $row->{'valid from'},
+            $row->{'rate'},
+            $row->{'rate type'},
+        ) or die "failed to insert exchange rate";
+    }
+};
+
 1;


### PR DESCRIPTION
Tests viewing, adding, deleting currencies. Confirms that page title
is displayed and that 'in use' or 'default' labels are correctly
displayed.