### PR TITLE
Fix #4878: Showing batch content fails

### DIFF
--- a/lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm
+++ b/lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm
@@ -239,7 +239,7 @@ Runs the report, and assigns rows to $self->rows.
 sub run_report{
     my ($self) = @_;
     my $locales = [ map { { text => code2country($_), value => $_ } }
-                    sort all_country_codes()
+                    sort (all_country_codes(), )
                   ];
     my $printer = [ {text => 'Screen', value => 'zip'},
                     map { {


### PR DESCRIPTION
Perl interpreted the sort statement as

  sort all_country_codes ()

which is an instance of `sort SUB LIST` where the SUB names a
sort routine. The statement meant to use an instance of
`sort LIST`, though, which this change makes explicit.
