### PR TITLE
Allow hosting on a non-root path by specifying relative api URLs

### DIFF
--- a/UI/js-src/lsmb/accounts/AccountRestStore.js
+++ b/UI/js-src/lsmb/accounts/AccountRestStore.js
@@ -30,7 +30,7 @@ define([
    var store = new cache(
       new accountsRest({
          idProperty: "accno",
-         target: "/erp/api/v0/accounts/"
+         target: "erp/api/v0/accounts/"
       }),
       new memory()
    );


### PR DESCRIPTION
Note that the same 'trick' is already used when retrieving the menu nodes.
