### PR TITLE
As per #4751, add '--preload-app' to example startup scripts

### DIFF
--- a/doc/conf/systemd/ledgersmb_starman.service
+++ b/doc/conf/systemd/ledgersmb_starman.service
@@ -20,6 +20,7 @@ WorkingDirectory=WORKING_DIR
 User=ledgersmb
 Group=ledgersmb
 ExecStart=/usr/bin/starman                     \
+    --preload-app                              \
     --listen localhost:5762                    \
     -I lib                                     \
     -I old/lib                                 \

--- a/doc/conf/sysvinit/starman.rh-centos
+++ b/doc/conf/sysvinit/starman.rh-centos
@@ -61,6 +61,7 @@ start(){
         --status-file=$STATUS_FILE \
         -- \
         $STARMAN \
+          --preload-app \
           --workers $WORKERS \
           --user $USER \
           --group $GROUP \


### PR DESCRIPTION
We really need that flag to be specified to reduce memory pressure
as well as single, consistent initialization of e.g. the cookie secret.
