### PR TITLE
Fix template uploads

### DIFF
--- a/lib/LedgerSMB/Scripts/template.pm
+++ b/lib/LedgerSMB/Scripts/template.pm
@@ -79,7 +79,15 @@ Saves the template.
 
 sub save {
     my ($request) = @_;
-    my $dbtemp = LedgerSMB::Template::DB->new(%$request);
+    my $content = $request->{template};
+
+    if (not $content) {
+        my $fh = $request->upload('template_content');
+        local $/ = undef;
+        $content = <$fh>;
+    }
+    my $dbtemp = LedgerSMB::Template::DB->new(
+        %$request, template => $content);
     $dbtemp->save();
     return display($request);
 }


### PR DESCRIPTION
Note that the error produced indicates that the template content
has to be provided in the 'template' constructor argument, which
isn't happening in case of an upload. Also, the format is wrong on
upload, because the data is uploaded as a file instead of as plain
content.
