### PR TITLE
Prevent downgrading Math::BigFloat to BigInt

### DIFF
--- a/lib/LedgerSMB/PGNumber.pm
+++ b/lib/LedgerSMB/PGNumber.pm
@@ -181,6 +181,7 @@ sub from_input {
             -thousands_sep => $lsmb_formats->{$format}->{thousands_sep},
             -decimal_point => $lsmb_formats->{$format}->{decimal_sep},
         );
+        local $Math::BigFloat::downgrade = undef;
         $newval = $formatter->unformat_number($string);
         $pgnum = LedgerSMB::PGNumber->new($newval);
         $self->round_mode('+inf');


### PR DESCRIPTION
This is a defensive pull request to make sure that our floating number handling stays immune from other modules interference.
The Math::BigFloat system routines rely on a global configuration which control downgrading to a smaller version, such as BigInt. This has serious impacts on output conversion for PGNumber, so this PR makes sure that no downgrading is allowed.