### PR TITLE
Fix #4946: Cannot post recurring GL transaction

### DIFF
--- a/old/bin/am.pl
+++ b/old/bin/am.pl
@@ -1003,7 +1003,7 @@ sub process_transactions {
             # forward to removing this code. --CT
             for ( keys %$form ) { delete $form->{$_}; }
             for (qw(header dbversion company dbh login path sessionid _auth
-                    stylesheet timeout id)
+                    stylesheet timeout id _locale)
             ) {
                 $form->{$_} = $pt->{$_};
             }
@@ -1253,27 +1253,30 @@ sub process_transactions {
 
             }
             else {
-
                 # GL transaction
                 GL->transaction( \%myconfig, \%$form );
 
                 $form->{reference} = $pt->{reference};
                 $form->{transdate} = $pt->{nextdate};
+                $form->{fx_transaction} = $ref->{fx_transaction};
 
                 $j = 0;
                 foreach my $ref ( @{ $form->{GL} } ) {
                     $form->{"accno_$j"} = "$ref->{accno}--$ref->{description}";
 
+                    $form->{"${_}_$j"} =
+                        $ref->{$_} for (qw/curr source memo/);
                     $form->{"projectnumber_$j"} =
                       "$ref->{projectnumber}--$ref->{project_id}"
                       if $ref->{project_id};
-                    $form->{"fx_transaction_$j"} = $ref->{fx_transaction};
 
-                    if ( $ref->{amount} < 0 ) {
-                        $form->{"debit_$j"} = $ref->{amount} * -1;
+                    if ( $ref->{amount_bc} < 0 ) {
+                        $form->{"debit_$j"} = $ref->{amount_bc} * -1;
+                        $form->{"debit_fx_$j"} = $ref->{amount_tc} * -1;
                     }
                     else {
-                        $form->{"credit_$j"} = $ref->{amount};
+                        $form->{"credit_$j"} = $ref->{amount_bc};
+                        $form->{"credit_fx_$j"} = $ref->{amount_tc};
                     }
 
                     $j++;

--- a/old/lib/LedgerSMB/GL.pm
+++ b/old/lib/LedgerSMB/GL.pm
@@ -247,6 +247,8 @@ UPDATE gl
     }
 
     $form->save_recurring( $dbh, $myconfig );
+
+    return 1;
 }
 
 sub transaction {


### PR DESCRIPTION
This change fixes the fieldnames being copied from the recurring transaction
to the transaction being posted. These field names changed with MC, but this
code wasn't adapted yet to the new names.

Additionally, it fixes a problem with rendering (translated) text in pages
being rendered as a result of $form->redirect().

Last but not least, GL->post_transaction() wasn't returning a truth value
after successfully posting a transaction, causing the recurring transaction
code to fail updating the sequence to the next update date.
