### PR TITLE
Fix #4528: non-FX GL transaction has transaction amount 0.00

### DIFF
--- a/old/lib/LedgerSMB/GL.pm
+++ b/old/lib/LedgerSMB/GL.pm
@@ -188,8 +188,10 @@ UPDATE gl
         $debit  = $form->parse_amount( $myconfig, $form->{"debit_$i"} );
         $credit = $form->parse_amount( $myconfig, $form->{"credit_$i"} );
         $debit_fx  =
+            (not $form->{fx_transaction}) ? $debit :
             $form->parse_amount( $myconfig, $form->{"debit_fx_$i"} );
         $credit_fx =
+            (not $form->{fx_transaction}) ? $credit :
             $form->parse_amount( $myconfig, $form->{"credit_fx_$i"} );
 
 


### PR DESCRIPTION
Note that the transaction *does* have the functional currency (_bc) set
correctly.
