### PR TITLE
Fix missing transaction date creating bulk payment batches

### DIFF
--- a/old/lib/LedgerSMB/DBObject/Payment.pm
+++ b/old/lib/LedgerSMB/DBObject/Payment.pm
@@ -707,7 +707,6 @@ partial payment (C<paid == 'some'>).
 sub post_bulk {
     my ($self, $data) = @_;
 
-    #$self->{payment_date} = $self->{datepaid};
     for my $contact (grep { $_->{id} } @{$data->{contacts}}) {
         my $invoice_array = "{}"; # Pg Array
         for my $invoice (@{$contact->{invoices}}) {
@@ -733,11 +732,21 @@ sub post_bulk {
                 $invoice_array =~ s/\}$/,$invoice_subarray\}/;
             }
         }
-        $self->{transactions} = $invoice_array;
-        $self->{source} = $contact->{source};
 
-
-        $self->call_dbmethod(funcname => 'payment_bulk_post');
+        $self->call_dbmethod(
+            funcname => 'payment_bulk_post',
+            args => {
+                transactions => $invoice_array,
+                batch_id => $self->{batch_id},
+                source => $contact->{source},
+                ar_ap_accno => $self->{ar_ap_accno},
+                cash_accno => $self->{cash_accno},
+                payment_date => $self->{datepaid},
+                account_class => $self->{account_class},
+                exchangerate => $self->{exchange_rate},
+                currency => $self->{currency},
+            }
+        );
     }
 
     return;

--- a/old/lib/LedgerSMB/DBObject/Payment.pm
+++ b/old/lib/LedgerSMB/DBObject/Payment.pm
@@ -648,6 +648,16 @@ sub get_payment_detail_data {
 
 This function posts the payments in bulk.
 
+Uses the following object properties:
+
+  * account_class
+  * ar_ap_accno
+  * batch_id
+  * cash_accno
+  * currency
+  * exchangerate
+  * payment_date
+
 The C<$data> hashref has the following keys:
 
 =over
@@ -737,14 +747,7 @@ sub post_bulk {
             funcname => 'payment_bulk_post',
             args => {
                 transactions => $invoice_array,
-                batch_id => $self->{batch_id},
                 source => $contact->{source},
-                ar_ap_accno => $self->{ar_ap_accno},
-                cash_accno => $self->{cash_accno},
-                payment_date => $self->{datepaid},
-                account_class => $self->{account_class},
-                exchangerate => $self->{exchange_rate},
-                currency => $self->{currency},
             }
         );
     }


### PR DESCRIPTION
Creating bulk payment batches was failing when tighter constraints
are being applied to the database because `acc_trans` cannot have a null
`transdate`.

This patch ensures that a payment date (usually same as the batch date)
is passed to the database when creating a payment batch and ensures
that the `acc_trans` rows have a valid `transdate`.

The patch makes explicit which parameters are being passed to the
database and avoids polluting the request object with data private
to the post_bulk method.