### PR TITLE
Fix primary keys of business unit linking tables not ensuring uniqueness

### DIFF
--- a/sql/changes/1.8/fix-reporting-units-pks.sql
+++ b/sql/changes/1.8/fix-reporting-units-pks.sql
@@ -1,0 +1,13 @@
+
+alter table business_unit_ac drop constraint business_unit_ac_pkey;
+alter table business_unit_inv drop constraint business_unit_inv_pkey;
+alter table business_unit_oitem drop constraint business_unit_oitem_pkey;
+-- note that the table 'business_unit_jl' is already correctly "keyed"
+
+alter table business_unit_ac add constraint business_unit_ac_pkey
+   primary key (entry_id, class_id);
+alter table business_unit_inv add constraint business_unit_inv_pkey
+   primary key (entry_id, class_id);
+alter table business_unit_oitem add constraint business_unit_oitem_pkey
+   primary key (entry_id, class_id);
+

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -115,7 +115,6 @@ mc/delete-migration-validation-data.sql
 1.8/update-payment-tables-documentation.sql
 1.8/simplify-menu.sql
 1.8/remove-fixes-table.sql
-1.8/remove-fixes-table.sql
 1.8/remove-custom-field-sprocs.sql
 1.8/remove-unused-sprocs.sql
 1.8/remove-unused-groups-admin.sql
@@ -133,3 +132,4 @@ mc/delete-migration-validation-data.sql
 1.8/constrain-transaction-tables.sql
 1.8/constrain-transactions-table-name.sql
 1.8/add-gl-batch-import-menu.sql
+1.8/fix-reporting-units-pks.sql


### PR DESCRIPTION
The existing PKEY constraints don't guarantee a single value per business unit
class on a single line linked to. There can't be more than one value per business
unit (=reporting unit) linked to a single line.

Closes #4622 