### PR TITLE
Fix upload of templates through the PUT on the content service

### DIFF
--- a/lib/LedgerSMB/Routes/ERP/API/Templates.pm
+++ b/lib/LedgerSMB/Routes/ERP/API/Templates.pm
@@ -137,9 +137,9 @@ put '/templates/:name/:format/:language' => sub {
             template_name => $match->{name},
             format        => $match->{format},
             language      => $match->{language},
+            template      => $req->content,
             dbh           => $app
             );
-        $dbtemplate->template($req->content);
         $dbtemplate->save;
         $done = 1;
     };


### PR DESCRIPTION
Note that by adding the template content to the object later,
we're violating the fact that the template text is required upon
object construction...
