### PR TITLE
Replace XML::Simple with XML::LibXML

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -81,6 +81,7 @@ Dependency updates
 * PGObject::Type::BigFloat >= 2.0.1 (from 1.0.0)
 * PGObject::Type::DateTime >= 2.0.2 (from 1.0.4)
 * PGObject::Type::ByteString >= 1.2.3 (from 1.1.1)
+* XML::Simple (dropped)
 
 
 Changelog for 1.7 Series

--- a/cpanfile
+++ b/cpanfile
@@ -68,7 +68,8 @@ requires 'Text::CSV';
 requires 'Text::Markdown';
 requires 'Try::Tiny';
 requires 'Version::Compare';
-requires 'XML::Simple';
+requires 'XML::LibXML';
+requires 'XML::LibXML::XPathContext';
 requires 'namespace::autoclean';
 
 recommends 'Math::BigInt::GMP';

--- a/t/20-camt053.t
+++ b/t/20-camt053.t
@@ -21,7 +21,6 @@ ok(! LedgerSMB::FileFormats::ISO20022::CAMT053->new(
    '<?xml version="1.0" ?> <foo />'
 ), 'Autodetection of wrong xml type correct');
 
-is(scalar $camt->lineitems_full(), 10, 'correct number of line items, raw');
 is(scalar $camt->lineitems_simple(), 10, 'correct number of line items, flattened');
 
 done_testing;


### PR DESCRIPTION
This PR replaces use of XML::Simple with XML::LibXML.

XML::Simple is documented as `PLEASE DO NOT USE THIS MODULE IN NEW CODE`.

This affects the ISO20022 CAMT053 bank statement file import, which
has been refactored to use the new XML module.

This change does not introduce a new dependency to lsmb. Rather
it removes a dependency, as XML::LibXML was already a dependency
of the XML::Simple module previously in use.