### PR TITLE
Remove the 'no_match_vars' specialization on 'use English'

### DIFF
--- a/lib/LedgerSMB/PSGI.pm
+++ b/lib/LedgerSMB/PSGI.pm
@@ -53,11 +53,7 @@ use Plack::Builder::Conditionals;
 use Plack::Util;
 
 
-# After Perl 5.20 is the minimum required version,
-# we can drop the restriction on the match vars
-# because 5.20 doesn't copy the data (but uses
-# string slices)
-use English qw(-no_match_vars);
+use English;
 if ($EUID == 0) {
     die join("\n",
         'Running a Web Service as root is a security problem.',

--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -20,11 +20,7 @@ use warnings;
 
 use Config;
 use Config::IniFiles;
-# After Perl 5.20 is the minimum required version,
-# we can drop the restriction on the match vars
-# because 5.20 doesn't copy the data (but uses
-# string slices)
-use English qw(-no_match_vars);
+use English;
 use String::Random;
 use Symbol;
 

--- a/t/12-sysconfig.t
+++ b/t/12-sysconfig.t
@@ -4,9 +4,6 @@ use Test2::V0;
 use Test2::Tools::Spec;
 no warnings 'once';
 
-use English qw(-no_match_vars); # required to 'require Sysconfig'
-
-
 chdir 't/data';
 
 require LedgerSMB::Sysconfig;

--- a/utils/devel/critic_html/critichtml
+++ b/utils/devel/critic_html/critichtml
@@ -9,7 +9,7 @@ use Perl::Critic::Utils;
 use Template;
 use Cwd qw(abs_path);
 use File::Basename;
-use English qw(-no_match_vars);
+use English;
 
 use constant SEVERITY  => 1; # Include all violations.
 use constant SKIP_GOOD => 0; # Skip files with no violations?

--- a/xt/perlcriticrc
+++ b/xt/perlcriticrc
@@ -117,8 +117,6 @@ pager = less
     set_themes = lsmb lsmb_new lsmb_old
 [Modules::RequireFilenameMatchesPackage]
     set_themes = lsmb lsmb_new lsmb_old_wip lsmb_tests
-[Modules::RequireNoMatchVarsWithUseEnglish]
-    set_themes = lsmb lsmb_new lsmb_old lsmb_tests
 
 
 [Moose::RequireMakeImmutable]
@@ -181,6 +179,11 @@ pager = less
 
 # LSMB is more application than lib
 #[Modules::RequireVersionVar]
+
+# After Perl 5.20 this is no longer a problem
+[Modules::RequireNoMatchVarsWithUseEnglish]
+    set_themes = lsmb_reject
+
 
 # Too many methods
 [Subroutines::ProhibitBuiltinHomonyms]


### PR DESCRIPTION
Before Perl 5.20, 'use English' without 'no_match_vars' would mean
a performance penalty on the entire application, because it caused
the 'match vars' to be initialized on every regex execution.

5.20+ use string slices instead of creation of separate matching
strings, which is a major performance boost and probably no longer
warrants the use of 'no match vars'.
