### PR TITLE
Fix #2319: Don't show GIFI when none are configured

### DIFF
--- a/UI/Reports/filters/balance_sheet.html
+++ b/UI/Reports/filters/balance_sheet.html
@@ -6,6 +6,7 @@
           action="reports.pl" method="get">
       <div class="listtop">[% text('Balance Sheet') %]</div>
 
+[% IF gifi_list.size > 0 -%]
       <fieldset>
         <legend>[% text('Report type') %]</legend>
         <div class="input_row">
@@ -37,7 +38,7 @@
           </div>
         </div>
       </fieldset>
-
+[% END -%]
 
       <fieldset data-dojo-type="lsmb/reports/PeriodSelector"
                 data-dojo-props="channel:'ui/reports/date-selection'">

--- a/UI/Reports/filters/income_statement.html
+++ b/UI/Reports/filters/income_statement.html
@@ -44,6 +44,7 @@
             </div>
           </div>
         </div>
+[% IF gifi_list.size > 0 -%]
         <div class="input_row">
           <div class="label">[% text('GIFI') %]</div>
           <div class="input_group">
@@ -72,6 +73,7 @@
             </div>
           </div>
         </div>
+[% END -%]
       </fieldset>
 
       <fieldset data-dojo-type="lsmb/reports/PeriodSelector"

--- a/UI/accounts/edit.html
+++ b/UI/accounts/edit.html
@@ -183,6 +183,7 @@
    </div>
 </div>
 <div id="accdetails">
+[% IF form.gifi_list.size > 0 -%]
 <div class="inputline" id="gifi-line">
    <label class="line" for="gifi-a">[% text('GIFI') %]</label>
    <div class="inputgroup">
@@ -203,6 +204,7 @@
        %]
    </div>
 </div>
+[% END -%]
 <div class="inputline" id="acctype-line">
    <label class="line" for="category-a">[% text('Account Type') %]</label>
    <div class="inputgroup">

--- a/lib/LedgerSMB/Scripts/reports.pm
+++ b/lib/LedgerSMB/Scripts/reports.pm
@@ -85,6 +85,8 @@ sub start_report {
                       funcname => 'account_heading_list');
     @{$request->{account_list}} =  $request->call_procedure(
                       funcname => 'account__list_by_heading');
+    @{$request->{gifi_list}} =  $request->call_procedure(
+                      funcname => 'gifi__list');
     @{$request->{batch_classes}} = $request->call_procedure(
                       funcname => 'batch_list_classes'
     );


### PR DESCRIPTION
Although GIFI was explicitly included in the selections in order to
make people aware the system supports this, apparently the fact that
these options are available when most users don't need them, serves
to confuse more that to clarify... This commit implements the request
to remove GIFI from output when none are defined.
