### PR TITLE
Replace advice on use of logos in templates

### DIFF
--- a/templates/demo/letterhead.html
+++ b/templates/demo/letterhead.html
@@ -10,11 +10,35 @@
             <?lsmb address ?>
             </h4>
           </td>
-          <!-- Commenting out the image tag for now.  In general, folks can
-               customize this to their servers, but if the server is behind a
-               firewall, then this won't work.  Recommend that if people do this,
-               they hardwire in a link to a publically accessible image. - CT -->
-          <th><!-- <img src=<?lsmb images ?>/logo.png border=0 height=58> --></th>
+          <?lsmb# using "comment block" template tag to suppress output
+
+           There are two options of including a picture in the output:
+
+           1. An external image available from your webserver
+              This option has the downside that the webserver and image
+              need to remain available for extended periods.
+
+              <img src="https://example.com/logo.png" border="0" height="58">
+
+           2. An image embedded in the invoice itself
+              This option has the downside that the invoice file will
+              be larger and the HTML source will be less readable, however,
+              it eliminates external dependencies, retaining the integrity
+              of the invoice, independent of what happens to publicly hosted
+              images
+
+              <img src="data:image/png;base64,<-?lsmb dbfile_base64('logo.png') ?->"
+                   border="0" height="58">
+
+              Please note that this is dependent on having a file uploaded by
+              the name 'logo.png' under "System - Files". Also, when using this
+              option, please remove the hyphens from '<-?lsmb' and '?->'; they
+              are used to hide the text from the template processor.
+
+          ?>
+          <th>
+            <!--Replace this comment with one of the two image tags above -->
+          </th>
 
           <td align=right>
             <h4>

--- a/templates/demo/letterhead.tex
+++ b/templates/demo/letterhead.tex
@@ -1,14 +1,29 @@
 \parbox{\textwidth}{%
   \parbox[b]{.42\textwidth}{%
     <?lsmb company ?>
-   
+
     <?lsmb address ?>
   }
   \parbox[b]{.2\textwidth}{
-    % If you want to use a logo uncomment this and set images to
-    % an absolute path to the images, or set the path appropriately here.
-    %\includegraphics[scale=0.3]{<?lsmb images ?>/logo}
-  }\hfill
+  <?lsmb#  using "comment block" template tag to suppress output
+
+  To include a logo in your LaTeX document, it needs to be retrieved from
+  the database and temporarily stored in a location accessible to the PDF
+  generator. The function 'dbfile_path' handles that.
+
+  To use this functionality, (a) remove the percent sign before the
+  \includegraphics command and (b) make sure all templates which INCLUDE
+  'letterhead', contain '\usepackage{graphics}'
+
+  If the generated output is to be PDF output, make sure that the image is
+  a PNG image as shown below. In case Postscript (PS) or EPS output, make
+  sure the image is (E)PS.
+
+  For information on the avaliable options for the 'includegraphics'
+  command, see https://en.wikibooks.org/wiki/LaTeX/Importing_Graphics
+    ?>
+    %\includegraphics[scale=0.3]{<?lsmb dbfile_path('logo.png') ?>}
+    }\hfill
   \begin{tabular}[b]{rr@{}}
   <?lsmb text('Tel:') ?> & <?lsmb tel ?>\\
   <?lsmb text('Fax:') ?> & <?lsmb fax ?>


### PR DESCRIPTION
The old advice was no longer applicable because we now support logo
(and other) files to be in the database.
