### PR TITLE
Remove the source dropdown from the payment screen

### DIFF
--- a/UI/payments/payment2.html
+++ b/UI/payments/payment2.html
@@ -107,22 +107,7 @@ onLoad="maximize_minimize_on_load(event, 'div_topay_state', 'payments/img/down.g
             <tr id="source_row">
               <?lsmb # here goes all the posible sources which we can use -?>
               <th align="right" nowrap id="source_label_column"><?lsmb text('Source')?></th>
-              <td width="28%" id="source_column">
-                <?lsmb sources = [];
-                       FOREACH item IN source ;
-                       sources.push( { text = item, value = item } );
-                       END;
-                       PROCESS select element_data = {
-                                                id="source"
-                                                name="source"
-                                                options=sources
-                                                default_values=[selected_source] }; ?>
-                <?lsmb INCLUDE tooltip element_data = {
-                       ref_id => 'source_column'
-                       msg => text("Only for documentation")
-                }; ?>
-              </td>
-              <td id="source_text_column">
+              <td id="source_text_column" colspan="2">
                 <?lsmb PROCESS input element_data={
                        class => 'source'
                        name  => 'source_value'
@@ -271,13 +256,6 @@ onLoad="maximize_minimize_on_load(event, 'div_topay_state', 'payments/img/down.g
               <tr id="<?lsmb "source_row$i" ?>">
                 <?lsmb # here goes all the posible sources which we can used ?>
                 <th align="right" nowrap id="<?lsmb "source_label_column$i" ?>"><?lsmb text('Source') ?></th>
-                <td width="28%" id="<?lsmb "source_column$i" ?>">
-                  <?lsmb PROCESS select element_data = {
-                            id="source_" _ row.invoice.id
-                            name="source_" _ row.invoice.id
-                            options=sources
-                            default_values=[row.selected_source] } ?>
-                </td>
                 <td><?lsmb PROCESS input element_data={
                            name  => "source_text_$row.invoice.id",
                   id    => "source_text_$row.invoice.id",
@@ -359,12 +337,7 @@ onLoad="maximize_minimize_on_load(event, 'div_topay_state', 'payments/img/down.g
                  value=item.cashaccount.id _ '--' _ item.cashaccount.accno _ '--' _ item.cashaccount.description } ?>
         </td>
         <td align="center">
-            <?lsmb item.source1 -?>     <?lsmb item.source2 -?>
-            <?lsmb PROCESS input element_data = {
-                   type="hidden"
-                   id="overpayment_source1_" _ overpayment_item
-                   name="overpayment_source1_" _ overpayment_item
-                   value=item.source1 } ?>
+            <?lsmb item.source2 -?>
             <?lsmb PROCESS input element_data = {
                    type="hidden"
                    id="overpayment_source2_" _ overpayment_item
@@ -432,15 +405,6 @@ onLoad="maximize_minimize_on_load(event, 'div_topay_state', 'payments/img/down.g
              options=options } ?>
     </td>
      <td align="center">
-       <?lsmb
-          options=[];
-          FOREACH item IN source;
-             options.push( { text = item, value = item } );
-          END;
-          PROCESS select element_data = {
-             id="overpayment_source1_" _ overpayment_item
-             name="overpayment_source1_" _ overpayment_item
-             options=options } ?>
        <?lsmb PROCESS input element_data = {
                  name="overpayment_source2_" _ overpayment_item
                  class="source"

--- a/lib/LedgerSMB/Scripts/payment.pm
+++ b/lib/LedgerSMB/Scripts/payment.pm
@@ -856,7 +856,6 @@ sub payment2 {
             value => $request->{department}};
     }
     my @account_options = $Payment->list_accounting();
-    my @sources_options = $Payment->get_sources(\%$locale);
     my $default_currency = $Payment->get_default_currency();
     my $currency_text  =
         $request->{curr} eq $default_currency ? '' : '('.$request->{curr}.')';
@@ -1083,7 +1082,6 @@ sub payment2 {
 
                 push @overpayment, {
                     amount  => LedgerSMB::PGNumber->from_input($request->{"overpayment_topay_$i"})->to_output(money => 1),
-                    source1 => $request->{"overpayment_source1_$i"},
                     source2 => $request->{"overpayment_source2_$i"},
                     memo    => $request->{"overpayment_memo_$i"},
                     account => {
@@ -1146,8 +1144,6 @@ sub payment2 {
             name => 'datepaid',
             value => $request->{datepaid} ? $request->{datepaid} : $Payment->{current_date}
         },
-        source => \@sources_options,
-        selected_source => $request->{source},
         source_value => $request->{source_value},
         defaultcurrency => {
             text => $default_currency },
@@ -1323,8 +1319,8 @@ sub post_payment {
 
             # We'll use this for both source and ap/ar accounts
             push @source, $request->{"optional_pay_$array_options[$ref]"}
-            ? $request->{"source_$array_options[$ref]->{invoice_id}"} .' ' . $request->{"source_text_$array_options[$ref]->{invoice_id}"}
-            : $request->{source}.' '.$request->{source_value};
+            ? $request->{"source_text_$array_options[$ref]->{invoice_id}"}
+            : $request->{source_value};
             push @memo,
                 $request->{"memo_invoice_$array_options[$ref]->{invoice_id}"};
             push @transaction_id, $array_options[$ref]->{invoice_id};
@@ -1361,8 +1357,7 @@ sub post_payment {
                 }
                 push @op_amount, $request->{"overpayment_topay_$i"};
                 push @op_cash_account_id, $cashid;
-                push @op_source, $request->{"overpayment_source1_$i"}
-                . ' ' .$request->{"overpayment_source2_$i"};
+                push @op_source, $request->{"overpayment_source2_$i"};
                 push @op_memo, $request->{"overpayment_memo_$i"};
                 if (not $id and $id ne '0'){
                     $request->error($request->{_locale}->text('No overpayment account selected.  Was one set up?'));

--- a/old/lib/LedgerSMB/DBObject/Payment.pm
+++ b/old/lib/LedgerSMB/DBObject/Payment.pm
@@ -408,22 +408,6 @@ sub list_overpayment_accounting {
 }
 
 
-=item get_sources
-
-This method builds all the possible sources of money,
-in the future it will look inside the DB.
-
-=cut
-
-sub get_sources {
- my ($self, $locale) = @_;
- @{$self->{cash_sources}} = ($locale->text('cash'),
-                             $locale->text('check'),
-                             $locale->text('deposit'),
-                             $locale->text('other'));
- return @{$self->{cash_sources}};
-}
-
 =item get_default_currency
 
 This method gets the default currency from the database (as a three-character


### PR DESCRIPTION
Closes #2320 

As documented, it is, it's just a prefix to the actual value stored in the
'source' field in the database, thus cluttering the source field for those
who want to use its clean value.

In the mail discussion following https://archive.ledgersmb.org/ledger-smb-devel/msg06519.html,
Chris Travers documented that it was added for POS purposes *and* that the
POS functionality has been removed; orphaning this functionality.
