### PR TITLE
Fix #1672: Set up better defaults for 'Add Employee'

### DIFF
--- a/lib/LedgerSMB/Scripts/contact.pm
+++ b/lib/LedgerSMB/Scripts/contact.pm
@@ -525,7 +525,7 @@ This method creates a blank screen for entering a company's information.
 
 sub add {
     my ($request) = @_;
-    $request->{target_div} = 'company_div';
+    $request->{target_div} //= 'company_div';
     return _main_screen($request, $request);
 }
 

--- a/sql/changes/1.8/fix-issue-1672.sql
+++ b/sql/changes/1.8/fix-issue-1672.sql
@@ -1,0 +1,5 @@
+
+update menu_node
+   set url = 'contact.pl?action=add&target_div=person_div&entity_class=3'
+ where url = 'contact.pl?action=add'
+   and label = 'Add Employee';

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -133,3 +133,4 @@ mc/delete-migration-validation-data.sql
 1.8/constrain-transactions-table-name.sql
 1.8/add-gl-batch-import-menu.sql
 1.8/fix-reporting-units-pks.sql
+1.8/fix-issue-1672.sql


### PR DESCRIPTION
Note that due to the fact that the 'url' column having been added to the
menu_node table in 1.8, this fix can't be backported further than 1.8.
