### PR TITLE
Remove HTML Snippet detection leftovers

### DIFF
--- a/UI/Contact/divs/address.html
+++ b/UI/Contact/divs/address.html
@@ -1,4 +1,3 @@
-[%# HTML Snippet, for import only %]
 <div id="address_div"
      title="[% text('Addresses') %]"
      data-dojo-type="dijit/layout/ContentPane"

--- a/UI/Contact/divs/bank_act.html
+++ b/UI/Contact/divs/bank_act.html
@@ -1,4 +1,3 @@
-[%# HTML Snippet, for import only %]
 <div id="bank_act_div"
      title="[% text('Bank Accounts') %]"
      data-dojo-type="dijit/layout/ContentPane"

--- a/UI/Contact/divs/company.html
+++ b/UI/Contact/divs/company.html
@@ -1,4 +1,3 @@
-[%# HTML Snippet, for import only %]
 <div id="company_div"
      title="[% text('Company') %]"
      data-dojo-type="dijit/layout/ContentPane"

--- a/UI/Contact/divs/contact_info.html
+++ b/UI/Contact/divs/contact_info.html
@@ -1,4 +1,3 @@
-[%# HTML Snippet, for import only %]
 <div id="contact_info_div"
      title="[% text('Contact Info') %]"
      data-dojo-type="dijit/layout/ContentPane"
@@ -136,4 +135,3 @@ PROCESS dynatable
         </form>
 
 </div>
-

--- a/UI/Contact/divs/credit.html
+++ b/UI/Contact/divs/credit.html
@@ -1,4 +1,3 @@
-[%# HTML Snippet, for import only %]
 <div id="credit_div"
      title="[% text('Credit Accounts') %]"
      data-dojo-type="dijit/layout/ContentPane"

--- a/UI/Contact/divs/employee.html
+++ b/UI/Contact/divs/employee.html
@@ -1,4 +1,3 @@
-[%# HTML Snippet, for import only %]
 <div id="employee_div"
      title="[% text('Employee') %]"
      data-dojo-type="dijit/layout/ContentPane"

--- a/UI/Contact/divs/files.html
+++ b/UI/Contact/divs/files.html
@@ -1,4 +1,3 @@
-[%# HTML Snippet, for import only %]
 <div id="files_div"
      title="[% text('Files') %]"
      data-dojo-type="dijit/layout/ContentPane"

--- a/UI/Contact/divs/notes.html
+++ b/UI/Contact/divs/notes.html
@@ -1,4 +1,3 @@
-[%# HTML Snippet, for import only %]
 <div id="notes_div"
      title="[% text('Notes') %]"
      data-dojo-type="dijit/layout/ContentPane"

--- a/UI/Contact/divs/person.html
+++ b/UI/Contact/divs/person.html
@@ -1,4 +1,3 @@
-[%# HTML Snippet, for import only %]
 <div id="person_div"
      title="[% text('Person') %]"
      data-dojo-type="dijit/layout/ContentPane"

--- a/UI/Contact/divs/user.html
+++ b/UI/Contact/divs/user.html
@@ -1,4 +1,3 @@
-[%# HTML Snippet, for import only %]
 [% IF employee.first_name %]
 <div id="user_div"
      title="[% text('User') %]"

--- a/UI/Contact/divs/wage.html
+++ b/UI/Contact/divs/wage.html
@@ -1,4 +1,3 @@
-[%# HTML Snippet, for import only %]
 <div id="wage_div"
      title='[% text("Wages and Deductions") %]'
      data-dojo-type="dijit/layout/ContentPane"

--- a/UI/lib/dynatable.html
+++ b/UI/lib/dynatable.html
@@ -1,4 +1,3 @@
-[%# HTML Snippet, for import only %]
 [%
    # Internal documentation for the DYNATABLE block
 

--- a/UI/lib/elements.html
+++ b/UI/lib/elements.html
@@ -1,4 +1,3 @@
-[%# HTML Snippet, for import only %]
 [%
   default_keys = ['id', 'class', 'title']  # Defaults for all attributes
 

--- a/UI/lib/report_base.html
+++ b/UI/lib/report_base.html
@@ -1,4 +1,3 @@
-[%# HTML Snippet, for import only %]
 [%- BLOCK business_classes;
         FOREACH BUC IN bu_classes %]
         <tr>

--- a/UI/lib/utilities.html
+++ b/UI/lib/utilities.html
@@ -1,4 +1,3 @@
-[%# HTML Snippet, for import only %]
 [% BLOCK print_options %]
 <div class="print-options">[%
 

--- a/UI/reconciliation/corrections.html
+++ b/UI/reconciliation/corrections.html
@@ -1,4 +1,3 @@
-[%# HTML Snippet, for import only %]
 <table border=0>
         <tr>
                 <td>Clear date</td>

--- a/UI/reconciliation/list.html
+++ b/UI/reconciliation/list.html
@@ -1,4 +1,3 @@
-[%# HTML Snippet, for import only %]
 [% INCLUDE 'report_base.html'%]
 
 <div class="content">

--- a/UI/setup/ui-db-credentials.html
+++ b/UI/setup/ui-db-credentials.html
@@ -1,4 +1,3 @@
-[%# HTML Snippet, for import only %]
 <div class="listtop">[% text('Database Credentials') %]</div>
 <table class='lsmb_info' id="credentials">
   <tbody>

--- a/UI/taxform/report_hiddens.html
+++ b/UI/taxform/report_hiddens.html
@@ -1,4 +1,3 @@
-[%# HTML Snippet, for import only %]
 [%
 PROCESS input element_data = {
    type="hidden"


### PR DESCRIPTION
Snippets comments were used to allow html tests to run successfully even on incomplete files.
Snippet detection is done per directory and file name now.