### PR TITLE
Make the 'POST AND PRINT' button on the Payment/Receipt screen work again

### DIFF
--- a/UI/js-src/lsmb/MainContentPane.js
+++ b/UI/js-src/lsmb/MainContentPane.js
@@ -32,7 +32,15 @@ define([
                           d.set("content",
                                 "Could not connect to server");
                       } else {
-                          d.set("content",err.response.data);
+                          var data = err.response.data;
+                          if (data instanceof Blob) {
+                              data.text().then(function (txt) {
+                                  d.set("content", txt);
+                              });
+                          }
+                          else {
+                              d.set("content",err.response.data);
+                          }
                       }
                       d.show();
                   },

--- a/UI/js-src/lsmb/payments/PostPrintButton.js
+++ b/UI/js-src/lsmb/payments/PostPrintButton.js
@@ -1,0 +1,61 @@
+define([
+    "dojo/_base/declare",
+    "dojo/_base/event",
+    "dijit/form/Button",
+    "dojo/request/xhr",
+    "dojo/dom-form",
+    "dojo/dom-attr",
+    "dijit/registry"
+],
+       function(declare, event, Button, xhr, domform, domattr, registry) {
+           return declare("lsmb/payments/PostPrintButton",
+                          [Button],
+               {
+                   onClick: function(evt) {
+                       var f = this.valueNode.form;
+                       event.stop(evt);
+
+                       var data = domform.toObject(f);
+                       data["action"] = this.get("value");
+
+                       xhr(domattr.get(f, "action"), {
+                           "method": "POST",
+                           "data": data,
+                           "handleAs": "blob"
+                       }).then(
+                           function(blob) {
+                               // IE doesn't allow using a blob object directly
+                               // as link href; instead it is necessary to use
+                               // msSaveOrOpenBlob
+                               if (window.navigator
+                                   && window.navigator.msSaveOrOpenBlob) {
+                                   window.navigator.msSaveOrOpenBlob(
+                                       blob, "print-payment.html");
+                                   return;
+                               }
+
+                               // For other browsers:
+                               // Create a link pointing to the ObjectURL
+                               // containing the blob.
+                               const data = window.URL.createObjectURL(blob);
+                               var link = document.createElement('a');
+                               link.href = data;
+                               link.download="print-payment.html";
+                               link.click();
+                               setTimeout(function(){
+                                   // For Firefox it is necessary to delay
+                                   // revoking the ObjectURL
+                                   window.URL.revokeObjectURL(data);
+                               }, 100);
+                               registry.byId("maindiv").load_link(
+                                   "payment.pl?action=payment&account_class="
+                                       + data["account_class"]
+                                       + "&type=" + data["type"]);
+                           },
+                           function(err) {
+                               registry.byId("maindiv")
+                                   .report_request_error(err);
+                           });
+                   }
+               });
+       });

--- a/UI/payments/payment2.html
+++ b/UI/payments/payment2.html
@@ -479,6 +479,7 @@ onLoad="maximize_minimize_on_load(event, 'div_topay_state', 'payments/img/down.g
          name = "action"
          value = "post_and_print_payment"
          text = text("POST AND PRINT")
+         "data-dojo-type" = "lsmb/payments/PostPrintButton"
          } ?>
   <?lsmb PROCESS select element_data=format ?>
   <?lsmb PROCESS select element_data=media ?>

--- a/lib/LedgerSMB/Scripts/payment.pm
+++ b/lib/LedgerSMB/Scripts/payment.pm
@@ -1423,9 +1423,6 @@ sub print_payment {
     ###############################################################################
     # First we need to solve some ugly behaviour in the template system
     $header->{amount} = abs("$header->{amount}");
-    # The next code will enable number to text conversion
-    $Payment->init();
-    $header->{amount2text} = $Payment->num2text($header->{amount});
     ############################################################################
     # IF YOU NEED MORE INFORMATION ON THE HEADER AND ROWS ITEMS CHECK SQL FUNCTIONS
     # payment_gather_header_info AND payment_gather_line_info
@@ -1446,11 +1443,16 @@ sub print_payment {
       path     => 'DB',
       template => 'printPayment',
       format => 'HTML' );
-    return $template->render(
+    $template->render(
         {
             DBNAME => $request->{company},
             %$select,
         }); ###TODO: psgi-render-to-attachment
+    return
+        [ 200,
+          [ 'Content-Disposition' =>
+            'attachment; filename="printPayment.html"' ],
+          [ $template->{output} ] ];
 }
 
 =item post_and_print_payment
@@ -1466,6 +1468,7 @@ sub post_and_print_payment {
     $request->{payment_id} = &post_payment($request);
     my $locale       = $request->{_locale};
     my $Payment = LedgerSMB::DBObject::Payment->new(%$request);
+
     return print_payment($request, $Payment);
 }
 


### PR DESCRIPTION
By triggering an async Post and Print action and downloading the result,
we can trigger a "to next page" action as the user expects it on the
"Post" button.

Incidentally fix the fact that 'print_payment' doesn't return a valid
PSGI triplet.

Fixes #3232
