### PR TITLE
Requires the weasel scrolling fix for test stability

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -139,7 +139,7 @@ on 'develop' => sub {
     requires 'Test2::V0';
     requires 'Text::Diff';
     requires 'Weasel', '0.21';
-    requires 'Weasel::Driver::Selenium2', '0.07';
+    requires 'Weasel::Driver::Selenium2', '0.11';
     requires 'Weasel::Session', '0.11';
     requires 'Weasel::Widgets::Dojo', '0.04';
 


### PR DESCRIPTION
Restore stability on CircleCI tests by using latest Weasel Selenium which makes sure that scrolled to elements are shown in the viewport.