### PR TITLE
Migrate to PGObject::Util::DBAdmin 1.2.2

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -79,7 +79,7 @@ requires 'PGObject::Type::BigFloat', '2.0.1';
 requires 'PGObject::Type::DateTime', '2.0.2';
 requires 'PGObject::Type::ByteString', '1.2.3';
 requires 'PGObject::Util::DBMethod';
-requires 'PGObject::Util::DBAdmin', '1.1.0';
+requires 'PGObject::Util::DBAdmin', '1.2.2';
 requires 'Plack', '1.0031';
 requires 'Plack::App::File';
 requires 'Plack::Builder';

--- a/lib/LedgerSMB/Database.pm
+++ b/lib/LedgerSMB/Database.pm
@@ -9,12 +9,14 @@ LedgerSMB::Database - APIs for database creation and management.
 
 This module wraps both DBI and the PostgreSQL commandline tools.
 
-  my $db = LedgerSMB::Database->new({
-       dbname => 'mycompany',
-       username => 'foo',
-       password => 'foospassword',
+  my $db = LedgerSMB::Database->new(
+       connect_data => {
+          user     => 'foo',
+          dbname   => 'mycompany',
+          password => 'foospassword',
+       },
        schema   => 'non_public',
-  });
+  );
 
   $db->load_modules('LOADORDER');
 
@@ -38,7 +40,7 @@ use DBI;
 use File::Spec;
 use File::Temp;
 use Log::Log4perl;
-
+use PGObject::Util::DBAdmin 'v1.2.1';
 
 use Moose;
 use namespace::autoclean;

--- a/xt/40-database.t
+++ b/xt/40-database.t
@@ -19,24 +19,6 @@ my $admin_dbh = DBI->connect('dbi:Pg:dbname=postgres',
                              undef, undef, { AutoCommit => 1 })
     or die 'Cannot set up master connection';
 
-#
-#
-#
-#  Object instantiation test
-#
-
-my %options = (
-    dbname       => 'dbname',
-    username     => 'username',
-    password     => 'password',
-    source_dir   => 'source_dir'
-    );
-
-$db = LedgerSMB::Database->new(\%options);
-for my $key (keys %options) {
-    is($db->{$key}, $options{$key}, "Database creation option: $key");
-}
-
 
 #
 #
