### PR TITLE
Needless script types

### DIFF
--- a/UI/lib/ui-header.html
+++ b/UI/lib/ui-header.html
@@ -1,5 +1,5 @@
 <!-- prettier-disable -->
-[%+#
+[%#
    # This helper should be included in files which will be served as
    # top-level responses (i.e. documents on their own); this includes
    # UI/login.html, UI/logout.html, UI/main.html and various UI/setup/ pages
@@ -35,11 +35,11 @@
     <link rel="stylesheet" href="css/[% s %]" type="text/css" />
     [% END %]
     [% IF warn_expire %]
-    <script type="text/javascript">
+    <script>
         window.alert("[% text('Warning:  Your password will expire in [_1]', pw_expires)%]");
     </script>
     [% END %]
-    <script type="text/javascript">
+    <script>
          var dojoConfig = {
              async: 1,
              locale: '[% USER.language.lower().replace('_','-') %]',
@@ -51,10 +51,10 @@
              [% END %]
          };
     </script>
-    <script type="text/javascript" src="js/dojo/dojo.js"></script>
-    <script type="text/javascript" src="js/lsmb/main.js"></script>
+    <script src="js/dojo/dojo.js"></script>
+    <script src="js/lsmb/main.js"></script>
     [% FOREACH s = include_script %]
-         <script type="text/javascript" src="[% s %]" ></script>
+         <script src="[% s %]" ></script>
     [% END %]
     <meta name="robots" content="noindex,nofollow" />
 </head>

--- a/t/16-schema-upgrade-html.t
+++ b/t/16-schema-upgrade-html.t
@@ -158,7 +158,7 @@ my @expected = split (/\n/, q{<!-- prettier-disable -->
         <link rel="stylesheet" href="js/dijit/themes/claro/claro.css" type="text/css" />
             <link rel="stylesheet" href="css/ledgersmb.css" type="text/css" />
             <link rel="stylesheet" href="css/setup.css" type="text/css" />
-        <script type="text/javascript">
+        <script>
             var dojoConfig = {
                 async: 1,
                 locale: '',
@@ -167,8 +167,8 @@ my @expected = split (/\n/, q{<!-- prettier-disable -->
             var lsmbConfig = {
             };
        </script>
-        <script type="text/javascript" src="js/dojo/dojo.js"></script>
-        <script type="text/javascript" src="js/lsmb/main.js"></script>
+        <script src="js/dojo/dojo.js"></script>
+        <script src="js/lsmb/main.js"></script>
         <meta name="robots" content="noindex,nofollow" />
 </head>
 <body class="claro">
@@ -242,7 +242,7 @@ filter_js_src($out);
         <link rel="stylesheet" href="js/dijit/themes/claro/claro.css" type="text/css" />
             <link rel="stylesheet" href="css/ledgersmb.css" type="text/css" />
             <link rel="stylesheet" href="css/setup.css" type="text/css" />
-        <script type="text/javascript">
+        <script>
             var dojoConfig = {
                 async: 1,
                 locale: '',
@@ -251,8 +251,8 @@ filter_js_src($out);
             var lsmbConfig = {
             };
        </script>
-        <script type="text/javascript" src="js/dojo/dojo.js"></script>
-        <script type="text/javascript" src="js/lsmb/main.js"></script>
+        <script src="js/dojo/dojo.js"></script>
+        <script src="js/lsmb/main.js"></script>
         <meta name="robots" content="noindex,nofollow" />
 </head>
 <body class="claro">
@@ -326,7 +326,7 @@ filter_js_src($out);
         <link rel="stylesheet" href="js/dijit/themes/claro/claro.css" type="text/css" />
             <link rel="stylesheet" href="css/ledgersmb.css" type="text/css" />
             <link rel="stylesheet" href="css/setup.css" type="text/css" />
-        <script type="text/javascript">
+        <script>
             var dojoConfig = {
                 async: 1,
                 locale: '',
@@ -335,8 +335,8 @@ filter_js_src($out);
             var lsmbConfig = {
             };
        </script>
-        <script type="text/javascript" src="js/dojo/dojo.js"></script>
-        <script type="text/javascript" src="js/lsmb/main.js"></script>
+        <script src="js/dojo/dojo.js"></script>
+        <script src="js/lsmb/main.js"></script>
         <meta name="robots" content="noindex,nofollow" />
 </head>
 <body class="claro">
@@ -411,7 +411,7 @@ filter_js_src($out);
         <link rel="stylesheet" href="js/dijit/themes/claro/claro.css" type="text/css" />
             <link rel="stylesheet" href="css/ledgersmb.css" type="text/css" />
             <link rel="stylesheet" href="css/setup.css" type="text/css" />
-        <script type="text/javascript">
+        <script>
             var dojoConfig = {
                 async: 1,
                 locale: '',
@@ -420,8 +420,8 @@ filter_js_src($out);
             var lsmbConfig = {
             };
        </script>
-        <script type="text/javascript" src="js/dojo/dojo.js"></script>
-        <script type="text/javascript" src="js/lsmb/main.js"></script>
+        <script src="js/dojo/dojo.js"></script>
+        <script src="js/lsmb/main.js"></script>
         <meta name="robots" content="noindex,nofollow" />
 </head>
 <body class="claro">
@@ -513,7 +513,7 @@ filter_js_src($out);
         <link rel="stylesheet" href="js/dijit/themes/claro/claro.css" type="text/css" />
             <link rel="stylesheet" href="css/ledgersmb.css" type="text/css" />
             <link rel="stylesheet" href="css/setup.css" type="text/css" />
-        <script type="text/javascript">
+        <script>
             var dojoConfig = {
                 async: 1,
                 locale: '',
@@ -522,8 +522,8 @@ filter_js_src($out);
             var lsmbConfig = {
             };
        </script>
-        <script type="text/javascript" src="js/dojo/dojo.js"></script>
-        <script type="text/javascript" src="js/lsmb/main.js"></script>
+        <script src="js/dojo/dojo.js"></script>
+        <script src="js/lsmb/main.js"></script>
         <meta name="robots" content="noindex,nofollow" />
 </head>
 <body class="claro">

--- a/t/data/Is_LSMB_running.html
+++ b/t/data/Is_LSMB_running.html
@@ -3,19 +3,19 @@
 <head>
         <title></title>
         <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
-
-
+        
+        
         <link rel="stylesheet" href="js/dojo/resources/dojo.css" type="text/css" />
         <link rel="stylesheet" href="js/dijit/themes/claro/claro.css" type="text/css" />
 
-
+        
             <link rel="stylesheet" href="css/ledgersmb.css" type="text/css" />
-
-
+        
+        
             <link rel="stylesheet" href="css/setup.css" type="text/css" />
 
 
-        <script type="text/javascript">
+        <script>
             var dojoConfig = {
                 async: 1,
                 locale: '',
@@ -27,8 +27,8 @@
 
             };
        </script>
-        <script type="text/javascript" src="js/dojo/dojo.js"></script>
-        <script type="text/javascript" src="js/lsmb/main.js"></script>
+        <script src="js/dojo/dojo.js"></script>
+        <script src="js/lsmb/main.js"></script>
 
         <meta name="robots" content="noindex,nofollow" />
 </head><body id="setup-login" class="lsmb claro">


### PR DESCRIPTION
Javascript types are no longer required for HTML5. Quiet the linter.