### PR TITLE
Add functional interface to LedgerSMB::Sysconfig initialization

### DIFF
--- a/bin/ledgersmb-server.psgi
+++ b/bin/ledgersmb-server.psgi
@@ -15,6 +15,8 @@ no lib '.';
 
 use FindBin;
 use lib $FindBin::Bin . '/..'; # For our 'old code'-"require"s
+
+use LedgerSMB::Locale;
 use LedgerSMB::PSGI;
 use LedgerSMB::PSGI::Preloads;
 use LedgerSMB::Sysconfig;
@@ -23,6 +25,7 @@ use Log::Log4perl::Layout::PatternLayout;
 use LedgerSMB::Middleware::RequestID;
 
 LedgerSMB::Sysconfig->initialize( $ENV{LSMB_CONFIG_FILE} // 'ledgersmb.conf' );
+LedgerSMB::Locale->initialize;
 
 require Plack::Middleware::Pod
     if ( $ENV{PLACK_ENV} && $ENV{PLACK_ENV} eq 'development' );

--- a/bin/ledgersmb-server.psgi
+++ b/bin/ledgersmb-server.psgi
@@ -17,12 +17,12 @@ use FindBin;
 use lib $FindBin::Bin . '/..'; # For our 'old code'-"require"s
 use LedgerSMB::PSGI;
 use LedgerSMB::PSGI::Preloads;
-use LedgerSMB::Sysconfig qw(initialize);
+use LedgerSMB::Sysconfig;
 use Log::Log4perl;
 use Log::Log4perl::Layout::PatternLayout;
 use LedgerSMB::Middleware::RequestID;
 
-initialize( $ENV{LSMB_CONFIG_FILE} // 'ledgersmb.conf' );
+LedgerSMB::Sysconfig->initialize( $ENV{LSMB_CONFIG_FILE} // 'ledgersmb.conf' );
 
 require Plack::Middleware::Pod
     if ( $ENV{PLACK_ENV} && $ENV{PLACK_ENV} eq 'development' );

--- a/bin/ledgersmb-server.psgi
+++ b/bin/ledgersmb-server.psgi
@@ -17,10 +17,12 @@ use FindBin;
 use lib $FindBin::Bin . '/..'; # For our 'old code'-"require"s
 use LedgerSMB::PSGI;
 use LedgerSMB::PSGI::Preloads;
-use LedgerSMB::Sysconfig;
+use LedgerSMB::Sysconfig qw(initialize);
 use Log::Log4perl;
 use Log::Log4perl::Layout::PatternLayout;
 use LedgerSMB::Middleware::RequestID;
+
+initialize( $ENV{LSMB_CONFIG_FILE} // 'ledgersmb.conf' );
 
 require Plack::Middleware::Pod
     if ( $ENV{PLACK_ENV} && $ENV{PLACK_ENV} eq 'development' );

--- a/lib/LedgerSMB/Auth.pm
+++ b/lib/LedgerSMB/Auth.pm
@@ -53,17 +53,21 @@ use strict;
 use warnings;
 
 use LedgerSMB::Sysconfig;
-use Module::Runtime qw(use_module);
+use Module::Runtime qw(use_module compose_module_name);
 
 
-my $plugin = 'LedgerSMB::Auth::' . LedgerSMB::Sysconfig::auth;
-use_module($plugin) or die "Can't locate Auth parser plugin $plugin";
+my $plugin = '';
 
 sub factory {
     my ($psgi_env, $domain) = @_;
 
-    return use_module($plugin)->new(env => $psgi_env,
-                                    domain => $domain);
+    unless ($plugin) {
+        $plugin =
+            compose_module_name('LedgerSMB::Auth', LedgerSMB::Sysconfig::auth);
+        use_module($plugin);
+    }
+
+    return $plugin->new(env => $psgi_env, domain => $domain);
 }
 
 

--- a/lib/LedgerSMB/Locale.pm
+++ b/lib/LedgerSMB/Locale.pm
@@ -13,6 +13,10 @@ Locale support module for LedgerSMB.  Uses Locale::Maketext::Lexicon as a base.
 
 =over
 
+=item initialize
+
+Class method to load the translation lexicons.
+
 =item get_handle ($language_code)
 
 Returns a locale handle for accessing the other methods.  Inherited from

--- a/lib/LedgerSMB/Locale.pm
+++ b/lib/LedgerSMB/Locale.pm
@@ -100,13 +100,15 @@ use LedgerSMB::Sysconfig;
 use Locale::Maketext::Lexicon;
 use Encode;
 
-Locale::Maketext::Lexicon->import(
-    {
-        '*'     => [ Gettext => (LedgerSMB::Sysconfig::localepath() . '/*.po'), ],
-        _auto   => 1,
-        _decode => 1,
-    }
-);
+sub initialize {
+    Locale::Maketext::Lexicon->import(
+        {
+            '*'     => [ Gettext => (LedgerSMB::Sysconfig::localepath() . '/*.po'), ],
+                _auto   => 1,
+                _decode => 1,
+        }
+        );
+}
 
 sub marktext {
     return shift;

--- a/lib/LedgerSMB/Middleware/SessionStorage.pm
+++ b/lib/LedgerSMB/Middleware/SessionStorage.pm
@@ -39,6 +39,10 @@ use LedgerSMB::Sysconfig;
 
 =head1 METHODS
 
+=head2 $self->prepare_app
+
+Implements C<Plack::Component->prepare_app()>.
+
 =head2 $self->call($env)
 
 Implements C<Plack::Middleware->call()>.
@@ -46,10 +50,15 @@ Implements C<Plack::Middleware->call()>.
 =cut
 
 # this variable exists to deal with the code in old/
-our $store = Session::Storage::Secure->new(
-    secret_key => LedgerSMB::Sysconfig::cookie_secret,
-    default_duration => 24*60*60*90, # 90 days
-    );
+our $store;
+
+sub prepare_app {
+    # delay initializing $store to allow LedgerSMB::Sysconfig to be loaded
+    $store = Session::Storage::Secure->new(
+        secret_key => LedgerSMB::Sysconfig::cookie_secret,
+        default_duration => 24*60*60*90, # 90 days
+        );
+}
 
 sub call {
     my $self = shift;

--- a/lib/LedgerSMB/PSGI/Preloads.pm
+++ b/lib/LedgerSMB/PSGI/Preloads.pm
@@ -35,7 +35,6 @@ use LedgerSMB;
 use LedgerSMB::Form;
 use LedgerSMB::Sysconfig;
 use LedgerSMB::Template::UI;
-use LedgerSMB::Locale;
 use LedgerSMB::File;
 use LedgerSMB::Scripts::login;
 use LedgerSMB::PGObject;

--- a/lib/LedgerSMB/Scripts/setup.pm
+++ b/lib/LedgerSMB/Scripts/setup.pm
@@ -42,7 +42,6 @@ use LedgerSMB::DBObject::User;
 use LedgerSMB::Entity::User;
 use LedgerSMB::Entity::Person::Employee;
 use LedgerSMB::I18N;
-use LedgerSMB::Locale;
 use LedgerSMB::Magic qw( EC_EMPLOYEE HTTP_454 PERL_TIME_EPOCH );
 use LedgerSMB::Mailer;
 use LedgerSMB::PGDate;

--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -107,24 +107,24 @@ sub def {
 
         # get the value of config key $section.$key.
         #  If it doesn't exist use $default instead
-        ${*{$ref}} = $cfg->val($sec, $key, $default);
+        my $var = $cfg->val($sec, $key, $default);
 
         # If an environment variable is associated and currently defined,
         #  override the configfile and default with the ENV VAR
-        ${*{$ref}} = $ENV{$envvar} if ( $envvar && defined $ENV{$envvar} );
+        $var = $ENV{$envvar} if ( $envvar && defined $ENV{$envvar} );
 
         # If an environment variable is associated, set it  based on the
         # current value (taken from the config file, default, or pre-existing
         #  env var.
-        $ENV{$envvar} = ${*{$ref}}    ## no critic   # sniff
-            if $envvar && defined ${*{$ref}};
+        $ENV{$envvar} = $var
+            if $envvar && defined $var;
 
         # create a functional interface
         *{$ref} = sub {
             my ($nv) = @_; # new value to be assigned
-            my $cv = ${*{$ref}};
+            my $cv = $var;
 
-            ${*{$ref}} = $nv if scalar(@_) > 0;
+            $var = $nv if scalar(@_) > 0;
             return $cv;
         };
     }

--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -24,10 +24,6 @@ use English;
 use String::Random;
 use Symbol;
 
-use parent qw(Exporter);
-
-our @EXPORT_OK = qw(initialize);
-
 
 =head2 def $name, %args;
 
@@ -596,7 +592,7 @@ sub override_defaults {
 
 
 sub initialize {
-    my $cfg_file = shift;
+    my ($module, $cfg_file) = @_;
 
     if ($cfg_file and -r $cfg_file) {
         $cfg = Config::IniFiles->new( -file => $cfg_file )

--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -36,9 +36,6 @@ else {
     $cfg = Config::IniFiles->new();
 }
 
-our %config;
-our %docs;
-
 =head2 def $name, %args;
 
 A function to define config keys and set their values on initialisation.
@@ -99,9 +96,7 @@ sub def {
     $default = $default->()
         if ref $default && ref $default eq 'CODE';
 
-    $docs{$sec}->{$key} = $args{doc};
     {
-
         my $ref = qualify_to_ref $name;
         no warnings 'redefine';     ## no critic ( ProhibitNoWarnings ) # sniff
 

--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -497,11 +497,6 @@ sub printer {
 }
 
 
-# ENV Paths
-for my $var (qw(PATH PERL5LIB)) {
-     $ENV{$var} .= $Config{path_sep} . ( join $Config{path_sep}, $cfg->val('environment', $var, ''));
-}
-
 
 
 
@@ -611,6 +606,14 @@ sub initialize {
         $cfg = Config::IniFiles->new();
     }
     $_->() for (@initializers);
+
+    # ENV Paths
+    for my $var (qw(PATH PERL5LIB)) {
+        $ENV{$var} .=
+            $Config{path_sep} .
+            ( join $Config{path_sep}, $cfg->val('environment', $var, ''));
+    }
+
 
     override_defaults();
 }

--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -594,10 +594,11 @@ sub override_defaults {
     return;
 }
 
+
 sub initialize {
     my $cfg_file = shift;
 
-    if (-r $cfg_file) {
+    if ($cfg_file and -r $cfg_file) {
         $cfg = Config::IniFiles->new( -file => $cfg_file )
             or die @Config::IniFiles::errors;
     }
@@ -617,8 +618,6 @@ sub initialize {
 
     override_defaults();
 }
-
-initialize( $ENV{LSMB_CONFIG_FILE} // 'ledgersmb.conf' );
 
 =head1 LICENSE AND COPYRIGHT
 

--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -599,7 +599,8 @@ sub initialize {
             or die @Config::IniFiles::errors;
     }
     else {
-        warn "No configuration file; running with default settings\n";
+        warn "No configuration file; running with default settings\n"
+            if $cfg_file;  # no name provided? no need to warn...
         $cfg = Config::IniFiles->new();
     }
     $_->() for (@initializers);

--- a/old/bin/oe.pl
+++ b/old/bin/oe.pl
@@ -50,7 +50,6 @@ use LedgerSMB::Setting;
 use LedgerSMB::Tax;
 use LedgerSMB::Template::UI;
 use LedgerSMB::Legacy_Util;
-use LedgerSMB::Locale;
 
 require "old/bin/arap.pl";
 require "old/bin/io.pl";

--- a/old/lib/LedgerSMB/Num2text.pm
+++ b/old/lib/LedgerSMB/Num2text.pm
@@ -45,7 +45,6 @@ package LedgerSMB::Num2text;
 use utf8;
 use strict;
 use warnings;
-use LedgerSMB::Locale;
 
 sub new {
     my ( $type, $locale ) = @_;

--- a/t/01-load.t
+++ b/t/01-load.t
@@ -218,6 +218,7 @@ my @modules =
 
 use Test2::Require::Module 'LedgerSMB::Sysconfig';
 delete $on_disk{'LedgerSMB::Sysconfig'};
+LedgerSMB::Sysconfig->initialize;
 
 module_loads 'LedgerSMB::Template::ODS' => qw( XML::Twig OpenOffice::OODoc );
 

--- a/t/01-load.t
+++ b/t/01-load.t
@@ -218,7 +218,6 @@ my @modules =
 
 use Test2::Require::Module 'LedgerSMB::Sysconfig';
 delete $on_disk{'LedgerSMB::Sysconfig'};
-LedgerSMB::Sysconfig->initialize;
 
 module_loads 'LedgerSMB::Template::ODS' => qw( XML::Twig OpenOffice::OODoc );
 

--- a/t/02.1-number-to-text.t
+++ b/t/02.1-number-to-text.t
@@ -6,6 +6,10 @@ use LedgerSMB::Locale;
 use LedgerSMB::Num2text;
 use LedgerSMB::PGNumber;
 
+use LedgerSMB::Sysconfig;
+LedgerSMB::Sysconfig->initialize;
+LedgerSMB::Locale->initialize;
+
 my %english = (
     0 => 'Zero',
     1 => 'One',

--- a/t/03-date-handling.t
+++ b/t/03-date-handling.t
@@ -8,7 +8,7 @@ use warnings;
 use Test2::V0;
 use Math::BigFloat;
 
-use LedgerSMB::Sysconfig;
+use LedgerSMB::Sysconfig qw(initialize);
 use LedgerSMB;
 use LedgerSMB::Form;
 use LedgerSMB::Locale;
@@ -16,6 +16,8 @@ use LedgerSMB::App_State;
 use Plack::Request;
 
 use Log::Log4perl qw( :easy );
+
+initialize( $ENV{LSMB_CONFIG_FILE} // 'ledgersmb.conf' );
 Log::Log4perl->easy_init($OFF);
 
 

--- a/t/03-date-handling.t
+++ b/t/03-date-handling.t
@@ -8,7 +8,7 @@ use warnings;
 use Test2::V0;
 use Math::BigFloat;
 
-use LedgerSMB::Sysconfig qw(initialize);
+use LedgerSMB::Sysconfig;
 use LedgerSMB;
 use LedgerSMB::Form;
 use LedgerSMB::Locale;
@@ -17,7 +17,8 @@ use Plack::Request;
 
 use Log::Log4perl qw( :easy );
 
-initialize( $ENV{LSMB_CONFIG_FILE} // 'ledgersmb.conf' );
+LedgerSMB::Sysconfig->initialize( $ENV{LSMB_CONFIG_FILE} // 'ledgersmb.conf' );
+LedgerSMB::Locale->initialize();
 Log::Log4perl->easy_init($OFF);
 
 

--- a/t/04-template-handling.t
+++ b/t/04-template-handling.t
@@ -7,7 +7,7 @@ use Test2::V0;
 
 use File::Temp;
 use LedgerSMB;
-use LedgerSMB::Sysconfig;
+use LedgerSMB::Sysconfig qw(initialize);
 use LedgerSMB::Locale;
 use LedgerSMB::Legacy_Util;
 use LedgerSMB::Template;
@@ -15,6 +15,8 @@ use LedgerSMB::Template::HTML;
 use Plack::Request;
 
 use Log::Log4perl qw(:easy);
+
+initialize( $ENV{LSMB_CONFIG_FILE} // 'ledgersmb.conf' );
 Log::Log4perl->easy_init($OFF);
 
 

--- a/t/04-template-handling.t
+++ b/t/04-template-handling.t
@@ -7,7 +7,7 @@ use Test2::V0;
 
 use File::Temp;
 use LedgerSMB;
-use LedgerSMB::Sysconfig qw(initialize);
+use LedgerSMB::Sysconfig;
 use LedgerSMB::Locale;
 use LedgerSMB::Legacy_Util;
 use LedgerSMB::Template;
@@ -16,7 +16,8 @@ use Plack::Request;
 
 use Log::Log4perl qw(:easy);
 
-initialize( $ENV{LSMB_CONFIG_FILE} // 'ledgersmb.conf' );
+LedgerSMB::Sysconfig->initialize( $ENV{LSMB_CONFIG_FILE} // 'ledgersmb.conf' );
+LedgerSMB::Locale->initialize();
 Log::Log4perl->easy_init($OFF);
 
 

--- a/t/06-blacklist.t
+++ b/t/06-blacklist.t
@@ -1,11 +1,13 @@
 #!/usr/bin/perl
 
-use LedgerSMB::Sysconfig;
+use LedgerSMB::Sysconfig qw(initialize);
 
 use Test2::V0;
 use Test2::Plugin::BailOnFail;
 use Digest::SHA 'sha512_base64'; #already a dependency
 use FindBin;
+
+initialize( $ENV{LSMB_CONFIG_FILE} // 'ledgersmb.conf' );
 
 my $sqldir = "$FindBin::Bin/../sql/modules";
 my $blacklist_file = "$sqldir/BLACKLIST";

--- a/t/06-blacklist.t
+++ b/t/06-blacklist.t
@@ -1,13 +1,13 @@
 #!/usr/bin/perl
 
-use LedgerSMB::Sysconfig qw(initialize);
+use LedgerSMB::Sysconfig;
 
 use Test2::V0;
 use Test2::Plugin::BailOnFail;
 use Digest::SHA 'sha512_base64'; #already a dependency
 use FindBin;
 
-initialize( $ENV{LSMB_CONFIG_FILE} // 'ledgersmb.conf' );
+LedgerSMB::Sysconfig->initialize( $ENV{LSMB_CONFIG_FILE} // 'ledgersmb.conf' );
 
 my $sqldir = "$FindBin::Bin/../sql/modules";
 my $blacklist_file = "$sqldir/BLACKLIST";

--- a/t/11-ledgersmb.t
+++ b/t/11-ledgersmb.t
@@ -8,6 +8,11 @@ use Test2::V0;
 use LedgerSMB;
 use Plack::Request;
 
+use LedgerSMB::Sysconfig;
+use LedgerSMB::Locale;
+LedgerSMB::Sysconfig->initialize;
+LedgerSMB::Locale->initialize;
+
 use Log::Log4perl qw(:easy);
 Log::Log4perl->easy_init($OFF);
 

--- a/t/12-dbconfig.t
+++ b/t/12-dbconfig.t
@@ -5,9 +5,9 @@ use Test::More;
 
 
 use LedgerSMB::Database::Config;
-use LedgerSMB::Sysconfig qw(initialize);
+use LedgerSMB::Sysconfig;
 
-initialize( $ENV{LSMB_CONFIG_FILE} // 'ledgersmb.conf' );
+LedgerSMB::Sysconfig->initialize( $ENV{LSMB_CONFIG_FILE} // 'ledgersmb.conf' );
 
 my $coa = LedgerSMB::Database::Config->new->charts_of_accounts;
 

--- a/t/12-dbconfig.t
+++ b/t/12-dbconfig.t
@@ -5,7 +5,9 @@ use Test::More;
 
 
 use LedgerSMB::Database::Config;
-use LedgerSMB::Sysconfig;
+use LedgerSMB::Sysconfig qw(initialize);
+
+initialize( $ENV{LSMB_CONFIG_FILE} // 'ledgersmb.conf' );
 
 my $coa = LedgerSMB::Database::Config->new->charts_of_accounts;
 

--- a/t/12-sysconfig.t
+++ b/t/12-sysconfig.t
@@ -4,10 +4,10 @@ use Test2::V0;
 use Test2::Tools::Spec;
 no warnings 'once';
 
-use LedgerSMB::Sysconfig qw(initialize);
+use LedgerSMB::Sysconfig;
 use LedgerSMB::Magic qw( SCRIPT_NEWSCRIPTS SCRIPT_OLDSCRIPTS );
 
-initialize( 't/data/ledgersmb.conf' );
+LedgerSMB::Sysconfig->initialize( 't/data/ledgersmb.conf' );
 
 is LedgerSMB::Sysconfig::auth(), 'DB2', 'Auth set correctly';
 is LedgerSMB::Sysconfig::cache_templates(), 5, 'template caching working';

--- a/t/12-sysconfig.t
+++ b/t/12-sysconfig.t
@@ -4,10 +4,10 @@ use Test2::V0;
 use Test2::Tools::Spec;
 no warnings 'once';
 
-chdir 't/data';
-
-require LedgerSMB::Sysconfig;
+use LedgerSMB::Sysconfig qw(initialize);
 use LedgerSMB::Magic qw( SCRIPT_NEWSCRIPTS SCRIPT_OLDSCRIPTS );
+
+initialize( 't/data/ledgersmb.conf' );
 
 is LedgerSMB::Sysconfig::auth(), 'DB2', 'Auth set correctly';
 is LedgerSMB::Sysconfig::cache_templates(), 5, 'template caching working';
@@ -41,12 +41,12 @@ tests latex_detection => sub {
 like $ENV{PATH}, qr/foo$/, 'appends config path correctly';
 
 for my $script (SCRIPT_OLDSCRIPTS->@*) {
-    ok(-f '../../old/bin/' . $script, "Whitelisted oldcode script $script exists");
+    ok(-f 'old/bin/' . $script, "Whitelisted oldcode script $script exists");
 }
 
 for my $script (SCRIPT_NEWSCRIPTS->@*) {
     $script =~ s/\.pl$/.pm/;
-    ok(-f '../../lib/LedgerSMB/Scripts/' . $script,
+    ok(-f 'lib/LedgerSMB/Scripts/' . $script,
        "Whitelisted script $script exists");
 }
 

--- a/t/13-auth-parsing.t
+++ b/t/13-auth-parsing.t
@@ -3,6 +3,11 @@
 use Test2::V0;
 use MIME::Base64;
 
+BEGIN {
+    use LedgerSMB::Sysconfig;
+    LedgerSMB::Sysconfig->initialize;
+}
+
 use ok 'LedgerSMB::Auth';
 
 my $colonpasswd = 'Test:Test2';

--- a/t/16-schema-upgrade-html.t
+++ b/t/16-schema-upgrade-html.t
@@ -15,8 +15,13 @@ use Log::Log4perl qw( :easy );
 Log::Log4perl->easy_init($OFF);
 
 use LedgerSMB;
+use LedgerSMB::Locale;
 use LedgerSMB::Database::ChangeChecks qw( run_checks load_checks );
 use LedgerSMB::Setup::SchemaChecks qw( html_formatter_context );
+use LedgerSMB::Sysconfig;
+
+LedgerSMB::Sysconfig->initialize;
+LedgerSMB::Locale->initialize;
 
 
 sub test_request {

--- a/utils/devel/ledgersmb-server-development.psgi
+++ b/utils/devel/ledgersmb-server-development.psgi
@@ -19,12 +19,12 @@ use FindBin;
 use lib $FindBin::Bin . '/../..'; # For our 'old code'-"require"s
 use LedgerSMB::PSGI;
 use LedgerSMB::PSGI::Preloads;
-use LedgerSMB::Sysconfig qw(initialize);
+use LedgerSMB::Sysconfig;
 use Log::Log4perl;
 use Log::Log4perl::Layout::PatternLayout;
 use LedgerSMB::Middleware::RequestID;
 
-initialize( $ENV{LSMB_CONFIG_FILE} // 'ledgersmb.conf' );
+LedgerSMB::Sysconfig->initialize( $ENV{LSMB_CONFIG_FILE} // 'ledgersmb.conf' );
 
 require Plack::Middleware::Pod
     if ( $ENV{PLACK_ENV} && $ENV{PLACK_ENV} eq 'development' );

--- a/utils/devel/ledgersmb-server-development.psgi
+++ b/utils/devel/ledgersmb-server-development.psgi
@@ -17,6 +17,8 @@ no lib '.';
 
 use FindBin;
 use lib $FindBin::Bin . '/../..'; # For our 'old code'-"require"s
+
+use LedgerSMB::Locale;
 use LedgerSMB::PSGI;
 use LedgerSMB::PSGI::Preloads;
 use LedgerSMB::Sysconfig;
@@ -25,6 +27,7 @@ use Log::Log4perl::Layout::PatternLayout;
 use LedgerSMB::Middleware::RequestID;
 
 LedgerSMB::Sysconfig->initialize( $ENV{LSMB_CONFIG_FILE} // 'ledgersmb.conf' );
+LedgerSMB::Locale->initialize;
 
 require Plack::Middleware::Pod
     if ( $ENV{PLACK_ENV} && $ENV{PLACK_ENV} eq 'development' );

--- a/utils/devel/ledgersmb-server-development.psgi
+++ b/utils/devel/ledgersmb-server-development.psgi
@@ -19,10 +19,12 @@ use FindBin;
 use lib $FindBin::Bin . '/../..'; # For our 'old code'-"require"s
 use LedgerSMB::PSGI;
 use LedgerSMB::PSGI::Preloads;
-use LedgerSMB::Sysconfig;
+use LedgerSMB::Sysconfig qw(initialize);
 use Log::Log4perl;
 use Log::Log4perl::Layout::PatternLayout;
 use LedgerSMB::Middleware::RequestID;
+
+initialize( $ENV{LSMB_CONFIG_FILE} // 'ledgersmb.conf' );
 
 require Plack::Middleware::Pod
     if ( $ENV{PLACK_ENV} && $ENV{PLACK_ENV} eq 'development' );

--- a/utils/test/makeblacklist.pl
+++ b/utils/test/makeblacklist.pl
@@ -7,9 +7,9 @@ use lib "$FindBin::Bin/../lib";
 use 5.010; # say makes things easier
 no lib '.'; # can run from anywhere
 
-use LedgerSMB::Sysconfig qw(initialize);
+use LedgerSMB::Sysconfig;
 
-initialize( $ENV{LSMB_CONFIG_FILE} // 'ledgersmb.conf' );
+LedgerSMB::Sysconfig->initialize( $ENV{LSMB_CONFIG_FILE} // 'ledgersmb.conf' );
 
 =head1 NAME
 

--- a/utils/test/makeblacklist.pl
+++ b/utils/test/makeblacklist.pl
@@ -7,7 +7,9 @@ use lib "$FindBin::Bin/../lib";
 use 5.010; # say makes things easier
 no lib '.'; # can run from anywhere
 
-use LedgerSMB::Sysconfig;
+use LedgerSMB::Sysconfig qw(initialize);
+
+initialize( $ENV{LSMB_CONFIG_FILE} // 'ledgersmb.conf' );
 
 =head1 NAME
 

--- a/xt/08-pod-coverage.t
+++ b/xt/08-pod-coverage.t
@@ -24,6 +24,9 @@ if ($ENV{COVERAGE} && $ENV{CI}) {
 }
 
 
+use LedgerSMB::Sysconfig;
+LedgerSMB::Sysconfig->initialize;
+
 #### Test setup
 
 my @on_disk;

--- a/xt/09-versioning.t
+++ b/xt/09-versioning.t
@@ -5,9 +5,14 @@ use Test2::V0;
 use LedgerSMB;
 use LedgerSMB::Form;
 use LedgerSMB::App_State;
+use LedgerSMB::Locale;
+use LedgerSMB::Sysconfig;
+
 use Log::Log4perl qw(:easy);
 use Plack::Request;
 
+LedgerSMB::Sysconfig->initialize;
+LedgerSMB::Locale->initialize;
 Log::Log4perl->easy_init($OFF);
 
 $ENV{REQUEST_METHOD} = 'GET';

--- a/xt/40-database.t
+++ b/xt/40-database.t
@@ -6,13 +6,13 @@ use DBI;
 
 use LedgerSMB::Database;
 use LedgerSMB;
-use LedgerSMB::Sysconfig qw(initialize);
+use LedgerSMB::Sysconfig;
 use LedgerSMB::DBObject::Admin;
 
 skip_all( 'LSMB_TEST_DB not set' )
     if not $ENV{LSMB_TEST_DB};
 
-initialize( $ENV{LSMB_CONFIG_FILE} // 'ledgersmb.conf' );
+LedgerSMB::Sysconfig->initialize( $ENV{LSMB_CONFIG_FILE} // 'ledgersmb.conf' );
 
 my $db;
 my $admin_dbh = DBI->connect('dbi:Pg:dbname=postgres',

--- a/xt/40-database.t
+++ b/xt/40-database.t
@@ -1,3 +1,4 @@
+#!perl
 
 use Test2::V0;
 
@@ -5,12 +6,13 @@ use DBI;
 
 use LedgerSMB::Database;
 use LedgerSMB;
-use LedgerSMB::Sysconfig;
+use LedgerSMB::Sysconfig qw(initialize);
 use LedgerSMB::DBObject::Admin;
 
 skip_all( 'LSMB_TEST_DB not set' )
     if not $ENV{LSMB_TEST_DB};
 
+initialize( $ENV{LSMB_CONFIG_FILE} // 'ledgersmb.conf' );
 
 my $db;
 my $admin_dbh = DBI->connect('dbi:Pg:dbname=postgres',

--- a/xt/40-dbsetup.t
+++ b/xt/40-dbsetup.t
@@ -6,7 +6,7 @@ use Test2::V0;
 use LedgerSMB;
 use LedgerSMB::App_State;
 use LedgerSMB::Database;
-use LedgerSMB::Sysconfig qw(initialize);
+use LedgerSMB::Sysconfig;
 use LedgerSMB::DBObject::Admin;
 use DBI;
 use Plack::Request;
@@ -21,7 +21,7 @@ defined $ENV{LSMB_TEST_DB} or plan skip_all => 'LSMB_TEST_DB is not set';
 # by xt/89-dropdb.t
 $ENV{LSMB_NEW_DB} or bail_out('LSMB_NEW_DB is not set');
 
-initialize( $ENV{LSMB_CONFIG_FILE} // 'ledgersmb.conf' );
+LedgerSMB::Sysconfig->initialize( $ENV{LSMB_CONFIG_FILE} // 'ledgersmb.conf' );
 
 my $temp = $ENV{TEMP} || '/tmp/';
 

--- a/xt/40-dbsetup.t
+++ b/xt/40-dbsetup.t
@@ -6,7 +6,7 @@ use Test2::V0;
 use LedgerSMB;
 use LedgerSMB::App_State;
 use LedgerSMB::Database;
-use LedgerSMB::Sysconfig;
+use LedgerSMB::Sysconfig qw(initialize);
 use LedgerSMB::DBObject::Admin;
 use DBI;
 use Plack::Request;
@@ -20,6 +20,8 @@ defined $ENV{LSMB_TEST_DB} or plan skip_all => 'LSMB_TEST_DB is not set';
 # the database will be created when this test is run and later dropped
 # by xt/89-dropdb.t
 $ENV{LSMB_NEW_DB} or bail_out('LSMB_NEW_DB is not set');
+
+initialize( $ENV{LSMB_CONFIG_FILE} // 'ledgersmb.conf' );
 
 my $temp = $ENV{TEMP} || '/tmp/';
 

--- a/xt/40-ledgersmb.t
+++ b/xt/40-ledgersmb.t
@@ -7,9 +7,14 @@ use Test2::V0;
 use Math::BigFloat;
 
 use LedgerSMB;
+use LedgerSMB::Locale;
+use LedgerSMB::Sysconfig;
 use Plack::Request;
 
 use Log::Log4perl qw(:easy);
+
+LedgerSMB::Sysconfig->initialize;
+LedgerSMB::Locale->initialize;
 Log::Log4perl->easy_init($OFF);
 
 my $request = Plack::Request->new({});

--- a/xt/62-api-legacy.t
+++ b/xt/62-api-legacy.t
@@ -6,14 +6,15 @@ BEGIN {
     use lib 'xt/lib';
     use LedgerSMB;
     use LedgerSMB::Template;
-    use LedgerSMB::Sysconfig qw(initialize);
+    use LedgerSMB::Sysconfig;
     use LedgerSMB::DBTest;
     use LedgerSMB::App_State;
     use LedgerSMB::Locale;
     use Plack::Request;
 }
 
-initialize( $ENV{LSMB_CONFIG_FILE} // 'ledgersmb.conf' );
+LedgerSMB::Sysconfig->initialize( $ENV{LSMB_CONFIG_FILE} // 'ledgersmb.conf' );
+LedgerSMB::Locale->initialize();
 
 # TODO: FIXME
 # This is a hack, and it's very bad!

--- a/xt/62-api-legacy.t
+++ b/xt/62-api-legacy.t
@@ -6,12 +6,14 @@ BEGIN {
     use lib 'xt/lib';
     use LedgerSMB;
     use LedgerSMB::Template;
-    use LedgerSMB::Sysconfig;
+    use LedgerSMB::Sysconfig qw(initialize);
     use LedgerSMB::DBTest;
     use LedgerSMB::App_State;
     use LedgerSMB::Locale;
     use Plack::Request;
 }
+
+initialize( $ENV{LSMB_CONFIG_FILE} // 'ledgersmb.conf' );
 
 # TODO: FIXME
 # This is a hack, and it's very bad!


### PR DESCRIPTION
This PR adds the next step in providing a functional interface to LedgerSMB::Sysconfig. The calling/using application is responsible for initializing the correct configuration; having the module do that itself is counter productive and an artifact from the time where it was assuming to be part of a web application (which it still is, but we don't want it to know).