### PR TITLE
Adjust development psgi

### DIFF
--- a/UI/css/ledgersmb-common.css
+++ b/UI/css/ledgersmb-common.css
@@ -159,6 +159,12 @@ body.menu,
     font-size: var(--body-font-size);
 }
 
+.mainpanel,
+.menupanel {
+    position: absolute !important;
+    z-index: 1000 !important;
+}
+
 .cornerlogo {
     background: var(--cornerlogo-bg);
     border: var(--cornerlogo-border);

--- a/cpanfile
+++ b/cpanfile
@@ -153,6 +153,7 @@ on 'develop' => sub {
             recommends 'Plack::Middleware::Debug::LazyLoadModules';
             recommends 'Plack::Middleware::Debug::Log4perl';
             recommends 'Plack::Middleware::Debug::Profiler::NYTProf';
+            recommends 'Plack::Middleware::Debug::RefCounts';
             recommends 'Plack::Middleware::Debug::TraceENV';
             recommends 'Plack::Middleware::Debug::W3CValidate';
             recommends 'Plack::Middleware::InteractiveDebugger';

--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -221,6 +221,11 @@ def 'PerlConfig',
     default => 0,
     doc => q{};
 
+def 'RefCounts',
+    section => 'debug',
+    default => 1,
+    doc => q{};
+
 def 'Response',
     section => 'debug',
     default => 0,

--- a/utils/devel/ledgersmb-server-development.psgi
+++ b/utils/devel/ledgersmb-server-development.psgi
@@ -29,8 +29,8 @@ require Plack::Middleware::Pod
 
 my $path = $INC{"LedgerSMB.pm"};
 my $version = $LedgerSMB::VERSION;
-die "Library verification failed (found $version from '$path', expected 1.7)"
-    unless $version =~ /^1\.7\./;
+die "Library verification failed (found $version from '$path', expected 1.9)"
+    unless $version =~ /^1\.9\./;
 
 # Report to the console what type of dojo we are running
 if ( $LedgerSMB::Sysconfig::dojo_built) {
@@ -76,7 +76,7 @@ builder {
                 enable "Debug::$_";
             }
         }
-        for (qw(LazyLoadModules Log4perl)) {
+        for (qw(LazyLoadModules Log4perl RefCounts)) {
             enable "Debug::$_"
                 if check_config_option("$_","Plack::Middleware::Debug::$_");
         }


### PR DESCRIPTION
This brings the development PSGI up to date.
- Adjust LedgerSMB version
- Allow main and menu frames to be behind heat map graphs
- Add RefCounts to check for memory leaks
