### PR TITLE
Use JSON::PP version 4.03 to suppress a warning about JSON::PP::Boolean

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,7 @@ commands:
               --with-feature=xls \
               --with-feature=edi \
               --installdeps .
+            cpanm --notest JSON::PP~4.03
             cpanm --notest Starlet
             if [ "x$COVERAGE" == "x1" ]
             then


### PR DESCRIPTION
Please note that Travis CI runs with this setup for ages already. Adding this to
CircleCI was much overdue.
