### PR TITLE
Dont filter exchange rates screen after add rate

### DIFF
--- a/lib/LedgerSMB/Scripts/currency.pm
+++ b/lib/LedgerSMB/Scripts/currency.pm
@@ -205,12 +205,8 @@ Displays a list of configured exchangerate types.  No inputs required or used.
 
 sub list_exchangerates {
     my ($request) = @_;
-    my @exchangerates = LedgerSMB::Exchangerate->list(
-        curr => $request->{curr},
-        type_id => $request->{type} || 1,
-        offset => $request->{offset},
-        limit => $request->{limit} || 30,
-        );
+    my @exchangerates = LedgerSMB::Exchangerate->list();
+
     $request->{title} =
         $request->{_locale}->text('Available exchange rates');
 

--- a/xt/66-cucumber/05-settings/rates.feature
+++ b/xt/66-cucumber/05-settings/rates.feature
@@ -6,12 +6,12 @@ Feature: Exchange rates
 Background:
   Given a standard test company
     And a logged in admin user
-
-Scenario: View the available exchange rates
- Given the following exchange rates:
+    And the following exchange rates:
      | currency | rate type    | valid from | rate |
      | EUR      | Default rate | 2020-01-01 | 1.1  |
      | CAD      | Default rate | 2020-01-02 | 0.8  |
+
+Scenario: View the available exchange rates
   When I navigate the menu and select the item at "System > Currency > Edit rates"
   Then I should see the Edit rates screen
    And I should see the title "Available exchange rates"
@@ -26,45 +26,39 @@ Scenario: View the available exchange rates
 Scenario: Add an exchange rate
   When I navigate the menu and select the item at "System > Currency > Edit rates"
   Then I should see the Edit rates screen
-   And I expect the report to contain 0 rows
+   And I expect the report to contain 2 rows
   When I select "EUR" from the drop down "Currency"
    And I select "Default rate" from the drop down "Rate type"
-   And I enter "2020-01-01" into "Valid from"
-   And I enter "1.1" into "Rate"
+   And I enter "2020-02-01" into "Valid from"
+   And I enter "1.2" into "Rate"
    And I press "Add"
   Then I should see the Edit rates screen
-   And I expect the report to contain 1 row
-   And I expect the 'Currency' report column to contain 'EUR' for Valid From '2020-01-01'
-   And I expect the 'Rate Type' report column to contain 'Default rate' for Valid From '2020-01-01'
-   And I expect the 'Rate' report column to contain '1.1' for Valid From '2020-01-01'
+   And I expect the report to contain 3 rows
+   And I expect the 'Currency' report column to contain 'EUR' for Valid From '2020-02-01'
+   And I expect the 'Rate Type' report column to contain 'Default rate' for Valid From '2020-02-01'
+   And I expect the 'Rate' report column to contain '1.2' for Valid From '2020-02-01'
 
 Scenario: Update an exchange rate
- Given the following exchange rate:
-     | currency | rate type    | valid from | rate |
-     | EUR      | Default rate | 2020-01-01 | 1.1  |
   When I navigate the menu and select the item at "System > Currency > Edit rates"
   Then I should see the Edit rates screen
    And I should see the title "Available exchange rates"
-   And I expect the report to contain 1 row
+   And I expect the report to contain 2 rows
   When I select "EUR" from the drop down "Currency"
    And I select "Default rate" from the drop down "Rate type"
    And I enter "2020-01-01" into "Valid from"
    And I enter "1.2" into "Rate"
    And I press "Add"
   Then I should see the Edit rates screen
-   And I expect the report to contain 1 row
+   And I expect the report to contain 2 rows
    And I expect the 'Currency' report column to contain 'EUR' for Valid From '2020-01-01'
    And I expect the 'Rate Type' report column to contain 'Default rate' for Valid From '2020-01-01'
    And I expect the 'Rate' report column to contain '1.2' for Valid From '2020-01-01'
 
 Scenario: Delete an exchange rate
- Given the following exchange rates:
-     | currency | rate type    | valid from | rate |
-     | EUR      | Default rate | 2020-01-01 | 1.1  |
   When I navigate the menu and select the item at "System > Currency > Edit rates"
   Then I should see the Edit rates screen
-   And I expect the report to contain 1 row
+   And I expect the report to contain 2 rows
   When I click "[delete]" for the row with Valid From "2020-01-01"
   Then I should see the Edit rates screen
-   And I expect the report to contain 0 rows
+   And I expect the report to contain 1 row
 


### PR DESCRIPTION
Don't filter exchange rates display after update or addition. Remnants of form submission
were incorrectly being used to filter exchange rates screen after an addition or update of
exchange rates.