### PR TITLE
Migration clean-up

### DIFF
--- a/UI/setup/confirm_operation.html
+++ b/UI/setup/confirm_operation.html
@@ -50,7 +50,7 @@ include_stylesheet=["setup.css"] ?>
 <div><?lsmb text('Users') ?></div>
 <?lsmb INCLUDE button element_data = {
     name = 'action'
-   value = 'create_initial_user'
+   value = 'add_user'
     type = 'submit'
    class = 'submit'
     text = text('Add User') #'
@@ -67,7 +67,7 @@ include_stylesheet=["setup.css"] ?>
 <div><?lsmb text('Templates') ?></div>
 <?lsmb INCLUDE button element_data = {
     name = 'action'
-   value = 'template_screen'
+   value = 'load_templates'
     type = 'submit'
    class = 'submit'
     text = text('Load Templates') #'

--- a/UI/setup/new_user.html
+++ b/UI/setup/new_user.html
@@ -178,7 +178,7 @@ INCLUDE select element_data = {
 <?lsmb INCLUDE button element_data = {
     text = text('Create User') #';
     name = 'action'
-   value = 'save_user'
+   value = save_action
     type = 'submit'
    class = 'submit'
 } ?>

--- a/UI/setup/template_info.html
+++ b/UI/setup/template_info.html
@@ -25,7 +25,7 @@ PROCESS select element_data = {
 } ?><br />
 <?lsmb PROCESS button element_data = {
       name = "action"
-     value = "load_templates"
+     value = templates_action
       text = text('Load Templates') #'
 } ?>
 </form>

--- a/UI/setup/upgrade/preamble.html
+++ b/UI/setup/upgrade/preamble.html
@@ -5,6 +5,6 @@ include_stylesheet=["setup.css"] ?>
   <form method="POST"
         enctype="multipart/form-data"
         action="<?lsmb action_url ?>">
-    <input type="hidden" name="action" value="rebuild_modules">
+    <input type="hidden" name="action" value="<?lsmb resubmit_action ?>">
     <input type="hidden" name="database" value="<?lsmb database ?>">
     <input type="hidden" name="check_id" value="<?lsmb check_id ?>">

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -580,13 +580,17 @@ sub _get_linked_accounts {
 =cut
 
 my %info_applicable_for_upgrade = (
-    'default_ar' => [ 'ledgersmb/1.2',
-                      'sql-ledger/2.7', 'sql-ledger/2.8', 'sql-ledger/3.0' ],
-    'default_ap' => [ 'ledgersmb/1.2',
-                      'sql-ledger/2.7', 'sql-ledger/2.8', 'sql-ledger/3.0' ],
+    'default_ar'      => [ 'ledgersmb/1.2',
+                           'sql-ledger/2.7',
+                           'sql-ledger/2.8', 'sql-ledger/3.0' ],
+    'default_ap'      => [ 'ledgersmb/1.2',
+                           'sql-ledger/2.7',
+                           'sql-ledger/2.8', 'sql-ledger/3.0' ],
     'default_country' => [ 'ledgersmb/1.2',
-                           'sql-ledger/2.7', 'sql-ledger/2.8', 'sql-ledger/3.0' ],
-    'slschema' => [ 'sql-ledger/2.7', 'sql-ledger/2.8', 'sql-ledger/3.0' ]
+                           'sql-ledger/2.7',
+                           'sql-ledger/2.8', 'sql-ledger/3.0' ],
+    'slschema'        => [ 'sql-ledger/2.7',
+                           'sql-ledger/2.8', 'sql-ledger/3.0' ]
     );
 
 =item applicable_for_upgrade
@@ -1285,7 +1289,7 @@ sub post_migration_schema_upgrade {
     # found also in pg_roles, so as to avoid errors.  --CT
     $guard->dismiss;
     $dbh->do(q{SELECT admin__add_user_to_role(username, 'base_user')
-                from users WHERE username IN (select rolname from pg_roles)});
+                 FROM users WHERE username IN (select rolname from pg_roles)});
 
     $dbh->commit;
     $dbh->disconnect;
@@ -1333,8 +1337,7 @@ sub run_upgrade {
         $request->{only_templates} = 1;
     }
 
-    my $templates = LedgerSMB::Setting->new(dbh => $dbh)
-        ->get('templates');
+    my $templates = LedgerSMB::Setting->new(dbh => $dbh)->get('templates');
     if ($templates){
        $request->{template_dir} = $templates;
        return load_templates($request);

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -1179,10 +1179,10 @@ sub save_user {
                                            'users_manage',
                                          ]
         );
-   }
-   $request->{dbh}->commit;
+    }
+    $request->{dbh}->commit;
 
-   return rebuild_modules($request);
+    return complete($request);
 }
 
 

--- a/lib/LedgerSMB/Setup/SchemaChecks.pm
+++ b/lib/LedgerSMB/Setup/SchemaChecks.pm
@@ -68,6 +68,7 @@ sub _wrap_html {
         {
             check_id => _check_hashid( $failing_check ),
             database => $request->{database},
+            resubmit_action => $request->{resubmit_action},
             action_url => $request->get_relative_url,
         });
 

--- a/t/16-schema-upgrade-html.t
+++ b/t/16-schema-upgrade-html.t
@@ -24,8 +24,9 @@ sub test_request {
     my $plack_req = Plack::Request->new({});
     my $req = LedgerSMB->new($plack_req);
 
-    $req->{script} = 'script.pl';
-    $req->{query_string} = 'action=rebuild';
+    $req->{script}          = 'script.pl';
+    $req->{query_string}    = 'action=rebuild';
+    $req->{resubmit_action} = 'rebuild_modules';
 
     return $req;
 }


### PR DESCRIPTION
Driven by the fact that the 1.2 migration wasn't working, this branch refactors the migration handling code and introduces the concept of `migration workflow`: the steps in the workflow no longer hard-code a workflow of screens, but delegate the sequence of screens to a central dispatcher.

Addititionally, it includes fixes for the 1.2 migration script -- which was totally broken due to the use of stored functions which can't exist in the schema because the modules haven't been loaded (and due to migrating tables out-of-order, causing dependency issues).