### PR TITLE
Manually backport ea31397e7; set SameSite policy on cookie

### DIFF
--- a/lib/LedgerSMB/Middleware/AuthenticateSession.pm
+++ b/lib/LedgerSMB/Middleware/AuthenticateSession.pm
@@ -203,7 +203,7 @@ sub call {
                     # Set the new cookie (with the extended life-time on response
                     Plack::Util::header_push(
                         $res->[1], 'Set-Cookie',
-                        qq|$cookie_name=$extended_cookie; path=$path$secure|);
+                        qq|$cookie_name=$extended_cookie; Path=$path$secure; SameSite=Strict|);
                 });
         }
         else {


### PR DESCRIPTION
Eliminates warning that the cookie will soon be ignored
