### PR TITLE
Fix 'uninitialized variable' warnings in Log4perl middleware for old code

### DIFF
--- a/lib/LedgerSMB/Middleware/Log4perl.pm
+++ b/lib/LedgerSMB/Middleware/Log4perl.pm
@@ -32,6 +32,8 @@ use parent qw ( Plack::Middleware );
 
 use Log::Log4perl;
 
+use Plack::Request;
+use Plack::Util::Accessor qw( script );
 
 =head1 METHODS
 
@@ -45,9 +47,11 @@ sub call {
     my $self = shift;
     my ($env) = @_;
 
-    my $logger = Log::Log4perl->get_logger('LedgerSMB.'
-                                           . $env->{'lsmb.script_name'}
-                                           . '.' . $env->{'lsmb.action_name'});
+    my $script_name = $self->script;
+    my $action_name =
+        Plack::Request->new($env)->parameters->get('action') // '__default';
+    my $logger_name = "LedgerSMB.$script_name.$action_name";
+    my $logger = Log::Log4perl->get_logger( $logger_name );
     $env->{'psgix.logger'} = sub {
         my $args = shift;
         my $level = $args->{level};

--- a/lib/LedgerSMB/PSGI.pm
+++ b/lib/LedgerSMB/PSGI.pm
@@ -230,7 +230,8 @@ sub setup_url_space {
                 # can marshall state in, but not back out (due to forking)
                 # so have the inner scope handle serialization itself
                 inner_serialize => 1;
-            enable '+LedgerSMB::Middleware::Log4perl';
+            enable '+LedgerSMB::Middleware::Log4perl',
+                script          => $script;
             enable '+LedgerSMB::Middleware::Authenticate::Company',
                 provide_connection => 'closed',
                 default_company    => LedgerSMB::Sysconfig::default_db();
@@ -252,7 +253,8 @@ sub setup_url_space {
                 duration => 60*60*24*90;
             enable '+LedgerSMB::Middleware::DynamicLoadWorkflow',
                 script   => $script;
-            enable '+LedgerSMB::Middleware::Log4perl';
+            enable '+LedgerSMB::Middleware::Log4perl',
+                script   => $script;
             enable '+LedgerSMB::Middleware::Authenticate::Company',
                 provide_connection => 'open',
                 default_company => LedgerSMB::Sysconfig::default_db();
@@ -275,7 +277,8 @@ sub setup_url_space {
                 duration => 60*60*24*90;
             enable '+LedgerSMB::Middleware::DynamicLoadWorkflow',
                 script   => 'login.pl';
-            enable '+LedgerSMB::Middleware::Log4perl';
+            enable '+LedgerSMB::Middleware::Log4perl',
+                script   => 'login.pl';
             enable '+LedgerSMB::Middleware::Authenticate::Company',
                 provide_connection => 'none',
                 default_company => LedgerSMB::Sysconfig::default_db();
@@ -313,7 +316,8 @@ sub setup_url_space {
                 format => 'Req:%{Request-Id}i %h %l %u %t "%r" %>s %b "%{Referer}i" "%{User-agent}i"';
             enable '+LedgerSMB::Middleware::DynamicLoadWorkflow',
                 script => 'setup.pl';
-            enable '+LedgerSMB::Middleware::Log4perl';
+            enable '+LedgerSMB::Middleware::Log4perl',
+                script => 'setup.pl';
             enable '+LedgerSMB::Middleware::SetupAuthentication';
             enable '+LedgerSMB::Middleware::DisableBackButton';
             $psgi_app;


### PR DESCRIPTION
Note that the current implementation assumes the DynamicWorkflow middleware
preceeds it in its call chain. However, for old code, this isn't the case.
Instead, don't derive the name of the script from the call context, but from
the parameters passed on initialization. The action name can be had from the
request object.

Fixes #4606
