### PR TITLE
Unless $form->{currencies} already is a reference, set its value

### DIFF
--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -2229,7 +2229,7 @@ sub create_links {
 sub currencies {
     my ($self) = @_;
 
-    return $self->{currencies} if $self->{currencies};
+    return $self->{currencies} if ref $self->{currencies};
 
     $self->{defaultcurrency} = $self->get_setting('curr');
     my $dbh = $self->{dbh};


### PR DESCRIPTION
Note that apparently, some forms (e.g. parts form), passes all $form
fields from one iteration to another. This serializes "currencies" as
a string "ARRAY(0x...)" (which later causes problems setting the
value due to a string-as-array-ref incompatibility).
