### PR TITLE
Fix missing 40-ledgersmb.t in test order

### DIFF
--- a/t/testrules.yml
+++ b/t/testrules.yml
@@ -14,6 +14,7 @@ seq:
     - xt/40-dbsetup.t
     - par:
       - xt/40-database.t
+      - xt/40-ledgersmb.t
       - xt/41-coaload.t
       - xt/45*.t
       - xt/47*.t


### PR DESCRIPTION
Make sure that test xt/40-ledgersmb.t is run at the proper moment