### PR TITLE
Analyze widget templates for dependent classes

### DIFF
--- a/UI/js-src/lsmb/lsmb.profile.js
+++ b/UI/js-src/lsmb/lsmb.profile.js
@@ -126,6 +126,10 @@ var profile = (function(){
                                 mid in miniExcludeMids;
                 },
 
+                declarative: function (filename) {
+                        return (/\.html$/).test(filename);
+                },
+
                 amd: function (filename) {
                         return (/lsmb\/.+\.js$/).test(filename);
                 }


### PR DESCRIPTION
This includes template dependencies in the pre-loaded set of Dojo
modules.
