### PR TITLE
Remove dojo gitsubmodules from the data-dojo-type computing

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -66,7 +66,8 @@ function findDataDojoTypes(fileName) {
 
 // Compute used data-dojo-type
 glob.sync("**/*.html", {
-    ignore: ["lib/ui-header.html", "js/**"],
+    ignore: ["lib/ui-header.html", "js/**", "js-src/dojo/**",
+             "js-src/dijit/**", "js-src/util/**"],
     cwd: "UI"
 }).map(function (filename) {
     const requires = findDataDojoTypes("UI/" + filename);


### PR DESCRIPTION
Make sure that git submodules are ignored when compiling the modules actually used by our JS code.