### PR TITLE
More reliable logging in during menu tests

### DIFF
--- a/UI/js-src/lsmb/MainContentPane.js
+++ b/UI/js-src/lsmb/MainContentPane.js
@@ -22,6 +22,10 @@ define([
               {
                   last_page: null,
                   interceptClick: null,
+                  startup: function () {
+                      this.inherited("startup", arguments);
+                      domClass.add(this.domNode,"done-parsing");
+                  },
                   report_request_error: function(err) {
                       var d = registry.byId("errorDialog");
                       if (0 === err.response.status) {

--- a/UI/main.html
+++ b/UI/main.html
@@ -5,7 +5,7 @@
        data-dojo-type="dijit/layout/BorderContainer"
        data-dojo-props="persist: true"
        style="width: 100%; height: 100%">
-    <div id="maindiv" class="mainpanel done-parsing"
+    <div id="maindiv" class="mainpanel"
          data-dojo-type="lsmb/MainContentPane"
          data-dojo-props="region: 'center', href:'welcome.html'">
     </div>

--- a/xt/66-cucumber/01-basic/menu.feature
+++ b/xt/66-cucumber/01-basic/menu.feature
@@ -1,4 +1,4 @@
-@one-db @weasel @weasel-one-session
+@one-db @weasel
 Feature: correct operation of the menu and immediate linked pages
   As an end-user, I want to be able to navigate the menu and open
   the screens from the available links. If my authorizations


### PR DESCRIPTION
This change is two-fold:
* Remove a (premature) optimization to reduce load on phantomjs
* Delay setting the 'done-parsing' class on #maindiv
