### PR TITLE
Re-add explicit setting of payment_date when posting bulk payments

### DIFF
--- a/old/lib/LedgerSMB/DBObject/Payment.pm
+++ b/old/lib/LedgerSMB/DBObject/Payment.pm
@@ -748,6 +748,7 @@ sub post_bulk {
             args => {
                 transactions => $invoice_array,
                 source => $contact->{source},
+                payment_date => $self->{datepaid},
             }
         );
     }


### PR DESCRIPTION
Explicitly set payment_date argument when calling `payment_post_bulk` sql
function in LedgerSMB::DBObject::Payment::post_bulk, so that `transdate`
field is set for `acc_trans` table.