### PR TITLE
Require a Cookie::Baker version with 'SameSite' support

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -7,7 +7,7 @@ requires 'Authen::SASL';
 requires 'CGI::Emulate::PSGI';
 requires 'CGI::Parse::PSGI';
 requires 'Config::IniFiles';
-requires 'Cookie::Baker';
+requires 'Cookie::Baker', '0.10'; # for 'samesite' attribute
 requires 'DBD::Pg', '3.3.0';
 requires 'DBI', '1.635';
 requires 'Data::UUID';


### PR DESCRIPTION
This eliminates "cookie will soon be ignored" warning on FireFox
at least in my development image, due to missing SameSite policy
on the cookie.
