### PR TITLE
Remove explicit page-load waiting

### DIFF
--- a/xt/66-cucumber/04-users/change-permissions.feature
+++ b/xt/66-cucumber/04-users/change-permissions.feature
@@ -18,7 +18,6 @@ Scenario: Remove a user permission
   Then I expect the "account all" checkbox to be selected
   When I deselect checkbox "account all"
    And I press "Save Groups"
-   And I wait for the page to load
   Then I should see the Edit Contact screen
   When I select the "User" tab
   Then I expect the "account all" checkbox to be not selected
@@ -34,7 +33,6 @@ Scenario: Add a user permission
   Then I expect the "account all" checkbox to be not selected
   When I select checkbox "account all"
    And I press "Save Groups"
-   And I wait for the page to load
   Then I should see the Edit Contact screen
   When I select the "User" tab
   Then I expect the "account all" checkbox to be selected

--- a/xt/66-cucumber/10-gl/account-add-delete.feature
+++ b/xt/66-cucumber/10-gl/account-add-delete.feature
@@ -34,6 +34,5 @@ Scenario: Delete the account from the chart of accounts
    And I expect the report to contain 79 rows
    And I expect the 'Description' report column to contain 'New Account' for Account Number 'T0001'
   When I click "[Delete]" for the row with Account Number "T0001"
-   And I wait for the page to load
   Then I should see the Chart of Accounts screen
    And I expect the report to contain 78 rows

--- a/xt/66-cucumber/10-gl/account-heading-add-delete.feature
+++ b/xt/66-cucumber/10-gl/account-heading-add-delete.feature
@@ -29,6 +29,5 @@ Scenario: Delete the account heading from the chart of accounts
    And I expect the report to contain 79 rows
    And I expect the 'Description' report column to contain 'New Heading' for Account Number 'H0001'
   When I click "[Delete]" for the row with Account Number "H0001"
-   And I wait for the page to load
   Then I should see the Chart of Accounts screen
    And I expect the report to contain 78 rows

--- a/xt/lib/Pherkin/Extension/pageobject_steps/nav_steps.pl
+++ b/xt/lib/Pherkin/Extension/pageobject_steps/nav_steps.pl
@@ -51,10 +51,6 @@ When qr/^I save the page( as new)?$/, sub {
     S->{ext_wsl}->page->body->maindiv->wait_for_content(replaces => $maindiv);
 };
 
-When qr/I wait for the page to load$/, sub {
-    # S->{ext_wsl}->page->body->maindiv->wait_for_content;
-};
-
 Then qr/I should see the (.*) page/, sub {
     my $page_name = $1;
     die "Unknown page '$page_name'"


### PR DESCRIPTION
Now that we have page-waiting after each When step through the
Pherkin PageObject extension, there's no need to have this step
in any scenarios.
