### PR TITLE
Fix and test deletion of currencies with short codes

### DIFF
--- a/sql/modules/Currency.sql
+++ b/sql/modules/Currency.sql
@@ -23,8 +23,8 @@ COMMENT ON FUNCTION currency__save(text, text) IS
 $$Creates a new currency if 'in_curr' doesn''t exist yet;
 otherwise, updates the description.$$;
 
-
-CREATE OR REPLACE FUNCTION currency__delete(in_curr text)
+DROP FUNCTION IF EXISTS currency__delete(in_curr text);
+CREATE OR REPLACE FUNCTION currency__delete(in_curr CHAR(3))
 RETURNS void AS $$
 BEGIN
    IF defaults_get_defaultcurrency() = in_curr THEN
@@ -35,7 +35,7 @@ BEGIN
    DELETE FROM currency WHERE curr = in_curr;
 END;$$ language plpgsql;
 
-COMMENT ON FUNCTION currency__delete(text) IS
+COMMENT ON FUNCTION currency__delete(CHAR(3)) IS
 $$Removes the indicated currency, if it''s not the default currency
 or subject to other integrity constraints.$$;
 

--- a/xt/66-cucumber/05-settings/currency.feature
+++ b/xt/66-cucumber/05-settings/currency.feature
@@ -41,8 +41,7 @@ Scenario: Delete a currency
   Then I should see the Edit currencies screen
    And I expect the report to contain 2 rows
 
-
-Scenario: Delete an exchange rate containing query string characters
+Scenario: Delete a currency containing query string characters
  Given the following currency:
      | currency | description    |
      | &&?      | test currency  |
@@ -50,6 +49,17 @@ Scenario: Delete an exchange rate containing query string characters
   Then I should see the Edit currencies screen
    And I expect the report to contain 4 rows
   When I click "[delete]" for the row with ID "&&?"
+  Then I should see the Edit currencies screen
+   And I expect the report to contain 3 rows
+
+Scenario: Delete a currency with less than three characters
+ Given the following currency:
+     | currency | description    |
+     | A        | test currency  |
+  When I navigate the menu and select the item at "System > Currency > Edit currencies"
+  Then I should see the Edit currencies screen
+   And I expect the report to contain 4 rows
+  When I click "[delete]" for the row with ID "A"
   Then I should see the Edit currencies screen
    And I expect the report to contain 3 rows
 


### PR DESCRIPTION
Previously attempting to delete a character with a code less than 3 characters failed. This PR fixes that issue and adds a test for it.