### PR TITLE
Randomize sequences to detect join issues

### DIFF
--- a/xt/lib/Pherkin/Extension/ledgersmb_steps/common_steps.pl
+++ b/xt/lib/Pherkin/Extension/ledgersmb_steps/common_steps.pl
@@ -357,7 +357,8 @@ Given qr/^(\d+) units inventory of ((?:a|the) part|part "(.*)") purchased at (\d
     $dbh->do(
         q{
         INSERT INTO gl (reference, description, transdate, person_id, approved)
-               VALUES ('INV-INIT', 'Initial setup', '2020-01-01', '1', true);
+               VALUES ('INV-INIT', 'Initial setup', '2020-01-01',
+                       person__get_my_id(), true);
         })
         or die $dbh->errstr;
 


### PR DESCRIPTION
Randomize sequence numbers in order to make them significantly different (instead of all starting at 1), increasing chances to find bugs in JOIN conditions.