### PR TITLE
Reference preamble files with their extension

### DIFF
--- a/templates/demo/ap_transaction.tex
+++ b/templates/demo/ap_transaction.tex
@@ -1,5 +1,5 @@
 <?lsmb FILTER latex { format="$FORMAT(pdflatex)" };
-       INCLUDE "preamble-pdflatex"; -?>
+       INCLUDE "preamble-pdflatex.tex"; -?>
 
 \begin{document}
 

--- a/templates/demo/ar_transaction.tex
+++ b/templates/demo/ar_transaction.tex
@@ -1,5 +1,5 @@
 <?lsmb FILTER latex { format="$FORMAT(pdflatex)" };
-       INCLUDE "preamble-pdflatex"; -?>
+       INCLUDE "preamble-pdflatex.tex"; -?>
 
 \begin{document}
 

--- a/templates/demo/bin_list.tex
+++ b/templates/demo/bin_list.tex
@@ -1,5 +1,5 @@
 <?lsmb FILTER latex { format="$FORMAT(pdflatex)" };
-       INCLUDE "preamble-pdflatex"; -?>
+       INCLUDE "preamble-pdflatex.tex"; -?>
 
 \begin{document}
 

--- a/templates/demo/invoice.tex
+++ b/templates/demo/invoice.tex
@@ -1,5 +1,5 @@
 <?lsmb FILTER latex { format="$FORMAT(pdflatex)" };
-       INCLUDE "preamble-pdflatex"; -?>
+       INCLUDE "preamble-pdflatex.tex"; -?>
 
 \setlength\LTleft{0pt}
 \setlength\LTright{0pt}

--- a/templates/demo/packing_list.tex
+++ b/templates/demo/packing_list.tex
@@ -1,5 +1,5 @@
 <?lsmb FILTER latex { format="$FORMAT(pdflatex)" };
-       INCLUDE "preamble-pdflatex"; -?>
+       INCLUDE "preamble-pdflatex.tex"; -?>
 
 \begin{document}
 

--- a/templates/demo/pick_list.tex
+++ b/templates/demo/pick_list.tex
@@ -1,5 +1,5 @@
 <?lsmb FILTER latex { format="$FORMAT(pdflatex)" };
-       INCLUDE "preamble-pdflatex"; -?>
+       INCLUDE "preamble-pdflatex.tex"; -?>
 
 \begin{document}
 

--- a/templates/demo/product_receipt.tex
+++ b/templates/demo/product_receipt.tex
@@ -1,5 +1,5 @@
 <?lsmb FILTER latex { format="$FORMAT(pdflatex)" };
-       INCLUDE "preamble-pdflatex"; -?>
+       INCLUDE "preamble-pdflatex.tex"; -?>
 
 \setlength\LTleft{0pt}
 \setlength\LTright{0pt}

--- a/templates/demo/purchase_order.tex
+++ b/templates/demo/purchase_order.tex
@@ -1,5 +1,5 @@
 <?lsmb FILTER latex { format="$FORMAT(pdflatex)" };
-       INCLUDE "preamble-pdflatex"; -?>
+       INCLUDE "preamble-pdflatex.tex"; -?>
 
 \setlength\LTleft{0pt}
 \setlength\LTright{0pt}

--- a/templates/demo/receipt.tex
+++ b/templates/demo/receipt.tex
@@ -1,5 +1,5 @@
 <?lsmb FILTER latex { format="$FORMAT(pdflatex)" };
-       INCLUDE "preamble-pdflatex"; -?>
+       INCLUDE "preamble-pdflatex.tex"; -?>
 
 \begin{document}
 

--- a/templates/demo/request_quotation.tex
+++ b/templates/demo/request_quotation.tex
@@ -1,5 +1,5 @@
 <?lsmb FILTER latex { format="$FORMAT(pdflatex)" };
-       INCLUDE "preamble-pdflatex"; -?>
+       INCLUDE "preamble-pdflatex.tex"; -?>
 
 \setlength\LTleft{0pt}
 \setlength\LTright{0pt}

--- a/templates/demo/sales_order.tex
+++ b/templates/demo/sales_order.tex
@@ -1,5 +1,5 @@
 <?lsmb FILTER latex { format="$FORMAT(pdflatex)" };
