### PR TITLE
Upgrade mimimum PGObject dependencies

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -77,6 +77,9 @@ Dependency updates
 * Session::Storage::Secure (new)
 * String::Random (new)
 * MIME::Lite (dropped)
+* PGObject >= 2.0.2 (from 1.403.2)
+* PGObject::Type::BigFloat >= 2.0.1 (from 1.0.0)
+* PGObject::Type::DateTime >= 2.0.2 (from 1.0.4)
 
 
 Changelog for 1.7 Series

--- a/cpanfile
+++ b/cpanfile
@@ -39,12 +39,12 @@ requires 'Moose::Role';
 requires 'Moose::Util::TypeConstraints';
 requires 'MooseX::NonMoose';
 requires 'Number::Format';
-requires 'PGObject', '1.403.2';
+requires 'PGObject', '2.0.2';
 # PGObject::Simple 3.0.1 breaks our file uploads
 requires 'PGObject::Simple', '>=3.0.2';
 requires 'PGObject::Simple::Role', '2.0.2';
-requires 'PGObject::Type::BigFloat', '1.0.0';
-requires 'PGObject::Type::DateTime', '1.0.4';
+requires 'PGObject::Type::BigFloat', '2.0.1';
+requires 'PGObject::Type::DateTime', '2.0.2';
 requires 'PGObject::Type::ByteString', '1.1.1';
 requires 'PGObject::Util::DBMethod';
 requires 'PGObject::Util::DBAdmin', '1.0.1';


### PR DESCRIPTION
Upgrades minimum version dependencies for the following modules, to
meet new LedgerSMB::PGTimestamp requirements and silence test deprecation warnings.

  * PGObject >= 2.0.2
  * PGObject::Type::BigFloat >= 2.0.1
  * PGObject::Type::DateTime >= 2.0.2
  * PGObject::Type::ByteString >= 1.2.3