### PR TITLE
Use single quotes instead of double quotes in interpolated JS string

### DIFF
--- a/UI/users/preferences.html
+++ b/UI/users/preferences.html
@@ -11,13 +11,13 @@
                value = user.company
 };
 
-password_strings = 'title:"' _ text("Change Password") _
-                   '", old password:"' _ text("Old Password") _
-                   '", new password:"' _ text("New password") _
-                   '", verify:"' _ text("Verify") _
-                   '", change:"' _ text("Change Password") _
-                   '", no-oldpw:"' _ text("No Old Password") _
-                   '", strength:"' _    text("Strength");
+password_strings = "title:'" _ text("Change Password") _
+                   "', old password:'" _ text("Old Password") _
+                   "', new password:'" _ text("New password") _
+                   "', verify:'" _ text("Verify") _
+                   "', change:'" _ text("Change Password") _
+                   "', no-oldpw:'" _ text("No Old Password") _
+                   "', strength:'" _    text("Strength");
 ?>
 <div>
     <div data-dojo-type="dijit/layout/TabContainer" style="width: 100%; height: 500px;">
@@ -123,7 +123,7 @@ password_strings = 'title:"' _ text("Change Password") _
   </form>
         </div>
         <div data-dojo-type="dijit/layout/ContentPane" title="Password" data-dojo-props="selected:true">
-          <div data-dojo-type='lsmb/users/ChangePassword'
+          <div data-dojo-type="lsmb/users/ChangePassword"
                data-dojo-properties="lstrings:{<?lsmb password_strings | html ?>}"></div>
         </div>
     </div>


### PR DESCRIPTION
Since single quotes don't need HTML encoding, the resulting page source
is much more developer-friendly (human readable).
