### PR TITLE
Fix missing buttons on new transaction in company with closed period

### DIFF
--- a/old/bin/is.pl
+++ b/old/bin/is.pl
@@ -649,7 +649,7 @@ sub form_header {
 
                 for ( keys %button ) { delete $button{$_} if !$allowed{$_} }
             }
-            elsif ($closedto) {
+            elsif ($closedto and $transdate) {
                 %button = ();
             }
             else {


### PR DESCRIPTION
The transdate on a new transaction is undefined; only clear the buttons when
the transdate *is* defined.
