### PR TITLE
Format payment amount for db-use instead of UI use

### DIFF
--- a/old/lib/LedgerSMB/DBObject/Payment.pm
+++ b/old/lib/LedgerSMB/DBObject/Payment.pm
@@ -751,7 +751,7 @@ sub post_bulk {
             next if ! $pay_amount;
 
             $pay_amount = LedgerSMB::PGNumber->from_input($pay_amount)
-                ->to_output(money => 1);
+                ->to_db();
 
             my $invoice_subarray = "{$invoice->{invoice},$pay_amount}";
             if ($invoice_subarray !~ /^\{\d+\,\-?\d*\.?\d+\}$/){


### PR DESCRIPTION
The amount will be inserted into a string sent to the database a few
lines below the changed line. By consequence, using 'user formatting'
instead of db formatting, causes all kinds of havoc.