-       INCLUDE "preamble-pdflatex"; -?>
+       INCLUDE "preamble-pdflatex.tex"; -?>
 
 \setlength\LTleft{0pt}
 \setlength\LTright{0pt}

--- a/templates/demo/sales_quotation.tex
+++ b/templates/demo/sales_quotation.tex
@@ -1,5 +1,5 @@
 <?lsmb FILTER latex { format="$FORMAT(pdflatex)" };
-       INCLUDE "preamble-pdflatex"; -?>
+       INCLUDE "preamble-pdflatex.tex"; -?>
 
 \setlength\LTleft{0pt}
 \setlength\LTright{0pt}

--- a/templates/demo/statement.tex
+++ b/templates/demo/statement.tex
@@ -1,5 +1,5 @@
 <?lsmb FILTER latex { format="$FORMAT(pdflatex)" };
-       INCLUDE "preamble-pdflatex"; -?>
+       INCLUDE "preamble-pdflatex.tex"; -?>
 
 \begin{document}
 

--- a/templates/demo/timecard.tex
+++ b/templates/demo/timecard.tex
@@ -1,5 +1,5 @@
 <?lsmb FILTER latex { format="$FORMAT(pdflatex)" };
-       INCLUDE "preamble-pdflatex"; -?>
+       INCLUDE "preamble-pdflatex.tex"; -?>
 
 \begin{document}
 

--- a/templates/demo/work_order.tex
+++ b/templates/demo/work_order.tex
@@ -1,5 +1,5 @@
 <?lsmb FILTER latex { format="$FORMAT(pdflatex)" };
-       INCLUDE "preamble-pdflatex"; -?>
+       INCLUDE "preamble-pdflatex.tex"; -?>
 
 \begin{document}
 

--- a/templates/lib/preamble-pdflatex.tex
+++ b/templates/lib/preamble-pdflatex.tex
@@ -1,4 +1,3 @@
-<?lsmb FILTER latex { format="$FORMAT(pdflatex)" } -?>
 \documentclass{scrartcl}
 \usepackage[T1]{fontenc}
 \usepackage[utf8]{inputenc}

--- a/templates/lib/preamble-xelatex.tex
+++ b/templates/lib/preamble-xelatex.tex
@@ -1,4 +1,4 @@
-<?lsmb FILTER latex { format="$FORMAT(xelatex)" } -?>
+
 \documentclass{scrartcl}
 \usepackage{fontspec}
 \usepackage{tabularx}

--- a/templates/xedemo/ap_transaction.tex
+++ b/templates/xedemo/ap_transaction.tex
@@ -1,5 +1,5 @@
 <?lsmb FILTER latex { format="$FORMAT(xelatex)" };
-       INCLUDE "preamble-xelatex" -?>
+       INCLUDE "preamble-xelatex.tex" -?>
 
 \begin{document}
 

--- a/templates/xedemo/ar_transaction.tex
+++ b/templates/xedemo/ar_transaction.tex
@@ -1,5 +1,5 @@
 <?lsmb FILTER latex { format="$FORMAT(xelatex)" };
-       INCLUDE "preamble-xelatex" -?>
+       INCLUDE "preamble-xelatex.tex" -?>
 
 \begin{document}
 

--- a/templates/xedemo/bin_list.tex
+++ b/templates/xedemo/bin_list.tex
@@ -1,5 +1,5 @@
 <?lsmb FILTER latex { format="$FORMAT(xelatex)" };
-       INCLUDE "preamble-xelatex" -?>
+       INCLUDE "preamble-xelatex.tex" -?>
 
 \begin{document}
 

--- a/templates/xedemo/invoice.tex
+++ b/templates/xedemo/invoice.tex
@@ -1,5 +1,5 @@
 <?lsmb FILTER latex { format="$FORMAT(xelatex)" };
-       INCLUDE "preamble-xelatex" -?>
+       INCLUDE "preamble-xelatex.tex" -?>
 
 \setlength\LTleft{0pt}
 \setlength\LTright{0pt}

--- a/templates/xedemo/packing_list.tex
+++ b/templates/xedemo/packing_list.tex
@@ -1,5 +1,5 @@
 <?lsmb FILTER latex { format="$FORMAT(xelatex)" };
