### PR TITLE
Make images references relatives to domain

### DIFF
--- a/UI/login.html
+++ b/UI/login.html
@@ -25,7 +25,7 @@
         <div class="login" align="center">
           <a href="http://www.ledgersmb.org/"
              target="_top">
-            <img src="images/ledgersmb.png"
+            <img src="/images/ledgersmb.png"
                  class="logo"
                  alt="LedgerSMB Logo" /></a>
           <div style="position:relative; width:100%; height:15em;">

--- a/UI/payments/payment2.html
+++ b/UI/payments/payment2.html
@@ -1,5 +1,5 @@
 <body id="payment_2_body" class="lsmb [% dojo_theme %]"
-onLoad="maximize_minimize_on_load(event, 'div_topay_state', 'payments/img/down.gif','payments/img/up.gif') ">
+onLoad="maximize_minimize_on_load(event, 'div_topay_state', 'img/down.gif','img/up.gif') ">
   <div id="payments">
   <form data-dojo-type="lsmb/Form" name="pay_single_dues" method="post" action="payment.pl">
 
@@ -159,16 +159,10 @@ onLoad="maximize_minimize_on_load(event, 'div_topay_state', 'payments/img/down.g
                          <button type="button"
                                  style="margin-left:auto;margin-right:auto"
                                  id="checkbox_all"
-                                 data-dojo-type="dijit/form/Button">
+                                 data-dojo-type="lsmb/payments/ToggleIncludeButton">
                                 [% column.text -%]
-                                <script type="dojo/on" data-dojo-event="click">
-                                    require(["dojo/domReady!"], function(){
-                                        dojo.query('input[name^="checkbox_"]', this.domNode).forEach(function (node, index, arr) {
-                                            var n = dijit.getEnclosingWidget(node);
-                                            n.set('checked',!n.get('checked'));
-                                        });
-                                    });
-                                </script>
+                                <!--<script type="dojo/on" data-dojo-event="click"
+                                        src="lsmb/html/payments2_html"></script>-->
                             </button>
                          [% INCLUDE tooltip element_data = {
                                 ref_id => "checkbox_all"
@@ -245,7 +239,7 @@ onLoad="maximize_minimize_on_load(event, 'div_topay_state', 'payments/img/down.g
                 name = "orig_" _ row.topay_fx.name
                 value = row.orig_topay_fx
           } %]
-          <img src="payments/img/up.gif" alt=[% text('Up') %]
+          <img src='/payments/img/up.gif' alt=[% text('Up') %]
                data-dojo-type="lsmb/MaximizeMinimize"
                data-dojo-props="mmNodeId: 'div_topay_[% row.invoice.id %]'"
                class="details-toggler">

--- a/UI/setup/credentials.html
+++ b/UI/setup/credentials.html
@@ -6,7 +6,7 @@
     <div class="setupconsole" style="position:relative;height:100%">
         <div id="loading">
             <img style="display: block; margin: auto auto;"
-                 src="js/dijit/icons/images/loadingAnimation.gif"
+                 src="/js/dijit/icons/images/loadingAnimation.gif"
                  alt="If this text is showing, there's most likely a problem with the Dojo setup"
                  title="Loading ..."
                  width="20" height="20" />
@@ -19,7 +19,7 @@
                 </h1>
                 <a href="http://www.ledgersmb.org/"
                    target="_top">
-                   <img src="images/ledgersmb.png"
+                   <img src="/images/ledgersmb.png"
                         class="logo"
                         alt="LedgerSMB Logo" />
                 </a>

--- a/t/data/Is_LSMB_running.html
+++ b/t/data/Is_LSMB_running.html
@@ -3,18 +3,18 @@
 <head>
         <title></title>
         <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
-        
-        
+
+
         <link rel="stylesheet" href="js/dojo/resources/dojo.css" type="text/css" />
         <link rel="stylesheet" href="js/dijit/themes/claro/claro.css" type="text/css" />
 
-        
+
             <link rel="stylesheet" href="css/ledgersmb.css" type="text/css" />
-        
-        
+
+
             <link rel="stylesheet" href="css/setup.css" type="text/css" />
-        
-        
+
+
         <script type="text/javascript">
             var dojoConfig = {
                 async: 1,
@@ -22,14 +22,14 @@
                 packages: [{"name":"lsmb","location":"../lsmb"}]
             };
             var lsmbConfig = {
-                
+
                  "dateformat": 'yyyy-mm-dd'
-                 
+
             };
        </script>
         <script type="text/javascript" src="js/dojo/dojo.js"></script>
         <script type="text/javascript" src="js/lsmb/main.js"></script>
-        
+
         <meta name="robots" content="noindex,nofollow" />
 </head><body id="setup-login" class="lsmb claro">
     <div class="setupconsole" style="position:relative;height:100%">
@@ -48,7 +48,7 @@
                 </h1>
                 <a href="http://www.ledgersmb.org/"
                    target="_top">
-                   <img src="images/ledgersmb.png"
+                   <img src="/images/ledgersmb.png"
                         class="logo"
                         alt="LedgerSMB Logo" />
                 </a>
@@ -68,19 +68,19 @@
                             <div class="inputrow">
                                 <label id="s-user-label" for="s-user" class="username">DB admin login</label>
           <select id="s-user" class="username" title="DB admin login" name="s_user" size="15" tabindex="1" data-dojo-type="dijit/form/ComboBox" data-dojo-props="value:'', placeHolder:'Select or Enter User'">
-            
+
             <option  id="s-user-1" value="lsmb_dbadmin" >lsmb_dbadmin</option><option  id="s-user-2" value="postgres" >postgres</option>
           </select>
                             </div>
                             <div class="inputrow">
                                 <label id="s-password-label" for="s-password" class="password">Password</label>
-      
+
           <input id="s-password" class="password" title="Password" type="password" name="s_password" size="15" data-dojo-type="dijit/form/ValidationTextBox" tabindex="2" />
                             </div>
                         </div>
                         <div class="inputrow">
                             <label id="database-label" for="database" class="database">Database</label>
-      
+
           <input id="database" class="database" title="Database" type="text" name="database" size="15" data-dojo-type="dijit/form/ValidationTextBox" tabindex="3" maxlength="255" />
                         </div>
                     </div>

--- a/xt/01-html-checks.t
+++ b/xt/01-html-checks.t
@@ -84,7 +84,7 @@ sub content_test {
             },
             'elem-img-sizes-missing' => sub {
                 my $param = shift;
-                if ($param->{src} eq "images/ledgersmb.png"
+                if ($param->{src} eq "/images/ledgersmb.png"
                  || $param->{src} =~ /payments\/img\/(up|down)\.gif/ )  {
                     return 1;
                 }


### PR DESCRIPTION
Quiet linter invalid image references by making them domain relative instead or current directory relative. HTML spec specifies that the latter is relative to the html source and linters enforce that, even though most browsers are tolerant.