### PR TITLE
Fix 'New Window' menu causing a 'not found' error

### DIFF
--- a/UI/js-src/lsmb/menus/Tree.js
+++ b/UI/js-src/lsmb/menus/Tree.js
@@ -100,8 +100,7 @@ define([
                location.origin +
                   location.pathname +
                   location.search +
-                  "#" +
-                  url,
+                  (url ? ("#" + url) : ""),
                "_blank",
                "noopener,noreferrer"
             );


### PR DESCRIPTION
When the 'url' variable is null, the fragment becomes '#null', causing
the page /null to be loaded. That doesn't exist, forcing a 'not found'
popup in the new window.
