### PR TITLE
Fix #4651: Tax on invoice off from search results

### DIFF
--- a/old/bin/io.pl
+++ b/old/bin/io.pl
@@ -94,6 +94,8 @@ sub _calc_taxes {
     $form->{subtotal} = $form->{invsubtotal};
     my $moneyplaces = $LedgerSMB::Company_Config::settings->{decimal_places};
     foreach my $i (1 .. $form->{rowcount}){
+        local $decimalplaces = $form->{"precision_$i"};
+
         my $discount_amount = $form->round_amount( $form->{"sellprice_$i"}
                                       * ($form->{"discount_$i"} / 100),
                                     $decimalplaces);

--- a/old/bin/oe.pl
+++ b/old/bin/oe.pl
@@ -204,6 +204,7 @@ sub prepare_order {
             ($dec) = ( $form->{"sellprice_$i"} =~ /\.(\d+)/ );
             $dec = length $dec;
             $decimalplaces = ( $dec > 2 ) ? $dec : 2;
+            $form->{"precision_$i"} = $decimalplaces;
 
             for ( map { "${_}_$i" } qw(sellprice listprice) ) {
                 $form->{$_} =


### PR DESCRIPTION
Note that the amounts posted in the books are correct and that
the search results show the amounts from the books (the correct ones).

However, when the invoice is presented, the amounts are recalculated
and the recalculation doesn't take the correct calculation precision into
account which results in the off-by-cents amounts.

This commit fixes the off-by-cents amounts by setting the rounding to
what was used when rendering the rows themselves, leading to correct
recalculation of the line totals (and thereby the correct tax amounts).
To make this explicit: it is the line total re-calculation which is off
due to the failed rounding. The tax is then calculated on the incorrectly
recalculated line total and by consequence incorrect as well, even though
there is nothing wrong with the tax calculation itself.

Whew.
