### PR TITLE
Fix #5175: Invoice conversion from order uses the order date instead of 'today'

### DIFF
--- a/old/bin/oe.pl
+++ b/old/bin/oe.pl
@@ -1400,9 +1400,8 @@ sub invoice {
 
     OE->save( \%myconfig, \%$form );
 
-    $form->{duedate} =
-      $form->current_date( \%myconfig, $form->{transdate}, $form->{terms} * 1 );
-
+    $form->{transdate} = '';
+    $form->{duedate} = '';
     $form->{id}     = '';
     $form->{closed} = 0;
     $form->{rowcount}--;


### PR DESCRIPTION
This is a regression from 1.7 where the invoice would be posted using
'today' unless the invoice date was changed. The regression is caused
by the fix for #2587 (Default date on new invoice is tomorrow).