-       INCLUDE "preamble-xelatex" -?>
+       INCLUDE "preamble-xelatex.tex" -?>
 
 \begin{document}
 

--- a/templates/xedemo/pick_list.tex
+++ b/templates/xedemo/pick_list.tex
@@ -1,5 +1,5 @@
 <?lsmb FILTER latex { format="$FORMAT(xelatex)" };
-       INCLUDE "preamble-xelatex" -?>
+       INCLUDE "preamble-xelatex.tex" -?>
 
 \begin{document}
 

--- a/templates/xedemo/product_receipt.tex
+++ b/templates/xedemo/product_receipt.tex
@@ -1,5 +1,5 @@
 <?lsmb FILTER latex { format="$FORMAT(xelatex)" };
-       INCLUDE "preamble-xelatex" -?>
+       INCLUDE "preamble-xelatex.tex" -?>
 
 \setlength\LTleft{0pt}
 \setlength\LTright{0pt}

--- a/templates/xedemo/purchase_order.tex
+++ b/templates/xedemo/purchase_order.tex
@@ -1,5 +1,5 @@
 <?lsmb FILTER latex { format="$FORMAT(xelatex)" };
-       INCLUDE "preamble-xelatex" -?>
+       INCLUDE "preamble-xelatex.tex" -?>
 
 \setlength\LTleft{0pt}
 \setlength\LTright{0pt}

--- a/templates/xedemo/receipt.tex
+++ b/templates/xedemo/receipt.tex
@@ -1,5 +1,5 @@
 <?lsmb FILTER latex { format="$FORMAT(xelatex)" };
-       INCLUDE "preamble-xelatex" -?>
+       INCLUDE "preamble-xelatex.tex" -?>
 
 \begin{document}
 

--- a/templates/xedemo/request_quotation.tex
+++ b/templates/xedemo/request_quotation.tex
@@ -1,5 +1,5 @@
 <?lsmb FILTER latex { format="$FORMAT(xelatex)" };
-       INCLUDE "preamble-xelatex" -?>
+       INCLUDE "preamble-xelatex.tex" -?>
 
 \setlength\LTleft{0pt}
 \setlength\LTright{0pt}

--- a/templates/xedemo/sales_order.tex
+++ b/templates/xedemo/sales_order.tex
@@ -1,5 +1,5 @@
 <?lsmb FILTER latex { format="$FORMAT(xelatex)" };
-       INCLUDE "preamble-xelatex" -?>
+       INCLUDE "preamble-xelatex.tex" -?>
 
 \setlength\LTleft{0pt}
 \setlength\LTright{0pt}

--- a/templates/xedemo/sales_quotation.tex
+++ b/templates/xedemo/sales_quotation.tex
@@ -1,5 +1,5 @@
 <?lsmb FILTER latex { format="$FORMAT(xelatex)" };
-       INCLUDE "preamble-xelatex" -?>
+       INCLUDE "preamble-xelatex.tex" -?>
 
 \setlength\LTleft{0pt}
 \setlength\LTright{0pt}

--- a/templates/xedemo/statement.tex
+++ b/templates/xedemo/statement.tex
@@ -1,5 +1,5 @@
 <?lsmb FILTER latex { format="$FORMAT(xelatex)" };
-       INCLUDE "preamble-xelatex" -?>
+       INCLUDE "preamble-xelatex.tex" -?>
 
 \begin{document}
 

--- a/templates/xedemo/timecard.tex
+++ b/templates/xedemo/timecard.tex
@@ -1,5 +1,5 @@
 <?lsmb FILTER latex { format="$FORMAT(xelatex)" };
-       INCLUDE "preamble-xelatex" -?>
+       INCLUDE "preamble-xelatex.tex" -?>
 
 \begin{document}
 

--- a/templates/xedemo/work_order.tex
+++ b/templates/xedemo/work_order.tex
@@ -1,5 +1,5 @@
 <?lsmb FILTER latex { format="$FORMAT(xelatex)" };
-       INCLUDE "preamble-xelatex" -?>
+       INCLUDE "preamble-xelatex.tex" -?>
 
 \begin{document}
 


### PR DESCRIPTION
Templates in the database get referenced without extension, but those on disc
(which the preambles are) do get their extensions included; the latter category
is handled by the regular TT routines, while the DB storage is handled by us.
