### PR TITLE
Fix #4645: manual taxes double-counted on invoice (but not on-screen)

### DIFF
--- a/old/bin/io.pl
+++ b/old/bin/io.pl
@@ -1114,13 +1114,6 @@ sub print {
     if ($form->{type} eq 'invoice') {
         &invoice_links;
         &prepare_invoice;
-
-        if ($form->{vc} eq 'vendor') {
-            IR->retrieve_invoice(\%myconfig, $form);
-        }
-        else {
-            IS->retrieve_invoice(\%myconfig, $form);
-        }
     }
     else {
         &order_links;


### PR DESCRIPTION
Note that this issue seems to be caused by double-calling of
IS/IR->retrieve_invoice(), which next to in the current sub is also called
in &invoice_links().
