### PR TITLE
Fix #4439: Default language on credit account is first-in-list

### DIFF
--- a/UI/Contact/divs/credit.html
+++ b/UI/Contact/divs/credit.html
@@ -278,6 +278,7 @@ PROCESS dynatable
                 label = text("Language")
                 name = "language_code"
                 default_values = [credit_act.language_code],
+                default_blank = 1,
                 options = language_code_list
                 text_attr = "text"
                 value_attr = "code"


### PR DESCRIPTION
Instead of automatically setting the credit account language to the first
in the list, don't select any value, so the user can select one when
desired.
