### PR TITLE
Fix #4604: AR Search Employee filter does not limit result

### DIFF
--- a/UI/Reports/filters/invoice_outstanding.html
+++ b/UI/Reports/filters/invoice_outstanding.html
@@ -54,7 +54,7 @@
           class = "control-code"
        } %]</td>
 </tr>
-[% PROCESS employee_row %]
+[% PROCESS employee_row SELECTNAME='employee_id' %]
 [% PROCESS business_classes %]
 <tr id="ship-via-row">
   <th>[% text('Ship Via') %]</th>

--- a/UI/Reports/filters/invoice_search.html
+++ b/UI/Reports/filters/invoice_search.html
@@ -57,7 +57,7 @@
           class = "control-code"
        } %]</td>
 </tr>
-[% PROCESS employee_row %]
+[% PROCESS employee_row SELECTNAME='employee_id' %]
 [% PROCESS business_classes %]
 <tr id="taxable-row">
   <th>[% text('Tax Status') %]</th>


### PR DESCRIPTION
The infrastructure is there, but the field  gets submitted as
'person_id' while the code expects the value to be in 'employee_id'.
