### PR TITLE
Spellchecked markdown files

### DIFF
--- a/.spelling
+++ b/.spelling
@@ -1,0 +1,35 @@
+# markdown-spellcheck spelling configuration file
+# Format - lines beginning # are comments
+# global dictionary is at the start, file overrides afterwards
+# one word per line, to define a file override use ' - filename'
+# where filename is relative to this configuration file
+systemd
+ledgersmb
+httpd
+plackup
+starman
+debian
+lighttpd
+javascript
+unbuilt
+preforks
+preloads
+perl
+plack
+FCGI
+readme
+rfqs
+e.g.
+i.e.
+daemonizing
+updatable
+apache-vhost
+unbuilt-dojo
+submodules
+README.md
+travis-ci
+travis
+RedHat
+prepended
+accessor
+accessors

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ Small and Medium business accounting and ERP
 # SYNOPSIS
 
 LedgerSMB is a free integrated web application accounting system, featuring
-double entry accounting, budgetting, invoicing, quotations, projects, timecards,
+double entry accounting, budgeting, invoicing, quotations, projects, timecards,
 inventory management, shipping and more ...
 
 The UI allows world-wide accessibility; with its data stored in the
-enterprise-strength PostgreSQL open source database system, the system is known
+enterprise-strength `PostgreSQL` open source database system, the system is known
 to operate smoothly for businesses with thousands of transactions per week.
 Screens and customer visible output are defined in templates, allowing easy and
 fast customization. Supported output formats are PDF, CSV, HTML, ODF and more.
