### PR TITLE
Fix Receipt totals wrong with number format

### DIFF
--- a/lib/LedgerSMB/Scripts/payment.pm
+++ b/lib/LedgerSMB/Scripts/payment.pm
@@ -1158,7 +1158,9 @@ sub payment2 {
             value => $request->{curr}, },
         column_headers => \@column_headers,
         rows        =>  \@invoice_data,
-        topay_subtotal => LedgerSMB::PGNumber->new((sum map { $_->{topay} } @invoice_data) // 0)->to_output(money => 1),
+        topay_subtotal => LedgerSMB::PGNumber->new(
+             (sum map {LedgerSMB::PGNumber->from_input($_->{topay} // 0)} @invoice_data) // 0
+        )->to_output(money => 1),
         topay_state   => \@topay_state,
         vendorcustomer => {
             name => 'vendor-customer',
@@ -1187,9 +1189,15 @@ sub payment2 {
         notes => $request->{notes},
         overpayment         => \@overpayment,
         overpayment_account => \@overpayment_account,
-        overpayment_subtotal => LedgerSMB::PGNumber->new((sum map { $_->{amount} } @overpayment) // 0)->to_output(money => 1),
-        payment_total => LedgerSMB::PGNumber->new((sum map { $_->{amount} } @overpayment)
-            + (sum map { $_->{topay} } @invoice_data))->to_output(money => 1),
+        overpayment_subtotal => LedgerSMB::PGNumber->new(
+              (sum map {LedgerSMB::PGNumber->from_input($_->{amount} // 0)} @overpayment)
+            + LedgerSMB::PGNumber->from_input(0) # never end up with undef
+        )->to_output(money => 1),
+        payment_total => LedgerSMB::PGNumber->new(
+              (sum map {LedgerSMB::PGNumber->from_input($_->{amount} // 0)} @overpayment)
+            + (sum map {LedgerSMB::PGNumber->from_input($_->{topay}  // 0)} @invoice_data)
+            + LedgerSMB::PGNumber->from_input(0) # never end up with undef
+        )->to_output(money => 1),
     };
 
     $select->{selected_account} = $vc_options[0]->{cash_account_id}


### PR DESCRIPTION
When a number format is in use (for example formatting an amount
with thousands and decimal separators as 1,234.56), the totals
on the Cash->Receipts screen were calculated incorrectly.

This is because the numbers were not being converted from the
display/input format before calculation. Logs were displaying
messages of the following form:

  `Argument "1,234.56" isn't numeric in subroutine entry at /srv/ledgersmb/lib/LedgerSMB/Scripts/payment.pm line 1178.`

This patch resolves this issue by converting such numbers using
LedgerSMB::PGNumber->from_input before calculating the total.