### PR TITLE
Replace a UNION select over 'ar', 'ap' and 'gl' with 'transactions'

### DIFF
--- a/sql/modules/Reconciliation.sql
+++ b/sql/modules/Reconciliation.sql
@@ -50,11 +50,7 @@ LANGUAGE SQL AS
 $$
 WITH unapproved_tx as (
      SELECT 'unapproved_transactions'::text, sum(c)::text
-       FROM (SELECT count(*) as c FROM ar
-              WHERE approved IS FALSE AND transdate <= $1
-      UNION  SELECT count(*) as c FROM ap
-              WHERE approved IS FALSE AND transdate <= $1
-      UNION  SELECT count(*) FROM gl
+       FROM (SELECT count(*) as c FROM transactions
               WHERE approved IS FALSE AND transdate <= $1
       UNION  SELECT count(DISTINCT source) FROM acc_trans
               WHERE approved IS FALSE AND transdate <= $1 AND chart_id = $2


### PR DESCRIPTION
There's no need to run a query on tables as wide as ar and ap;
nor is there a good reason to run a UNION now that we have transdate
in 'transactions' too.
