### PR TITLE
Cleanup templates

### DIFF
--- a/templates/demo/ap_transaction.tex
+++ b/templates/demo/ap_transaction.tex
@@ -91,7 +91,7 @@ Tax Number: <?lsmb vendortaxnumber ?>
 
 <?lsmb IF notes ?>
 \vspace{0.3cm}
-<?lsmb FOREACH P IN notes.split('\n{2,}') ?>
+<?lsmb FOREACH P IN notes.split('\n\n+') ?>
 <?lsmb P ?>\medskip
 
 <?lsmb END ?>

--- a/templates/demo/ar_transaction.tex
+++ b/templates/demo/ar_transaction.tex
@@ -108,7 +108,7 @@
 
 <?lsmb IF notes ?>
 \vspace{0.3cm}
-<?lsmb FOREACH P IN notes.split('\n{2,}') ?>
+<?lsmb FOREACH P IN notes.split('\n\n+') ?>
 <?lsmb P ?>\medskip
 
 <?lsmb END ?>

--- a/templates/demo/check.tex
+++ b/templates/demo/check.tex
@@ -1,6 +1,6 @@
 <?lsmb FILTER latex { format="$FORMAT(pdflatex)" } ?>
 \documentclass{scrartcl}
-\usepackage[latin1]{inputenc}
+\usepackage[utf8]{inputenc}
 \usepackage{tabularx}
 \usepackage[letterpaper,top=2cm,bottom=1.5cm,left=1.1cm,right=1.5cm]{geometry}
 \usepackage{graphicx}

--- a/templates/demo/check.tex
+++ b/templates/demo/check.tex
@@ -1,5 +1,6 @@
 <?lsmb FILTER latex { format="$FORMAT(pdflatex)" } ?>
 \documentclass{scrartcl}
+\usepackage[T1]{fontenc}
 \usepackage[utf8]{inputenc}
 \usepackage{tabularx}
 \usepackage[letterpaper,top=2cm,bottom=1.5cm,left=1.1cm,right=1.5cm]{geometry}

--- a/templates/demo/check_multiple.tex
+++ b/templates/demo/check_multiple.tex
@@ -1,5 +1,6 @@
 <?lsmb FILTER latex { format="$FORMAT(pdflatex)" } ?>
 \documentclass{scrartcl}
+\usepackage[T1]{fontenc}
 \usepackage[utf8]{inputenc}
 \usepackage{tabularx}
 \usepackage{graphicx}

--- a/templates/demo/check_multiple.tex
+++ b/templates/demo/check_multiple.tex
@@ -1,6 +1,6 @@
 <?lsmb FILTER latex { format="$FORMAT(pdflatex)" } ?>
 \documentclass{scrartcl}
-\usepackage[latin1]{inputenc}
+\usepackage[utf8]{inputenc}
 \usepackage{tabularx}
 \usepackage{graphicx}
 \usepackage[letterpaper,top=2cm,bottom=1.5cm,left=1.1cm,right=1.5cm]{geometry}

--- a/templates/demo/envelope.tex
+++ b/templates/demo/envelope.tex
@@ -1,5 +1,6 @@
 <?lsmb FILTER latex { format="$FORMAT(pdflatex)" } ?>
 \documentclass{scrartcl}
+\usepackage[T1]{fontenc}
 \usepackage[utf8]{inputenc}
 \usepackage{tabularx}
 \usepackage[paperheight=11cm, paperwidth=23cm,top=3.5cm,bottom=3cm,left=12cm,right=1cm]{geometry}

--- a/templates/demo/envelope.tex
+++ b/templates/demo/envelope.tex
@@ -1,6 +1,6 @@
 <?lsmb FILTER latex { format="$FORMAT(pdflatex)" } ?>
 \documentclass{scrartcl}
-\usepackage[latin1]{inputenc}
+\usepackage[utf8]{inputenc}
 \usepackage{tabularx}
 \usepackage[paperheight=11cm, paperwidth=23cm,top=3.5cm,bottom=3cm,left=12cm,right=1cm]{geometry}
 \begin{document}

