### PR TITLE
Fix listing asset classes

### DIFF
--- a/lib/LedgerSMB/Scripts/asset.pm
+++ b/lib/LedgerSMB/Scripts/asset.pm
@@ -129,7 +129,7 @@ Displays the asset category search screen
 
 sub asset_category_search {
     my ($request) = @_;
-    my $ac = LedgerSMB::DBObject::Asset_Class->new();
+    my $ac = LedgerSMB::DBObject::Asset_Class->new({ base => $request });
     $ac->get_metadata;
 
     my $template = LedgerSMB::Template::UI->new_UI;


### PR DESCRIPTION
Manual backport of 412c37bd4562615d1423055923312a463a16bbf4 due to differences
in LedgerSMB::PGOld.
