### PR TITLE
Fix saving of assemblies

### DIFF
--- a/old/bin/ic.pl
+++ b/old/bin/ic.pl
@@ -1226,7 +1226,7 @@ sub assembly_row {
 
         # escape ampersands
         $form->{$key} =~ s/&/%26/g;
-        $previousform .= qq|$key=$form->{$key}&| if $form->{$key};
+        $previousform .= qq|$key=$form->{$key}&| if $form->{$key} && ! ref $form->{$key};
     }
     chop $previousform;
     $form->{previousform} = $form->escape( $previousform, 1 );
@@ -1782,7 +1782,6 @@ sub name_selected {
 }
 
 sub save {
-
     if ( $form->{obsolete} ) {
         $form->error(
             $locale->maketext(
@@ -1817,7 +1816,7 @@ sub save {
         $baseassembly = $form->{baseassembly};
 
         # don't trample on previous variables
-        for ( keys %newform ) { delete $form->{$_} if $_ ne 'dbh' }
+        for ( keys %newform ) { delete $form->{$_} if $_ ne 'dbh' && $_ !~ /^_/ }
 
         # now take it apart and restore original values
         foreach my $item ( split /&/, $previousform ) {

--- a/old/lib/LedgerSMB/IC.pm
+++ b/old/lib/LedgerSMB/IC.pm
@@ -1019,8 +1019,6 @@ sub create_links {
             SELECT value FROM defaults
              WHERE setting_key = 'weightunit'|;
         ( $form->{weightunit} ) = $dbh->selectrow_array($query);
-        @{$form->{currencies}} =
-            (LedgerSMB::Setting->new(%$form))->get_currencies;
     }
 }
 

--- a/old/lib/LedgerSMB/Setting.pm
+++ b/old/lib/LedgerSMB/Setting.pm
@@ -179,9 +179,10 @@ Returns an array of currencies defined for the current company.
 
 sub get_currencies {
     my $self = shift;
-    @{$self->{currencies}} =
+
+    $self->{currencies} = [
         map { $_->{curr} }
-        $self->call_procedure(funcname => 'currency__list');
+        $self->call_procedure(funcname => 'currency__list') ];
     return @{$self->{currencies}};
 }
 


### PR DESCRIPTION
The assembly saving code saves state in the request parameters; however
it saves arrays as a stringified array reference "ARRAY(0x...)", which
can't be used as an array refference later on, obviously.

Prevent saving (array) references in the request state. At the same time,
when the currencies have been set up during request initialization, don't
do that again somewhwere deep down in the IC library.
