### PR TITLE
Constrain transactions.table_name field

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -55,6 +55,7 @@ Code cleanup
 * Remove remnants of custom field support
 * Remove unused infrastructure to administer access role groups
 * Stricter data model for storage of foreign currency exchange rates
+* Stricter data constraints for storage of transactions
 * Simplified request handling by
   * Making old/bin/old-handler.pl a PSGI app (LedgerSMB::oldHandler)
   * Stripping LedgerSMB::Form from anything handled by middleware

--- a/sql/changes/1.8/constrain-transactions-table-name.sql
+++ b/sql/changes/1.8/constrain-transactions-table-name.sql
@@ -1,0 +1,5 @@
+ALTER TABLE transactions
+ALTER COLUMN table_name SET NOT NULL,
+ADD CONSTRAINT transactions_table_name_check CHECK (
+    table_name = ANY (ARRAY['gl', 'ar', 'ap'])
+);

--- a/sql/changes/1.8/constrain-transactions-table-name.sql.checks.pl
+++ b/sql/changes/1.8/constrain-transactions-table-name.sql.checks.pl
@@ -1,0 +1,60 @@
+package _18_upgrade_checks;
+use LedgerSMB::Database::ChangeChecks;
+
+
+check q|Ensure that the transactions table contains no invalid table names|,
+    query => q|
+        SELECT *
+        FROM transactions
+        WHERE table_name IS NULL
+        OR table_name NOT IN ('gl', 'ar', 'ap')
+    |,
+    description => q|
+The upgrade process found transactions table entries with an invalid
+table_name field.
+
+This field can only be set to one of "gl", "ar" or "ap".
+
+Please provide the missing data below and press 'Save' to fix this
+issue, or manually remove the invalid rows and re-run the upgrade
+process.
+|,
+
+    tables => {
+        transactions => {
+            prim_key => 'id',
+        },
+    },
+    on_failure => sub {
+        my ($dbh, $rows) = @_;
+
+        describe;
+        grid (
+            $rows,
+            name => 'transactions',
+            columns => [qw(id table_name approved transdate)],
+            edit_columns => [qw(table_name)],
+            dropdowns => {
+                table_name => {
+                    'gl' => 'gl',
+                    'ar' => 'ar',
+                    'ap' => 'ap',
+                },
+            }
+        );
+        confirm save => 'Save';
+    },
+    on_submit => sub {
+        my ($dbh, $rows) = @_;
+        my $confirm = provided 'confirm';
+
+        if ($confirm eq 'save') {
+            save_grid $dbh, $rows, name => 'transactions';
+        }
+        else {
+            die "Unexpected confirmation value found: $confirm";
+        }
+    }
+;
+
+1;

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -130,3 +130,4 @@ mc/delete-migration-validation-data.sql
 1.8/drop_queue_payments_setting.sql
 1.8/drop_poll_frequency_setting.sql
 1.8/constrain-transaction-tables.sql
+1.8/constrain-transactions-table-name.sql

--- a/t/16-prechecks/1.8/constrain-transactions-table-name.precheck
+++ b/t/16-prechecks/1.8/constrain-transactions-table-name.precheck
@@ -1,0 +1,26 @@
+{
+    q|Ensure that the transactions table contains no invalid table names| => [{
+         failure_data => [
+             [ qw(id table_name locked_by approved approved_by approved_at transdate) ],
+             [ 22, undef, undef, 1, undef, undef, '2020-01-01' ],
+         ],
+         response => {
+             confirm => 'save',
+             'transactions' => [
+                 {
+                     '__pk' => 'MjI=',
+                     table_name => 'gl',
+                 },
+             ]
+         },
+         submit_session => [
+             {
+                 statement => q{UPDATE "transactions"
+                      SET "table_name" = ?
+                    WHERE "id" = ?},
+                  bound_params => [ 'gl', 22 ],
+                  results => [],
+             },
+         ],
+    }],
+}


### PR DESCRIPTION
Stricter database constraints to ensure that the `transactions`.`table_name`
field has to be one of the valid values (`ap`|`ar`|`gl`) and cannot be `NULL`.