### PR TITLE
Exclude variables to be round-tripped through the client

### DIFF
--- a/old/bin/ic.pl
+++ b/old/bin/ic.pl
@@ -1224,6 +1224,7 @@ sub assembly_row {
     $form->{selectcustomer} = "";    # we seem to have run into a 40kb limit
     foreach my $key ( sort keys %$form ) {
 
+        next if grep { $_ eq $key } qw/ currencies version /;
         # escape ampersands
         $form->{$key} =~ s/&/%26/g;
         $previousform .= qq|$key=$form->{$key}&| if $form->{$key} && ! ref $form->{$key};


### PR DESCRIPTION
Due to the round-tripping, variables (like currencies) may be serialized
incorrectly, causing havoc when unserialized.
