### PR TITLE
1.6: Fix #5115 - Salesperson/Employee cannot save

### DIFF
--- a/old/lib/LedgerSMB/AA.pm
+++ b/old/lib/LedgerSMB/AA.pm
@@ -360,7 +360,7 @@ sub post_transaction {
                 entity_credit_account)
                  VALUES (?,    (select  u.entity_id from users u
                  join entity e on(e.id = u.entity_id)
-                 where u.username=? and u.entity_id in(select p.entity_id from person p) ), ?)|;
+                 where e.name=? and u.entity_id in(select p.entity_id from person p) ), ?)|;
 
         # the second param is undef, as the DBI api expects a hashref of
         # attributes to pass to $dbh->prepare. This is not used here.


### PR DESCRIPTION
$form->{employee} only contain Entity Name and Entity Id from entity table. not username from user table.
Since entity id is already in the $form we don't need to run sub query that take entity from user table. But for 1.6, just changing the where clause with entity name is enough because we don't want to change much in legacy code.