### PR TITLE
Backport syntax fixes from #4819 (templates cleanup)

### DIFF
--- a/templates/demo/PNL.tex
+++ b/templates/demo/PNL.tex
@@ -1,6 +1,6 @@
-%<?lsmb FILTER latex ?>
-%
-%<?lsmb
+<?lsmb FILTER latex ?>
+
+<?lsmb
   IF hierarchy == 'flat-hierarchy';
     max_path_depth = 1;
   ELSE;
@@ -116,4 +116,4 @@ END; -?>
 \end{longtable}
 \end{document}
 
-%<?lsmb END ?>
+<?lsmb END ?>

--- a/templates/demo/balance_sheet.tex
+++ b/templates/demo/balance_sheet.tex
@@ -1,6 +1,6 @@
-%<?lsmb FILTER latex ?>
-%
-%<?lsmb
+<?lsmb FILTER latex ?>
+
+<?lsmb
   IF hierarchy == 'flat-hierarchy';
     max_path_depth = 1;
   ELSE;

--- a/templates/demo_with_images/PNL.tex
+++ b/templates/demo_with_images/PNL.tex
@@ -1,6 +1,6 @@
-%<?lsmb FILTER latex ?>
-%
-%<?lsmb
+<?lsmb FILTER latex ?>
+
+<?lsmb
   IF hierarchy == 'flat-hierarchy';
     max_path_depth = 1;
   ELSE;
@@ -116,4 +116,4 @@ END; -?>
 \end{longtable}
 \end{document}
 
-%<?lsmb END ?>
+<?lsmb END ?>

--- a/templates/demo_with_images/balance_sheet.tex
+++ b/templates/demo_with_images/balance_sheet.tex
@@ -1,6 +1,6 @@
-%<?lsmb FILTER latex ?>
-%
-%<?lsmb
+<?lsmb FILTER latex ?>
+
+<?lsmb
   IF hierarchy == 'flat-hierarchy';
     max_path_depth = 1;
   ELSE;

--- a/templates/xedemo/PNL.tex
+++ b/templates/xedemo/PNL.tex
@@ -116,4 +116,4 @@ END; -?>
 \end{longtable}
 \end{document}
 
-%<?lsmb END ?>
+<?lsmb END ?>


### PR DESCRIPTION
Some of the PNL and B/S templates have incorrect syntax. Especially now
that these are moving to the database, it's important to have them be
correct: more than average attention is going to go their way.

Manual backport from a bigger change which itself shouldn't land verbatim
on the 1.8 branch.
