### PR TITLE
Quiet linter about spurious /html tag

### DIFF
--- a/UI/logout.html
+++ b/UI/logout.html
@@ -9,4 +9,4 @@
           END; %]</h1>
 <p><a target="_top" href="login.pl">[% text('Return to the login screen.') %]</a>
 </body>
-</html>
+[% end_html %]

--- a/UI/setup/begin_backup.html
+++ b/UI/setup/begin_backup.html
@@ -73,4 +73,4 @@ disabled = "disabled"
 </form>
 </div>
 </body>
-</html>
+[% end_html %]

--- a/UI/setup/complete.html
+++ b/UI/setup/complete.html
@@ -30,4 +30,4 @@
 [% END %]
 </div>
 </body>
-</html>
+[% end_html %]

--- a/UI/setup/complete_migration_revert.html
+++ b/UI/setup/complete_migration_revert.html
@@ -11,4 +11,4 @@ include_stylesheet=["setup.css"]
 <p><a href="setup.pl">[% text('Return to setup') %]</a></p>
 </div>
 </body>
-</html>
+[% end_html %]

--- a/UI/setup/confirm_operation.html
+++ b/UI/setup/confirm_operation.html
@@ -129,4 +129,4 @@ INCLUDE input element_data = {
 [% END %]
 </div>
 </body>
-</html>
+[% end_html %]

--- a/UI/setup/credentials.html
+++ b/UI/setup/credentials.html
@@ -107,4 +107,4 @@
       });
     </script>
 </body>
-</html>
+[% end_html %]

--- a/UI/setup/edit_user.html
+++ b/UI/setup/edit_user.html
@@ -156,4 +156,4 @@ include_stylesheet=["setup.css"];
 [% END %]
 </div>
 </body>
-</html>
+[% end_html %]

--- a/UI/setup/list_databases.html
+++ b/UI/setup/list_databases.html
@@ -17,4 +17,4 @@ include_stylesheet=["setup.css"];
               id = 'db_list' %]
 </div>
 </body>
-</html>
+[% end_html %]

--- a/UI/setup/list_users.html
+++ b/UI/setup/list_users.html
@@ -18,4 +18,4 @@
         %]
     </div>
 </body>
-</html>
+[% end_html %]

--- a/UI/setup/migration_step.html
+++ b/UI/setup/migration_step.html
@@ -32,4 +32,4 @@
     </form>
   </div>
 </body>
-</html>
+[% end_html %]

--- a/UI/setup/new_user.html
+++ b/UI/setup/new_user.html
@@ -192,4 +192,4 @@ INCLUDE select element_data = {
 </form>
 </div>
 </body>
-</html>
+[% end_html %]

--- a/UI/setup/select_coa.html
+++ b/UI/setup/select_coa.html
@@ -104,4 +104,4 @@ END %]
 </form>
 </div>
 </body>
-</html>
+[% end_html %]

--- a/UI/setup/system_info.html
+++ b/UI/setup/system_info.html
@@ -45,4 +45,4 @@
 
 </div>
 </body>
-</html>
+[% end_html %]

--- a/UI/setup/template_info.html
+++ b/UI/setup/template_info.html
@@ -31,4 +31,4 @@ PROCESS select element_data = {
 </form>
 </div>
 </body>
-</html>
+[% end_html %]

--- a/UI/setup/upgrade_info.html
+++ b/UI/setup/upgrade_info.html
@@ -106,4 +106,4 @@ END %]
 </form>
 </div>
 </body>
-</html>
+[% end_html %]

--- a/templates/demo/PNL.html
+++ b/templates/demo/PNL.html
@@ -94,4 +94,4 @@ END ;
 
 </div>
 </body>
-</html>
+<?lsmb end_html ?>

--- a/templates/demo/balance_sheet.html
+++ b/templates/demo/balance_sheet.html
@@ -109,4 +109,4 @@ END ;
 </div>
 
 </body>
-</html>
+<?lsmb end_html ?>

--- a/templates/demo/display_report.html
+++ b/templates/demo/display_report.html
@@ -31,4 +31,4 @@ PROCESS "dynatable.html";
   <?lsmb PROCESS dynatable tbody = {rows = rows }
                  attributes = {class = 'report', order_url = order_url } ?>
 </body>
-</html>
+<?lsmb end_html ?>

--- a/templates/demo_with_images/PNL.html
+++ b/templates/demo_with_images/PNL.html
@@ -94,4 +94,4 @@ END ;
 
 </div>
 </body>
-</html>
+<?lsmb end_html ?>

--- a/templates/demo_with_images/balance_sheet.html
+++ b/templates/demo_with_images/balance_sheet.html
@@ -109,4 +109,4 @@ END ;
 </div>
 
 </body>
-</html>
+<?lsmb end_html ?>

--- a/templates/demo_with_images/display_report.html
+++ b/templates/demo_with_images/display_report.html
@@ -31,4 +31,4 @@ PROCESS "dynatable.html";
   <?lsmb PROCESS dynatable tbody = {rows = rows }
                  attributes = {class = 'report', order_url = order_url } ?>
 </body>
-</html>
+<?lsmb end_html ?>

--- a/templates/xedemo/PNL.html
+++ b/templates/xedemo/PNL.html
@@ -94,4 +94,4 @@ END ;
 
 </div>
 </body>
-</html>
+<?lsmb end_html ?>

--- a/templates/xedemo/balance_sheet.html
+++ b/templates/xedemo/balance_sheet.html
@@ -109,4 +109,4 @@ END ;
 </div>
 
 </body>
-</html>
+<?lsmb end_html ?>

--- a/templates/xedemo/display_report.html
+++ b/templates/xedemo/display_report.html
@@ -31,4 +31,4 @@ PROCESS "dynatable.html";
   <?lsmb PROCESS dynatable tbody = {rows = rows }
                  attributes = {class = 'report', order_url = order_url } ?>
 </body>
-</html>
+<?lsmb end_html ?>


### PR DESCRIPTION
HTML headers is provided through an included file in most cases. Make sure that the html closing tag is provided in the same way so that linting tools see a coherent usage.