### PR TITLE
Fix upload of CSV reconciliation files with clean-up

### DIFF
--- a/lib/LedgerSMB/Reconciliation/ISO20022.pm
+++ b/lib/LedgerSMB/Reconciliation/ISO20022.pm
@@ -20,14 +20,16 @@ use strict;
 use warnings;
 
 
-=head2 process_xml
+=head2 process_xml($content)
 
-Processes an ISO 20022 file for recon.
+Processes the supplied ISO 20022 file content for reconciliation.
+
+Returns an array of transaction lines.
 
 =cut
 
 sub process_xml {
-    my ($self, $recon, $contents) = @_;
+    my ($contents) = @_;
     my $camt053 = LedgerSMB::FileFormats::ISO20022::CAMT053->new($contents);
     return unless $camt053;
 

--- a/lib/LedgerSMB/Reconciliation/ISO20022.pm
+++ b/lib/LedgerSMB/Reconciliation/ISO20022.pm
@@ -19,18 +19,6 @@ use LedgerSMB::FileFormats::ISO20022::CAMT053;
 use strict;
 use warnings;
 
-use XML::Simple;
-
-=head2 is_camt053
-
-Returns true if the content is detected to be an ISO 20022 file
-
-=cut
-
-sub is_camt053 {
-    my ($self, $content) = @_;
-    return LedgerSMB::FileFormats::ISO20022::CAMT053->new($content);
-}
 
 =head2 process_xml
 
@@ -40,7 +28,7 @@ Processes an ISO 20022 file for recon.
 
 sub process_xml {
     my ($self, $recon, $contents) = @_;
-    my $camt053 = $self->is_camt053($contents);
+    my $camt053 = LedgerSMB::FileFormats::ISO20022::CAMT053->new($contents);
     return unless $camt053;
 
     my @elements =
@@ -56,7 +44,7 @@ sub process_xml {
 
 =head1 LICENSE AND COPYRIGHT
 
-Copyright (C) 2016-2018 The LedgerSMB Core Team
+Copyright (C) 2016-2020 The LedgerSMB Core Team
 
 This file is licensed under the GNU General Public License version 2, or at your
 option any later version.  A copy of the license should have been included with

--- a/lib/LedgerSMB/Scripts/recon.pm
+++ b/lib/LedgerSMB/Scripts/recon.pm
@@ -454,9 +454,6 @@ sub _process_upload {
         $contents = <$handle> if defined $handle;
     }
 
-    # An empty string is recognized by the entry-importer (ISO20022)
-    # as a file name (due to absense of '<' and '>'); only call it
-    # when there's actual content to handle.
     if ($contents) {
         $recon->add_entries($recon->import_file($contents));
     }

--- a/old/lib/LedgerSMB/Reconciliation/CSV.pm
+++ b/old/lib/LedgerSMB/Reconciliation/CSV.pm
@@ -72,15 +72,4 @@ sub process {
    return $self->{entries};
 }
 
-=head2 $self->is_error()
-
-Well,...
-
-=cut
-
-sub is_error {
-   my $self = shift @_;
-   return $self->{invalid_format};
-}
-
 1;

--- a/old/lib/LedgerSMB/Reconciliation/CSV.pm
+++ b/old/lib/LedgerSMB/Reconciliation/CSV.pm
@@ -56,20 +56,16 @@ sub process {
     my ($recon, $contents) = @_;
 
     if (@{$self->{entries}} = LedgerSMB::Reconciliation::ISO20022->process_xml($recon, $contents)){
-        $self->{file_upload} = 1;
         return $self->{entries};
     }
+
     my $func = "parse_$self->{company}_$recon->{chart_id}";
     if ($self->can($func)){
        my @entries = $self->can($func)->($self,$contents);
        @{$self->{entries}} = @entries;
+    }
 
-       $self->{file_upload} = 1;
-   }
-   else {
-       $self->{file_upload} = 0;
-   }
-   return $self->{entries};
+    return $self->{entries};
 }
 
 1;

--- a/old/lib/LedgerSMB/Reconciliation/CSV.pm
+++ b/old/lib/LedgerSMB/Reconciliation/CSV.pm
@@ -4,13 +4,15 @@ LedgerSMB::Reconciliation::CSV - A framework for fixed-width format file handlin
 
 =head2 SYNOPSIS
 
+Parses reconciliation data files using the appropriate parsing function,
+including installation-specific parsers loaded from
+C<old/lib/LedgerSMB/Reconciliation/CSV/Formats>.
 
-
+As the name suggests, this was initially built to import CSV files, but
+now handles all supported reconciliation data formats.
 
 =cut
 
-# CSV parser is basically a framework to handle any CSV files or fixed-width format files.
-# Parsers are defined in CSV/parser_type.
 
 package LedgerSMB::Reconciliation::CSV;
 use LedgerSMB::Reconciliation::ISO20022;
@@ -21,6 +23,7 @@ use warnings;
 use Try::Tiny;
 use base qw(LedgerSMB::PGOld);
 
+# Import installation-specific parsing functions
 try {
     no warnings;
     opendir (DCSV, 'old/lib/LedgerSMB/Reconciliation/CSV/Formats');
@@ -42,27 +45,25 @@ try {
 
 =head2 $self->process()
 
-Processes the input reconciliation file by calling the function
-$self->parse_<account_id>() with the parsed content of the CSV file.
+Processes the input reconciliation file, returning a list of the transactions
+it contains.
 
-For now, does SEPA detection here, though that needs to be refactored.
+First tries to read the file as ISO200022 CAMT053 XML. If that fails,
+parses the file by calling method $self->parse_<company>_<account_id>()
+with the content of the CSV file, if that method exists.
 
 =cut
 
 sub process {
-    my $self = shift @_;
+    my ($self, $recon, $contents) = @_;
 
-    # thoroughly implementation-dependent, so depends on helper-functions
-    my ($recon, $contents) = @_;
-
-    if (@{$self->{entries}} = LedgerSMB::Reconciliation::ISO20022->process_xml($recon, $contents)){
+    if (@{$self->{entries}} = LedgerSMB::Reconciliation::ISO20022->process_xml($contents)){
         return $self->{entries};
     }
 
     my $func = "parse_$self->{company}_$recon->{chart_id}";
     if ($self->can($func)){
-       my @entries = $self->can($func)->($self,$contents);
-       @{$self->{entries}} = @entries;
+       @{$self->{entries}} = $self->can($func)->($self,$contents);
     }
 
     return $self->{entries};

--- a/old/lib/LedgerSMB/Reconciliation/CSV.pm
+++ b/old/lib/LedgerSMB/Reconciliation/CSV.pm
@@ -57,7 +57,7 @@ with the content of the CSV file, if that method exists.
 sub process {
     my ($self, $recon, $contents) = @_;
 
-    if (@{$self->{entries}} = LedgerSMB::Reconciliation::ISO20022->process_xml($contents)){
+    if (@{$self->{entries}} = LedgerSMB::Reconciliation::ISO20022::process_xml($contents)){
         return $self->{entries};
     }
 

--- a/old/lib/LedgerSMB/Reconciliation/CSV.pm
+++ b/old/lib/LedgerSMB/Reconciliation/CSV.pm
@@ -65,6 +65,9 @@ sub process {
     if ($self->can($func)){
        @{$self->{entries}} = $self->can($func)->($self,$contents);
     }
+    else {
+        die "no custom method `$func` exists to parse the reconciliation file";
+    }
 
     return $self->{entries};
 }

--- a/t/20-camt053.t
+++ b/t/20-camt053.t
@@ -3,8 +3,17 @@ use Test2::V0;
 
 use LedgerSMB::FileFormats::ISO20022::CAMT053;
 
+my $file_content;
+{
+    local $/ = undef;
+    my $filename = 't/data/inout_tests/campt053-sample.xml';
+    open my $fh, '<', $filename
+        or die "failed to open $filename for reading";
+    $file_content = <$fh>;
+}
+
 my $camt = LedgerSMB::FileFormats::ISO20022::CAMT053->new(
-   't/data/inout_tests/campt053-sample.xml'
+    $file_content
 );
 
 ok($camt, 'Parse of camt file returned true');


### PR DESCRIPTION
This PR cleans-up and fixes parsing of CSV reconciliation files.

Previously, unless the csv file happened to contain a `<` or `>` character, the 
camt053 parser would interpret the file contents as the name of a file to be
read from, triggering a fatal error when that file was found not to exist, before
reaching the csv parsers.

If no appropriate CSV parser is found, an error is now raised, rather than
silently failing.