### PR TITLE
Add Reconciliation import for OFX Bank Statements

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -17,6 +17,7 @@ Added functionalities
 * SysV init script template for RedHat/CentOS (#2900)
 * New configuration keys in '[mail]' section of ledgersmb.conf (#4378)
 * Beginnings of a web services API, served at /erp/api/v0 (#4452)
+* Import of OFX bank statement files for reconciliation
 
 Changed functionalities
 * Faster loading of the menu

--- a/lib/LedgerSMB/FileFormats/OFX/BankStatement.pm
+++ b/lib/LedgerSMB/FileFormats/OFX/BankStatement.pm
@@ -1,0 +1,156 @@
+package LedgerSMB::FileFormats::OFX::BankStatement;
+
+use warnings;
+use strict;
+use Try::Tiny;
+use XML::LibXML;
+
+=head1 NAME
+
+LedgerSMB::FileFormats::OFX::BankStatement - Parse OFX Bank Statement files
+
+=head1 SYNOPSIS
+
+    my $ofx = LedgerSMB::FileFormats::OFX::BankStatement->new($filecontents);
+    my @transactions = $ofx->transactions;
+
+=head1 DESCRIPTION
+
+This module provides basic parsing and data extraction of OFX bank statement
+files for LedgerSMB.
+
+=head1 OFX SPECIFICATION
+
+This parser has been created with reference to the Open Financial
+Exchange Specification, available from
+L<https://www.ofx.net/downloads/OFX%202.2.pdf>.
+
+This document, as retrieved on 2020-03-29 carries the following licence:
+
+A royalty-free, worldwide, and perpetual license is hereby granted to any
+party to use the Open Financial Exchange Specification to make, use, and
+sell products and services that conform to this Specification.
+
+=head2 Statement Transactions
+
+A C<STMTTRN> aggregate describes a single transaction. It identifies the type
+of the transaction and the date it was posted. It can also
+provide additional information to help recognize the
+transaction: check number, payee name, and memo.
+
+Each C<STMTTRN> contains an C<FITID> (Financial Institution Trasaction ID)
+that the client can use to detect whether the transaction  has previously
+been downloaded.
+
+=head2 Transaction Types
+
+The following C<TRNTYPE>s are specified:
+
+CREDIT, DEBIT, INT, DIV, FEE, SRVCHG, DEP, ATM, POS, XFER, CHECK,
+PAYMENT, CASH, DIRECTDEP, DIRECTDEBIT, REPEATPMT, OTHER.
+
+=head2 Amounts
+
+Amounts that do not represent whole numbers (for example, 540.32), must
+include a decimal point or comma to indicate the start of the fractional
+amount.
+
+Amounts should not include any punctuation separating thousands, millions,
+and so forth. The maximum value accepted depends on the client.
+
+=head2 Transaction Sign
+
+Transaction amounts are signed from the perspective of the customer.
+For example, a credit card payment is positive while a credit card purchase
+is negative.
+
+=head2 Payee Name
+
+Either C<NAME> or C<PAYEE> elements may be provided within a STMTTRN element,
+but not both.
+
+C<PAYEE> provides a complete billing address for a payee. C<NAME> will be
+provided as one of its child elements.
+
+=head1 AUTODETECTION
+
+The constructor returns C<undef> if the file is not a OFX docuent.
+
+=head1 METHODS
+
+=head2 new($xml_string)
+
+Pass in a string of XML data. Returns undef if the string is not valid XML or
+not identified as a OFX document.
+
+=cut
+
+sub new {
+    my ($class, $content) = @_;
+    return unless defined $content;
+
+    my ($dom, $is_ofx);
+    try {
+        $dom = XML::LibXML->load_xml(
+            string => $content
+        );
+        $is_ofx = $dom->find('/processing-instruction("OFX")')
+    };
+
+    return unless $dom and $is_ofx;
+
+    return bless ({dom => $dom}, $class);
+}
+
+
+=head2 dom
+
+Returns the XML::LibXML DOM tree representing the input xml.
+
+=cut
+
+sub dom {
+    my ($self) = @_;
+    return $self->{dom};
+}
+
+
+=head2 transactions
+
+Returns a transaction list reference, each transaction being a hash with the
+following elements:
+
+  * amount
+  * cleared_date
+  * scn
+  * type
+
+=cut
+
+sub transactions {
+    my ($self) = @_;
+
+    my $transactions = $self->dom->find('//STMTTRNRS/STMTRS/BANKTRANLIST/STMTTRN');
+
+    my @transactions = map {{
+        amount => $_->findvalue('TRNAMT') * -1,
+        cleared_date => $_->findvalue('DTPOSTED'),
+        scn => $_->findvalue('NAME'),
+        type => 'OFX FITID:' . $_->findvalue('FITID'),
+    }} @{$transactions};
+
+    return \@transactions;
+}
+
+
+=head1 LICENSE AND COPYRIGHT
+
+Copyright (C) 2020 The LedgerSMB Core Team
+
+This file is licensed under the GNU General Public License version 2, or at your
+option any later version.  A copy of the license should have been included with
+your software.
+
+=cut
+
+1;

--- a/t/01-load.t
+++ b/t/01-load.t
@@ -124,6 +124,7 @@ my @modules =
           'LedgerSMB::Reconciliation::CSV',
           'LedgerSMB::Reconciliation::ISO20022',
           'LedgerSMB::FileFormats::ISO20022::CAMT053',
+          'LedgerSMB::FileFormats::OFX::BankStatement',
           'LedgerSMB::Report::Axis',
           'LedgerSMB::Report::File', 'LedgerSMB::Report::GL',
           'LedgerSMB::Report::Orders', 'LedgerSMB::Report::Timecards',

--- a/t/21-ofx-bank-statement.t
+++ b/t/21-ofx-bank-statement.t
@@ -1,0 +1,51 @@
+use Test2::V0;
+use warnings;
+use strict;
+
+use LedgerSMB::FileFormats::OFX::BankStatement;
+
+my $file_content;
+{
+    local $/ = undef;
+    my $filename = 't/data/inout_tests/ofx_bank_statement.xml';
+    open my $fh, '<', $filename
+        or die "failed to open $filename for reading";
+    $file_content = <$fh>;
+}
+
+my $ofx = LedgerSMB::FileFormats::OFX::BankStatement->new(
+    $file_content
+);
+ok($ofx, 'Parse of OFX bank statement file returned true');
+is(scalar @{$ofx->transactions}, 3, 'correct number of transaction items');
+is(
+    $ofx->transactions,
+    [
+        {
+            amount => 26.59,
+            cleared_date => '20200220',
+            scn => 'SUPPLIER ONE',
+            type => 'OFX FITID:202002202659117123782934'
+        },
+        {
+            amount => -25.00,
+            cleared_date => '20200302',
+            scn => 'CUSTOMER ONE',
+            type => 'OFX FITID:202003022500117148782934'
+        },
+        {
+            amount => 6.50,
+            cleared_date => '20200304',
+            scn => 'TOTAL CHARGES TO 11FEB2020',
+            type => 'OFX FITID:20200304650116645202934'
+        },
+    ],
+    'Yielded expected transactions'
+);
+
+ok(
+    !LedgerSMB::FileFormats::OFX::BankStatement->new('<?xml>'),
+    'Detected wrong data format'
+);
+
+done_testing;

--- a/t/data/inout_tests/ofx_bank_statement.xml
+++ b/t/data/inout_tests/ofx_bank_statement.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<?OFX OFXHEADER="200"  VERSION="220" SECURITY="NONE" OLDFILEUID="NONE" NEWFILEUID="NONE"?>
+<OFX>    
+  <SIGNONMSGSRSV1>        
+    <SONRS>            
+      <STATUS>                
+        <CODE>0</CODE>                
+        <SEVERITY>INFO</SEVERITY>
+      </STATUS>
+      <LANGUAGE>ENG</LANGUAGE>
+    </SONRS>
+  </SIGNONMSGSRSV1>
+  <BANKMSGSRSV1>
+    <STMTTRNRS>
+      <TRNUID>99</TRNUID>
+      <STATUS>
+        <CODE>0</CODE>
+        <SEVERITY>INFO</SEVERITY>
+      </STATUS>
+      <STMTRS>
+        <CURDEF>GBP</CURDEF>
+        <BANKACCTFROM>
+          <BANKID>200000</BANKID>
+          <ACCTID>55779911</ACCTID>
+          <ACCTTYPE>DDA</ACCTTYPE>
+        </BANKACCTFROM>
+        <BANKTRANLIST>
+          <DTSTART>20200220</DTSTART>
+          <DTEND>20200309</DTEND>
+          <STMTTRN>
+            <TRNTYPE>DIRECTDEBIT</TRNTYPE>
+            <DTPOSTED>20200220</DTPOSTED>
+            <TRNAMT>-26.59</TRNAMT>
+            <FITID>202002202659117123782934</FITID>
+            <NAME>SUPPLIER ONE</NAME>
+          </STMTTRN>
+          <STMTTRN>
+            <TRNTYPE>CREDIT</TRNTYPE>
+            <DTPOSTED>20200302</DTPOSTED>
+            <TRNAMT>25.00</TRNAMT>
+            <FITID>202003022500117148782934</FITID>
+            <NAME>CUSTOMER ONE</NAME>
+          </STMTTRN>
+          <STMTTRN>
+            <TRNTYPE>DEBIT</TRNTYPE>
+            <DTPOSTED>20200304</DTPOSTED>
+            <TRNAMT>-6.50</TRNAMT>
+            <FITID>20200304650116645202934</FITID>
+            <NAME>TOTAL CHARGES TO 11FEB2020</NAME>
+          </STMTTRN>
+        </BANKTRANLIST>
+        <LEDGERBAL>
+          <BALAMT>1234.56</BALAMT>
+          <DTASOF>20200220</DTASOF>
+        </LEDGERBAL>
+      </STMTRS>
+    </STMTTRNRS>
+  </BANKMSGSRSV1>
+</OFX>


### PR DESCRIPTION
Basic import of OFX Bank Statement files for reconciliation. Matches
functionality of existing CSV and CAMT importers.

Future extension is possible. There is more information we can extract
from a standard OFX bank statement file, such as closing balance,
date range and currency, but that will require the file to be loaded
at a different point in the reconciliation process.