@@ -40,9 +40,9 @@ and [current 1.7 version](https://github.com/ledgersmb/LedgerSMB/tree/1.7#system
 
 ## Server
 
-* Perl 5.20+
-* PostgreSQL 9.4+
-* Web server (e.g. nginx, Apache, lighttpd)
+* `Perl 5.20+`
+* `PostgreSQL 9.4+`
+* Web server (e.g. `nginx`, `Apache`, `lighttpd`, `Varnish`)
 
 The web external server is only required for production installs;
 for evaluation purposes a simpler setup can be used, as detailed
@@ -50,21 +50,21 @@ below.
 
 ## Client
 
-A [Dojo 1.15 compatible web browser](http://dojotoolkit.org/reference-guide/1.10/releasenotes/1.10.html#user-agent-support)
+A [`Dojo` 1.15 compatible web browser](http://dojotoolkit.org/reference-guide/1.10/releasenotes/1.10.html#user-agent-support)
 is all that's required on the client (except IE8 and 9); it includes all
-current versions of Chrome and FireFox as of 3.6, as well as MS Internet
-Explorer as of version 10 and a wide range of mobile browsers.
+current versions of `Chrome` and `FireFox` as of 3.6, as well as `MS Internet
+Explorer` as of version 10 and a wide range of mobile browsers.
 
-# Quick start (Docker compose)
+# Quick start (`Docker compose`)
 
-The quickest way to get the Docker image up and running is by using the
-docker-compose file available through the GitHub repository at:
+The quickest way to get the `Docker` image up and running is by using the
+docker-compose file available through the `GitHub` repository at:
 
 https://github.com/ledgersmb/ledgersmb-docker/blob/1.7/docker-compose.yml
 
 which sets up both the LedgerSMB image and a supporting database image for
 production purposes (i.e. with persistent (database) data, with the
-exception of one thing: setting up an Nginx or Apache reverse proxy
+exception of one thing: setting up an `Nginx` or `Apache` reverse proxy
 with TLS 1.2 support -- a requirement if you want to access your
 installation over any type of network.
 
@@ -79,28 +79,28 @@ for **production** installs.
 ## System (library) dependencies
 
 The following non-Perl (system) dependencies need to be in place for the
-```cpanm``` command mentioned below to work, in addition to what's documented
+`cpanm` command mentioned below to work, in addition to what's documented
 on the [How to install CPAN modules](http://www.cpan.org/modules/INSTALL.html)
 page on CPAN.
 
-* cpanminus  This can be manually installed, or installed as a system package.
-  It may not be necessary to install cpanminus if you are only going to install
+* `cpanminus`  This can be manually installed, or installed as a system package.
+  It may not be necessary to install `cpanminus` if you are only going to install
   from debian packages.
-* PostgreSQL client libraries
-* PostgreSQL server
-* DBD::Pg 3.4.2+ (so cpanm recognises that it won't need to compile it)
-  This package is called `libdbd-pg-perl` in Debian and `perl-DBD-Pg`
-  in RedHat/Fedora
-* make       This is used by cpan dependencies during thier build process
+* `PostgreSQL` client libraries
+* `PostgreSQL` server
+* `DBD::Pg 3.4.2+` (so `cpanm` recognizes that it won't need to compile it)
+  This package is called `libdbd-pg-perl` in `Debian` and `perl-DBD-Pg`
+  in `RedHat/Fedora`
+* `make`       This is used by `cpan` dependencies during their build process
 
 Then, some of the features listed below have system requirements as well:
 
-* latex-pdf-ps depends on these binaries or libraries:
-  * latex (usually provided through a texlive package)
-  * pdflatex
-  * dvipdfm
-  * dvips
-  * pdf2ps
+* `latex-pdf-ps` depends on these binaries or libraries:
+  * `latex` (usually provided through a `texlive` package)
+  * `pdflatex`
+  * `dvipdfm`
+  * `dvips`
+  * `pdf2ps`
 
 ## Perl module dependencies
 
@@ -110,41 +110,42 @@ your distribution's package repository (Debian calls them `liblocal-lib-perl`
 and `cpanminus` respectively). `cpanm` depends on the `make` and `gcc` commands
 being available.
 
-NOTE: gcc can be removed after all cpan dependencies are installed.
+NOTE: `gcc` can be removed after all `cpan` dependencies are installed.
       However, it may be necessary to reinstall it if additional modules are
       required during an upgrade
 
-To install the Perl module dependencies, run:
+To install the `Perl` module dependencies, run:
 
 ```sh
  cpanm --quiet --notest --with-feature=starman [other features] --installdeps .
 ```
 
-NOTE: Don't miss the "." at the end of the cpanm command!
+NOTE: Don't miss the "." at the end of the `cpanm` command!
 Don't forget to make sure the environment variable
-`PERL5LIB=/home/ledgersmb/perl5/lib/perl5` points at the running user's perl5 dir
-Also, NEVER run cpanm as root, it's best to run it as the user you intend to
-run ledgersmb as when possible. This installs the cpan modules in `~/perl5`
+`PERL5LIB=/home/ledgersmb/perl5/lib/perl5` points at the running user's `perl5` dir
+Also, NEVER run `cpanm` as root, it's best to run it as the user you intend to
+run ledgersmb as when possible. This installs the `cpan` modules in `~/perl5`
+
 If you can't run it as the final user, don't worry, just run it as any
-user (eg: johnny), and make sure the environment variable
-`PERL5LIB=/home/johhny/perl5/lib/perl5` points at jonny's perl5 dir
+user (e.g.: johnny), and make sure the environment variable
+`PERL5LIB=/home/johnny/perl5/lib/perl5` points at johnny's `perl5` directory
 
 Setting the `PERL5` environment variable is normally done by editing the
-initscript, or systemd service file. If you are running manually, then you will
-need to set and export `PERL5` before running starman/plack
+`initscript`, or `systemd` service file. If you are running manually, then you will
+need to set and export `PERL5` before running `starman/plack`
 
 The following features may be selected by
-specifying ```--with-feature=<feature>```:
+specifying `--with-feature=<feature>`:
 
 | Feature          | Description                         |
 |------------------|-------------------------------------|
-| latex-pdf-ps     | Enable PDF and PostScript output    |
-| starman          | Starman Perl/PSGI webserver         |
-| openoffice       | OpenOffice.org document output      |
-| edi              | (EXPERIMENTAL) X12 EDI support      |
-| xls              | Excel output filters (xls+xlsx)     |
+| `latex-pdf-ps`     | Enable PDF and `PostScript` output    |
+| `starman`          | `Starman Perl/PSGI webserver`         |
+| `openoffice`       | `OpenOffice.org` document output      |
+| `edi`              | (EXPERIMENTAL) X12 EDI support      |
+| `xls`              | `Excel` output filters (`xls+xlsx`)     |
 
-Note: The example command contains ```--with-feature=starman``` for the
+Note: The example command contains `--with-feature=starman` for the
 purpose of the quick start.
 
 When not installing as root or through `sudo`, `cpanm` will install unfulfilled
@@ -156,11 +157,11 @@ number of dependencies installed from CPAN.
 
 **NOTES**
 
- 1. For the pdf-ps target, LaTeX is required.
+ 1. For the `pdf-ps` target, `LaTeX` is required.
 
-## PostgreSQL configuration
+## `PostgreSQL` configuration
 
-While it's possible to use LedgerSMB with the standard ```postgres``` user,
+While it's possible to use LedgerSMB with the standard `postgres` user,
 it's good practice to create a separate 'LedgerSMB database administrator':
 
 ```plain
@@ -189,8 +190,8 @@ host    all                            all             ::1/128          md5
  > Note: `pg_hba.conf` can be found in `/etc/postgresql/<version>/main/` on Debian
  >  and in `/var/lib/pgsql/data/` on RedHat/Fedora
 
-After editing the ```pg_hba.conf``` file, reload the PostgreSQL server
-(or without 'sudo' by running the commands as root user):
+After editing the `pg_hba.conf` file, reload the `PostgreSQL server`
+(or without `sudo` by running the commands as root user):
 
 ```sh
  $ sudo service postgresql reload
@@ -203,7 +204,7 @@ After editing the ```pg_hba.conf``` file, reload the PostgreSQL server
 (Installation from tarball is highly preferred over installation from GitHub for
 production installs.)
 
-```bash
+```sh
  cp doc/conf/ledgersmb.conf.default ledgersmb.conf
 ```
 
@@ -216,7 +217,7 @@ With the above steps completed, the system is ready to run the web server:
  >     Instead, if you need to start LedgerSMB from a root process, drop
  >     privileges to a user that doesn't have write access to the LedgerSMB
  >     Directories first.
- >     Most daemonising mechanisms (eg: systemd) provide a mechanism to do this.
+ >     Most daemonizing mechanisms (e.g.: systemd) provide a mechanism to do this.
  >     Do not use the starman --user= mechanism, it currently drops privileges
  >     too late.
 
@@ -232,14 +233,15 @@ Setting gid to "1000 1000 24 25 27 29 30 44 46 108 111 121 1000"
 
 ## Environment Variables
 
-All regular Perl environment variables can be used. In particular, it's
+All regular `Perl` environment variables can be used. In particular, it's
 important to make sure `PERL5LIB` is set correctly when setting up `local::lib`
 for the first time.
 
 We support the following Environment Variables within our code
 
-* LSMB_WORKINGDIR : Optional
-  * Causes a chdir to the specified directory as the first thing done in starman.psgi
+* `LSMB_WORKINGDIR` : Optional
+  * Causes a `chdir` to the specified directory as the first thing done in
+    `starman.psgi`
   * If not set the current dir is used.
   * An example would be
 
@@ -247,44 +249,43 @@ We support the following Environment Variables within our code
   LSMB_WORKINGDIR='/usr/local/ledgersmb/'
   ```
 
-
 We support the following Environment Variables for our dependencies
 
-* PGHOST : Optional
-  * Specifies the Postgres server Domain Name or IP address
-* PGPORT : Optional
-  * Sepcifies the Postgres server Port
-* PGSSLMODE : Optional
-  * Enables SSL for the Postgres connection
+* `PGHOST` : Optional
+  * Specifies the `Postgres server` Domain Name or IP address
+* `PGPORT` : Optional
+  * Specifies the `Postgres server` Port
+* `PGSSLMODE` : Optional
+  * Enables SSL for the `Postgres` connection
 
 All Environment Variables supported by our dependencies should be passed
-through to them, that includes the standard Postgres Variables and others
+through to them, that includes the standard `Postgres` Variables and others
 
 
 ## Next steps
 
 The system is installed and should be available for evaluation through
 
-* http://localhost:5762/setup.pl    # creation and privileged management of
+* `http://localhost:5762/setup.pl`    # creation and privileged management of
                                       company databases
-* http://localhost:5762/login.pl    # Normal login for the application
+* `http://localhost:5762/login.pl`    # Normal login for the application
 
 The system is ready for [preparation for first
 use](http://ledgersmb.org/topic/preparing/preparing-ledgersmb-15-first-use).
 
 # Project information
 
-Web site: [http://ledgersmb.org/](http://ledgersmb.org)
+Web site: [`http://ledgersmb.org/`](http://ledgersmb.org)
 
 Live chat:
 
-* IRC: [freenode #ledgersmb](irc://irc.freenode.net/#ledgersmb)
-* Matrix: [#ledgersmb:matrix.org](https://vector.im/#/room/#ledgersmb:matrix.org)
+* IRC: [`freenode #ledgersmb`](irc://irc.freenode.net/#ledgersmb)
+* Matrix: [`#ledgersmb:matrix.org`](https://vector.im/#/room/#ledgersmb:matrix.org)
   (bridged IRC channel)
 
-Forums: [http://forums.ledgersmb.org/](http://forums.ledgersmb.org/)
+Forums: [`http://forums.ledgersmb.org/`](http://forums.ledgersmb.org/)
 
-Mailing list archives: [http://archive.ledgersmb.org](http://archive.ledgersmb.org)
+Mailing list archives: [`http://archive.ledgersmb.org`](http://archive.ledgersmb.org)
 
 Mailing lists:
 
@@ -292,15 +293,15 @@ Mailing lists:
 * [User Discussion](https://lists.ledgersmb.org/mailman/listinfo/users)
 * [Developer Discussion](https://lists.ledgersmb.org/mailman/listinfo/devel)
 
-Repository: https://github.com/ledgersmb/LedgerSMB
+Repository: `https://github.com/ledgersmb/LedgerSMB`
 
 ## Project contributors
 
-Source code contributors can be found in the project's Git commit history
+Source code contributors can be found in the project's `Git` commit history
 as well as in the CONTRIBUTORS file in the repository root.
 
-Translation contributions can be found in the project's Git commit history
-as well as in the Transifex project Timeline.
+Translation contributions can be found in the project's `Git` commit history
+as well as in the `Transifex` project Timeline.
 
 
 # Copyright
@@ -312,4 +313,4 @@ Copyright (c) 1999 - 2006 DWS Systems Inc (under the name SQL Ledger)
 
 # License
 
-[GPLv2](http://open-source.org/licenses/GPL-2.0)
+[`GPLv2`](http://open-source.org/licenses/GPL-2.0)

--- a/UI/js-src/README.md
+++ b/UI/js-src/README.md
@@ -1,8 +1,8 @@
-Dojo source files are no longer included in LedgerSMB.
+`Dojo` source files are no longer included in LedgerSMB.
 
-The directories here are git submodules.
+The directories here are `git` submodules.
 
-To load them from the upstream gitsources, make sure you are in the project
+To load them from the upstream `gitsources`, make sure you are in the project
 root and enter:
 
 ```bash
@@ -10,14 +10,14 @@ git submodule init
 git submodule update
 ```
 
-This will check out current releases of Dojo, Dijit, and Utils.
+This will check out current releases of `Dojo`, `Dijit`, and `Dojo/Util`.
 
-To rebuild the dojo and lsmb javascript, you should have node.js installed.
-Change into the UI/js-src/lsmb directory, and run:
+To rebuild the `dojo` and `lsmb` `javascript`, you should have `node.js` installed.
+Change into the `UI/js-src/lsmb` directory, and run:
 
 ```bash
 ../util/buildscripts/build.sh --profile lsmb.profile.js
 ```
 
 This command will clear out the `UI/js/` directory and create a new build of all
-Javascript files.
+`Javascript` files.

--- a/doc/conf/README.md
+++ b/doc/conf/README.md
@@ -1,6 +1,6 @@
-# The files in this dir are sample config files
+# The files in this directory are sample configuration files
 
-You should not modify any files directly in this dir.
+You should not modify any files directly in this directory.
 Rather you should copy the ones you need into their correct locations and edit
 the copies to match your installation
 
@@ -9,54 +9,54 @@ the copies to match your installation
 * systemd
 This directory provides sample systemd service files to run ledgersmb on boot
 
-## Httpd & cache daemon config files
+## Httpd & cache daemon configuration files
 
 We don't directly serve LedgerSMB via the HTTP Daemon, rather we use the daemon
 to reverse proxy to a plackup or starman instance.
 This is done for security, flexibility and web acceleration.
-ONLY one of these should be copied into the appropriate system config dir and
-modified as explained within the file.
-On debian systems it would be a subdir of /etc/nginx/ or /etc/apache/
+ONLY one of these should be copied into the appropriate system configuration
+directory and modified as explained within the file.
+On debian systems it would be a sub-directory of `/etc/nginx/` or `/etc/apache/`
 
-* apache-vhost.conf
-Sample apache config file
-* lighttpd-vhost.conf
-Sample lighttpd config file
-* nginx-vhost.conf
-Sample nginx config file
-* default.vcl
-Sample Varnish config file
+* `apache-vhost.conf`
+Sample `apache` configuration file
+* `lighttpd-vhost.conf`
+Sample `lighttpd` configuration file
+* `nginx-vhost.conf`
+Sample `nginx` configuration file
+* `default.vcl`
+Sample `Varnish` configuration file
 
-## LedgerSMB config files
+## LedgerSMB configuration files
 
-One of these should be copied into the ledgersmb install dir unless the
+One of these should be copied into the ledgersmb install directory unless the
 location is overridden with an environment variable.
 
-* ledgersmb.conf.default
-a "normal" config, it uses the bundled built Dojo and is the preferred config
-* ledgersmb.conf.unbuilt-dojo
+* `ledgersmb.conf.default`
+a "normal" configuration, it uses the bundled built `Dojo` and is the preferred configuration
+* `ledgersmb.conf.unbuilt-dojo`
 
 If installing using a tarball or system package, this file should only be used.
 
-If local changes to any of our Dojo, Javascript, or HTML resources are made.
+If local changes to any of our `Dojo`, `Javascript`, or `HTML` resources are made.
 
 However if running from a git or other source install, then you will either need
-to run with unbuilt-dojo (src) or pull in our submodules and build our Dojo target.
+to run with unbuilt-dojo (`src`) or pull in our submodules and build our `Dojo` target.
 
-__WARNING:__ Running with unbuilt Dojo will have a noticable performance
+__WARNING:__ Running with unbuilt `Dojo` will have a noticeable performance
 reduction in most cases.
 
 ## Other Files
 
-* README.md
+* `README.md`
 This readme file of course ;-)
 
 ## Testing infrastructure files
 
 These files are not for normal use,
-they are intended for use on the travis-ci testing servers
+they are intended for use on the `travis-ci` testing servers
 
-* ledgersmb.conf.travis-ci
-ledgersmb.conf file configured for running tests on travis
-* nginx-travis.conf
-httpd config file configured for running tests on travis
+* `ledgersmb.conf.travis-ci`
+`ledgersmb.conf` file configured for running tests on `travis`
+* `nginx-travis.conf`
+httpd configuration file configured for running tests on `travis`

--- a/doc/conf/systemd/README.md
+++ b/doc/conf/systemd/README.md
@@ -1,45 +1,45 @@
-# Config files for systemd to start LedgerSMB on boot
+# Configuration files for systemd to start LedgerSMB on boot
 
-You should not modify any files directly in this dir.
+You should not modify any files directly in this directory.
 Rather you should copy the ones you need into their correct locations and edit
 the copies to match your installation
 
-* README.md
+* `README.md`
 This file of course ;-)
 
-## Config Files
+## Configuration Files
 
-ONLY one of these should be copied into the appropriate system config dir and
-modified as explained within the file.
+ONLY one of these should be copied into the appropriate system configuration
+directory and modified as explained within the file.
 On debian systems it would be `/etc/systemd/system/`
 
-* ledgersmb_starman.service
+* `ledgersmb_starman.service`
 The recommended way to run the LedgerSMB service.
-Starman preforks and preloads a number of workers and all code.
+`Starman` preforks and preloads a number of workers and all code.
 This is known to be a performance gain over other ways of running perl web
 applications
-* ledgersmb-development_plackup.service
+* `ledgersmb-development_plackup.service`
 A development profile that runs LedgerSMB directly under plackup instead of
-starman, it WILL be slower, as it neither preloads, nor preforks.
+`starman`, it WILL be slower, as it neither preloads, nor preforks.
 It also monitors most files for changes allowing development without constant
 reloading of the service.
 If the appropriate dependencies are installed, it will also enable a debugger
 pane that can be accessed from your browser.
-* ledgersmb_plackup.service
-A legacy file that can be expected to be removed. __DON"T USE IT__
-* ledgersmb_plack-fcgi.service
+* `ledgersmb_plackup.service`
+A legacy file that can be expected to be removed. __DON'T USE IT__
+* `ledgersmb_plack-fcgi.service`
 This file runs LedgerSMB under plack as an FCGI process, it's not tested as
 well as running under starman, and is believed to not perform as well either.
 
 ## NOTE
 
-LedgerSMB should be run under starman or another plack runner,
+LedgerSMB should be run under `starman` or another `plack` runner,
 *but* it should not be directly exposed to a network this way.
 Instead it should be served behind a Reverse Proxy.
-There are many httpd's that can act as a reverse proxy, including,
+There are many `httpd`'s that can act as a reverse proxy, including,
 but not limited to:
 
-* nginx
-* apache
-* lighttpd
-* varnish
+* `nginx`
+* `apache`
+* `lighttpd`
+* `varnish`

--- a/doc/database/README.md
+++ b/doc/database/README.md
@@ -1,5 +1,5 @@
 
-# ledgersmb-database-doc
+# `ledgersmb-database-doc`
 
 Database documentation to assist LedgerSMB users and developers
 
@@ -11,70 +11,70 @@ Copyright (c) 2006 - 2017 LedgerSMB Project
 
 ## Scripted
 
-You will need at least postgresql_autodoc and graphviz installed
+You will need at least `postgresql_autodoc` and `graphviz` installed
 on your system.
 
 The script found here will automatically build the docs and images,
-outputing them into /tmp/LedgerSMB-doc:
+outputting them into `/tmp/LedgerSMB-doc`:
 
 ```bash
  utils/devel/regen_db_docs.sh`
 ```
 
-regen_db_docs.sh takes 2 arguments
+`regen_db_docs.sh` takes 2 arguments
 
 * `--release`: only for use during the official release process.
-* `--statistics`: generates table statistics using the pgstattuple extension
+* `--statistics`: generates table statistics using the `pgstattuple` extension
 
-regen_db_docs.sh will use these environment variables
+`regen_db_docs.sh` will use these environment variables
 
-* PGHOST
-* PGUSER
-* PGPORT
-* PGDATABASE
-* PGPASSWORD
+* `PGHOST`
+* `PGUSER`
+* `PGPORT`
+* `PGDATABASE`
+* `PGPASSWORD`
 
-It uses a password from $PGPASSWORD, ~/.pgpass, or falls back to asking the
+It uses a password from `$PGPASSWORD`, `~/.pgpass`, or falls back to asking the
 user for a password.
 
-Viewing the .svg or .svg.html versions of the images will likely provide
+Viewing the `.svg` or `.svg.html` versions of the images will likely provide
 the best user experience
 
 ## Manually
 
 Alternatively you can generate the documentation manually with
 
-* PostgreSQL Autodoc - https://github.com/cbbrowne/autodoc
+* [`PostgreSQL Autodoc`](https://github.com/cbbrowne/autodoc)
 
-    postgresql_autodoc -d <databasename> -u postgres -f ledgersmb
+    `postgresql_autodoc -d <databasename> -u postgres -f ledgersmb`
 
-* GraphViz - http://graphviz.org/
+* [`GraphViz`](http://graphviz.org/)
 
 
-The ledgersmb.dot file from PostgreSQL Autodoc is a text output meant to
-be processed by GraphViz (or a compatible program), to make a image of
+The `ledgersmb.dot` file from `PostgreSQL Autodoc` is a text output meant to
+be processed by `GraphViz` (or a compatible program), to make a image of
 all the database tables in LedgerSMB.
 
-Use the dot utility from GraphViz, to export a SVG image (Scalable Vector
+Use the dot utility from `GraphViz`, to export a `SVG` image (Scalable Vector
 Graphics)
 
 ```bash
     dot -Tsvg <databasename>.dot -o <databasename>.svg
 ```
 
-You can open <databasename>.svg in many image viewers, or your web browser
+You can open `<databasename>.svg` in many image viewers, or your web browser
 and zoom in our out on the image.
 
-Use the dot utility from GraphViz, to export a PDF. NOTE: the PDF has a
-large number of elements, and will be slow to load, and may have limited
-zoom capabilities in some viewers
+Use the dot utility from `GraphViz`, to export a PDF.
+_NOTE_: the PDF has a large number of elements, and will be slow to load, and may
+have limited zoom capabilities in some viewers
 
 ```bash
     dot -Tpdf <databasename>.dot -o <databasename>.pdf
 ```
 
-Use the dot utility from GraphViz, to export a PNG image:  NOTE: This is
-a large image, and while readable, the resolution is not great.
+Use the dot utility from `GraphViz`, to export a PNG image:
+NOTE: This is a large image, and while readable, the resolution is not great.
 
 ```bash
     dot -Tpng <databasename>.dot -o <databasename>.png

--- a/locale/README.md
+++ b/locale/README.md
@@ -1,66 +1,76 @@
 Between LedgerSMB 1.1.1 and LedgerSMB 1.2, translations were changed to using a
-standard naming scheme and formatting.  Upon upgrade, you may find that
-LedgerSMB displays in a language different to which you previously configured, 
-i.e. Swedish instead of Spanish, or more likely, English.  The table below
-contains the mapping of old name to new name that is used in the user config
-files.
+standard naming scheme and formatting.
 
-be_fr	-> fr_BE
-be_nl	-> nl_BE
-bg_utf	-> bg
-br	-> pt_BR
-ca_en	-> en_CA
-ca_fr	-> fr_CA
-ch	-> de_CH
-ch_utf	-> de_CH
-cn_utf	-> zh_CN
-co	-> es_CO
-co_utf	-> es_CO
-ct	-> ca
-cz	-> cs
-de	-> de
-de_utf	-> de
-dk	-> da
-ec	-> es_EC
-ee	-> ee
-ee_utf	-> ee
-eg_utf	-> ar_EG
-en_GB	-> en_GB
-es	-> es
-es_utf	-> es
-fi	-> fi
-fi_utf	-> fi
-fr	-> fr
-gr	-> el
-hu	-> hu
-id	-> id
-is	-> is
-it	-> it
-lt	-> lt
-lv	-> lv
-mx	-> es_MX
-nb	-> nb
-nl	-> nl
-pa	-> es_PA
-pl	-> pl
-pt	-> pt
-py	-> es_PY
-ru	-> ru
-ru_utf	-> ru
-se	-> sv
-sv	-> es_SV
-tr	-> tr
-tw_big5	-> zh_TW
-tw_utf	-> zh_TW
-ua	-> uk
-ua_utf	-> uk
-ve	-> es_VE
+Upon upgrade, you may find that LedgerSMB displays in a language different to
+which you previously configured, for example, Swedish instead of Spanish,
+or, more likely, English.
+
+The table below contains the mapping of old name to new name that is used in
+the user configuration files.
+
+|old|new|
+|----:|----:|
+|`be_fr`|`fr_BE`|
+|`be_nl`|`nl_BE`|
+|`bg_utf`|`bg`|
+|`br`|`pt_BR`|
+|`ca_en`|`en_CA`|
+|`ca_fr`|`fr_CA`|
+|`ch`|`de_CH`|
+|`ch_utf`|`de_CH`|
+|`cn_utf`|`zh_CN`|
+|`co`|`es_CO`|
+|`co_utf`|`es_CO`|
+|`ct`|`ca`|
+|`cz`|`cs`|
+|`de`|`de`|
+|`de_utf`|`de`|
+|`dk`|`da`|
+|`ec`|`es_EC`|
+|`ee`|`ee`|
+|`ee_utf`|`ee`|
+|`eg_utf`|`ar_EG`|
+|`en_GB`|`en_GB`|
+|`es`|`es`|
+|`es_utf`|`es`|
+|`fi`|`fi`|
+|`fi_utf`|`fi`|
+|`fr`|`fr`|
+|`gr`|`el`|
+|`hu`|`hu`|
+|`id`|`id`|
+|`is`|`is`|
+|`it`|`it`|
+|`lt`|`lt`|
+|`lv`|`lv`|
+|`mx`|`es_MX`|
+|`nb`|`nb`|
+|`nl`|`nl`|
+|`pa`|`es_PA`|
+|`pl`|`pl`|
+|`pt`|`pt`|
+|`py`|`es_PY`|
+|`ru`|`ru`|
+|`ru_utf`|`ru`|
+|`se`|`sv`|
+|`sv`|`es_SV`|
+|`tr`|`tr`|
+|`tw_big5`|`zh_TW`|
+|`tw_utf`|`zh_TW`|
+|`ua`|`uk`|
+|`ua_utf`|`uk`|
+|`ve`|`es_VE`|
 
 
 Examples of translation-coding
-in source-file:
- $locale->text( 'Edit Preferences for [_1]', $form->{login} );
 
-in locale/po/nl_BE:
+in source-file:
+
+ `$locale->text( 'Edit Preferences for [_1]', $form->{login} );`
+
+in `locale/po/nl_BE`:
+
+```.po
  msgid "Edit Preferences for %1"
  msgstr "Instellingen aanpassen voor %1"
+```

--- a/t/README.md
+++ b/t/README.md
@@ -1,5 +1,4 @@
 
-
 # Running the tests
 
 ```sh
@@ -9,8 +8,8 @@
 will run tests, depending on the installed features and environment
 variables. See below for info on setting environment variables.
 
-To run the '66' tests, the following works with the right PostgreSQL,
-PhantomJS and Starman configurations:
+To run the '66' tests, the following works with the right `PostgreSQL`,
+`PhantomJS` and `Starman` configurations:
 
 ```sh
  $ PGUSER=postgres PGPASSWORD=password \
@@ -20,13 +19,11 @@ PhantomJS and Starman configurations:
 ```
 
 Note that the '66' tests may be run at a much smaller granularity
-as documented in the [specific README file](66-cucumber/README.md).
-
+as documented in the [specific `README` file](66-cucumber/README.md).
 
 # Test summary
 
-
-````plain
+```plain
 00 - 09: General base checks
 10 - 39: Module checks, no LSMB database required
      40: Set up test LSMB database
@@ -36,20 +33,19 @@ as documented in the [specific README file](66-cucumber/README.md).
 60 - 88: Interface checks
      89: Clean up test LSMB database
 90 - 99: Packaging checks
-````
+```
 
 Special notes on specific test cases:
 
-## 43-dbtest.t
+## `43-dbtest.t`
 
-This runs defined test cases from sql/modules/test/.  If new
+This runs defined test cases from `sql/modules/test/`.  If new
 scripts are added, they must be listed in this script as well.
 
-## 62-api.t
+## `62-api.t`
 
 Runs on the database non-destructively, by rolling back commits.
-Uses request hashes defined in xt/data/62-request-data.
-
+Uses request hashes defined in `xt/data/62-request-data`.
 
 # ENVIRONMENT VARIABLES
 
@@ -57,7 +53,7 @@ Environment variables are used to provide inputs for tests >= 40.
 
 ## For database tests (40 - 89)
 
-````plain
+```plain
 LSMB_TEST_DB        enables this set of tests
 PGUSER              username for logging in in PostgreSQL
 PGPASSWORD          password for above username
@@ -66,37 +62,35 @@ PGDATABASE          database to test against, if LSMB_NEW_DB not provided
 LSMB_INSTALL_DB     if set, database will NOT be removed after tests are run
 LSMB_BASE_URL       address used for requests to lsmb (may be a proxy)
 PSGI_BASE_URL       address used to test if plack/starman server is running
-````
+```
 
 ### Admin user creation
 
 For the interface checks (60-88), at least an admin user is required to log
 into the application.
 
-````plain
+```plain
 LSMB_ADMIN_USERNAME username for admin user
 LSMB_ADMIN_PASSWORD password for admin user
 LSMB_ADMIN_FNAME    Admin's first name
 LSMB_ADMIN_LNAME    Admin's last name
 LSMB_COUNTRY_CODE   Country code for administrator and for loading chart of
                     accounts
-````
+```
 
 ### Chart of accounts loading
 
 When a new company is being created,
 
-````plain
+```plain
 LSMB_LOAD_COA       name of the Chart of Accounts file, not including extension
 LSMB_LOAD_GIFI      name of the GIFI file, not including extension
 LSMB_COUNTRY_CODE   Country code for administrator and for loading chart of
                     accounts
-````
-
-
+```
 
 ## For database cleanup test (89)
 
-If the variable LSMB_INSTALL_DB is set, the database will NOT be removed after
+If the variable `LSMB_INSTALL_DB` is set, the database will _NOT_ be removed after
 test cases are run.  Should be used with the `admin user creation` and
 `chart of accounts loading` variables.

--- a/utils/devel/README.md
+++ b/utils/devel/README.md
@@ -4,46 +4,46 @@
 Copyright (c) 2006 - 2020 LedgerSMB Project
 ```
 
-Licensed under the GPLv2 a copy of which can be found in /LICENSE
+Licensed under the `GPLv2` a copy of which can be found in `/LICENSE`
 
 For more information about any of these files, Read The Source Luke
 
-## extract_mimes.sh
+## `extract_mimes.sh`
 
-Searches /usr/share/mime for freedesktop.xml files and builds a list of sql
-statements for populating the mime_types table
+Searches `/usr/share/mime` for `freedesktop.xml` files and builds a list of
+`sql` statements for populating the `mime_types` table
 
-## extract-perl
+## `extract-perl`
 
-Scans various Perl files for translatable strings
+Scans various `Perl` files for translatable strings
 
-## extract-sql
+## `extract-sql`
 
-Scans various SQL files for translatable strings
+Scans various `SQL` files for translatable strings
 
-## extract-template-translations
+## `extract-template-translations`
 
 Scans various Template files for translatable strings
 
-## generate-language-table-contents.pl
+## `generate-language-table-contents.pl`
 
 Scans the locale directory and read in the LANGUAGE files
 
-## rebuild_pot.sh
+## `rebuild_pot.sh`
 
 Rebuilds the language file
 
-## regen_db_docs.sh
+## `regen_db_docs.sh`
 
-This is a utility which will run through PostgreSQL system tables and returns
+This is a utility which will run through `PostgreSQL` system tables and returns
 HTML, DOT, and several styles of XML which describe the database.
 
 As a result, documentation about a project can be generated quickly and be
 automatically updatable, yet have a quite professional look
 
-## wc-pot-file
+## `wc-pot-file`
 
-A script to generate some stats on our currently translateable strings.
+A script to generate some stats on our currently translatable strings.
 
 ```bash
 usage:

--- a/utils/diagnostics/t/README.md
+++ b/utils/diagnostics/t/README.md
@@ -1,16 +1,17 @@
-This README explains a bit about the scripts in utils/diagnostics/t/
+This README explains a bit about the scripts in `utils/diagnostics/t/`.
 
-all scripts must start with a 2 or 3 digit number and end with the extension ".t"
+All scripts must start with a 2 or 3 digit number and end with the extension ".t"
 
 The number describes the type of information the script will gather and should
 follow this list.
 
+```plain
 100 - system info
 200 - user environment tests
 300 - perl environment tests
 400 - postgres tests
 500 - performance tests
-
+```
 
 The most basic test script could look like this....
 
@@ -19,23 +20,22 @@ The most basic test script could look like this....
 
 echo "this to the user: your username is $USER"
 echo "this to the log: this test was run as user $USER" 1>&5
-
 ```
 
-As you can see, any output that is sent to fd5 will end up in the appropriate
+As you can see, any output that is sent to `fd5` will end up in the appropriate
 log file.
 
 ____
 
-When run, any scripts matching utils/diagnostics/t/*.t will be executed in
+When run, any scripts matching `utils/diagnostics/t/*.t` will be executed in
 lexical order.
 
-* std in and std out are available to those scripts for user interaction.
-* fd5 will be redirected to a logfile named the same as the test script
-* all logfiles will be created in a tempdir created with `mktemp -dt lsmb-diag.XXXX`
-* a `.lock` file will be created within each tempdir and removed on exit from diagnose.sh
-* all non-locked tempdirs will be removed at the start of running `diagnose.sh`
-* `diagnose.sh` handles creation of the tempdir, and actual redirection of fd5
-to the logfile
-* `diagnose.sh` creates a tarball of the contents of the tempdir before
+* `stdin` and `stdout` are available to those scripts for user interaction.
+* `fd5` will be redirected to a `logfile` named the same as the test script
+* all `logfiles` will be created in a `tempdir` created with `mktemp -dt lsmb-diag.XXXX`
+* a `.lock` file will be created within each `tempdir` and removed on exit from `diagnose.sh`
+* all non-locked `tempdirs` will be removed at the start of running `diagnose.sh`
+* `diagnose.sh` handles creation of the `tempdir`, and actual redirection of `fd5`
+to the `logfile`
+* `diagnose.sh` creates a `tarball` of the contents of the `tempdir` before
 "normal" exit

--- a/utils/lib/README.md
+++ b/utils/lib/README.md
@@ -13,10 +13,10 @@ For more information about any of these files, Read The Source Luke
 
 A library of functions that are common to most of the scripts
 
-If you are intending to use the config file functions
+If you are intending to use the configuration file functions
 One Environment Variable MUST be set before sourcing this file.
 
-eg:
+e.g.:
 
 `ConfigFile="$HOME/.lsmb-release"`
 

--- a/xt/66-cucumber/README.md
+++ b/xt/66-cucumber/README.md
@@ -1,7 +1,7 @@
 
 # BDD Tests
 
-The category '66-cucumber' is a bit of a misnomer: these tests are
+The category `66-cucumber` is a bit of a misnomer: these tests are
 really browser based tests and we use the principles from BDD to
 specify the test scripts and drive the browser engine.
 
@@ -18,9 +18,9 @@ Tests have been grouped by function:
 
 # Running the tests
 
-The tests are integrated with the 'make test' test framework. However,
-they can be run separately as well, using the 'pherkin' test runner
-which comes with Test:BDD::Cucumber:
+The tests are integrated with the `make test` test framework. However,
+they can be run separately as well, using the `pherkin` test runner
+which comes with `Test:BDD::Cucumber`:
 
 ```sh
  $ PGUSER=postgres PGPASSWORD=password \
@@ -48,7 +48,7 @@ root of the development tree for the above to work:
 
 The code consists of the following components:
 
-* Feature files (*.feature), grouped by function into the directories
+* Feature files (`*.feature`), grouped by function into the directories
   numbered as defined above (e.g. `t/66-cucumber/01-basic/`)
 * Step files, which implement function specific steps, in a
   `step_definitions` subdirectory of each numbered directory
@@ -61,14 +61,15 @@ The code consists of the following components:
 * `PageObject`s (in `xt/lib/`)
   * implementing access to browser page functionality, deriving from
     `Weasel::Element`, thereby referring to their root DOM element
-  * self-registering Weasel::WidgetHandler-s and Weasel::FindExpander-s,
-     keeping DOM-tree knowledge local to the PageObject
+  * self-registering `Weasel::WidgetHandler-s` and `Weasel::FindExpander-s`,
+     keeping `DOM-tree` knowledge local to the `PageObject`
 
 ## Structure of feature files
 
 The general structure of feature files is well documented elsewhere on
-the web ([See https://cucumber.io/docs/gherkin/reference/](https://cucumber.io/docs/gherkin/reference/))
-The general structure consists of N sections:
+the web ([See `Gherkin` reference](https://cucumber.io/docs/gherkin/reference/))
+
+It consists of N sections:
 
 * Feature (only one section allowed)
 * Background (optional; only a single background allowed)
@@ -81,10 +82,10 @@ of what will be tested in the scenarios.
 The `Background` section (when available) specifies steps to be prepended
 to every scenario in the feature file.
 
-The `Scenario` sections test the various behaviours of the feature. There
+The `Scenario` sections test the various behaviors of the feature. There
 are several best practices for writing scenarios:
 
-* Each scenario tests one behaviour
+* Each scenario tests one behavior
 * Each scenario is independent from others
    which means that scenarios can be run without requiring
    the others to run as well, in any specific sequence
@@ -119,25 +120,25 @@ The following tags are available:
    This tag signals to the LedgerSMB plugin that all the scenarios
    in this feature should run against the same database. This is a
    performance optimization which should *only* be applied when the
-   tests don't modify the database they're running againsts. That way
+   tests don't modify the database they're running against. That way
    independence of scenarios within the feature is maintained.
 
 # DOM tree mapping
 
-The DOM tree's root element (`html`), maps to PageObject::Root, by
-overriding Weasel::Session's `page_class` attribute.
+The DOM tree's root element (`html`), maps to `PageObject::Root`, by
+overriding `Weasel::Session's` `page_class` attribute.
 
-The pages from setup.pl and the two pages from login.pl (the login page
-and the single-page app) are identified through the 'id' attribute of the
+The pages from `setup.pl` and the two pages from `login.pl` (the login page
+and the single-page app) are identified through the `id` attribute of the
 `body` tag.
 
 The single page app's DOM tree:
 
-* Weasel::Session's `page` attribute (PageObject::Root)
-  * `body` attribute (PageObject::App)
-    * `menu` attribute (PageObject::App::Menu)
-      * `maindiv` attribute (PageObject::App::Main)
-        * `content` attribute (PageObject::App::*)
+* `Weasel::Session's` `page` attribute (`PageObject::Root`)
+  * `body` attribute (`PageObject::App`)
+    * `menu` attribute (`PageObject::App::Menu`)
+      * `maindiv` attribute (`PageObject::App::Main`)
+        * `content` attribute (`PageObject::App::*`)
 
 The BDD scripts refer to the `body` attribute's value above as
 "the page", while they refer to the `content` attribute's value as
@@ -150,7 +151,7 @@ replacing the entire page or the `#maindiv` content referred to
 by `body` and `content` respectively.
 
 The `content` accessor compensates for DOM tree changes and stale
-attribute values by testing 'staleness' before returning the value,
+attribute values by testing `staleness` before returning the value,
 thereby reducing the window of opportunity for race conditions.
 
 As far as timing is concerned: steps prior to the current one aren't
@@ -162,12 +163,12 @@ attribute.
 ## Expecting specific widgets as return values
 
 When a specific widget is expected to be returned, the receiver should
-use the session's wait_for() function to poll for the correct return
-type. The default settings for wait_for make it poll for a number of
+use the session's `wait_for` function to poll for the correct return
+type. The default settings for `wait_for` make it poll for a number of
 seconds.  A good example is the `Then 'I should see the <screen-name>
 screen'` step in `xt/lib/Pherkin/Extensions/pageobject_steps/nav_steps.pl`.
 
-Caching accessors, such as `content` above, should be resistent to the
-'repeated accessing' pattern caused by this polling behaviour by validating
+Caching accessors, such as `content` above, should be resistant to the
+`repeated accessing` pattern caused by this polling behavior by validating
 the validity (not being stale) of the return value and refreshing the
 cache when staleness is detected.


### PR DESCRIPTION
This PR fixes many typos and spelling errors in our documentation files.
US english was used as a reference.