### PR TITLE
Set newest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "depcheck": "0.9.2",
     "dojo-util": "1.16.2",
     "dojo-webpack-loader": "^0.9.2",
-    "dojo-webpack-plugin": "^2.8.14",
+    "dojo-webpack-plugin": "^2.8.15",
     "eslint": "^7.1.0",
     "eslint-config-airbnb-base": "^14.1.0",
     "eslint-config-eslint": "^6.0.0",


### PR DESCRIPTION
Hopefully preventing the absMid() error we've been experiencing intermittently
