### PR TITLE
Fix #4781: Cannot save batch in Payments due to date format

### DIFF
--- a/lib/LedgerSMB/Scripts/payment.pm
+++ b/lib/LedgerSMB/Scripts/payment.pm
@@ -380,9 +380,15 @@ sub post_payments_bulk {
     my ($request) = @_;
     if ($request->close_form){
         my $payment =  LedgerSMB::DBObject::Payment->new(
-            dbh          => $request->{dbh},
-            payment_date => LedgerSMB::PGDate->from_input(
-                $request->{datepaid})
+            dbh           => $request->{dbh},
+            ar_ap_accno   => $request->{ar_ap_accno},
+            account_class => $request->{account_class},
+            batch_id      => $request->{batch_id},
+            cash_accno    => $request->{cash_accno},
+            currency      => $request->{currency},
+            exchangerate  => $request->{exchangerate},
+            payment_date  => LedgerSMB::PGDate->from_input(
+                $request->{datepaid}),
             );
         my $data = $bulk_post_map->($request);
         $data->{contacts} = [ grep { $_->{id} } @{$data->{contacts}} ];


### PR DESCRIPTION
The existing code passes all values from the request straight into the
inner layers of the application, forfeiting its role as decoupling point
between the web and the inner operation of the application.

This commit separates the concerns of 'handling of web input' from
'marshalling payments into the database' into their respective
modules. This also means that the workflow script filters out the
contacts and invoices which have been indicated /not/ to be part of
the payment(s).
