### PR TITLE
Before, we left enabling/disabling "the back button" (caching) to the user

### DIFF
--- a/lib/LedgerSMB/PSGI.pm
+++ b/lib/LedgerSMB/PSGI.pm
@@ -151,10 +151,6 @@ sub psgi_app {
     catch {
         my $error = $_;
 
-        # Explicitly roll back, because middleware may require the
-        # database connection to be in a working state (e.g. DisableBackbutton)
-        $request->{dbh}->rollback
-            if $request->{dbh};
         if ($error !~ /^Died at/) {
             $env->{'psgix.logger'}->({
                 level => 'error',

--- a/lib/LedgerSMB/Scripts/configuration.pm
+++ b/lib/LedgerSMB/Scripts/configuration.pm
@@ -68,9 +68,6 @@ sub _default_settings {
               ] },
         { title => $locale->text('Security Settings'),
           items => [
-              { name => 'disable_back',
-                label => $locale->text('Disable Back Button'),
-                type => 'YES_NO', },
               { name => 'password_duration',
                 label => $locale->text('Password Duration (days)')
               },


### PR DESCRIPTION
Lets decide for the user that they truely don't want to cache our pages,
because they are application responses, not just static HTML pages. These
application responses potentially contain confidential information. Lets
err on the safe side instead of leaving it to our users.
