### PR TITLE
Consolidate common BDD steps

### DIFF
--- a/xt/66-cucumber/05-settings/step_definitions/pageobject_steps.pl
+++ b/xt/66-cucumber/05-settings/step_definitions/pageobject_steps.pl
@@ -32,32 +32,4 @@ When qr/^I enter "(.*)" as the description for a new currency/, sub {
 };
 
 
-When qr/^I click "(.*)" for the row with (.*) "(.*)"$/, sub {
-    my $link_text = $1;
-    my $column = $2;
-    my $value = $3;
-    my @rows = S->{ext_wsl}->page->body->maindiv->content->rows;
-
-    foreach my $row(@rows) {
-        if ($row->{$column} eq $value) {
-            my $link = $row->{_element}->find(
-                qq{.//a[.="$1"]}
-            );
-            ok($link, "found $link_text link for $column '$value'");
-            $link->click;
-            last;
-        }
-    }
-};
-
-
-Then qr/I should see the title "(.*)"/, sub {
-    my $page = S->{ext_wsl}->page->body->maindiv->content;
-    my $title = $1;
-
-    my $div = $page->title(title => $title);
-    ok($div, "Found title '$title'");
-};
-
-
 1;

--- a/xt/66-cucumber/10-gl/step_definitions/pageobject_steps.pl
+++ b/xt/66-cucumber/10-gl/step_definitions/pageobject_steps.pl
@@ -44,26 +44,6 @@ When qr/^I (select|deselect) every checkbox in "(.*)"$/, sub {
 };
 
 
-When qr/^I click "(.*)" for the row with (.*) "(.*)"$/, sub {
-    my $link_text = $1;
-    my $column = $2;
-    my $value = $3;
-    my @rows = S->{ext_wsl}->page->body->maindiv->content->rows;
-
-    foreach my $row(@rows) {
-        if ($row->{$column} eq $value) {
-            my $link = $row->{_element}->find(
-                qq{.//a[.="$1"]}
-            );
-            ok($link, "found $link_text link for $column '$value'");
-            $link->click;
-            last;
-        }
-    }
-
-};
-
-
 Then qr/^I expect to see (\d+) selected checkboxes in "(.*)"$/, sub {
     my $wanted_count = $1;
     my $section = $2;

--- a/xt/lib/PageObject/App/Cash/Vouchers/Payments/Filter.pm
+++ b/xt/lib/PageObject/App/Cash/Vouchers/Payments/Filter.pm
@@ -9,6 +9,7 @@ use PageObject;
 use Moose;
 use namespace::autoclean;
 extends 'PageObject';
+with 'PageObject::App::Roles::Dynatable';
 
 __PACKAGE__->self_register(
               'cash-vouchers-payments-filter',
@@ -17,23 +18,6 @@ __PACKAGE__->self_register(
               attributes => {
                   id => 'payments-filter',
               });
-
-
-# title ()
-#
-# Returns the page title div with content matching the specified
-# `title` parameter
-# Normally contains text "Filtering Payments"
-
-sub title {
-    my $self = shift;
-    my %params = @_;
-    my $title = $self->find(sprintf(
-        './div[@class="listtop" and normalize-space(.)="%s"]',
-        $params{title},
-    ));
-    return $title
-}
 
 
 sub _verify {

--- a/xt/lib/PageObject/App/Roles/Dynatable.pm
+++ b/xt/lib/PageObject/App/Roles/Dynatable.pm
@@ -1,0 +1,71 @@
+package PageObject::App::Roles::Dynatable;
+
+use strict;
+use warnings;
+
+use Carp;
+use PageObject;
+
+use Moose::Role;
+use namespace::autoclean;
+
+
+# title ()
+#
+# Returns the page title div with content matching the specified
+# `title` parameter
+
+sub title {
+    my $self = shift;
+    my %params = @_;
+    my $title = $self->find(sprintf(
+        './div[@class="listtop" and normalize-space(.)="%s"]',
+        $params{title},
+    ));
+    return $title
+}
+
+sub find_heading {
+    my $self = shift;
+    my $heading = shift;
+    my $header_div = $self->find(
+        '//form[@id="search-report-dynatable"]'.
+        '/div[@class="heading_section"]'.
+        qq{/div[label[.="$heading->{Heading}:"]]}.
+        qq{/span[\@class="report_header" and normalize-space(.)="$heading->{Contents}"]}
+    ) or die "Matching heading not found '$heading->{Heading}' : '$heading->{Contents}'";
+    return $header_div;
+}
+
+sub _extract_column_headings {
+    my $self = shift;
+
+    my @heading_nodes = $self->find_all('.//table/thead/tr/th
+                                         | .//table/thead/tr/td');
+    return map { $_->get_text } @heading_nodes;;
+}
+
+# rows()
+#
+# Returns an array of hashrefs representing the rows in
+# the table. The hashref contains the text content of each
+# column, keyed by the column heading, plus an additional
+# `_element` key representing the original <tr> element.
+
+sub rows {
+    my $self = shift;
+
+    my @headings = $self->_extract_column_headings;
+    my @rows = $self->find_all('.//table/tbody/tr');
+
+    return map {
+        my @cells = $_->find_all('./td | ./th');
+        my %row_values;
+        @row_values{@headings} = map { $_->get_text } @cells;
+        $row_values{_element} = $_;
+        \%row_values;
+    } @rows;
+}
+
+
+1;

--- a/xt/lib/PageObject/App/Search/ReportDynatable.pm
+++ b/xt/lib/PageObject/App/Search/ReportDynatable.pm
@@ -7,6 +7,7 @@ use warnings;
 use Moose;
 use namespace::autoclean;
 extends 'PageObject';
+with 'PageObject::App::Roles::Dynatable';
 
 __PACKAGE__->self_register(
               'search-report-dynatable',
@@ -16,48 +17,6 @@ __PACKAGE__->self_register(
                   id => 'search-report-dynatable',
               });
 
-
-sub _extract_column_headings {
-    my $self = shift;
-
-    my @heading_nodes = $self->find_all('.//table/thead/tr/th
-                                         | .//table/thead/tr/td');
-    return map { $_->get_text } @heading_nodes;;
-}
-
-# rows()
-#
-# Returns an array of hashrefs representing the rows in
-# the table. The hashref contains the text content of each
-# column, keyed by the column heading, plus an additional
-# `_element` key representing the original <tr> element.
-
-sub rows {
-    my $self = shift;
-
-    my @headings = $self->_extract_column_headings;
-    my @rows = $self->find_all('.//table/tbody/tr');
-
-    return map {
-        my @cells = $_->find_all('./td | ./th');
-        my %row_values;
-        @row_values{@headings} = map { $_->get_text } @cells;
-        $row_values{_element} = $_;
-        \%row_values;
-    } @rows;
-}
-
-sub find_heading {
-    my $self = shift;
-    my $heading = shift;
-    my $header_div = $self->find(
-        '//form[@id="search-report-dynatable"]'.
-        '/div[@class="heading_section"]'.
-        qq{/div[label[.="$heading->{Heading}:"]]}.
-        qq{/span[\@class="report_header" and normalize-space(.)="$heading->{Contents}"]}
-    ) or die "Matching heading not found '$heading->{Heading}' : '$heading->{Contents}'";
-    return $header_div;
-}
 
 sub _verify {
     my ($self) = @_;

--- a/xt/lib/PageObject/App/System/Currency/EditCurrencies.pm
+++ b/xt/lib/PageObject/App/System/Currency/EditCurrencies.pm
@@ -9,6 +9,7 @@ use PageObject;
 use Moose;
 use namespace::autoclean;
 extends 'PageObject';
+with 'PageObject::App::Roles::Dynatable';
 
 __PACKAGE__->self_register(
     'system-currency',
@@ -20,58 +21,8 @@ __PACKAGE__->self_register(
 );
 
 
-
-# title ()
-#
-# Returns the page title div with content matching the specified
-# `title` parameter
-
-sub title {
-    my $self = shift;
-    my %params = @_;
-    my $title = $self->find(sprintf(
-        './div[@class="listtop" and normalize-space(.)="%s"]',
-        $params{title},
-    ));
-    return $title
-}
-
-
-sub _extract_column_headings {
-    my $self = shift;
-
-    my @heading_nodes = $self->find_all('.//table/thead/tr/th
-                                         | .//table/thead/tr/td');
-    return map { $_->get_text } @heading_nodes;;
-}
-
-# rows()
-#
-# Returns an array of hashrefs representing the rows in
-# the table. The hashref contains the text content of each
-# column, keyed by the column heading, plus an additional
-# `_element` key representing the original <tr> element.
-
-sub rows {
-    my $self = shift;
-
-    my @headings = $self->_extract_column_headings;
-    my @rows = $self->find_all('.//table/tbody/tr');
-
-    return map {
-        my @cells = $_->find_all('./td | ./th');
-        my %row_values;
-        @row_values{@headings} = map { $_->get_text } @cells;
-        $row_values{_element} = $_;
-        \%row_values;
-    } @rows;
-}
-
-
-
 sub _verify {
     my ($self) = @_;
-
     return $self;
 }
 

--- a/xt/lib/Pherkin/Extension/pageobject_steps/report_steps.pl
+++ b/xt/lib/Pherkin/Extension/pageobject_steps/report_steps.pl
@@ -104,5 +104,32 @@ Then qr/I should see these headings:$/, sub {
 };
 
 
+When qr/^I click "(.*)" for the row with (.*) "(.*)"$/, sub {
+    my $link_text = $1;
+    my $column = $2;
+    my $value = $3;
+    my @rows = S->{ext_wsl}->page->body->maindiv->content->rows;
+
+    foreach my $row(@rows) {
+        if ($row->{$column} eq $value) {
+            my $link = $row->{_element}->find(
+                qq{.//a[.="$1"]}
+            );
+            ok($link, "found $link_text link for $column '$value'");
+            $link->click;
+            last;
+        }
+    }
+};
+
+
+Then qr/I should see the title "(.*)"/, sub {
+    my $page = S->{ext_wsl}->page->body->maindiv->content;
+    my $title = $1;
+
+    my $div = $page->title(title => $title);
+    ok($div, "Found title '$title'");
+};
+
 
 1;


### PR DESCRIPTION
In developing bdd tests for various parts of LedgerSMB, there are various
steps that are common to a number of screens. This stems from our re-use
of UI components, such as dynatable for displaying tabular information.

This PR is a first step in aiming to reduce the copy/paste code used to
interact with such common components.