### PR TITLE
Make absolutely sure the database handle gets cleaned up

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -58,6 +58,7 @@ requires 'Plack::Request';
 requires 'Plack::Request::WithEncoding';
 requires 'Plack::Util';
 requires 'Plack::Util::Accessor';
+requires 'Scope::Guard', '0.10';
 requires 'Session::Storage::Secure';
 requires 'String::Random';
 requires 'Template', '2.14';


### PR DESCRIPTION
Note that in case of an exception, the result callback may not be
executed (the entire stack frame will be skipped). To be certain the
database handle gets cleaned up, register a scope handler to do
cleaning up as soon as the environment gets discarded (at the end
of the request...).
