### PR TITLE
Run fewer combinations on a single test run on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,47 +58,6 @@ addons:
 
 matrix:
   include:
-    - perl: '5.28'
-      addons:
-        postgresql: '9.6'
-        apt:
-          packages:
-            - *default_packages
-            - postgresql-9.6-pgtap
-      env:
-    - perl: '5.26'
-      addons:
-        postgresql: '9.6'
-        apt:
-          packages:
-            - *default_packages
-            - postgresql-9.6-pgtap
-      env:
-    - perl: '5.24'
-      addons:
-        postgresql: '9.6'
-        apt:
-          packages:
-            - *default_packages
-            - postgresql-9.6-pgtap
-      env:
-    - perl: '5.22'
-      addons:
-        postgresql: "9.6"
-        apt:
-          packages:
-            - *default_packages
-            - postgresql-9.6-pgtap
-      env:
-    - perl: '5.20'
-      addons:
-        postgresql: "9.6"
-        apt:
-          packages:
-            - *default_packages
-            - postgresql-9.6-pgtap
-      env:
-        - COA_TESTING=1
     - perl: '5.30'
       addons:
         postgresql: "9.6"
@@ -108,6 +67,47 @@ matrix:
             - postgresql-9.6-pgtap
       env:
         - DB_TESTING=1
+    - perl: '5.28'
+      addons:
+        postgresql: '9.6'
+        apt:
+          packages:
+            - *default_packages
+            - postgresql-9.6-pgtap
+      env:
+    # - perl: '5.26'
+    #   addons:
+    #     postgresql: '9.6'
+    #     apt:
+    #       packages:
+    #         - *default_packages
+    #         - postgresql-9.6-pgtap
+    #   env:
+    - perl: '5.24'
+      addons:
+        postgresql: '9.6'
+        apt:
+          packages:
+            - *default_packages
+            - postgresql-9.6-pgtap
+      env:
+    # - perl: '5.22'
+    #   addons:
+    #     postgresql: "9.6"
+    #     apt:
+    #       packages:
+    #         - *default_packages
+    #         - postgresql-9.6-pgtap
+    #   env:
+    - perl: '5.20'
+      addons:
+        postgresql: "9.6"
+        apt:
+          packages:
+            - *default_packages
+            - postgresql-9.6-pgtap
+      env:
+        - COA_TESTING=1
 
 before_cache:
   - mkdir -p $HOME/dojo_archive


### PR DESCRIPTION
By running fewer Perl versions (we hardly ever get different outcomes
on any of them anyway), we keep more resources for running multiple
integration runs in quick succession.
