### PR TITLE
Don't display ID column on Rate Types screen

### DIFF
--- a/lib/LedgerSMB/Scripts/currency.pm
+++ b/lib/LedgerSMB/Scripts/currency.pm
@@ -128,11 +128,6 @@ sub list_exchangerate_types {
     my @exchangerate_types = LedgerSMB::Exchangerate_Type->list();
     my $columns = [
         {
-            col_id => 'id',
-            name   => 'ID',
-            type   => 'text',
-        },
-        {
             col_id => 'description',
             name   => $request->{_locale}->text('Description'),
             type   => 'text',
@@ -142,7 +137,7 @@ sub list_exchangerate_types {
             type   => 'href',
             href_base => 'currency.pl?action=delete_exchangerate_type&id='
         },
-        ];
+    ];
     my $rows = [];
     for my $s (@exchangerate_types) {
         $s->{row_id} = $s->{id};


### PR DESCRIPTION
The ID of an exchange rate type is an internal primary key, based
on an auto-increment field. There is no need to display this to a
user - it confuses the UI for no benefit.