### PR TITLE
Fix #4872: Inability to sort AR > Search results for filter with spaces

### DIFF
--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -50,6 +50,9 @@ If an index is specified, the merged keys are given a form of
 Returns the script and query string part of the URL of the GET request,
 without the script path, or undef.
 
+Returns a URL-decoded string to prevent double-encoding when the URL
+is round-tripped.x
+
 =cut
 
 =item upload([$filename])
@@ -193,6 +196,7 @@ use HTTP::Status qw( HTTP_OK ) ;
 use Log::Log4perl;
 use PGObject;
 use Plack;
+use URI::Escape;
 
 use LedgerSMB::Sysconfig;
 use LedgerSMB::App_State;
@@ -325,8 +329,11 @@ sub _process_args {
 sub get_relative_url {
     my ($self) = @_;
 
-    return $self->{script} .
-        ($self->{query_string} ? "?$self->{query_string}" : '');
+    return Encode::decode(
+        'utf8',
+        uri_unescape(
+            $self->{script} .
+            ($self->{query_string} ? "?$self->{query_string}" : '')));
 }
 
 sub upload {


### PR DESCRIPTION
Because the URL was round-tripped without URL-unescaping before passing
the URL back into the template again, the '%'-sign was re-escaped as
'%25' over and over. This also makes the filter behave different between
the first and second time the data is loaded. By unescaping between iterations,
the URL in the actual HTML page remains the same between iterations.
