### PR TITLE
Report all classes in the fixed asset classes report

### DIFF
--- a/sql/modules/Assets.sql
+++ b/sql/modules/Assets.sql
@@ -276,8 +276,8 @@ $$
                         m.method, ac.method,
                         ac.label
                 FROM asset_class ac
-                JOIN account aa ON (aa.id = ac.asset_account_id)
-                JOIN account ad ON (ad.id = ac.dep_account_id)
+                LEFT JOIN account aa ON (aa.id = ac.asset_account_id)
+                LEFT JOIN account ad ON (ad.id = ac.dep_account_id)
                 JOIN asset_dep_method m ON (ac.method = m.id)
                 WHERE
                         (in_asset_account_id is null


### PR DESCRIPTION
Due to the fact that apparently the fixed asset classes table allows
NULL account ids, the report is incomplete when running an inner join.
