### PR TITLE
Fix COGS calculations for purchases-in-arrears

### DIFF
--- a/sql/modules/COGS.sql
+++ b/sql/modules/COGS.sql
@@ -198,7 +198,6 @@ DECLARE t_alloc numeric := 0;
         t_avail numeric;
 BEGIN
 
-
 IF in_qty > 0 THEN
    return (cogs__reverse_ap(in_parts_id, in_qty * -1))[1] * in_lastcost;
 END IF;
@@ -240,7 +239,7 @@ LOOP
        WHERE  id = t_inv.parts_id AND inventory_accno_id IS NOT NULL
               AND expense_accno_id IS NOT NULL
        UNION
-       SELECT income_accno_id,
+       SELECT inventory_accno_id,
               CASE WHEN t_transdate > coalesce(t_cp.end_date, t_transdate - 1)
                    THEN t_transdate
                    ELSE t_cp.end_date + '1 day'::interval
@@ -269,18 +268,17 @@ LOOP
        WHERE  id = t_inv.parts_id AND inventory_accno_id IS NOT NULL
               AND expense_accno_id IS NOT NULL
        UNION
-       SELECT income_accno_id,
+       SELECT inventory_accno_id,
               CASE WHEN t_transdate > coalesce(t_cp.end_date, t_transdate - 1)
                    THEN t_transdate
                    ELSE t_cp.end_date + '1 day'::interval
-               END, -t_avail * in_lastcost, t_inv.id, true, t_inv.trans_id
+               END, t_avail * in_lastcost, t_inv.id, true, t_inv.trans_id
          FROM parts
        WHERE  id = t_inv.parts_id AND inventory_accno_id IS NOT NULL
               AND expense_accno_id IS NOT NULL;
        t_alloc := t_alloc + t_avail;
        t_cogs := t_cogs + t_avail * in_lastcost;
    END IF;
-
 
 END LOOP;
 


### PR DESCRIPTION
Based on the newly implemented tests, it's clear that the purchases-in-arrears
COGS incorrectly doesn't post to the inventory account (instead posting to the
income account) and also uses incorrect signs for the cogs posting, taking away
from income as well as from expenses.
