### PR TITLE
Drop `queue_payments` configuration setting

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -56,6 +56,7 @@ Code cleanup
   * Making old/bin/old-handler.pl a PSGI app (LedgerSMB::oldHandler)
   * Stripping LedgerSMB::Form from anything handled by middleware
   * Separating 'setup.pl authentication' into its own middleware
+* Remove unused 'queue_payments' setting
 
 Dependency updates
 * Dojo Toolkit updated to 1.16.0

--- a/old/lib/LedgerSMB/DBObject/Payment.pm
+++ b/old/lib/LedgerSMB/DBObject/Payment.pm
@@ -706,22 +706,7 @@ partial payment (C<paid == 'some'>).
 
 sub post_bulk {
     my ($self, $data) = @_;
-    my $total_count = 0;
-    my ($ref) = $self->call_procedure(
-          funcname => 'setting_get',
-          args     => ['queue_payments'],
-    );
-    my $queue_payments = $ref->{setting_get};
-    if ($queue_payments){
-        my ($job_ref) = $self->call_dbmethod(
-                 funcname => 'job__create'
-        );
-        $self->{job_id} = $job_ref->{job__create};
 
-         ($self->{job}) = $self->call_dbmethod(
-        funcname => 'job__status'
-         );
-    }
     #$self->{payment_date} = $self->{datepaid};
     for my $contact (grep { $_->{id} } @{$data->{contacts}}) {
         my $invoice_array = "{}"; # Pg Array
@@ -750,16 +735,12 @@ sub post_bulk {
         }
         $self->{transactions} = $invoice_array;
         $self->{source} = $contact->{source};
-        if ($queue_payments){
-            $self->{batch_class} = BC_PAYMENT;
-             $self->call_dbmethod(
-                 funcname => 'payment_bulk_queue'
-             );
-        } else {
-            $self->call_dbmethod(funcname => 'payment_bulk_post');
-        }
+
+
+        $self->call_dbmethod(funcname => 'payment_bulk_post');
     }
-    return $self->{queue_payments} = $queue_payments;
+
+    return;
 }
 
 =item post_payment

--- a/sql/Pg-database.sql
+++ b/sql/Pg-database.sql
@@ -1362,7 +1362,6 @@ customernumber|1
 vendornumber|1
 glnumber|1
 projectnumber|1
-queue_payments|0
 poll_frequency|1
 rcptnumber|1
 paynumber|1

--- a/sql/changes/1.8/drop_queue_payments_setting.sql
+++ b/sql/changes/1.8/drop_queue_payments_setting.sql
@@ -1,0 +1,1 @@
+DELETE FROM defaults WHERE setting_key = 'queue_payments';

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -127,3 +127,4 @@ mc/delete-migration-validation-data.sql
 1.8/explicit-reconciliation.sql
 1.8/constrain-default-exchange-rates.sql
 1.8/constrain-exchangerate-type.sql
+1.8/drop_queue_payments_setting.sql


### PR DESCRIPTION
Removes non-functioning queue_payments setting from the `defaults`
table and the LedgerSMB::DBObjext::Payment::post_bulk()
method. This was the only place the setting was referenced and the
sql code to support it did not exist.