### PR TITLE
Use only language code if country variant is not in list

### DIFF
--- a/old/lib/LedgerSMB/DBObject/User.pm
+++ b/old/lib/LedgerSMB/DBObject/User.pm
@@ -161,6 +161,8 @@ sub get {
     $self->{user} = $user;
     my ($prefs) = $self->call_dbmethod(funcname=>'user__get_preferences');
     $self->{prefs} = $prefs;
+    $self->{prefs}{language} =~ s/_[a-z]{2}//gi
+        if $self->{prefs}{language} && !code2language($self->{prefs}{language});
     my ($emp) = $self->call_procedure(
         funcname=>'employee__get',
         args=>[$self->{user}->{entity_id}]
@@ -221,4 +223,3 @@ sub get_all_users {
 =cut
 
 1;
-


### PR DESCRIPTION
User preferences defaults to first entry if the user uses a country variant which is not in the database. Default to the language only if the variant is not found.