### PR TITLE
Fix overpayment reversal failing to post

### DIFF
--- a/lib/LedgerSMB/Scripts/reports.pm
+++ b/lib/LedgerSMB/Scripts/reports.pm
@@ -234,13 +234,14 @@ Reverses overpayments selected from the search overpayments screen.
 
 sub reverse_overpayment {
     my ($request) = @_;
+    my $payment = LedgerSMB::DBObject::Payment->new(%$request);
     for my $rc (1 .. $request->{rowcount_}){
         next unless $request->{"select_$rc"};
         my $args = {id => $request->{"select_$rc"}};
         $args->{$_} = $request->{$_} for qw(post_date batch_id account_class
                                             exchangerate currency);
         $args->{curr} = $args->{currency};
-        LedgerSMB::DBObject::Payment->overpayment_reverse($args);
+        $payment->overpayment_reverse($args);
     }
     $request->{report_name} = 'overpayments';
     return start_report($request);

--- a/old/lib/LedgerSMB/DBObject/Payment.pm
+++ b/old/lib/LedgerSMB/DBObject/Payment.pm
@@ -743,14 +743,14 @@ return @{$self->{available_overpayment_amount}};
 
 sub overpayment_reverse {
     my ($self, $args) = @_;
-    return __PACKAGE__->call_procedure(
-                                 funcname => 'overpayment__reverse',
-                                     args => [$args->{id},
-                                              $args->{post_date},
-                                              $args->{batch_id},
-                                              $args->{account_class},
-                                              $args->{exchangerate},
-                                              $args->{curr}] );
+    return $self->call_procedure(
+        funcname => 'overpayment__reverse',
+        args => [$args->{id},
+                 $args->{post_date},
+                 $args->{batch_id},
+                 $args->{account_class},
+                 $args->{exchangerate},
+                 $args->{curr}] );
 }
 
 =item init


### PR DESCRIPTION
The reversal action shows a hashref-while-strict problem mentioning
LedgerSMB::DBObject::Payment.
