### PR TITLE
Disentangle DBObject::Payment from Num2text

### DIFF
--- a/lib/LedgerSMB/Scripts/payment.pm
+++ b/lib/LedgerSMB/Scripts/payment.pm
@@ -55,6 +55,7 @@ use LedgerSMB::Batch;
 use LedgerSMB::DBObject::Payment;
 use LedgerSMB::DBObject::Date;
 use LedgerSMB::Magic qw( MAX_DAYS_IN_MONTH EC_VENDOR );
+use LedgerSMB::Num2text;
 use LedgerSMB::PGDate;
 use LedgerSMB::PGNumber;
 use LedgerSMB::Report::Invoices::Payments;
@@ -400,7 +401,9 @@ is not merged in, meaning that $request->{multiple} must be set to a true value.
 
 sub print {
     my ($request) = @_;
+    my $fmt = LedgerSMB::Num2text->new($request->{_locale});
     my $payment =  LedgerSMB::DBObject::Payment->new(%$request);
+    $fmt->init();
     $payment->{company} = $payment->{_user}->{company};
     $payment->{address} = $payment->{_user}->{address};
 
@@ -465,7 +468,7 @@ sub print {
             }
             my $amt = $check->{amount}->copy;
             $amt->bfloor();
-            $check->{text_amount} = $payment->text_amount($amt);
+            $check->{text_amount} = $fmt->num2text($amt);
             $check->{decimal} = ($check->{amount} - $amt) * 100;
             $check->{amount} = $check->{amount}->to_output(
                     format => '1000.00',

--- a/old/lib/LedgerSMB/DBObject/Payment.pm
+++ b/old/lib/LedgerSMB/DBObject/Payment.pm
@@ -19,7 +19,7 @@ see the included COPYRIGHT and LICENSE files for more information.
 =cut
 
 package LedgerSMB::DBObject::Payment;
-use base qw(LedgerSMB::PGOld LedgerSMB::Num2text);
+use base qw(LedgerSMB::PGOld);
 use strict;
 use warnings;
 use LedgerSMB::PGNumber;
@@ -50,26 +50,6 @@ attached to it.  Customer/vendor payment threshold is not considered for this
 calculation.
 
 =back
-
-=over
-
-=item text_amount($value)
-
-Returns the textual representation, as defined in localization rules, for the
-numeric value passed.
-
-=back
-
-=cut
-
-sub text_amount {
-    use LedgerSMB::Num2text;
-    my ($self, $value) = @_;
-    $self->{locale} = $self->{_locale};
-    $self->init();
-    return $self->num2text($value);
-}
-
 
 =over
 

--- a/old/lib/LedgerSMB/IS.pm
+++ b/old/lib/LedgerSMB/IS.pm
@@ -654,13 +654,11 @@ sub invoice_details {
     $form->{invtotal} =
       ( $form->{taxincluded} ) ? $form->{total} : $form->{total} + $tax;
 
-    my $c;
-    if ( $form->{language_code} ne "" ) {
-        $c = LedgerSMB::Num2text->new( $form->{language_code});
-    }
-    else {
-        $c = LedgerSMB::Num2text->new( $myconfig->{countrycode});
-    }
+    my $c = LedgerSMB::Num2text->new(
+        LedgerSMB::Locale->get_handle(
+            ($form->{language_code} ne "")
+            ? $form->{language_code} : $myconfig->{countrycode}
+        ));
     $c->init;
     my $whole;
     ( $whole, $form->{decimal} ) = split /\./, $form->{invtotal};

--- a/old/lib/LedgerSMB/Num2text.pm
+++ b/old/lib/LedgerSMB/Num2text.pm
@@ -48,19 +48,15 @@ use warnings;
 use LedgerSMB::Locale;
 
 sub new {
-    my ( $type, $countrycode ) = @_;
+    my ( $type, $locale ) = @_;
 
-    my $self = {};
-    $self->{'locale'} = LedgerSMB::Locale->get_handle($countrycode);
-    bless $self, $type;
-
-    return $self;
+    return bless { locale => $locale }, $type;
 }
 
 
 sub init {
     my $self    = shift;
-    my $locale  = $self->{'locale'} || $self->{'_locale'};
+    my $locale  = $self->{'locale'};
     my $langtag = substr( $locale->language_tag, 0, 2 );
     $self->{'numrules'} = 'en';
     $self->{'numrules'} = $langtag

--- a/old/lib/LedgerSMB/OE.pm
+++ b/old/lib/LedgerSMB/OE.pm
@@ -1320,13 +1320,11 @@ sub order_details {
       ? $form->{ordtotal}
       : $form->{ordtotal} + $tax;
 
-    my $c;
-    if ( $form->{language_code} ne "" ) {
-        $c = LedgerSMB::Num2text->new( $form->{language_code});
-    }
-    else {
-        $c = LedgerSMB::Num2text->new( $myconfig->{countrycode});
-    }
+    my $c = LedgerSMB::Num2text->new(
+        LedgerSMB::Locale->get_handle(
+            ($form->{language_code} ne "")
+            ? $form->{language_code} : $myconfig->{countrycode}
+        ));
     $c->init;
     my $whole;
     ( $whole, $form->{decimal} ) = split /\./, $form->{ordtotal};

--- a/t/02.1-number-to-text.t
+++ b/t/02.1-number-to-text.t
@@ -1,8 +1,10 @@
 #!/usr/bin/perl
 
 use Test2::V0;
-use LedgerSMB::PGNumber;
+
+use LedgerSMB::Locale;
 use LedgerSMB::Num2text;
+use LedgerSMB::PGNumber;
 
 my %english = (
     0 => 'Zero',
@@ -19,7 +21,7 @@ my %english = (
  1455 => 'One Thousand Four Hundred Fifty Five'
 );
 
-my $en = LedgerSMB::Num2text->new('en');
+my $en = LedgerSMB::Num2text->new(LedgerSMB::Locale->get_handle('en'));
 $en->init;
 is($en->num2text($_, 1) , $english{$_}, "$_ -> $english{$_}, Plain") for keys %english;
 


### PR DESCRIPTION
Note that the imported method was used in exactly one location;
also note that each invocation would fully re-initialize the translations
(which is overkill).