--- a/templates/demo/invoice.tex
+++ b/templates/demo/invoice.tex
@@ -191,7 +191,7 @@ Fax: <?lsmb shiptofax ?>
 <?lsmb text('All prices in [_1].', currency) ?>
 
 \vspace{12pt}
-<?lsmb FOREACH P IN notes.split('\n{2,}') ?>
+<?lsmb FOREACH P IN notes.split('\n\n+') ?>
 <?lsmb P ?>\medskip
 
 <?lsmb END ?>

--- a/templates/demo/packing_list.tex
+++ b/templates/demo/packing_list.tex
@@ -129,7 +129,7 @@
 
 \vspace{12pt}
 
-<?lsmb FOREACH P IN notes.split('\n{2,}') ?>
+<?lsmb FOREACH P IN notes.split('\n\n+') ?>
 <?lsmb P ?>\medskip
 
 <?lsmb END ?>

--- a/templates/demo/product_receipt.tex
+++ b/templates/demo/product_receipt.tex
@@ -99,11 +99,11 @@
 \vspace{1cm}
 \begin{tabularx}{\textwidth}{*{6}{|X}|} \hline
   \textbf{<?lsmb text('Invoice #') ?>} & \textbf{<?lsmb text('Date') ?>}
-   & \textbf{<?lsmb text('Contact') ?>}
+   & \textbf{<?lsmb text('Required by') ?>} & \textbf{<?lsmb text('Contact') ?>}
    & \textbf{<?lsmb text('Shipping Point') ?>}
    & \textbf{<?lsmb text('Ship via') ?>} \\ [0.5ex]
   \hline
-  <?lsmb invnumber ?> & <?lsmb transdate ?> & <?lsmb employee ?> & <?lsmb shippingpoint ?> & <?lsmb shipvia ?> \\
+  <?lsmb invnumber ?> & <?lsmb transdate ?> & <?lsmb reqdate ?> & <?lsmb employee ?> & <?lsmb shippingpoint ?> & <?lsmb shipvia ?> \\
   \hline
 \end{tabularx}
 
@@ -144,7 +144,7 @@
 
 \vspace{12pt}
 
-<?lsmb FOREACH P IN notes.split('\n{2,}') ?>
+<?lsmb FOREACH P IN notes.split('\n\n+') ?>
 <?lsmb P ?>\medskip
 
 <?lsmb END ?>

--- a/templates/demo/purchase_order.tex
+++ b/templates/demo/purchase_order.tex
@@ -150,7 +150,7 @@
 
 \vspace{12pt}
 
-<?lsmb FOREACH P IN notes.split('\n{2,}') ?>
+<?lsmb FOREACH P IN notes.split('\n\n+') ?>
 <?lsmb P ?>\medskip
 
 <?lsmb END ?>

--- a/templates/demo/request_quotation.tex
+++ b/templates/demo/request_quotation.tex
@@ -134,7 +134,7 @@
 
 \hfill
 
-<?lsmb FOREACH P IN notes.split('\n{2,}') ?>
+<?lsmb FOREACH P IN notes.split('\n\n+') ?>
 <?lsmb P ?>\medskip
 
 <?lsmb END ?>

--- a/templates/demo/sales_order.tex
+++ b/templates/demo/sales_order.tex
@@ -159,7 +159,7 @@
 
 \vspace{12pt}
 
-<?lsmb FOREACH P IN notes.split('\n{2,}') ?>
+<?lsmb FOREACH P IN notes.split('\n\n+') ?>
 <?lsmb P ?>\medskip
 
 <?lsmb END ?>

--- a/templates/demo/sales_quotation.tex
+++ b/templates/demo/sales_quotation.tex
@@ -79,7 +79,7 @@
 
 \vspace{1cm}
 
-\begin{longtable}{@{\extracolsep{\fill}}llrlrr|r@{\extracolsep{0pt}}}
+\begin{longtable}{@{\extracolsep{\fill}}llrlrrr@{\extracolsep{0pt}}}
   \textbf{<?lsmb text('Number') ?>} & \textbf{<?lsmb text('Description') ?>}
    & \textbf{<?lsmb text('Qty') ?>} & \textbf{<?lsmb text('Unit') ?>}
    & \textbf{<?lsmb text('Price') ?>} & \textbf{<?lsmb text('Disc %') ?>}
