### PR TITLE
Close #5113: Add selectable empty value to non-required SELECTs

### DIFF
--- a/UI/lib/elements.html
+++ b/UI/lib/elements.html
@@ -206,7 +206,10 @@
            PROCESS option
                parent_id   = element_data.id,
                optindex    = 0,
-               option_data = {},
+               option_data = {
+                  $text_attr = "",
+                  $value_attr = element_data.required ? "" : "_!lsmb!empty!_"
+               },
                text_attr   = text_attr,
                value_attr  = value_attr;
         END;

--- a/lib/LedgerSMB.pm
+++ b/lib/LedgerSMB.pm
@@ -321,7 +321,10 @@ sub _process_args {
         my @values = grep { defined $_ && $_ ne '' } $args->get_all($key);
         next if ! @values;
 
-        $self->{$key} = (@values == 1) ? $values[0] : \@values;
+        my $value = (@values == 1) ? $values[0] : \@values;
+        next if $value eq '_!lsmb!empty!_';
+
+        $self->{$key} = $value;
     }
     return;
 }

--- a/old/lib/LedgerSMB/Form.pm
+++ b/old/lib/LedgerSMB/Form.pm
@@ -114,6 +114,7 @@ sub new {
         for my $p(keys %$self){
             utf8::decode($self->{$p});
             utf8::upgrade($self->{$p});
+            delete $self->{$p} if $self->{$p} eq '_!lsmb!empty!_';
             $self->{$p} =~ s/\N{NULL}//g;
         }
         $self->{nextsub} //= '';


### PR DESCRIPTION
The empty string is used by Dojo to indicate a separator line in the
drop-down. So, we can't use the empty string as an 'empty' indicator.
To work around that, we now use the special value "_!lsmb!empty!_"
to model the empty value -- which we filter out on the Perl side
to indicate that no value was selected.
