### PR TITLE
Add Docker support to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,17 @@
 
-DIST_VER=$(shell utils/install/build-id)
+-include Makefile.local
+
+
+DIST_VER=$(shell git rev-parse --short HEAD)
 DIST_DIR=/tmp
 ifeq ($(DIST_VER),travis)
 DIST_DEPS=cached_dojo
 else
 DIST_DEPS=dojo
+endif
+
+ifneq ($(origin CONTAINER),undefined)
+DOCKER_CMD=docker exec -ti $(CONTAINER)
 endif
 
 .DEFAULT_GOAL := help
@@ -313,6 +320,7 @@ clean-libs:
 pod:
 	rm -rf UI/pod
 	mkdir UI/pod
+	chmod 777 UI/pod
 	utils/pod2projdocs.pl 2>&1 pod2projdocs.log
 
 # make critic
@@ -462,12 +470,17 @@ feature_XLS: $(OS_feature_XLS)
 postgres_user:
 	sudo createuser -S -d -r -l -P lsmb_dbadmin
 
+test: TESTS ?= t/
 test:
-	prove -Ilib t/*.t
+	$(DOCKER_CMD) prove $(TESTS)
 
+devtest: TESTS ?= t/ xt/
 devtest:
-	prove -Ilib t/*.t
-	prove -Ilib xt/*.t
+	$(DOCKER_CMD) prove --time --recurse \
+	                    --pgtap-option dbname=lsmbinstalltest \
+	                    --pgtap-option username=postgres \
+	                    --feature-option tags=~@wip \
+	                    $(TESTS)
 
 ########
 # todo list


### PR DESCRIPTION
Make sure we run commands inside Docker when the dev-docker scripts created a
Makefile.local indicating a container has been created.
