### PR TITLE
Fix #4604: AR Search Employee filter does not limit result

### DIFF
--- a/UI/Reports/filters/invoice_outstanding.html
+++ b/UI/Reports/filters/invoice_outstanding.html
@@ -58,7 +58,7 @@
           class = "control-code"
        } ?></td>
 </tr>
-<?lsmb PROCESS employee_row ?>
+<?lsmb PROCESS employee_row SELECTNAME='employee_id' ?>
 <?lsmb PROCESS business_classes ?>
 <tr id="ship-via-row">
   <th><?lsmb text('Ship Via') ?></th>

--- a/UI/Reports/filters/invoice_search.html
+++ b/UI/Reports/filters/invoice_search.html
@@ -57,7 +57,7 @@
           class = "control-code"
        } ?></td>
 </tr>
-<?lsmb PROCESS employee_row ?>
+<?lsmb PROCESS employee_row SELECTNAME='employee_id' ?>
 <?lsmb PROCESS business_classes ?>
 <tr id="taxable-row">
   <th><?lsmb text('Tax Status') ?></th>


### PR DESCRIPTION
The infrastructure is there, but the field  gets submitted as
'person_id' while the code expects the value to be in 'employee_id'.
