### PR TITLE
1.7: Fix #5115 - Salesperson/Employee cannot save

### DIFF
--- a/old/lib/LedgerSMB/AA.pm
+++ b/old/lib/LedgerSMB/AA.pm
@@ -331,8 +331,7 @@ sub post_transaction {
          person_id, entity_credit_account, approved,
          setting_sequence
         )
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-              (SELECT u.entity_id FROM users u WHERE u.username = ?), ?, ?, ?)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       RETURNING id
     |;
    }
@@ -344,8 +343,7 @@ sub post_transaction {
          notes, intnotes, ponumber, crdate, reverse,
          person_id, entity_credit_account, approved
         )
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-              (SELECT u.entity_id FROM users u WHERE u.username = ?), ?, ?)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       RETURNING id
     |;
    }
@@ -364,7 +362,7 @@ sub post_transaction {
         $form->{duedate},
         $form->{notes},            $form->{intnotes},
         $form->{ponumber},         $form->{crdate},
-        $form->{reverse},          $form->{employee_name},
+        $form->{reverse},          $form->{employee_id},
         $form->{"$form->{vc}_id"}, $form->{approved}
         );
    if ($table eq 'ar') {


### PR DESCRIPTION
$form->{employee} only contain Entity Name and Entity Id from entity table. not username from user table.
Since entity id is already in the $form we don't need to run sub query that take entity from user table.