### PR TITLE
Make `currency__list()` SECURITY DEFINER to workaround access restrictions

### DIFF
--- a/sql/modules/Currency.sql
+++ b/sql/modules/Currency.sql
@@ -64,7 +64,7 @@ BEGIN
        OR EXISTS (SELECT 1 FROM oe WHERE curr = in_curr)
        OR EXISTS (SELECT 1 FROM partscustomer WHERE curr = in_curr)
        OR EXISTS (SELECT 1 FROM partsvendor WHERE curr = in_curr);
-END;$$ language plpgsql;
+END;$$ language plpgsql security definer;
 
 COMMENT ON FUNCTION currency__is_used(text) IS
 $$Returns true if currency 'in_curr' is used within the current commpany


### PR DESCRIPTION
Not every user who needs a list of currencies has access to all the
tables that use them. By consequence, we need to escalate privileges
as a workaround.

Note that at some later date, it'd be better to query existence
only when *really* required.
