### PR TITLE
Install Locale::Codes from CPAN if it's not

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -134,7 +134,9 @@ install:
   # Suppress warnings in Perl 5.28 about Locale::* being moved out of 'core'
   # Further more is there a warning regarding redifinition of JSON::PP::Boolean
   # which is fixed in 4.03 (so, reinstall, in order to get to newest)
-  - cpanm --reinstall --notest Locale::Country Locale::Codes Locale::Language JSON::PP
+  - perldoc -lm Locale::Codes
+  - if [ -z "$(perldoc -lm Locale::Codes | grep locallib)" ]; then cpanm --quiet --notest Locale::Country Locale::Codes Locale::Language ; fi
+  - cpanm --quiet --notest JSON::PP~4.03
   - cpanm --quiet --notest Cpanel::JSON::XS~3.0206
   - cpanm --quiet --notest Starlet
   - cpanm --quiet --notest --metacpan --installdeps --with-develop --with-feature=edi --with-feature=latex-pdf-ps --with-feature=openoffice  --with-feature=starman --with-feature=xls .


### PR DESCRIPTION
Note that Locale::Codes is installed on all perls before 5.30, but 5.26+
issue a warning to install from CPAN. We want clean tests, so install
from CPAN into local::lib when it isn't already.
