### PR TITLE
Eliminate warning about sort being interpreted as a function call

### DIFF
--- a/lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm
+++ b/lib/LedgerSMB/Report/Unapproved/Batch_Detail.pm
@@ -239,7 +239,7 @@ Runs the report, and assigns rows to $self->rows.
 sub run_report{
     my ($self) = @_;
     my $locales = [ map { { text => code2country($_), value => $_ } }
-                    sort (all_country_codes(), )
+                    sort { $a cmp $b } (all_country_codes(), )
                   ];
     my $printer = [ {text => 'Screen', value => 'zip'},
                     map { {


### PR DESCRIPTION
Due to the fact that sort is followed by parens, it's "upgraded" to
a function call, instead of being its special operator.
