### PR TITLE
Fix links at bottom of CoA screen

### DIFF
--- a/lib/LedgerSMB/Scripts/journal.pm
+++ b/lib/LedgerSMB/Scripts/journal.pm
@@ -32,14 +32,35 @@ Returns and displays the chart of accounts
 sub chart_of_accounts {
     my ($request) = @_;
 
-    # Buttons on the Chart of Account screen are handled by a different script
-    $request->{script} = 'account.pl';
-
     return $request->render_report(
         LedgerSMB::Report::COA->new(_locale => $request->{_locale},
                                     dbh => $request->{dbh})
         );
 }
+
+=head2 new_account
+
+Forwards request processing to LedgerSMB::Scripts::account.
+
+=cut
+
+sub new_account {
+    # The CoA report buttons submit here, but functionality is in 'account'
+    return LedgerSMB::Scripts::account::new_account(@_);
+}
+
+=head2 new_heading
+
+Forwards request processing to LedgerSMB::Scripts::account.
+
+=cut
+
+sub new_heading {
+    # The CoA report buttons submit here, but functionality is in 'account'
+    return LedgerSMB::Scripts::account::new_heading(@_);
+}
+
+
 
 =head2 delete_account
 


### PR DESCRIPTION
Note that in order *not* to break the buttons, we need to forward
processing to the handler which truely implements the action in account.pl

Fixes #4568.
