### PR TITLE
Implement LedgerSMB::PGTimestamp and fix single-item timecards

### DIFF
--- a/lib/LedgerSMB/File.pm
+++ b/lib/LedgerSMB/File.pm
@@ -56,7 +56,7 @@ Timestamp of attachment point.
 
 =cut
 
-has uploaded_at => (is => 'ro', isa => 'Maybe[Str]');
+has uploaded_at => (is => 'ro', isa => 'Maybe[LedgerSMB::Moose::Timestamp]');
 
 =item content
 

--- a/lib/LedgerSMB/MooseTypes.pm
+++ b/lib/LedgerSMB/MooseTypes.pm
@@ -22,6 +22,7 @@ use Moose::Util::TypeConstraints;
 use PGObject::Type::ByteString;
 use LedgerSMB::PGDate;
 use LedgerSMB::PGNumber;
+use LedgerSMB::PGTimestamp;
 
 =head1 SYNPOSIS
 
@@ -51,7 +52,6 @@ date formats.
 subtype 'LedgerSMB::Moose::Date', as 'Maybe[LedgerSMB::PGDate]';
 
 
-
 =head3 Coercions
 
 The only coercion provided is from a string, and it calls the PGDate class's
@@ -63,6 +63,29 @@ Maybe[LedgerSMB::Moose::Date].
 coerce 'LedgerSMB::Moose::Date'
     => from 'Str'
     => via { LedgerSMB::PGDate->from_input($_) };
+
+
+=head2 LedgerSMB::Moose::Timestamp
+
+This wraps the LedgerSMB::PGTimestamp class for automagic handling of i18n and
+date formats.
+
+=cut
+
+subtype 'LedgerSMB::Moose::Timestamp', as 'Maybe[LedgerSMB::PGTimestamp]';
+
+=head3 Coercions
+
+The only coercion provided is from a string, and it calls the PGTimestamp class's
+from_input method.  A second coercion is provided for
+Maybe[LedgerSMB::Moose::Timestamp].
+
+=cut
+
+coerce 'LedgerSMB::Moose::Timestamp'
+    => from 'Str'
+    => via { LedgerSMB::PGTimestamp->from_input($_) };
+
 
 =head2 LedgerSMB::Moose::Number
 

--- a/lib/LedgerSMB/PGDate.pm
+++ b/lib/LedgerSMB/PGDate.pm
@@ -8,7 +8,7 @@ LedgerSMB::PgDate - Date handling and serialization to database
 =head1 DESCRIPTION
 
 This class handles formatting and mapping between the DateTime module and
-PostgreSQL. It provides a handler for date and timestamp datatypes.
+PostgreSQL. It provides a handler for date datatype.
 
 The type behaves internally as a Datetime module.
 

