### PR TITLE
Fix #4791: Can't post reversal of (sales) invoice due to disassembly

### DIFF
--- a/sql/modules/COGS.sql
+++ b/sql/modules/COGS.sql
@@ -101,6 +101,10 @@ FOR t_inv IN
             union
             select id, approved, transdate from gl) a ON a.id = i.trans_id
      WHERE allocated > 0 and a.approved and parts_id = in_parts_id
+           -- the sellprice check is here because of github issue #4791:
+           -- when a negative number of assemblies has been "stocked",
+           -- reversal of a sales invoice for that part, fails.
+           and sellprice is not null
   ORDER BY a.transdate DESC, a.id DESC, i.id DESC
 LOOP
    t_reversed := least((in_qty - t_alloc) * -1, t_inv.allocated);


### PR DESCRIPTION
This change fixes the situation as described in issue 4791, where
due to the fact that the 'invoice' record of an assembly doesn't
contain a 'sellprice', the amount being posted from the cogs code
becomes NULL, which the column definition prohibits.
