### PR TITLE
Increase speed of menu tests by re-using browser session

### DIFF
--- a/xt/66-cucumber/01-basic/menu.feature
+++ b/xt/66-cucumber/01-basic/menu.feature
@@ -1,4 +1,4 @@
-@one-db @weasel
+@one-db @weasel @weasel-one-session
 Feature: correct operation of the menu and immediate linked pages
   As an end-user, I want to be able to navigate the menu and open
   the screens from the available links. If my authorizations

--- a/xt/lib/PageObject/App/Menu.pm
+++ b/xt/lib/PageObject/App/Menu.pm
@@ -134,9 +134,13 @@ sub click_menu {
         for my $path (@$paths) {
             $self->session->wait_for(
                 sub {
-                    my $xpath = "./*[\@role='$role']" .
-                                "/*[\@role='presentation'" .
-                                " and .//*[\@role='treeitem' and text()='$path']]";
+                    my $xpath =
+                        "./*[\@class='dijitTreeNodeContainer']" .
+                        "/*[contains(\@class,'dijitTreeNode')" .
+                        "   and ./*[contains(\@class,'dijitTreeRow')" .
+                        "           and .//*[normalize-space(text())" .
+                        "                    =normalize-space('$path')]]]";
+
                     my $item1 = $item->find($xpath);
                     my $valid = $item1 && ($item1->get_text ne '');
                     $item = $item1 if $valid;
@@ -160,6 +164,13 @@ sub click_menu {
         maindiv->wait_for_content(replaces => $maindiv);
 }
 
+sub close_menus {
+    my ($self) = @_;
+
+    my @nodes = $self->find_all('.//*[@aria-expanded="true"'
+                                . '   and @role="treeitem"]');
+    $_->click for reverse @nodes;
+}
 
 __PACKAGE__->meta->make_immutable;
 

--- a/xt/lib/Pherkin/Extension/pageobject_steps/login_steps.pl
+++ b/xt/lib/Pherkin/Extension/pageobject_steps/login_steps.pl
@@ -10,11 +10,16 @@ use Test::More;
 use Test::BDD::Cucumber::StepFile;
 
 Given qr/a logged in admin/, sub {
-    PageObject::App::Login->open(S->{ext_wsl});
-    S->{ext_wsl}->page->body->login(
-        user => S->{"the admin"},
-        password => S->{"the admin password"},
-        company => S->{"the company"});
+    if (S->{ext_wsl}->state ne 'started') {
+        PageObject::App::Login->open(S->{ext_wsl});
+        S->{ext_wsl}->page->body->login(
+            user => S->{"the admin"},
+            password => S->{"the admin password"},
+            company => S->{"the company"});
+    }
+    else {
+        S->{ext_wsl}->page->body->menu->close_menus;
+    }
 };
 
 


### PR DESCRIPTION
Note that in order to re-use the browser session, we need to be much
more specific on which nodes we're trying to match in the menu: as it
turns out, previous failures to re-use browser sessions failed on the
menu DOM having been built up much further than when not re-using the
session -- causing the wrong DOM nodes to match the search criteria
(such as AR > Reports, when we were actually looking for
 Reports > Balancesheet).
