### PR TITLE
Fix #4688: AR Outstanding report shows negative taxes

### DIFF
--- a/sql/modules/Report.sql
+++ b/sql/modules/Report.sql
@@ -430,7 +430,7 @@ RETURNS SETOF aa_transactions_line LANGUAGE SQL AS $$
 
 SELECT a.id, a.invoice, eeca.id, eca.meta_number, eeca.name, a.transdate,
        a.invnumber, a.ordnumber, a.ponumber, a.curr, a.amount_bc, a.netamount_bc,
-       a.netamount_bc - a.amount_bc as tax,
+       a.amount_bc - a.netamount_bc as tax,
        a.amount_bc - p.due as paid, p.due, p.last_payment, a.duedate, a.notes,
        a.till, ee.name, me.name, a.shippingpoint, a.shipvia,
        '{}'::text[] as business_units -- TODO


### PR DESCRIPTION
At some point (likely during MC implementation) the tax calculation
was reversed with respect to what it was on 1.6.

Regressed on 1.7 and 1.8-beta1.
