### PR TITLE
Follow-up to 75c6e07e6a8f, restore loading account from db

### DIFF
--- a/old/bin/aa.pl
+++ b/old/bin/aa.pl
@@ -144,6 +144,7 @@ sub add {
 sub edit {
 
     &create_links;
+    $form->{$form->{ARAP}} = $form->{"$form->{ARAP}_1"};
     $form->{title} = $locale->text("Edit");
     if ($form->{reverse}){
         if ($form->{ARAP} eq 'AR'){


### PR DESCRIPTION
Without this commit, transactions loaded from the database don't show
the account as it was saved, but the default account.
