### PR TITLE
Reduce test warnings

### DIFF
--- a/xt/40-ledgersmb.t
+++ b/xt/40-ledgersmb.t
@@ -20,12 +20,13 @@ my @r;
 ok(defined $lsmb);
 isa_ok($lsmb, ['LedgerSMB']);
 
+my $pgdatabase = $ENV{PGDATABASE} // '';
 my $pghost = "";
 $pghost = ";host=" . $ENV{PGHOST}
         if $ENV{PGHOST} && $ENV{PGHOST} ne 'localhost';
-$lsmb->{dbh} = DBI->connect("dbi:Pg:dbname=$ENV{PGDATABASE}$pghost",
+$lsmb->{dbh} = DBI->connect("dbi:Pg:dbname=$pgdatabase$pghost",
         undef, undef, {AutoCommit => 0 });
-ok($lsmb->{dbh},"Connected to $ENV{PGDATABASE}");
+ok($lsmb->{dbh},"Connected to $pgdatabase");
 LedgerSMB::App_State::set_DBH($lsmb->{dbh});
 @r = $lsmb->call_procedure('procname' => 'character_length',
         'funcschema' => 'pg_catalog',

--- a/xt/66-cucumber/01-basic/closing.feature
+++ b/xt/66-cucumber/01-basic/closing.feature
@@ -5,9 +5,11 @@ Feature: correct operation of period closing and year end posting
 
 
 Background:
+    Note that the user used to log in below is a generic 'admin'
+    yet we should be testing this code with a user who has strict
+    'accounting' rights!
   Given a standard test company
     And a logged in admin
-# should have been : And a logged in accounting user
 
 Scenario: Closed books disallow posting
  Given the following GL transaction posted on 2015-11-01:

--- a/xt/66-cucumber/30-inventory/adjustments.feature
+++ b/xt/66-cucumber/30-inventory/adjustments.feature
@@ -6,10 +6,15 @@ Feature: Adjusting stock levels
   report and be able to search for inventory adjustment reports.
 
 
-Scenario: Adjusting recorded inventory down (to a lower count)
-   Given a standard test company
 # Note: we need a way to list inventory; 'part_edit' isn't that role...
 #     And a logged in user with 'part_edit' rights
+
+
+Scenario: Adjusting recorded inventory down (to a lower count)
+     Note that half way through, we check that the adjustment was entered, but
+     not yet approved. In that stage, there should not be a balance or inventory
+     impact yet.
+   Given a standard test company
      And a vendor "v1"
      And a part with these properties:
        | name       | value          |
@@ -27,7 +32,6 @@ Scenario: Adjusting recorded inventory down (to a lower count)
     When I create an inventory adjustment dated 2016-11-28 with these counts:
        | Partnumber | Counted |
        | P001       | 8       |
-# Entered but not approved: no impact
      And I open the parts screen for 'P001'
     Then I expect to see the 'onhand' value of '10'
     When I search for part 'P001'


### PR DESCRIPTION
Reduce test warnings again.

With this PR, we're back to the UTF-8 warning caused by the "checkmark character" in the reconciliation checks. Apart from that, the checks are now silent again.