### PR TITLE
In the preferences screen, offer a list of languages rather than countries

### DIFF
--- a/UI/users/preferences.html
+++ b/UI/users/preferences.html
@@ -68,10 +68,10 @@ password_strings = "title:'" _ text("Change Password") _
               </tr>
               <tr>
                 <th align="right"><?lsmb text('Language') ?></th>
-                <td><?lsmb country_codes.unshift({}) ?>
+                <td><?lsmb language_codes.unshift({}) ?>
                     <?lsmb PROCESS select_language element_data={
                      name = 'language',
-                     options = user.country_codes,
+                     options = user.language_codes,
                      default_values = [ user.prefs.language ],
                      text_attr = 'label',
                      value_attr = 'id',

--- a/old/lib/LedgerSMB/DBObject/User.pm
+++ b/old/lib/LedgerSMB/DBObject/User.pm
@@ -12,6 +12,8 @@ use warnings;
 use base qw(LedgerSMB::PGOld);
 
 use Locale::Country;
+use Locale::Language;
+
 use Log::Log4perl;
 
 use Try::Tiny;
@@ -108,6 +110,16 @@ sub get_option_data {
     }
     @{$self->{country_codes}} =
         sort { $a->{label} cmp $b->{label} } @{$self->{country_codes}};
+
+    foreach my $key ( all_language_codes() )
+    {
+        push @{$self->{language_codes}}, {
+            label => code2language($key),
+            id => $key,
+        };
+    }
+    @{$self->{language_codes}} =
+        sort { $a->{label} cmp $b->{label} } @{$self->{language_codes}};
 
     $self->{cssfiles} = [];
     opendir CSS, "UI/css/.";


### PR DESCRIPTION
Without this fix, I was unable to save the preferences screen: It had the first country selected (Afghanistan) which has letters 'af', for which there seems to be no language associated.