### PR TITLE
Add logging to database creation

### DIFF
--- a/lib/LedgerSMB/Database.pm
+++ b/lib/LedgerSMB/Database.pm
@@ -589,12 +589,16 @@ Returns true when successful, dies on error.
 
 sub create_and_load {
     my ($self, $args) = @_;
+    $logger->info('Creating database');
     $self->create;
+    $logger->info('Loading schema');
     $self->load_base_schema(
         log_stdout     => $args->{log},
         errlog  => $args->{errlog},
         );
+    $logger->info('Applying schema changes');
     $self->apply_changes();
+    $logger->info('Loading LedgerSMB application database modules');
     return $self->load_modules('LOADORDER', {
     log     => $args->{log},
     errlog  => $args->{errlog},

--- a/xt/40-database.t
+++ b/xt/40-database.t
@@ -9,6 +9,9 @@ use LedgerSMB;
 use LedgerSMB::Sysconfig;
 use LedgerSMB::DBObject::Admin;
 
+use Log::Log4perl qw(:easy);
+Log::Log4perl->easy_init($OFF);
+
 skip_all( 'LSMB_TEST_DB not set' )
     if not $ENV{LSMB_TEST_DB};
 

--- a/xt/40-dbsetup.t
+++ b/xt/40-dbsetup.t
@@ -11,6 +11,10 @@ use LedgerSMB::DBObject::Admin;
 use DBI;
 use Plack::Request;
 
+use Log::Log4perl qw(:easy);
+Log::Log4perl->easy_init($OFF);
+
+
 # This entire test suite will be skipped unless environment
 # variable LSMB_TEST_DB is true
 defined $ENV{LSMB_TEST_DB} or plan skip_all => 'LSMB_TEST_DB is not set';

--- a/xt/41-coaload.t
+++ b/xt/41-coaload.t
@@ -10,6 +10,10 @@ use Capture::Tiny qw(capture);
 
 use LedgerSMB::Database;
 
+use Log::Log4perl qw(:easy);
+Log::Log4perl->easy_init($OFF);
+
+
 my @missing = grep { ! $ENV{$_} } (qw(LSMB_NEW_DB COA_TESTING LSMB_TEST_DB));
 skip_all((join ', ', @missing) . ' not set') if @missing;
 

--- a/xt/43-dbchange.t
+++ b/xt/43-dbchange.t
@@ -9,6 +9,9 @@ use Test2::V0;
 use LedgerSMB::Database::Change;
 use DBI;
 
+use Log::Log4perl qw(:easy);
+Log::Log4perl->easy_init($OFF);
+
 #
 #
 ######################################

--- a/xt/43-schema-upgrades.t
+++ b/xt/43-schema-upgrades.t
@@ -27,6 +27,11 @@ use DBI;
 use IO::Scalar;
 use Carp::Always;
 
+use Log::Log4perl qw(:easy);
+Log::Log4perl->easy_init($OFF);
+
+
+
 ####### Create test run conditions
 
 my $dbh = DBI->connect("dbi:Pg:dbname=$ENV{LSMB_NEW_DB}", undef, undef,

--- a/xt/lib/Pherkin/Extension/LedgerSMB.pm
+++ b/xt/lib/Pherkin/Extension/LedgerSMB.pm
@@ -20,6 +20,7 @@ use LedgerSMB::Entity::Person::Employee;
 use LedgerSMB::Entity::User;
 use Test::BDD::Cucumber::Extension;
 use List::Util qw(any);
+use Log::Log4perl qw(:easy);
 
 use Moose;
 use namespace::autoclean;
@@ -75,6 +76,9 @@ sub step_directories {
 my $startup_pid = $$;
 
 sub pre_execute {
+    if (not Log::Log4perl->initialized()) {
+        Log::Log4perl->easy_init($OFF);
+    }
 }
 
 sub post_execute {


### PR DESCRIPTION
In order to understand the failing step, if there is one,
we need to log which steps have been completed succesfully.