@@ -100,13 +100,14 @@
  & & & & & \\
 <?lsmb END ?>
 \hline \hline
-\multicolumn{6}{r|}{<?lsmb text('Subtotal') ?>} & <?lsmb subtotal ?> \\*
+\multicolumn{6}{r}{<?lsmb text('Subtotal') ?>} & <?lsmb subtotal ?> \\*
 <?lsmb FOREACH tax ?>
 <?lsmb lc = loop.count - 1 ?>
-\multicolumn{6}{r|}{<?lsmb taxdescription.${lc}
+\multicolumn{6}{r}{<?lsmb taxdescription.${lc}
                     ?>  on <?lsmb taxbase.${lc} ?> }
  & <?lsmb tax.${lc} ?> \\*
 <?lsmb END ?>
+\multicolumn{6}{r}{<?lsmb text('Total') ?> } & <?lsmb quototal ?> \\*
 \end{longtable}
 
 
@@ -124,7 +125,7 @@
 
 \vspace{12pt}
 
-<?lsmb FOREACH P IN notes.split('\n{2,}') ?>
+<?lsmb FOREACH P IN notes.split('\n\n+') ?>
 <?lsmb P ?>\medskip
 
 <?lsmb END ?>

--- a/templates/demo/shipping_label.tex
+++ b/templates/demo/shipping_label.tex
@@ -1,6 +1,6 @@
 <?lsmb FILTER latex { format="$FORMAT(pdflatex)" } ?>
 \documentclass{scrartcl}
-\usepackage[latin1]{inputenc}
+\usepackage[utf8]{inputenc}
 \usepackage{tabularx}
 \usepackage[paperheight=10.5cm, paperwidth=16.2cm,top=1cm,bottom=1.5cm,left=2cm,right=2cm]{geometry}
 \begin{document}

--- a/templates/demo/shipping_label.tex
+++ b/templates/demo/shipping_label.tex
@@ -1,5 +1,6 @@
 <?lsmb FILTER latex { format="$FORMAT(pdflatex)" } ?>
 \documentclass{scrartcl}
+\usepackage[T1]{fontenc}
 \usepackage[utf8]{inputenc}
 \usepackage{tabularx}
 \usepackage[paperheight=10.5cm, paperwidth=16.2cm,top=1cm,bottom=1.5cm,left=2cm,right=2cm]{geometry}

--- a/templates/demo/timecard.tex
+++ b/templates/demo/timecard.tex
@@ -43,7 +43,7 @@
   
 \vspace{0.3cm}
 
-<?lsmb FOREACH P IN notes.split('\n{2,}') ?>
+<?lsmb FOREACH P IN notes.split('\n\n+') ?>
 <?lsmb P ?>\medskip
 
 <?lsmb END ?>

--- a/templates/demo/work_order.tex
+++ b/templates/demo/work_order.tex
@@ -136,7 +136,7 @@
 
 \vspace{12pt}
 
-<?lsmb FOREACH P IN notes.split('\n{2,}') ?>
+<?lsmb FOREACH P IN notes.split('\n\n+') ?>
 <?lsmb P ?>\medskip
 
 <?lsmb END ?>

--- a/templates/lib/preamble-pdflatex.tex
+++ b/templates/lib/preamble-pdflatex.tex
@@ -1,5 +1,6 @@
 <?lsmb FILTER latex { format="$FORMAT(pdflatex)" } -?>
 \documentclass{scrartcl}
+\usepackage[T1]{fontenc}
 \usepackage[utf8]{inputenc}
 \usepackage{tabularx}
 \usepackage{longtable}

--- a/templates/xedemo/ap_transaction.tex
+++ b/templates/xedemo/ap_transaction.tex
@@ -89,7 +89,7 @@ Tax Number: <?lsmb vendortaxnumber ?>
 
 <?lsmb IF notes ?>
 \vspace{0.3cm}
-<?lsmb FOREACH P IN notes.split('\n\n') ?>
+<?lsmb FOREACH P IN notes.split('\n\n+') ?>
 <?lsmb P ?>\medskip
 
 <?lsmb END ?>

--- a/templates/xedemo/ar_transaction.tex
+++ b/templates/xedemo/ar_transaction.tex
@@ -106,7 +106,7 @@
 
 <?lsmb IF notes ?>
 \vspace{0.3cm}
-<?lsmb FOREACH P IN notes.split('\n\n') ?>
+<?lsmb FOREACH P IN notes.split('\n\n+') ?>
 <?lsmb P ?>\medskip
 
 <?lsmb END ?>

--- a/templates/xedemo/check.tex
+++ b/templates/xedemo/check.tex
@@ -1,8 +1,6 @@
 <?lsmb FILTER latex { format="$FORMAT(xelatex)" } ?>
 \documentclass{scrartcl}
- \usepackage{xltxtra}
- \usepackage{fontspec}
- \setmainfont{LiberationSans-Regular.ttf}
+\usepackage{fontspec}
 \usepackage{tabularx}
 \usepackage[letterpaper,top=2cm,bottom=1.5cm,left=1.1cm,right=1.5cm]{geometry}
 \usepackage{graphicx}

--- a/templates/xedemo/check_base.tex
+++ b/templates/xedemo/check_base.tex
@@ -52,7 +52,7 @@ format_amount({amount = amount, format = '1,000.00', money = 1}) ?>
 \textbf{<?lsmb text('Invoice #') ?>} & \textbf{<?lsmb text('Invoice Date') ?>}
   & \textbf{<?lsmb text('Amount Due') ?>} & \textbf{<?lsmb text('Applied') ?>} \\
 <?lsmb FOR inv = invoices ?>
-<?lsmb inv.invnumber ?> & <?lsmb inv.invdate ?> \dotfill
+<?lsmb inv.invnumber ?> & <?lsmb inv.invoice_date ?> \dotfill
   & <?lsmb inv.due ?> & <?lsmb inv.paid ?> \\
 <?lsmb END # FOREACH inv ?>
 \end{tabularx}

--- a/templates/xedemo/check_multiple.tex
+++ b/templates/xedemo/check_multiple.tex
@@ -1,11 +1,9 @@
 <?lsmb FILTER latex { format="$FORMAT(xelatex)" } ?>
 \documentclass{scrartcl}
- \usepackage{xltxtra}
- \usepackage{fontspec}
- \setmainfont{LiberationSans-Regular.ttf}
+\usepackage{fontspec}
 \usepackage{tabularx}
-\usepackage[letterpaper,top=2cm,bottom=1.5cm,left=1.1cm,right=1.5cm]{geometry}
 \usepackage{graphicx}
+\usepackage[letterpaper,top=2cm,bottom=1.5cm,left=1.1cm,right=1.5cm]{geometry}
 
 <?lsmb PROCESS check_base ?>
 

--- a/templates/xedemo/envelope.tex
+++ b/templates/xedemo/envelope.tex
@@ -1,5 +1,6 @@
 <?lsmb FILTER latex { format="$FORMAT(xelatex)" } ?>
 \documentclass{scrartcl}
+\usepackage{fontspec}
 \usepackage{tabularx}
 \usepackage[paperheight=11cm, paperwidth=23cm,top=3.5cm,bottom=3cm,left=12cm,right=1cm]{geometry}
 \begin{document}

--- a/templates/xedemo/invoice.tex
+++ b/templates/xedemo/invoice.tex
@@ -104,8 +104,12 @@ Fax: <?lsmb shiptofax ?>
 
 \vspace{1cm}
 
-\textbf{\MakeUppercase{<?lsmb IF reverse; text('Credit Invoice');
-    ELSE; text('Invoice'); END; ?>}}
+\textbf{\MakeUppercase{<?lsmb
+    IF reverse;
+       text('Credit Invoice');
+    ELSE;
+       text('Invoice');
+    END; ?>}}
 \hfill
 
 \vspace{1cm}
@@ -134,7 +138,8 @@ Fax: <?lsmb shiptofax ?>
   & \textbf{<?lsmb text('Unit') ?>} 
   & \textbf{<?lsmb text('Price') ?>} 
   &  \textbf{<?lsmb text('Disc %') ?>} 
-  & \textbf{<?lsmb text('Amount') ?>} 
+  & \textbf{<?lsmb text('Amount') ?>} \\
+\hline
 \endhead
 <?lsmb FOREACH number ?>
 <?lsmb lc = loop.count - 1 ?>
@@ -185,7 +190,7 @@ Fax: <?lsmb shiptofax ?>
 
 \vspace{12pt}
 
-<?lsmb FOREACH P IN notes.split('\n\n') ?>
+<?lsmb FOREACH P IN notes.split('\n\n+') ?>
 <?lsmb P ?>\medskip
 
 <?lsmb END ?>
@@ -202,8 +207,12 @@ Fax: <?lsmb shiptofax ?>
 <?lsmb FOREACH payment ?>
 <?lsmb lc = loop.count - 1 ?>
   <?lsmb paymentdate.${lc} ?> & <?lsmb paymentaccount.${lc} ?> & <?lsmb paymentsource.${lc} ?> & <?lsmb payment.${lc} ?> \\
+<?lsmb END ?>
 \end{tabularx}
 <?lsmb END ?>
+
+<?lsmb FOR FILE IN file_list ?>
+\includegraphics[scale=0.3]{<?lsmb file_path _ '/' _ FILE.file_name ?>}
 <?lsmb END ?>
 
 \vspace{1cm}

--- a/templates/xedemo/packing_list.tex
+++ b/templates/xedemo/packing_list.tex
@@ -127,7 +127,7 @@
 
 \vspace{12pt}
 
-<?lsmb FOREACH P IN notes.split('\n\n') ?>
+<?lsmb FOREACH P IN notes.split('\n\n+') ?>
 <?lsmb P ?>\medskip
 
 <?lsmb END ?>

--- a/templates/xedemo/product_receipt.tex
+++ b/templates/xedemo/product_receipt.tex
@@ -97,7 +97,7 @@
 \vspace{1cm}
 \begin{tabularx}{\textwidth}{*{6}{|X}|} \hline
   \textbf{<?lsmb text('Invoice #') ?>} & \textbf{<?lsmb text('Date') ?>} 
-   & \textbf{<?lsmb text('Required by') ?>} & \textbf{<?lsmb text('Contact') ?>} 
+   & \textbf{<?lsmb text('Required by') ?>} & \textbf{<?lsmb text('Contact') ?>}
    & \textbf{<?lsmb text('Shipping Point') ?>} 
    & \textbf{<?lsmb text('Ship via') ?>} \\ [0.5ex]
   \hline
@@ -142,7 +142,7 @@
 
 \vspace{12pt}
 
-<?lsmb FOREACH P IN notes.split('\n\n') ?>
+<?lsmb FOREACH P IN notes.split('\n\n+') ?>
 <?lsmb P ?>\medskip
 
 <?lsmb END ?>

--- a/templates/xedemo/purchase_order.tex
+++ b/templates/xedemo/purchase_order.tex
@@ -148,7 +148,7 @@
 
 \vspace{12pt}
 
-<?lsmb FOREACH P IN notes.split('\n\n') ?>
+<?lsmb FOREACH P IN notes.split('\n\n+') ?>
 <?lsmb P ?>\medskip
 
 <?lsmb END ?>

--- a/templates/xedemo/request_quotation.tex
+++ b/templates/xedemo/request_quotation.tex
@@ -132,7 +132,7 @@
 
 \hfill
 
-<?lsmb FOREACH P IN notes.split('\n\n') ?>
+<?lsmb FOREACH P IN notes.split('\n\n+') ?>
 <?lsmb P ?>\medskip
 
 <?lsmb END ?>

--- a/templates/xedemo/sales_order.tex
+++ b/templates/xedemo/sales_order.tex
@@ -157,7 +157,7 @@
 
 \vspace{12pt}
 
-<?lsmb FOREACH P IN notes.split('\n\n') ?>
+<?lsmb FOREACH P IN notes.split('\n\n+') ?>
 <?lsmb P ?>\medskip
 
 <?lsmb END ?>

--- a/templates/xedemo/sales_quotation.tex
+++ b/templates/xedemo/sales_quotation.tex
@@ -34,8 +34,7 @@
 <?lsmb address2 ?>
 
 <?lsmb city ?>
-<?lsmb IF state ?>
-\hspace{-0.1cm}, <?lsmb state ?>
+<?lsmb IF state ?>\hspace{-0.1cm}, <?lsmb state ?>
 <?lsmb END ?>
 <?lsmb zipcode ?>
 
@@ -87,13 +86,25 @@
 <?lsmb FOREACH number ?>
 <?lsmb lc = loop.count - 1 ?>
   <?lsmb number.${lc} ?> &
-  <?lsmb item_description.${lc} ?> &
+\begin{minipage}{2in}
+\raggedright
+  <?lsmb item_description.${lc} ?>
+\end{minipage}&
   <?lsmb qty.${lc} ?> &
   <?lsmb unit.${lc} ?> &
   <?lsmb sellprice.${lc} ?> &
   <?lsmb discountrate.${lc} ?> &
   <?lsmb linetotal.${lc} ?> \\
 <?lsmb END ?>
+\hline \hline
+\multicolumn{6}{r}{<?lsmb text('Subtotal') ?>} & <?lsmb subtotal ?> \\*
+<?lsmb FOREACH tax ?>
+<?lsmb lc = loop.count - 1 ?>
+\multicolumn{6}{r}{<?lsmb taxdescription.${lc}
+                    ?>  on <?lsmb taxbase.${lc} ?> }
+ & <?lsmb tax.${lc} ?> \\*
+<?lsmb END ?>
+\multicolumn{6}{r}{<?lsmb text('Total') ?> } & <?lsmb quototal ?> \\*
 \end{longtable}
 
 
@@ -101,19 +112,6 @@
 \rule{\textwidth}{2pt}
 
 \vspace{0.2cm}
-
-\hfill
-\begin{tabularx}{7cm}{Xr@{\hspace{1cm}}r@{}}
-  & Subtotal & <?lsmb subtotal ?> \\
-<?lsmb FOREACH tax ?>
-<?lsmb lc = loop.count - 1 ?>
-  & <?lsmb taxdescription.${lc} ?> on <?lsmb taxbase.${lc} ?> & <?lsmb tax.${lc} ?>\\
-<?lsmb END ?>
-  \hline
-  & Total & <?lsmb quototal ?>\\
-\end{tabularx}
-
-\vspace{0.3cm}
 
 \hfill
 <?lsmb text('All prices in [_1].', currency) ?>
@@ -124,7 +122,7 @@
 
 \vspace{12pt}
 
-<?lsmb FOREACH P IN notes.split('\n\n') ?>
+<?lsmb FOREACH P IN notes.split('\n\n+') ?>
 <?lsmb P ?>\medskip
 
 <?lsmb END ?>

--- a/templates/xedemo/shipping_label.tex
+++ b/templates/xedemo/shipping_label.tex
@@ -1,5 +1,6 @@
 <?lsmb FILTER latex { format="$FORMAT(xelatex)" } ?>
 \documentclass{scrartcl}
+\usepackage{fontspec}
 \usepackage{tabularx}
 \usepackage[paperheight=10.5cm, paperwidth=16.2cm,top=1cm,bottom=1.5cm,left=2cm,right=2cm]{geometry}
 \begin{document}

--- a/templates/xedemo/timecard.tex
+++ b/templates/xedemo/timecard.tex
@@ -41,7 +41,7 @@
   
 \vspace{0.3cm}
 
-<?lsmb FOREACH P IN notes.split('\n\n') ?>
+<?lsmb FOREACH P IN notes.split('\n\n+') ?>
 <?lsmb P ?>\medskip
 
 <?lsmb END ?>

--- a/templates/xedemo/work_order.tex
+++ b/templates/xedemo/work_order.tex
@@ -134,7 +134,7 @@
 
 \vspace{12pt}
 
-<?lsmb FOREACH P IN notes.split('\n\n') ?>
+<?lsmb FOREACH P IN notes.split('\n\n+') ?>
 <?lsmb P ?>\medskip
 
 <?lsmb END ?>


### PR DESCRIPTION
After merging this PR, there's only 1 functional difference between the templates for XeLaTeX and PDFLaTeX: some templates for pdflatex select the `cmss` font family and change the font to size 10 which none of the XeLaTeX documents do.