### PR TITLE
Remove dependency on dojo/domReady!

### DIFF
--- a/UI/js-src/lsmb/Reconciliation.js
+++ b/UI/js-src/lsmb/Reconciliation.js
@@ -6,8 +6,7 @@ define("lsmb/Reconciliation", [
    "dojo/query",
    "lsmb/Form",
    "dijit/_Container",
-   "dojo/NodeList-dom", // To load extensions in query
-   "dojo/domReady!"
+   "dojo/NodeList-dom" // To load extensions in query
 ], function (declare, topic, query, Form, _Container) {
    return declare("lsmb/Reconciliation", [Form, _Container], {
       update: function (targetValue, prefix) {

--- a/UI/js-src/lsmb/login.js
+++ b/UI/js-src/lsmb/login.js
@@ -86,7 +86,10 @@ require([
       return false;
    }
 
-   setIndicator();
-   // Make it public
-   window.submitForm = submitForm;
+   window.addEventListener('load',
+                           function () {
+                               setIndicator();
+                               // Make it public
+                               window.submitForm = submitForm;
+                           })
 });

--- a/UI/js-src/lsmb/lsmb.profile.js
+++ b/UI/js-src/lsmb/lsmb.profile.js
@@ -95,7 +95,6 @@ var profile = (function () {
             include: [
                "dojo/dojo",
                "dojo/query",
-               "dojo/domReady",
                "dojo/on",
                "dijit/Tooltip"
             ],

--- a/UI/js-src/lsmb/main.js
+++ b/UI/js-src/lsmb/main.js
@@ -11,8 +11,7 @@ require([
    "dojo/topic",
    "dojo/dom-class",
    "dojo/mouse",
-   "dojo/ready",
-   "dojo/domReady!"
+   "dojo/ready"
 ], function (
    parser,
    query,
@@ -25,62 +24,65 @@ require([
    mouse,
    ready
 ) {
-   parser.parse().then(function () {
-      // delay the option of triggering load_link() until
-      // the parser has run: before then, the maindiv widget
-      // doesn't exist!
-      var mainDiv = registry.byId("maindiv");
+    window.addEventListener(
+        'load', function () {
+            parser.parse().then(function () {
+                // delay the option of triggering load_link() until
+                // the parser has run: before then, the maindiv widget
+                // doesn't exist!
+                var mainDiv = registry.byId("maindiv");
 
-      // we need a centralized interceptClick function so
-      // the hash part we generate to make it unique, really *is*
-      // Without the hash part, clicking on a link twice won't
-      // reload it. That's not too bad, except if a POST was sent
-      // in the mean time; which causes the page content *not* to
-      // correspond (directly) to the link in the browser location,
-      // yet clicking on the link won't return the user to the -e.g.-
-      // search page (that is -- without the hash part below)
-      var c = 0;
-      var interceptClick = function (dnode) {
-         if (dnode.target || !dnode.href) {
-            return;
-         }
+                // we need a centralized interceptClick function so
+                // the hash part we generate to make it unique, really *is*
+                // Without the hash part, clicking on a link twice won't
+                // reload it. That's not too bad, except if a POST was sent
+                // in the mean time; which causes the page content *not* to
+                // correspond (directly) to the link in the browser location,
+                // yet clicking on the link won't return the user to the -e.g.-
+                // search page (that is -- without the hash part below)
+                var c = 0;
+                var interceptClick = function (dnode) {
+                    if (dnode.target || !dnode.href) {
+                        return;
+                    }
 
-         var href = dnode.href + "#s";
-         on(dnode, "click", function (e) {
-            if (!e.ctrlKey && !e.shiftKey && mouse.isLeft(e)) {
-               event.stop(e);
-               c++;
-               hash(href + c.toString(16));
-               mainDiv.fade_main_div();
-            }
-         });
-         var l = window.location;
-         dnode.href =
-            l.origin +
-            l.pathname +
-            l.search +
-            "#" +
-            dnode.href.substring(l.origin.length);
-      };
-      if (mainDiv != null) {
-         mainDiv.interceptClick = interceptClick;
-         if (window.location.hash) {
-            mainDiv.load_link(hash());
-         }
-         topic.subscribe("/dojo/hashchange", function (_hash) {
-            mainDiv.load_link(_hash);
-         });
-      }
+                    var href = dnode.href + "#s";
+                    on(dnode, "click", function (e) {
+                        if (!e.ctrlKey && !e.shiftKey && mouse.isLeft(e)) {
+                            event.stop(e);
+                            c++;
+                            hash(href + c.toString(16));
+                            mainDiv.fade_main_div();
+                        }
+                    });
+                    var l = window.location;
+                    dnode.href =
+                        l.origin +
+                        l.pathname +
+                        l.search +
+                        "#" +
+                        dnode.href.substring(l.origin.length);
+                };
+                if (mainDiv != null) {
+                    mainDiv.interceptClick = interceptClick;
+                    if (window.location.hash) {
+                        mainDiv.load_link(hash());
+                    }
+                    topic.subscribe("/dojo/hashchange", function (_hash) {
+                        mainDiv.load_link(_hash);
+                    });
+                }
 
-      query("a.menu-terminus").forEach(interceptClick);
+                query("a.menu-terminus").forEach(interceptClick);
 
-      ready(999, function () {
-         query("#console-container").forEach(function (node) {
-            domClass.add(node, "done-parsing");
-         });
-         query("body").forEach(function (node) {
-            domClass.add(node, "done-parsing");
-         });
-      });
-   });
+                ready(999, function () {
+                    query("#console-container").forEach(function (node) {
+                        domClass.add(node, "done-parsing");
+                    });
+                    query("body").forEach(function (node) {
+                        domClass.add(node, "done-parsing");
+                    });
+                });
+            });
+        });
 });


### PR DESCRIPTION
The only thing domReady does, is compensate for behaviour in IE which
exposes the 'onload' instead of the 'load' event -- but this is no longer
relevant, since we don't support IE anyway.

As a result, we are now switching to directly using the 'window Event' api
with the 'load' event, in preparation of a move to webpack which doesn't
deal with domReady.

Note that this commit also removes domReady from lsmb/Reconciliation as it
can't be required anymore, since that module will be loaded once the dom
has been ready for ages: it's typically loaded as part of loading an HTML
fragment being loaded in response to a menu-click into a DOM that's ready.
