### PR TITLE
Turn off autocomplete values on login form

### DIFF
--- a/UI/login.html
+++ b/UI/login.html
@@ -58,7 +58,8 @@
                          title=text('User Name')
                          value = login
                          accesskey="l"
-                         tabindex=1 } #' ?>
+                         tabindex=1,
+                         attributes = { autocomplete = 'off'} } #' ?>
                 </div>
                 <div>
                   <?lsmb PROCESS input
@@ -71,7 +72,8 @@
                          title=text('Password')
                          value = ''
                          accesskey="p"
-                         tabindex=2 } ?>
+                         tabindex=2,
+                         attributes = { autocomplete = 'off'} } ?>
                 </div>
               </div>
               <?lsmb PROCESS input

--- a/UI/setup/credentials.html
+++ b/UI/setup/credentials.html
@@ -52,6 +52,7 @@
                                       label = text('DB admin login') #'
                                         "data-dojo-type" = "dijit/form/ComboBox"
                                         "data-dojo-props" = "value:'$s_user', placeHolder:'$select_hint'"
+                                    attributes = { autocomplete = 'off'}
                                 } ?>
                             </div>
                             <div class="inputrow">
@@ -64,7 +65,8 @@
                                          class = 'password'
                                        tabindex = 2
                                          label = text('Password')
-                                } ?>
+                                         attributes = { autocomplete = 'off'}
+                                        } ?>
                             </div>
                         </div>
                         <div class="inputrow">


### PR DESCRIPTION
Turn off autocomplete attributes for the moment.
Autocomplete attributes help password managers to infer the purpose of a field in a form, saving them from accidentally saving or autofilling the wrong data.
“username” and “current-password” should be used if we turn on autocomplete.
[skip_ci]