### PR TITLE
Remove useless webpack-dev-server

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
     "web-webpack-plugin": "^4.6.7",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.11",
-    "webpack-dev-server": "^3.11.0",
     "webpack-entry-plus": "^1.0.18",
     "webpack-hasjs-plugin": "^1.0.3",
     "webpack-i18n-extractor-plugin": "^2.0.7",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -300,11 +300,7 @@ const webpackConfigs = {
 
     optimization: optimizationList,
 
-    performance: { hints: devMode ? "warning" : false },
-
-    devtool: "#source-map",
-
-    devServer: devServerOptions
+    performance: { hints: devMode ? "warning" : false }
 };
 
 /* eslint-disable-next-line no-unused-vars */


### PR DESCRIPTION
Webpack-dev-server is only useful for a single page application and pulls deprecated requirements into our application.