### PR TITLE
Increase Perl minimum requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ matrix:
             - postgresql-9.6-pgtap
       env:
         - COA_TESTING=1
-    - perl: '5.18'
+    - perl: '5.30'
       addons:
         postgresql: "9.6"
         apt:

--- a/Changelog
+++ b/Changelog
@@ -68,6 +68,7 @@ Code cleanup
 * Removal of dead code
 
 Dependency updates
+* Perl 5.20 (upgraded from 5.18)
 * Dojo Toolkit updated to 1.16.0
 * TeX::Encode >= 2.007
 * Authen::SASL (new)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ and [current 1.7 version](https://github.com/ledgersmb/LedgerSMB/tree/1.7#system
 
 ## Server
 
- * Perl 5.18+
+ * Perl 5.20+
  * PostgreSQL 9.4+
  * Web server (e.g. nginx, Apache, lighttpd)
 

--- a/cpanfile
+++ b/cpanfile
@@ -1,7 +1,7 @@
 #!perl
 
 
-requires 'perl', '5.18.0';
+requires 'perl', '5.20.0';
 
 requires 'Authen::SASL';
 requires 'CGI::Emulate::PSGI';


### PR DESCRIPTION
Requiring 5.20 unlocks the use of hash slices and postfix dereferencing.