--- a/lib/LedgerSMB/PGTimestamp.pm
+++ b/lib/LedgerSMB/PGTimestamp.pm
@@ -50,13 +50,10 @@ sub _stringify {
 
 =head1 CONSTRUCTOR SYNTAX
 
-LedgerSMB::PgDate->new({ date => DateTime->new(year => 2012, day => 31, month =>
-12)});
+Note the constructor is private, and not intended to be called directly.
 
-Note the constructor here is private, and not intended to be called directly.
-
-Use from_db and from_input methods instead since these handle appropriately
-different formats and handle construction differently.
+Use from_db and from_input methods instead since these handle different
+formats appropriately and handle construction
 
 =cut
 
@@ -119,28 +116,24 @@ sub add_interval {
     return $self;
 }
 
-=item from_input($date_string, [$format])
+=item from_input($timestamp_string)
 
-Parses this from an input string according to the user's dateformat,
-unless C<$format> has been specified to override it.
+Parses the input string as 'YYYY-MM-DD HH:mm:ss' or without the
+time part, setting it to 00:00:00.
 
 =cut
 
 our $formats = {
-    'YYYY-MM-DD' => ['%F'],
-    'DD-MM-YYYY' => ['%d-%m-%Y', '%d-%m-%y'],
-    'DD.MM.YYYY' => ['%d.%m.%Y', '%d.%m.%y'],
-    'DD/MM/YYYY' => ['%d/%m/%Y', '%D'],
-    'MM-DD-YYYY' => ['%m-%d-%Y', '%m-%d-%y'],
-    'MM/DD/YYYY' => ['%m/%d/%Y', '%m/%d/%y'],
-    'MM.DD.YYYY' => ['%m.%d.%Y', '%m.%d.%y'],
-      'YYYYMMDD' => ['%Y%m%d'],
-        'YYMMDD' => ['%y%m%d'],
-      'DDMMYYYY' => ['%d%m%Y'],
-        'DDMMYY' => ['%d%m%y'],
-      'MMDDYYYY' => ['%m%d%Y'],
-        'MMDDYY' => ['%m%d%y'],
-     'DDmonYYYY' => ['%d%b%Y', '%d%b%y']
+    'YYYY-MM-DD' => '%F',
+    'DD-MM-YYYY' => '%d-%m-%Y',
+    'DD.MM.YYYY' => '%d.%m.%Y',
+    'DD/MM/YYYY' => '%d/%m/%Y',
+    'MM-DD-YYYY' => '%m-%d-%Y',
+    'MM/DD/YYYY' => '%m/%d/%Y',
+    'MM.DD.YYYY' => '%m.%d.%Y',
+      'YYYYMMDD' => '%Y%m%d',
+      'DDMMYYYY' => '%d%m%Y',
+      'MMDDYYYY' => '%m%d%Y',
 };
 
 sub from_input{
@@ -179,11 +172,14 @@ sub to_output {
     } else {
         $fmt = '%F';
     }
-    $fmt = $formats->{uc($fmt)}->[0] if defined $formats->{uc($fmt)};
+    $fmt = $formats->{uc($fmt)} if defined $formats->{uc($fmt)};
 
     $fmt .= ' %T' if $self->is_time();
     $fmt =~ s/^\s+//;
 
+    # the hard-coded 'en_US' locale here is no problem: it's used
+    # for the %b format ('mon') to look up the names of the months;
+    # however, we only support numeric formats
     my $formatter = DateTime::Format::Strptime->new(
              pattern => $fmt,
               locale => 'en_US',

--- a/lib/LedgerSMB/PGTimestamp.pm
+++ b/lib/LedgerSMB/PGTimestamp.pm
@@ -1,0 +1,223 @@
+
+package LedgerSMB::PGTimestamp;
+
+=head1 NAME
+
+LedgerSMB::PGTimestamp - Timestamp handling and serialization to database
+
+=head1 DESCRIPTION
+
+This class handles formatting and mapping between the DateTime module and
+PostgreSQL. It provides a handler for the timestamp datatype.
+
+The type behaves internally as a Datetime module.
+
+=cut
+
+use strict;
+use warnings;
+use base qw(PGObject::Type::DateTime);
+
+use Carp;
+use DateTime::Format::Strptime qw(strptime);
+
+use LedgerSMB::App_State;
+use LedgerSMB::Magic
+    qw( MONTHS_PER_QUARTER YEARS_PER_CENTURY FUTURE_YEARS_LIMIT );
+
+use overload (
+    fallback => 1,
+    q{""}    => '_stringify',
+    );
+
+__PACKAGE__->register(registry => 'default',
+                      types => ['timestamp', 'timestamptz']);
+
+sub _stringify {
+    my $self = shift;
+
+    # Stringify without the 'T' in the middle
+    #   which is the same way Pg stringifies
+    return $self->strftime('%F %T');
+}
+
+=head1 SUPPORTED FORMATS
+
+### TO DOCUMENT
+
+=cut
+
+
+=head1 CONSTRUCTOR SYNTAX
+
+LedgerSMB::PgDate->new({ date => DateTime->new(year => 2012, day => 31, month =>
+12)});
+
+Note the constructor here is private, and not intended to be called directly.
+
+Use from_db and from_input methods instead since these handle appropriately
+different formats and handle construction differently.
+
+=cut
+
+
+=head1 METHODS
+
+=over
+
+=item new
+
+Returns an empty timestamp object when the input is an empty string; otherwise
+defers object creation to the superclass.
+
+=cut
+
+sub new {
+    my $class = shift;
+    my @args = @_;
+
+    if (! @args) {
+        my $self = {};
+        bless $self, $class;
+
+        $self->is_date(0);
+        $self->is_time(0);
+
+        return $self;
+    }
+    return $class->SUPER::new(@args);
+}
+
+
+=item add_interval(string $interval, optional integer $n)
+
+This adds $n * $interval to the date, defaulting to 1 if $n is not supplied.
+
+=cut
+
+sub add_interval {
+    my ($self,$interval,$n) = @_;
+
+    my %delta_names = (
+        day => 'days',
+        week => 'weeks',
+        month => 'months',
+        quarter => 'months',
+        year => 'years',
+    );
+    my $delta_name = $delta_names{$interval};
+    #Validate asked interval
+    die "Bad interval: $interval" if not defined $delta_name;
+
+    $n //= 1;    # Default to 1
+    $n *= MONTHS_PER_QUARTER if $interval eq 'quarter'; # A quarter is 3 months
+
+    my $has_time = $self->is_time();
+    $self->add($delta_name => $n, end_of_month => 'preserve');
+    $self->is_time($has_time);  # Make sure that is_time sticks
+
+    return $self;
+}
+
+=item from_input($date_string, [$format])
+
+Parses this from an input string according to the user's dateformat,
+unless C<$format> has been specified to override it.
+
+=cut
+
+our $formats = {
+    'YYYY-MM-DD' => ['%F'],
+    'DD-MM-YYYY' => ['%d-%m-%Y', '%d-%m-%y'],
+    'DD.MM.YYYY' => ['%d.%m.%Y', '%d.%m.%y'],
+    'DD/MM/YYYY' => ['%d/%m/%Y', '%D'],
+    'MM-DD-YYYY' => ['%m-%d-%Y', '%m-%d-%y'],
+    'MM/DD/YYYY' => ['%m/%d/%Y', '%m/%d/%y'],
+    'MM.DD.YYYY' => ['%m.%d.%Y', '%m.%d.%y'],
+      'YYYYMMDD' => ['%Y%m%d'],
+        'YYMMDD' => ['%y%m%d'],
+      'DDMMYYYY' => ['%d%m%Y'],
+        'DDMMYY' => ['%d%m%y'],
+      'MMDDYYYY' => ['%m%d%Y'],
+        'MMDDYY' => ['%m%d%y'],
+     'DDmonYYYY' => ['%d%b%Y', '%d%b%y']
+};
+
+sub from_input{
+    my ($self, $input) = @_;
+
+    local $@ = undef;
+    return $input if eval {$input->isa(__PACKAGE__)} && $input->is_date;
+
+    return __PACKAGE__->new()
+        if ! $input; # matches undefined as well as ''
+
+    my $dt = eval { strptime('%F %T', $input) }
+        // strptime('%F', $input);
+
+    die "Bad timestamp ($input)" if $input && ! $dt;
+    bless $dt, __PACKAGE__;
+    $dt->is_date(1);
+    $dt->is_time(($input && $input =~ /\:/) ? 1 : 0); # Define time
+    return $dt;
+}
+
+
+=item to_output(optional string $format)
+
+This returns the human readable formatted date.  If $format is supplied, it is
+used.  If $format is not supplied, the dateformat of the user is used.
+
+=cut
+
+sub to_output {
+    my ($self) = @_;
+    return '' if not $self->is_date();
+    my $fmt;
+    if (defined $LedgerSMB::App_State::User->{dateformat}){
+        $fmt = $LedgerSMB::App_State::User->{dateformat};
+    } else {
+        $fmt = '%F';
+    }
+    $fmt = $formats->{uc($fmt)}->[0] if defined $formats->{uc($fmt)};
+
+    $fmt .= ' %T' if $self->is_time();
+    $fmt =~ s/^\s+//;
+
+    my $formatter = DateTime::Format::Strptime->new(
+             pattern => $fmt,
+              locale => 'en_US',
+            on_error => 'croak',
+    );
+    my $date = $formatter->format_datetime($self);
+    if ($date =~ /\:/ and not $self->is_time()) { die 'to_output'; }
+    return $date;
+}
+
+=item $self->to_sort()
+
+Returns sortable key for the Date/Time value (epoch)
+
+=cut
+
+sub to_sort {
+    my $self = shift;
+    return $self->epoch;
+}
+
+#__PACKAGE__->meta->make_immutable;
+
+=back
+
+=head1 LICENSE AND COPYRIGHT
+
+Copyright (C) 2011-2020 The LedgerSMB Core Team
+
+This file is licensed under the GNU General Public License version 2, or at your
+option any later version.  A copy of the license should have been included with
+your software.
+
+=cut
+
+
+1;

--- a/lib/LedgerSMB/Timecard.pm
+++ b/lib/LedgerSMB/Timecard.pm
@@ -135,7 +135,7 @@ Time and date work started
 
 =cut
 
-has checkedin  => (isa => 'LedgerSMB::Moose::Date', is => 'ro', required => '0',
+has checkedin  => (isa => 'LedgerSMB::Moose::Timestamp', is => 'ro', required => '0',
                 coerce => 1);
 
 =item checkedout timestamp
@@ -144,7 +144,7 @@ Time and date work ended for this card
 
 =cut
 
-has checkedout  => (isa => 'LedgerSMB::Moose::Date', is => 'ro',
+has checkedout  => (isa => 'LedgerSMB::Moose::Timestamp', is => 'ro',
                required => '0', coerce => 1);
 
 =item person_id int

--- a/t/01-load.t
+++ b/t/01-load.t
@@ -73,6 +73,7 @@ my @modules =
           'LedgerSMB::AA', 'LedgerSMB::AM', 'LedgerSMB::Batch',
           'LedgerSMB::IC', 'LedgerSMB::IR', 'LedgerSMB::PGDate',
           'LedgerSMB::PGNumber', 'LedgerSMB::PGOld',
+          'LedgerSMB::PGTimestamp',
           'LedgerSMB::Setting', 'LedgerSMB::Tax', 'LedgerSMB::Upgrade_Tests',
           'LedgerSMB::Upgrade_Preparation',
           'LedgerSMB::Database::SchemaChecks::JSON',

--- a/xt/45.2-ledgersmb-file-internal.t
+++ b/xt/45.2-ledgersmb-file-internal.t
@@ -111,7 +111,7 @@ is($result->{ref_key}, 0, 'ref_key set to 0 for new file');
 is($result->{mime_type_id}, 153, 'mime_type_id represents text/plain for new file');
 like($result->{id}, qr/^\d+$/, 'id is numeric for new file');
 like($result->{uploaded_by}, qr/^\d+$/, 'uploaded_by is numeric for new file');
-like($result->{uploaded_at}, qr/^\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d\.\d+$/, 'uploaded_at is correct format for new file');
+like($result->{uploaded_at}, qr/^\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d$/, 'uploaded_at is correct format for new file');
 
 
 # Overwrite an existing 'internal' file
@@ -136,7 +136,7 @@ ok($result && ref $result, 'overwritten an existing file');
 #is($result->{mime_type_id}, 153, 'mime_type_id represents text/plain when overwriting file');
 #is($result->{id}, $old_result->{id}, 'id remains the same when overwriting file');
 #like($result->{uploaded_by}, qr/^\d+$/, 'uploaded_by is numeric for new file');
-#like($result->{uploaded_at}, qr/^\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d\.\d+$/, 'uploaded_at is correct format when overwriting file');
+#like($result->{uploaded_at}, qr/^\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d$/, 'uploaded_at is correct format when overwriting file');
 #isnt($result->{uploaded_at}, $old_result->{uploaded_at}, 'uploaded_at changes when overwriting file');
 
 
@@ -155,7 +155,7 @@ is($file->{ref_key}, 0, 'ref_key set to 0 when retrieving file');
 is($file->{mime_type_id}, 153, 'mime_type_id represents text/plain when retrieving file');
 is($file->{id}, $old_result->{id}, 'correct id when retrieving file');
 is($file->{uploaded_by}, $old_result->{uploaded_by}, 'correct uploaded_by when retrieving file');
-like($file->{uploaded_at}, qr/^\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d\.\d+$/, 'uploaded_at is correct format when retrieving file');
+like($file->{uploaded_at}, qr/^\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d$/, 'uploaded_at is correct format when retrieving file');
 isnt($file->{uploaded_at}, $old_result->{uploaded_at}, 'uploaded_at has been changed by overwriting file');
 is($file->{file_path}, undef, 'file_path is undef when retrieving file');
 is($file->{reference}, undef, 'reference is undef when retrieving file');


### PR DESCRIPTION
The blocking item for fixing timecards has been the missing Timestamp type all along. Finally implement it to fix (single item) timecards.