### PR TITLE
Re #1015: Make sure to show sales emps on existing transactions

### DIFF
--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -1944,7 +1944,6 @@ sub get_regular_metadata {
     my $dbh = $self->{dbh};
     local $@;
     $transdate = $transdate->to_db if eval { $transdate->can('to_db') };
-
     $self->all_employees( $myconfig, $dbh, $transdate, 1 );
     $self->all_business_units( $myconfig, $dbh, $transdate, $job );
     $self->all_taxaccounts( $myconfig, $dbh, $transdate );
@@ -2056,7 +2055,7 @@ sub all_employees {
     }
 
     if ($sales) {
-        $query .= qq| sales = '1' AND|;
+        $query .= qq| sales AND|;
     }
 
     $query =~ s/(WHERE|AND)$//;


### PR DESCRIPTION
Note that at least on recent PostgreSQL versions, comparing a
boolean with the string '1' always results in a false condition.
