### PR TITLE
Create an index on `trans_id` in `acc_trans`

### DIFF
--- a/sql/changes/1.7/create-trans_id-index.sql
+++ b/sql/changes/1.7/create-trans_id-index.sql
@@ -1,0 +1,2 @@
+
+CREATE INDEX acc_trans_trans_id_idx ON acc_trans(trans_id);

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -108,4 +108,5 @@ mc/delete-migration-validation-data.sql
 1.7/limit_summary_account_links.sql
 1.7/rename-menu-option-gl-search.sql
 1.7/to-location-pkeys-optimization.sql
+1.7/create-trans_id-index.sql
 1.7/fix-oe-person_id-fkey.sql


### PR DESCRIPTION
Although triggered by deleting batches being slow, lots of queries
filter or join by `trans_id`, meaning that the general speed of
responses should improve with this change.

Fixes #4449.
