### PR TITLE
Fix #4949: Fix sequence number generator returning the name of the sequence

### DIFF
--- a/lib/LedgerSMB/Setting/Sequence.pm
+++ b/lib/LedgerSMB/Setting/Sequence.pm
@@ -173,10 +173,8 @@ sub increment {
        $vars = $val2;
     }
     my ($ref) = __PACKAGE__->call_procedure(funcname => 'sequence__increment',
-                                          args => [$label]);
-    my ($value) = values %$ref;
-    return increment_process($value, $vars);
-
+                                            args => [$label]);
+    return increment_process($ref->{value}, $vars);
 }
 
 =head2 should_increment($vars, $fldname, [$label]);


### PR DESCRIPTION
The existing code no longer works due to hash randomization (the fact that
it used to work is merely coincidental): due to hash randomization,
sometimes the 'value' key's value is returned as the first element and
some other times, the name of the sequence is returned.
The latter is what @aungzwin10 observes in the issue he reports.
