### PR TITLE
Fix #4388 - Reconciliation report search lists entity_ids not user names

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -38,6 +38,7 @@ Bugs fixed
 * Overpayments not shown in Cash > Reports > Receipts (#3577)
 * Handling of currencies with short codes or unusual characters (#4435, #4436)
 * Formatting of columns in the 'Inventory Activity' report
+* Reconciliation reports list now shows usernames rather than user ids (#4388)
 
 Code cleanup
 * Reduce use of LedgerSMB::App_State and LedgerSMB::App_State::Locale

--- a/lib/LedgerSMB/Report/Reconciliation/Summary.pm
+++ b/lib/LedgerSMB/Report/Reconciliation/Summary.pm
@@ -153,10 +153,10 @@ sub columns {
              {col_id => 'updated',
                 name => $self->Text('Last Updated'),
                 type => 'text', },
-             {col_id => 'entered_by',
+             {col_id => 'entered_username',
                 name => $self->Text('Entered By'),
                 type => 'text', },
-             {col_id => 'approved_by',
+             {col_id => 'approved_username',
                 name => $self->Text('Approved By'),
                 type => 'text', },
           ];
@@ -226,7 +226,7 @@ sub run_report {
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2012 The LedgerSMB Core Team
+Copyright (C) 2012-2020 The LedgerSMB Core Team
 
 This file is licensed under the GNU General Public License version 2, or at your
 option any later version.  A copy of the license should have been included with

--- a/xt/66-cucumber/13-cash/reconciliation.feature
+++ b/xt/66-cucumber/13-cash/reconciliation.feature
@@ -69,7 +69,7 @@ Scenario: Search for reconciliation report and delete it,
    And I expect the 'Statement Balance' report column to contain '101.00' for Statement Date '2018-01-01'
    And I expect the 'Approved' report column to contain '' for Statement Date '2018-01-01'
    And I expect the 'Submitted' report column to contain '' for Statement Date '2018-01-01'
-   And I expect the 'Entered By' report column to contain '1' for Statement Date '2018-01-01'
+   And I expect the 'Entered By' report column to contain 'test-user-admin' for Statement Date '2018-01-01'
    And I expect the 'Approved By' report column to contain '' for Statement Date '2018-01-01'
   When I click the "2018-01-01" link
   Then I should see the Reconciliation Report screen


### PR DESCRIPTION
Changed field content of Reconciliation report search results so that
`approved by` and `entered by` columns display user name instead of
entity id number.