### PR TITLE
Fix #4615: Reporting units from invoice don't filter Income statement

### DIFF
--- a/old/lib/LedgerSMB/IR.pm
+++ b/old/lib/LedgerSMB/IR.pm
@@ -373,7 +373,8 @@ sub post_invoice {
 
                 # add purchase to inventory
                 push @{ $form->{acc_trans}{lineitems} },
-                  {
+                {
+                    row_num       => $i,
                     chart_id      => $form->{"inventory_accno_id_$i"},
                     amount        => $amount,
                     fxlinetotal   => $fxlinetotal,
@@ -397,7 +398,8 @@ sub post_invoice {
 
                 # add purchase to expense
                 push @{ $form->{acc_trans}{lineitems} },
-                  {
+                {
+                    row_num       => $i,
                     chart_id      => $form->{"expense_accno_id_$i"},
                     amount        => $amount,
                     fxlinetotal   => $fxlinetotal,
@@ -482,8 +484,10 @@ sub post_invoice {
         $diff   = 0;
         $fxdiff = 0;
         for my $cls(@{$form->{bu_class}}){
-            if ($form->{"b_unit_$cls->{id}_$i"}){
-             $b_unit_sth_ac->execute($cls->{id}, $form->{"b_unit_$cls->{id}_$i"});
+            if ($form->{"b_unit_$cls->{id}_$ref->{row_num}"}){
+             $b_unit_sth_ac->execute(
+                 $cls->{id},
+                 $form->{"b_unit_$cls->{id}_$ref->{row_num}"});
             }
         }
     }

--- a/old/lib/LedgerSMB/IS.pm
+++ b/old/lib/LedgerSMB/IS.pm
@@ -1142,8 +1142,10 @@ sub post_invoice {
         $diff   = 0;
         $fxdiff = 0;
         for my $cls(@{$form->{bu_class}}){
-            if ($form->{"b_unit_$cls->{id}_$i"}){
-               $b_unit_sth->execute($cls->{id}, $form->{"b_unit_$cls->{id}_$i"});
+            if ($form->{"b_unit_$cls->{id}_$ref->{row_num}"}){
+               $b_unit_sth->execute(
+                   $cls->{id},
+                   $form->{"b_unit_$cls->{id}_$ref->{row_num}"});
             }
         }
     }


### PR DESCRIPTION
IS.pm and IR.pm failed to recognise and insert the reporting units from the
UI as values linked to the `acc_trans` table. (They succesfully link to the
`invoice` table, to reproduce the UI, though.)

Note that the `row_num` was already set up correctly in IS.pm; possibly, it
is part of an initial attempt to fix this problem. For IR.pm the same was
missing. This commit simply *uses* the row numbers to feed the INSERT.
