### PR TITLE
Output only offending lines on failed htm schema upgrade test

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -135,6 +135,7 @@ on 'develop' => sub {
     requires 'Test::Pod', '1.00';
     requires 'Test::Pod::Coverage';
     requires 'Test2::V0';
+    requires 'Text::Diff';
     requires 'Weasel', '0.21';
     requires 'Weasel::Driver::Selenium2', '0.07';
     requires 'Weasel::Session', '0.11';

--- a/t/16-schema-upgrade-html.t
+++ b/t/16-schema-upgrade-html.t
@@ -1,6 +1,7 @@
 # Database schema upgrade pre-checks
 
 use Test2::V0;
+use Text::Diff;
 
 use Data::Dumper;
 use DBI;
@@ -16,8 +17,6 @@ Log::Log4perl->easy_init($OFF);
 use LedgerSMB;
 use LedgerSMB::Database::ChangeChecks qw( run_checks load_checks );
 use LedgerSMB::Setup::SchemaChecks qw( html_formatter_context );
-
-
 
 
 sub test_request {
@@ -38,15 +37,17 @@ sub filter_js_src {
     # perform in-place substitution of javascript paths
     # so that differences between built and unbuilt dojo
     # installations are ignored.
+    # Also make sure that we don't abort on whitespace differences
     my $lines = shift;
-    foreach my $line(@{$lines}) {
-        $line =~ s|"js-src/|"js/|g;
-    }
+    my $line = join("\n",@{$lines});
+    $line =~ s|"js-src/|"js/|g;
+    $line =~ s|\s*\n+|\n|g;
+    # Split in lines
+    @{$lines} = split(/\n/, $line);
 }
 
 
 ###############################################
-#
 #
 #  Test helper routines
 #
@@ -107,7 +108,6 @@ my $out;
 
 ###############################################
 #
-#
 #  First test: Render the description && title
 #
 ###############################################
@@ -147,23 +147,16 @@ $out = html_formatter_context {
 } test_request();
 
 filter_js_src($out);
-is join("\n", @$out), q{<!DOCTYPE html>
+
+my @expected = split (/\n/, q{<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
         <title></title>
         <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
-        
-        
         <link rel="stylesheet" href="js/dojo/resources/dojo.css" type="text/css" />
         <link rel="stylesheet" href="js/dijit/themes/claro/claro.css" type="text/css" />
-
-        
             <link rel="stylesheet" href="css/ledgersmb.css" type="text/css" />
-        
-        
             <link rel="stylesheet" href="css/setup.css" type="text/css" />
-        
-        
         <script type="text/javascript">
             var dojoConfig = {
                 async: 1,
@@ -171,12 +164,10 @@ is join("\n", @$out), q{<!DOCTYPE html>
                 packages: [{"name":"lsmb","location":"../lsmb"}]
             };
             var lsmbConfig = {
-                
             };
        </script>
         <script type="text/javascript" src="js/dojo/dojo.js"></script>
         <script type="text/javascript" src="js/lsmb/main.js"></script>
-        
         <meta name="robots" content="noindex,nofollow" />
 </head>
 <body class="claro">
@@ -188,18 +179,18 @@ is join("\n", @$out), q{<!DOCTYPE html>
     <input type="hidden" name="check_id" value="d5d3db1765287eef77d7927cc956f50a">
 <div class="description">
   <h1>title</h1>
-
   <p>
     <p>a description</p>
-
   </p>
 </div>
 </form>
-</body>}, 'print a description on failure';
+</body>});
+
+is @$out, @expected, 'Render the description && title',
+    diff $out,\@expected,{ STYLE => 'Table', CONTEXT => 2 };
 
 
 ###############################################
-#
 #
 #  Second test: Render a custom description
 #
@@ -239,23 +230,15 @@ $out = html_formatter_context {
 } test_request();
 
 filter_js_src($out);
-is join("\n", @$out), q{<!DOCTYPE html>
+@expected = split (/\n/, q{<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
         <title></title>
         <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
-        
-        
         <link rel="stylesheet" href="js/dojo/resources/dojo.css" type="text/css" />
         <link rel="stylesheet" href="js/dijit/themes/claro/claro.css" type="text/css" />
-
-        
             <link rel="stylesheet" href="css/ledgersmb.css" type="text/css" />
-        
-        
             <link rel="stylesheet" href="css/setup.css" type="text/css" />
-        
-        
         <script type="text/javascript">
             var dojoConfig = {
                 async: 1,
@@ -263,12 +246,10 @@ is join("\n", @$out), q{<!DOCTYPE html>
                 packages: [{"name":"lsmb","location":"../lsmb"}]
             };
             var lsmbConfig = {
-                
             };
        </script>
         <script type="text/javascript" src="js/dojo/dojo.js"></script>
         <script type="text/javascript" src="js/lsmb/main.js"></script>
-        
         <meta name="robots" content="noindex,nofollow" />
 </head>
 <body class="claro">
@@ -280,18 +261,18 @@ is join("\n", @$out), q{<!DOCTYPE html>
     <input type="hidden" name="check_id" value="d5d3db1765287eef77d7927cc956f50a">
 <div class="description">
   <h1>title</h1>
-
   <p>
     <p>another description</p>
-
   </p>
 </div>
 </form>
-</body>}, 'print the custom description on failure';
+</body>});
+
+is @$out, @expected, 'Render a custom description',
+    diff $out,\@expected,{ STYLE => 'Table', CONTEXT => 2 };
 
 
 ###############################################
-#
 #
 #  Third test: Render a confirmation
 #
@@ -331,23 +312,15 @@ $out = html_formatter_context {
 } test_request();
 
 filter_js_src($out);
-is join("\n", @$out), q{<!DOCTYPE html>
+@expected = split (/\n/, q{<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
         <title></title>
         <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
-        
-        
         <link rel="stylesheet" href="js/dojo/resources/dojo.css" type="text/css" />
         <link rel="stylesheet" href="js/dijit/themes/claro/claro.css" type="text/css" />
-
-        
             <link rel="stylesheet" href="css/ledgersmb.css" type="text/css" />
-        
-        
             <link rel="stylesheet" href="css/setup.css" type="text/css" />
-        
-        
         <script type="text/javascript">
             var dojoConfig = {
                 async: 1,
@@ -355,12 +328,10 @@ is join("\n", @$out), q{<!DOCTYPE html>
                 packages: [{"name":"lsmb","location":"../lsmb"}]
             };
             var lsmbConfig = {
-                
             };
        </script>
         <script type="text/javascript" src="js/dojo/dojo.js"></script>
         <script type="text/javascript" src="js/lsmb/main.js"></script>
-        
         <meta name="robots" content="noindex,nofollow" />
 </head>
 <body class="claro">
@@ -378,10 +349,13 @@ is join("\n", @$out), q{<!DOCTYPE html>
    data-dojo-type="dijit/form/Button"
    >Abc</button>
 </form>
-</body>}, 'print the button/confirmation on failure';
+</body>});
+
+is @$out, @expected, 'Render a confirmation',
+    diff $out,\@expected,{ STYLE => 'Table', CONTEXT => 2 };
+
 
 ###############################################
-#
 #
 #  Fourth test: Render multiple confirmations
 #
@@ -421,23 +395,15 @@ $out = html_formatter_context {
 } test_request();
 
 filter_js_src($out);
-is join("\n", @$out), q{<!DOCTYPE html>
+@expected = split (/\n/, q{<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
         <title></title>
         <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
-        
-        
         <link rel="stylesheet" href="js/dojo/resources/dojo.css" type="text/css" />
         <link rel="stylesheet" href="js/dijit/themes/claro/claro.css" type="text/css" />
-
-        
             <link rel="stylesheet" href="css/ledgersmb.css" type="text/css" />
-        
-        
             <link rel="stylesheet" href="css/setup.css" type="text/css" />
-        
-        
         <script type="text/javascript">
             var dojoConfig = {
                 async: 1,
@@ -445,12 +411,10 @@ is join("\n", @$out), q{<!DOCTYPE html>
                 packages: [{"name":"lsmb","location":"../lsmb"}]
             };
             var lsmbConfig = {
-                
             };
        </script>
         <script type="text/javascript" src="js/dojo/dojo.js"></script>
         <script type="text/javascript" src="js/lsmb/main.js"></script>
-        
         <meta name="robots" content="noindex,nofollow" />
 </head>
 <body class="claro">
@@ -475,10 +439,13 @@ is join("\n", @$out), q{<!DOCTYPE html>
    data-dojo-type="dijit/form/Button"
    >Def</button>
 </form>
-</body>}, 'print the buttons/confirmations on failure';
+</body>});
+
+is @$out, @expected, 'Render multiple confirmations',
+    diff $out,\@expected,{ STYLE => 'Table', CONTEXT => 2 };
+
 
 ###############################################
-#
 #
 #  Fifth test: Render a grid (2-column p-key)
 #
@@ -528,23 +495,15 @@ $out = html_formatter_context {
 } test_request();
 
 filter_js_src($out);
-is join("\n", @$out), q{<!DOCTYPE html>
+@expected = split (/\n/, q{<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
         <title></title>
         <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
-        
-        
         <link rel="stylesheet" href="js/dojo/resources/dojo.css" type="text/css" />
         <link rel="stylesheet" href="js/dijit/themes/claro/claro.css" type="text/css" />
-
-        
             <link rel="stylesheet" href="css/ledgersmb.css" type="text/css" />
-        
-        
             <link rel="stylesheet" href="css/setup.css" type="text/css" />
-        
-        
         <script type="text/javascript">
             var dojoConfig = {
                 async: 1,
@@ -552,12 +511,10 @@ is join("\n", @$out), q{<!DOCTYPE html>
                 packages: [{"name":"lsmb","location":"../lsmb"}]
             };
             var lsmbConfig = {
-                
             };
        </script>
         <script type="text/javascript" src="js/dojo/dojo.js"></script>
         <script type="text/javascript" src="js/lsmb/main.js"></script>
-        
         <meta name="robots" content="noindex,nofollow" />
 </head>
 <body class="claro">
@@ -580,10 +537,9 @@ is join("\n", @$out), q{<!DOCTYPE html>
 </tbody><input id="rowcount-grid" type="hidden" name="rowcount_grid" value="1" />
 </table>
 </form>
-</body>}, 'print the grid on failure';
+</body>});
 
-
-
-
+is @$out, @expected, 'Render a grid (2-column p-key)',
+    diff $out,\@expected,{ STYLE => 'Table', CONTEXT => 2 };
 
 done_testing;


### PR DESCRIPTION
Adjust the output so that only the differences between the expected and actual html are outputed on a failing test, to ease corrections.