### PR TITLE
Cache Travis CPAN

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -116,6 +116,7 @@ cache:
   directories:
     - $HOME/locallib
     - $HOME/dojo_archive
+    - $HOME/perl5
 
 before_install:
   - sudo mount -o remount,size=50% /var/ramfs


### PR DESCRIPTION
Perl code and modules seldom change yet we reinstall everything on Travis on each build.
This PR introduces caching of the local perl5 directory to speed up builds
