### PR TITLE
1.7 fix error displaying null exchange rates

### DIFF
--- a/lib/LedgerSMB/Scripts/currency.pm
+++ b/lib/LedgerSMB/Scripts/currency.pm
@@ -228,7 +228,8 @@ sub _list_exchangerates {
     my $base_url = 'currency.pl?action=delete_exchangerate';
     for my $s (@$exchangerates) {
         $s->{i} = $rowcount % 2;
-        $s->{rate} = $s->{rate}->to_output();
+        $s->{rate} = defined $s->{rate} ? $s->{rate}->to_output()
+                                        : 'undefined';
         $s->{drop} = {
             href =>"$base_url&curr=$s->{curr}&rate_type=$s->{rate_type}&valid_from=" . $s->{valid_from}->to_output(),
             text => '[' . $request->{_locale}->text('delete') . ']',


### PR DESCRIPTION
In 1.7, the database can contain null default exchange rates. This
caused an error displaying the Edit rates screen, which is fixed
by this patch.

In 1.8, the database is constrained to disallow null exchange rates,
making this patch unnecessary.