### PR TITLE
Remove trailing spaces from strings to translate

### DIFF
--- a/UI/setup/ui-db-credentials.html
+++ b/UI/setup/ui-db-credentials.html
@@ -2,9 +2,9 @@
 <div class="listtop">[% text('Database Credentials') %]</div>
 <table class='lsmb_info' id="credentials">
   <tbody>
-    <tr><td>[% text('Username ') %] :</td>
+    <tr><td>[% text('Username') %] :</td>
       <td id="username">[% login %]</td></tr>
-    <tr><td>[% text('Database ') %] :</td>
+    <tr><td>[% text('Database') %] :</td>
       <td id="databasename">[% database %]</td></tr>
   </tbody>
 </table>

--- a/old/bin/aa.pl
+++ b/old/bin/aa.pl
@@ -69,7 +69,7 @@ my $is_update;
 # $locale->text('February')
 # $locale->text('March')
 # $locale->text('April')
-# $locale->text('May ')
+# $locale->text('May')
 # $locale->text('June')
 # $locale->text('July')
 # $locale->text('August')

--- a/old/bin/gl.pl
+++ b/old/bin/gl.pl
@@ -64,7 +64,7 @@ require "old/bin/arap.pl";
 # $locale->text('February')
 # $locale->text('March')
 # $locale->text('April')
-# $locale->text('May ')
+# $locale->text('May')
 # $locale->text('June')
 # $locale->text('July')
 # $locale->text('August')

--- a/old/bin/io.pl
+++ b/old/bin/io.pl
@@ -64,7 +64,7 @@ if ( -f "old/bin/custom/io.pl" ) {
 # $locale->text('February')
 # $locale->text('March')
 # $locale->text('April')
-# $locale->text('May ')
+# $locale->text('May')
 # $locale->text('June')
 # $locale->text('July')
 # $locale->text('August')


### PR DESCRIPTION
Remove trailing spaces from translated strings to make sure that:
 - they show properly on Transifex, which doesn't display trailing spaces for strings to translate;
 - duplicates are removed;
 - words are shown in the user preferred language