### PR TITLE
Fix Preferences -> Password tab coming up empty

### DIFF
--- a/UI/js-src/lsmb/users/templates/PasswordChange.html
+++ b/UI/js-src/lsmb/users/templates/PasswordChange.html
@@ -1,9 +1,7 @@
 <div>
   <div id="pwtitle" style="width:100%" class="listheading"></div>
   <div id="pwfeedback" data-dojo-type="dijit/layout/ContentPane" data-dojo-attach-point="feedback">&#xA0;</div>
-  <div data-dojo-type="lsmb/layout/TableContainer"
-       id="pwcontainer"
-       data-dojo-props="cols:1">
+  <div id="pwcontainer">
     <div class="input-line">
       <input id="old-pw" data-dojo-type="dijit/form/TextBox" type="password" data-dojo-attach-point="oldpw" />
     </div>


### PR DESCRIPTION
The password tab referenced a long-removed Dojo class... which then
fails to build the UI correctly.