@@ -50,12 +32,14 @@ for my $key (keys %options) {
 # missing schema file
 #
 $admin_dbh->do(q{DROP DATABASE IF EXISTS lsmbtest_database});
-$db = LedgerSMB::Database->new({
-    dbname     => 'lsmbtest_database',
-    username   => $ENV{PGUSER},
-    password   => $ENV{PGPASSWORD},
+$db = LedgerSMB::Database->new(
+    connect_data => {
+        dbname     => 'lsmbtest_database',
+        user       => $ENV{PGUSER},
+        password   => $ENV{PGPASSWORD},
+    },
     source_dir => './xt/data'
-                               });
+    );
 like( dies { $db->create_and_load; },
           qr/(APPLICATION ERROR|Specified file does not exist)/,
     'Database creation fails on missing schema file');
@@ -64,12 +48,14 @@ like( dies { $db->create_and_load; },
 # missing schema file's directory
 #
 $admin_dbh->do(q{DROP DATABASE IF EXISTS lsmbtest_database});
-$db = LedgerSMB::Database->new({
-    dbname     => 'lsmbtest_database',
-    username   => $ENV{PGUSER},
-    password   => $ENV{PGPASSWORD},
+$db = LedgerSMB::Database->new(
+    connect_data => {
+        dbname     => 'lsmbtest_database',
+        user       => $ENV{PGUSER},
+        password   => $ENV{PGPASSWORD},
+    },
     source_dir => './xt/data/missing-directory'
-                               });
+    );
 like( dies { $db->create_and_load; },
           qr/(APPLICATION ERROR|Specified file does not exist)/,
      'Database creation fails on missing schema');
@@ -85,12 +71,14 @@ like( dies { $db->create_and_load; },
 # We'll load a schema without a defaults table to simulate the failure
 
 $admin_dbh->do(q{DROP DATABASE IF EXISTS lsmbtest_database});
-$db = LedgerSMB::Database->new({
-    dbname     => 'lsmbtest_database',
-    username   => $ENV{PGUSER},
-    password   => $ENV{PGPASSWORD},
+$db = LedgerSMB::Database->new(
+    connect_data => {
+        dbname     => 'lsmbtest_database',
+        user       => $ENV{PGUSER},
+        password   => $ENV{PGPASSWORD},
+    },
     source_dir => './xt/data/40-database/no-defaults-table'
-                               });
+    );
 like( dies { $db->create_and_load; }, qr/Base schema failed to load/,
     'Database creation fails on missing defaults table');
 
@@ -103,12 +91,14 @@ like( dies { $db->create_and_load; }, qr/Base schema failed to load/,
 #
 
 $admin_dbh->do(q{DROP DATABASE IF EXISTS lsmbtest_database});
-$db = LedgerSMB::Database->new({
-    dbname     => 'lsmbtest_database',
-    username   => $ENV{PGUSER},
-    password   => $ENV{PGPASSWORD},
+$db = LedgerSMB::Database->new(
+    connect_data => {
+        dbname     => 'lsmbtest_database',
+        user       => $ENV{PGUSER},
+        password   => $ENV{PGPASSWORD},
+    },
     source_dir => './xt/data/40-database/schema-failure'
-                               });
+    );
 like( dies { $db->create_and_load; },
           qr/(ERROR:\s*relation "defal" does not exist|error running command)/,
     'Database creation fails on base schema load failure');
@@ -123,24 +113,28 @@ like( dies { $db->create_and_load; },
 
 
 $admin_dbh->do(q{DROP DATABASE IF EXISTS lsmbtest_database});
-$db = LedgerSMB::Database->new({
-    dbname     => 'lsmbtest_database',
-    username   => $ENV{PGUSER},
-    password   => $ENV{PGPASSWORD},
+$db = LedgerSMB::Database->new(
+    connect_data => {
+        dbname     => 'lsmbtest_database',
+        user       => $ENV{PGUSER},
+        password   => $ENV{PGPASSWORD},
+    },
     source_dir => './xt/data/40-database/module-failure-1'
-                               });
+    );
 like( dies { $db->create_and_load; }, qr/Module FaultyModule.sql failed to load/,
     'Database creation fails when a module fails to load (empty module)');
 
 
 
 $admin_dbh->do(q{DROP DATABASE IF EXISTS lsmbtest_database});
-$db = LedgerSMB::Database->new({
-    dbname     => 'lsmbtest_database',
-    username   => $ENV{PGUSER},
-    password   => $ENV{PGPASSWORD},
+$db = LedgerSMB::Database->new(
+    connect_data => {
+        dbname     => 'lsmbtest_database',
+        user       => $ENV{PGUSER},
+        password   => $ENV{PGPASSWORD},
+    },
     source_dir => './xt/data/40-database/module-failure-2'
-                               });
+    );
 like( dies { $db->create_and_load; },
         qr/(ERROR:\s*function "fail_me" already exists|error running command)/,
     'Database creation fails when a module fails to load (syntax error)');

--- a/xt/40-dbsetup.t
+++ b/xt/40-dbsetup.t
@@ -29,11 +29,12 @@ $ENV{PGDATABASE} = $ENV{LSMB_NEW_DB};
 #LedgerSMB::Sysconfig::db_namespace('altschema');
 LedgerSMB::Sysconfig::language('en');
 
-my $db = LedgerSMB::Database->new({
+my $db = LedgerSMB::Database->new(
+    connect_data => {
          dbname       => $ENV{LSMB_NEW_DB},
-         username     => $ENV{PGUSER},
+         user         => $ENV{PGUSER},
          password     => $ENV{PGPASSWORD},
-});
+    });
 
 # Manual tests
 ok($db->create, 'Database Created')
@@ -117,7 +118,7 @@ my $copy_sth =
     $copy_dbh->prepare(q|select value from defaults
                           where setting_key='role_prefix'|);
 ok($copy_sth, 'Prepare validation statement');
-$copy_sth->execute();
+ok lives { $copy_sth->execute() or die $copy_sth->errstr };
 my ($role_prefix) =
     @{$copy_sth->fetchrow_arrayref()};
 is($role_prefix, "lsmb_$ENV{LSMB_NEW_DB}__",

--- a/xt/41-coaload.t
+++ b/xt/41-coaload.t
@@ -41,9 +41,9 @@ for my $sqlfile (@files) {
         ok((system('psql', $db, '-f', $sqlfile) >> 8) == 0, "psql run file succeeded ($!)");
 
         my $lsmb_db = LedgerSMB::Database->new(
-            {
+            connect_data => {
                 dbname       => $db,
-                username     => $ENV{PGUSER},
+                user         => $ENV{PGUSER},
                 password     => $ENV{PGPASSWORD},
             });
         my $dbh = $lsmb_db->connect;


### PR DESCRIPTION
This new version allows for a much broader set of connection
parameter specifications than the ones which 1.1.0 and before do.
Especially the new admin CLI benefits from this newly gained
flexibility.
