### PR TITLE
Fix deletion of currencies with strange characters

### DIFF
--- a/UI/lib/dynatable.html
+++ b/UI/lib/dynatable.html
@@ -176,14 +176,16 @@ END; ?>
          <?lsmb- ELSIF TYPE == 'href';
                    HREF_SFX = COL.col_id _ "_href_suffix";
                    IF ROW.$HREF_SFX;
-                      HREF = COL.href_base _ ROW.$HREF_SFX;
+                      ESCAPED_HREF = COL.href_base _ ROW.$HREF_SFX | url;
                    ELSE;
-                      HREF = COL.href_base _ ROW.row_id;
+                      ESCAPED_BASE = COL.href_base | url;
+                      ESCAPED_PARAM = UNESCAPE(ROW.row_id) | uri;
+                      ESCAPED_HREF = ESCAPED_BASE _ ESCAPED_PARAM;
                    END;
                    IF COL.href_target;
                       HREF_TGT = ' target="' _ COL.href_target _ '"';
                    END;
-          ?><a href="<?lsmb HREF | url ?>"<?lsmb HREF_TGT ?>><?lsmb ROW.${COL.col_id} ?></a>
+          ?><a href="<?lsmb ESCAPED_HREF ?>"<?lsmb HREF_TGT ?>><?lsmb ROW.${COL.col_id} ?></a>
          <?lsmb ELSIF TYPE == 'mirrored';
                                          NAME = PFX _ COL.col_id _ '_' _ ROW.row_id;
                                          ROW.${COL.col_id} ?>

--- a/lib/LedgerSMB/Scripts/currency.pm
+++ b/lib/LedgerSMB/Scripts/currency.pm
@@ -103,15 +103,21 @@ sub save_currency {
 
 =item delete_currency
 
-Deletes a currency. Returns an error in case the currency is
+Deletes a currency. Returns an error if the currency is
 still referenced in the system.
+
+Requires the following request parameters:
+
+  * curr
 
 =cut
 
 sub delete_currency {
     my ($request) = @_;
 
-    my $currency = LedgerSMB::Currency->new(%$request);
+    my $currency = LedgerSMB::Currency->new(
+        curr => $request->{curr}
+    );
     $currency->delete;
 
     return &list_currencies($request);
@@ -324,7 +330,11 @@ Requires the following request parameters:
 sub delete_exchangerate {
     my ($request) = @_;
 
-    my $ratetype = LedgerSMB::Exchangerate->new(%$request);
+    my $ratetype = LedgerSMB::Exchangerate->new(
+        curr => $request->{curr},
+        rate_type => $request->{rate_type},
+        valid_from => $request->{valid_from},
+    );
     $ratetype->delete;
 
     return &list_exchangerates($request);

--- a/xt/66-cucumber/05-settings/currency.feature
+++ b/xt/66-cucumber/05-settings/currency.feature
@@ -41,3 +41,15 @@ Scenario: Delete a currency
   Then I should see the Edit currencies screen
    And I expect the report to contain 2 rows
 
+
+Scenario: Delete an exchange rate containing query string characters
+ Given the following currency:
+     | currency | description    |
+     | &&?      | test currency  |
+  When I navigate the menu and select the item at "System > Currency > Edit currencies"
+  Then I should see the Edit currencies screen
+   And I expect the report to contain 4 rows
+  When I click "[delete]" for the row with ID "&&?"
+  Then I should see the Edit currencies screen
+   And I expect the report to contain 3 rows
+

--- a/xt/lib/Pherkin/Extension/ledgersmb_steps/common_steps.pl
+++ b/xt/lib/Pherkin/Extension/ledgersmb_steps/common_steps.pl
@@ -682,6 +682,27 @@ Given qr/a gl account heading with these properties:$/, sub {
         or die $dbh->errstr;
 };
 
+Given qr/the following currenc(?:y|ies):$/, sub {
+    # Expects data in the following form:
+    # | currency | description   |
+    # | SEK      | Swedish Krona |
+    my $dbh = S->{ext_lsmb}->admin_dbh;
+
+    my $q = $dbh->prepare('
+        INSERT INTO currency (
+            curr,
+            description
+        )
+        VALUES (?,?)
+    ');
+
+    foreach my $row (@{C->data}) {
+        $q->execute(
+            $row->{'currency'},
+            $row->{'description'},
+        ) or die 'failed to insert currency';
+    }
+};
 
 Given qr/the following exchange rates?:$/, sub {
     # Expects data in the following form:


### PR DESCRIPTION
This PR fixes and adds tests for the deletion of currencies whose codes comprise 'strange'
characters, such as `&` used in HTTP query strings.