### PR TITLE
Fix creditors/debtors account not 'sticking' between Update-s

### DIFF
--- a/old/bin/aa.pl
+++ b/old/bin/aa.pl
@@ -783,6 +783,8 @@ qq|<td><input data-dojo-type="dijit/form/TextBox" name="description_$i" size=40 
 
     $form->hide_form( "oldinvtotal", "oldtotalpaid", "taxaccounts" );
 
+     $selectARAP = $form->{"select$form->{ARAP}"};
+     $selectARAP =~ s/(\Qoption value="$form->{$form->{ARAP}}"\E)/$1 selected="selected"/;
     print qq|
         <tr class="transaction-line $form->{ARAP} total" id="line-total">
       <th align=left>$form->{invtotal}</th>
@@ -791,7 +793,7 @@ qq|<td><input data-dojo-type="dijit/form/TextBox" name="description_$i" size=40 
                                      $form->{invtotal}
                                      * $form->{exchangerate}, 2) : '') . qq|</td>
      <td><select data-dojo-type="dijit/form/Select" name="$form->{ARAP}" id="$form->{ARAP}">
-                 $form->{"select$form->{ARAP}"}
+                 $selectARAP
               </select></td>
         </tr>
         <tr>


### PR DESCRIPTION
Between clicks on Update, the Receivables/Payables account resets
back to the default value.
