### PR TITLE
Close #3908: GL entry screen should prefer prefix match

### DIFF
--- a/lib/LedgerSMB/Routes/ERP/API/Accounts.pm
+++ b/lib/LedgerSMB/Routes/ERP/API/Accounts.pm
@@ -41,6 +41,14 @@ get '/accounts/', sub {
              [ 'Content-Type' => '' ],
              [ json()->encode(
                    [
+                    # if there's a $label, non-matching items are filtered
+                    # meaning that it doesn't matter that index() returns -1
+                    # on no match...
+                    # a lower index means higher relevance
+                    sort {
+                        index($a->{label},$label) <=> index($b->{label},$label)
+                            || $a cmp $b
+                    }
                     grep { (! $label) || $_->{label} =~ m/\Q$label\E/i }
                     map { $_->{label} = $_->{accno} . '--' . $_->{description};
                           $_ }


### PR DESCRIPTION
This commit approximates the purpose of the issue to prefer
exact account matches by favoring prefix matches over infix
matches (or more precise: favoring matches with lower index()es,
meaning matches earlier in strings).
