### PR TITLE
Fix being unable to open employee+user screen

### DIFF
--- a/sql/modules/admin.sql
+++ b/sql/modules/admin.sql
@@ -225,7 +225,7 @@ CREATE OR REPLACE FUNCTION admin__get_roles_for_user(in_user_id INT) returns set
             ) as ar
          where
             r.oid = ar.roleid
-            and r.rolname like (lsmb__role_prefix() || '%')
+            and position(lsmb__role_prefix() in r.rolname) = 1
          LOOP
 
             RETURN NEXT lsmb__global_role(u_role.rolname);
@@ -289,7 +289,7 @@ CREATE OR REPLACE FUNCTION admin__get_roles_for_user_by_entity(in_entity_id INT)
             ) as ar
          where
             r.oid = ar.roleid
-            and r.rolname like (lsmb__role_prefix() || '%')
+            and position(lsmb__role_prefix() in r.rolname) = 1
          LOOP
 
             RETURN NEXT lsmb__global_role(u_role.rolname);


### PR DESCRIPTION
When there are two companies with sufficiently similar names,
(e.g. one's name being a subset of the other) opening the Contact
screen for an employee who is also a user, fails with an error
about the 'role_list' attribute of the user not matching the
specification. This is due to the fact that the query returns
NULL values in the result.
