### PR TITLE
Do not force-reinstall JSON::PP module to save on TravisCI caches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -117,7 +117,7 @@ before_install:
 install:
   # Suppress warnings in Perl 5.28 about redifinition of JSON::PP::Boolean
   # which is fixed in 4.03 (so, reinstall, in order to get to newest)
-  - cpanm --reinstall --notest JSON::PP
+  - cpanm --quiet --notest JSON::PP~4.03
   - cpanm --quiet --notest Cpanel::JSON::XS~3.0206
   - cpanm --quiet --notest Starlet
   - cpanm --quiet --notest --metacpan --installdeps --with-develop --with-feature=edi --with-feature=latex-pdf-ps --with-feature=openoffice  --with-feature=starman --with-feature=xls .


### PR DESCRIPTION
Note that creating fewer caches also reduces total run time, because
creation and uploading of caches obviously takes time.
