### PR TITLE
Add BDD tests for exchange rate type screen

### DIFF
--- a/xt/66-cucumber/05-settings/rate_types.feature
+++ b/xt/66-cucumber/05-settings/rate_types.feature
@@ -1,0 +1,42 @@
+@weasel
+Feature: Rate types
+  As a LedgerSMB user, I want to be able to view the available exchange
+  rate types and delete unused exchange rate types. I should not be able
+  to delete the company's default exchanage rate type, or those currencies
+  which are being used and the interface should indicate these conditions.
+
+Background:
+  Given a standard test company
+    And a logged in admin user
+
+Scenario: View the available exchange rate types
+  When I navigate the menu and select the item at "System > Currency > Edit rate types"
+  Then I should see the Edit rate types screen
+   And I should see the title "Defined exchange rate types"
+   And I expect the report to contain 1 row
+
+Scenario: Used exchange rate types identified
+ Given the following exchange rate type:
+     | description |
+     | Test        |
+ Given the following exchange rate:
+     | currency | rate type    | valid from | rate |
+     | EUR      | Test         | 2020-01-01 | 1.1  |
+  When I navigate the menu and select the item at "System > Currency > Edit rate types"
+  Then I should see the Edit rate types screen
+   And I expect the report to contain 2 rows
+   And I expect the '' report column to contain 'system type' for Description 'Default rate'
+   And I expect the '' report column to contain 'in use' for Description 'Test'
+
+Scenario: Add and delete an exchange rate type
+  When I navigate the menu and select the item at "System > Currency > Edit rate types"
+  Then I should see the Edit rate types screen
+   And I expect the report to contain 1 row
+  When I enter "Test" as the description for a new rate type
+   And I press "Add"
+  Then I should see the Edit rate types screen
+   And I expect the report to contain 2 rows
+  When I click "[delete]" for the row with Description "Test"
+  Then I should see the Edit rate types screen
+   And I expect the report to contain 1 row
+

--- a/xt/66-cucumber/05-settings/step_definitions/pageobject_steps.pl
+++ b/xt/66-cucumber/05-settings/step_definitions/pageobject_steps.pl
@@ -8,6 +8,18 @@ use Test::More;
 use Test::BDD::Cucumber::StepFile;
 
 
+When qr/^I enter "(.*)" as the description for a new rate type/, sub {
+    my $data = $1;
+    my $page = S->{ext_wsl}->page->body->maindiv->content;
+
+    my $input = $page->find('//input[@id="description"]')
+        or die 'failed to find description field for defining a new rate type';
+
+    $input->clear;
+    $input->send_keys($data);
+};
+
+
 When qr/^I enter "(.*)" as the id for a new currency/, sub {
     my $data = $1;
     my $page = S->{ext_wsl}->page->body->maindiv->content;

--- a/xt/lib/PageObject/App/System/Currency/EditRateTypes.pm
+++ b/xt/lib/PageObject/App/System/Currency/EditRateTypes.pm
@@ -9,6 +9,7 @@ use PageObject;
 use Moose;
 use namespace::autoclean;
 extends 'PageObject';
+with 'PageObject::App::Roles::Dynatable';
 
 __PACKAGE__->self_register(
               'system-ratetype',

--- a/xt/lib/Pherkin/Extension/ledgersmb_steps/common_steps.pl
+++ b/xt/lib/Pherkin/Extension/ledgersmb_steps/common_steps.pl
@@ -708,8 +708,27 @@ Given qr/the following exchange rates?:$/, sub {
             $row->{'valid from'},
             $row->{'rate'},
             $row->{'rate type'},
-        ) or die "failed to insert exchange rate";
+        ) or die 'failed to insert exchange rate';
     }
 };
+
+Given qr/the following exchange rate types?:$/, sub {
+    # Expects data in the following form:
+    # | description |
+    # | Buy rate    |
+    my $dbh = S->{ext_lsmb}->admin_dbh;
+
+    my $q = $dbh->prepare('
+        INSERT INTO exchangerate_type (description)
+        VALUES (?)
+    ');
+
+    foreach my $row (@{C->data}) {
+        $q->execute(
+            $row->{'description'},
+        ) or die 'failed to insert exchange rate type';
+    }
+};
+
 
 1;


### PR DESCRIPTION
Tests viewing, adding, deleting exchange rate types and ensures
in use or system types are indicated.