### PR TITLE
Fix #3236: part description dropdown on invoice active after part selected

### DIFF
--- a/old/bin/io.pl
+++ b/old/bin/io.pl
@@ -331,6 +331,13 @@ qq|<option value="$ref->{partsgroup}--$ref->{id}">$ref->{partsgroup}\n|;
             $column_data{description} = qq|<td>$form->{"description_$i"} |
              . qq|<input type="hidden" name="description_$i"
                         value="$form->{"description_$i"}" /></td>|
+        } elsif ($form->{"partnumber_$i"}) {
+            $form->{"description_$i"} //= '';
+            $column_data{description} =
+                qq|<td><div data-dojo-type="dijit/form/Textarea"
+                            id="description_$i" name="description_$i"
+                            size=48 style="width: 100%;font:inherit !important"
+                            >$form->{"description_$i"}</div></td>|;
         } else {
             $form->{"description_$i"} //= '';
             $column_data{description} =


### PR DESCRIPTION
After a part has been selected, the drop-down on the part number disappears
because no further selection is required. The part description needs to stay
active, because the description can be edited. However, the drop-down also
remained active, which suggests a new part can be selected. This isn't the
case and this commit removes the dropdown showing up after the part has been
selected.
