### PR TITLE
Fix #5152: Cannot post recurring transaction

### DIFF
--- a/old/bin/aa.pl
+++ b/old/bin/aa.pl
@@ -144,7 +144,6 @@ sub add {
 sub edit {
 
     &create_links;
-    $form->{$form->{ARAP}} = $form->{"$form->{ARAP}_1"};
     $form->{title} = $locale->text("Edit");
     if ($form->{reverse}){
         if ($form->{ARAP} eq 'AR'){
@@ -358,6 +357,7 @@ sub create_links {
     }
     delete $form->{selectcurrency};
     #$form->generate_selects(\%myconfig);
+    $form->{$form->{ARAP}} = $form->{"$form->{ARAP}_1"};
 }
 
 sub form_header {


### PR DESCRIPTION
Recurring AR/AP transactions fail to post succesfully,
showing an error about a NULL value in a not-null column.
