### PR TITLE
Fix #4946: Cannot post recurring GL transaction

### DIFF
--- a/old/lib/LedgerSMB/GL.pm
+++ b/old/lib/LedgerSMB/GL.pm
@@ -245,6 +245,8 @@ UPDATE gl
     }
 
     $form->save_recurring( $dbh, $myconfig );
+
+    return 1;
 }
 
 sub transaction {


### PR DESCRIPTION
This change fixes the fieldnames being copied from the recurring transaction
to the transaction being posted. These field names changed with MC, but this
code wasn't adapted yet to the new names.

Additionally, it fixes a problem with rendering (translated) text in pages
being rendered as a result of $form->redirect().

Last but not least, GL->post_transaction() wasn't returning a truth value
after successfully posting a transaction, causing the recurring transaction
code to fail updating the sequence to the next update date.
