### PR TITLE
Make sure variable are always initialized

### DIFF
--- a/UI/Configuration/sequence.html
+++ b/UI/Configuration/sequence.html
@@ -12,6 +12,7 @@
 <th class="listheading">[% text('Sequence') %]</th>
 <th class="listheading">[% text('Suffix') %]</th>
 </tr>
+[% count = 0 %]
 [% FOR seq IN sequence_list; count = loop.count %]
 <tr>
  <td>[% PROCESS input element_data = {


### PR DESCRIPTION
Make sure that variables are always initialized, even if there are no sequences. Quiet the linter.