### PR TITLE
Change table heading on Exchange Rate screen

### DIFF
--- a/lib/LedgerSMB/Scripts/currency.pm
+++ b/lib/LedgerSMB/Scripts/currency.pm
@@ -240,7 +240,7 @@ sub _list_exchangerates {
     my $columns = [
         {
             col_id => 'curr',
-            name   => 'ID'
+            name   => $request->{_locale}->text('Currency'),
         },
         {
             col_id => 'rate_type',


### PR DESCRIPTION
Change title of `ID` column to `Currency`. `ID` is the internal
field name, but to a user, this column is the currency. It's more
descriptive, meaningful and accessible to use `Currency` as the
column heading. It also provides consistency with the dropdown
field label lower down the screen.