### PR TITLE
Stop adding the progress bar widget more than once

### DIFF
--- a/UI/js-src/lsmb/login.js
+++ b/UI/js-src/lsmb/login.js
@@ -80,12 +80,13 @@ require([
 
    // Submit form and show a 10 seconds progress bar
    function submitForm() {
-      setIndicator();
+      showIndicator();
       window.setTimeout(showIndicator, 0);
       window.setTimeout(sendForm, 10);
       return false;
    }
 
+   setIndicator();
    // Make it public
    window.submitForm = submitForm;
 });


### PR DESCRIPTION
Adding it more than once results in unexpected behaviour of second and
further login attempts and errors in the console.
