### PR TITLE
Fix save-after-update on assemblies

### DIFF
--- a/old/lib/LedgerSMB/Setting.pm
+++ b/old/lib/LedgerSMB/Setting.pm
@@ -205,9 +205,9 @@ Returns an array of currencies defined for the current company.
 
 sub get_currencies {
     my $self = shift;
-    @{$self->{currencies}} =
-        map { $_->{curr} }
-        $self->call_procedure(funcname => 'currency__list');
+    $self->{currencies} =
+        [ map { $_->{curr} }
+          $self->call_procedure(funcname => 'currency__list') ];
     return @{$self->{currencies}};
 }
 


### PR DESCRIPTION
When saving assemblies, the 'currencies' value gets initialized with
a string value. Instead of depending on the value to be an array (or
uninitialized), simply overwrite the value with the array we need to
store in it.

This error isn't on master or 1.8 because the code was already changed
to what's in this commit.
