### PR TITLE
Align 'Adjusted' number in Inventory Activity with 'Variance' on adjustment

### DIFF
--- a/sql/modules/Goods.sql
+++ b/sql/modules/Goods.sql
@@ -231,7 +231,7 @@ $$
            AS used,
            SUM(CASE WHEN transtype = 'as' AND i.qty < 0 then -1*i.qty ELSE 0 END)
            AS assembled,
-           SUM(CASE WHEN transtype = 'ia' THEN i.qty ELSE 0 END)
+           SUM(CASE WHEN transtype = 'ia' THEN -1 * i.qty ELSE 0 END)
            AS adjusted
       FROM invoice i
       JOIN parts p ON (i.parts_id = p.id)

--- a/xt/42-goods.pg
+++ b/xt/42-goods.pg
@@ -498,12 +498,12 @@ BEGIN;
                                            0::numeric, 0::numeric,
                                            0::numeric, 0::numeric,
                                            0::numeric, 0::numeric,
-                                           -20::numeric),
+                                           20::numeric),
                                       (-2, 'GOODS Test Series 2', 'TS2',
                                            0::numeric, 0::numeric,
                                            0::numeric, 0::numeric,
                                            0::numeric, 0::numeric,
-                                           5::numeric)$$,
+                                           -5::numeric)$$,
                        'adjustment inventory activity TS1, TS2');
     DEALLOCATE test;
 


### PR DESCRIPTION
When the inventory adjustment report had a positive variance (leading to added
inventory), the Inventory Activity report used to show a negative number
in the 'Adjusted' column. This commit makes positive Variances show up as
positive Adjustments.

Fixes #4454.
