### PR TITLE
Fix #5078: Check printing shows random number in amount block

### DIFF
--- a/lib/LedgerSMB/Scripts/payment.pm
+++ b/lib/LedgerSMB/Scripts/payment.pm
@@ -419,7 +419,12 @@ sub print {
     }
 
     $payment->{format_amount} =
-        sub {return LedgerSMB::PGNumber->from_input(@_)->to_output(money => 1); };
+        sub {
+            my $args = shift;
+            return LedgerSMB::PGNumber
+                ->from_input($args->{amount})
+                ->to_output(%$args);
+    };
 
     my $data = $bulk_post_map->($request);
     if ($data->{multiple}){


### PR DESCRIPTION
The problem is that the wrong arguments are passed in the wrong place,
resulting in the memory address being used as the number to be printed...
This code changes which argument goes to which subroutine call, causing
the *correct* arguments going into number parsing and number formatting.