### PR TITLE
Sort Income statement and Balance sheet reports correctly

### DIFF
--- a/lib/LedgerSMB/Report/Balance_Sheet.pm
+++ b/lib/LedgerSMB/Report/Balance_Sheet.pm
@@ -142,6 +142,7 @@ sub run_report {
         sub { my ($line) = @_;
               $line->{account_number} = $line->{gifi_accno};
               $line->{account_desc} = $line->{gifi_description};
+              $line->{order} = $line->{account_number};
               return $line;
         } : ($self->legacy_hierarchy) ?
         sub { my ($line) = @_;
@@ -152,7 +153,9 @@ sub run_report {
               }
               return $line;
          } :
-         sub { my ($line) = @_; return $line; };
+         sub { my ($line) = @_;
+               $line->{order} = $line->{account_number};
+               return $line; };
 
     my $col_id = $self->cheads->map_path($self->column_path_prefix);
     $self->cheads->id_props($col_id,

--- a/lib/LedgerSMB/Report/PNL.pm
+++ b/lib/LedgerSMB/Report/PNL.pm
@@ -144,9 +144,12 @@ sub run_report {
         sub { my ($line) = @_;
               $line->{account_number} = $line->{gifi};
               $line->{account_description} = $line->{gifi_description};
+              $line->{order} = $line->{account_number};
               return $line;
        } :
-       sub { my ($line) = @_; return $line; };
+       sub { my ($line) = @_;
+             $line->{order} = $line->{account_number};
+             return $line; };
 
 
     my $col_id = $self->cheads->map_path($self->column_path_prefix);


### PR DESCRIPTION
In the hierarchical report, sort the sections by their account
numbers instead of their database IDs.
