### PR TITLE
Initialize Log::Any to use Log::Log4perl

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -50,6 +50,8 @@ Dependency updates
 * Locale::CLDR::* (new)
 * Locale::Country (dropped)
 * Locale::Language (dropped)
+* Log::Any (new)
+* Log::Any::Adapter::Log4perl (new)
 * MooseX::ClassAttribute (new)
 * PGObject::Util::DBAdmin 1.2.2 (updated from 1.0.1)
 * Syntax::Keyword::Try (0.15)

--- a/Changelog
+++ b/Changelog
@@ -53,7 +53,7 @@ Dependency updates
 * Log::Any (new)
 * Log::Any::Adapter::Log4perl (new)
 * MooseX::ClassAttribute (new)
-* PGObject::Util::DBAdmin 1.2.2 (updated from 1.0.1)
+* PGObject::Util::DBAdmin 1.4.0 (updated from 1.0.1)
 * Syntax::Keyword::Try (0.15)
 * URI::Escape (new)
 * Try::Tiny (dropped)

--- a/bin/ledgersmb-server.psgi
+++ b/bin/ledgersmb-server.psgi
@@ -20,6 +20,7 @@ use LedgerSMB::Locale;
 use LedgerSMB::PSGI;
 use LedgerSMB::PSGI::Preloads;
 use LedgerSMB::Sysconfig;
+use Log::Any::Adapter;
 use Log::Log4perl;
 use Log::Log4perl::Layout::PatternLayout;
 use LedgerSMB::Middleware::RequestID;
@@ -46,8 +47,8 @@ Log::Log4perl::Layout::PatternLayout::add_global_cspec(
     'Z',
     sub { return $LedgerSMB::Middleware::RequestID::request_id.''; });
 my $log_config = LedgerSMB::Sysconfig::log4perl_config();
-Log::Log4perl::init(\$log_config);
-
+Log::Log4perl->init(\$log_config);
+Log::Any::Adapter->set('Log4perl');
 
 LedgerSMB::PSGI::setup_url_space(
         development => ($ENV{PLACK_ENV} eq 'development'),

--- a/bin/ledgersmb-server.psgi
+++ b/bin/ledgersmb-server.psgi
@@ -46,8 +46,25 @@ if ( LedgerSMB::Sysconfig::dojo_built() ) {
 Log::Log4perl::Layout::PatternLayout::add_global_cspec(
     'Z',
     sub { return $LedgerSMB::Middleware::RequestID::request_id.''; });
-my $log_config = LedgerSMB::Sysconfig::log4perl_config();
-Log::Log4perl->init(\$log_config);
+
+my $log_config = LedgerSMB::Sysconfig::log_config();
+if ($log_config) {
+    Log::Log4perl->init($log_config);
+}
+else {
+    my %log_levels = (
+        OFF   => $OFF,
+        FATAL => $FATAL,
+        ERROR => $ERROR,
+        WARN  => $WARN,
+        INFO  => $INFO,
+        DEBUG => $DEBUG,
+        TRACE => $TRACE,
+        );
+    my $log_level = LedgerSMB::Sysconfig::log_level();
+    die "Invalid log level: $log_level" unless exists $log_levels{$log_level};
+    Log::Log4perl->easy_init($log_levels{$log_level});
+}
 Log::Any::Adapter->set('Log4perl');
 
 LedgerSMB::PSGI::setup_url_space(

--- a/bin/migrate-company
+++ b/bin/migrate-company
@@ -115,6 +115,7 @@ use File::Basename qw(dirname);
 use File::Spec;
 use Getopt::Long;
 use List::Util qw(none);
+use Log::Any::Adapter;
 use Log::Log4perl qw(:easy);
 use Pod::Usage qw( pod2usage );
 use Text::CSV qw( csv );
@@ -170,12 +171,12 @@ GetOptions(
 
 
 if (-e $logconf) {
-    Log::Log4perl::init($logconf);
+    Log::Log4perl->init($logconf);
 }
 else {
     Log::Log4perl->easy_init($loglevel_map{$loglevel})
 }
-
+Log::Any::Adapter->set('Log4perl');
 
 sub ensure_data_dir {
     if (-d $data) {

--- a/cpanfile
+++ b/cpanfile
@@ -81,7 +81,7 @@ requires 'PGObject::Type::BigFloat', '2.0.1';
 requires 'PGObject::Type::DateTime', '2.0.2';
 requires 'PGObject::Type::ByteString', '1.2.3';
 requires 'PGObject::Util::DBMethod';
-requires 'PGObject::Util::DBAdmin', '1.2.2';
+requires 'PGObject::Util::DBAdmin', '1.4.0';
 requires 'Plack', '1.0031';
 requires 'Plack::App::File';
 requires 'Plack::Builder';

--- a/cpanfile
+++ b/cpanfile
@@ -56,6 +56,8 @@ requires 'Locale::CLDR::Locales::Tr';
 requires 'Locale::CLDR::Locales::Uk';
 requires 'Locale::CLDR::Locales::Zh';
 requires 'Locale::Maketext::Lexicon', '0.62';
+requires 'Log::Any::Adapter';
+requires 'Log::Any::Adapter::Log4perl';
 requires 'Log::Log4perl';
 requires 'Log::Log4perl::Layout::PatternLayout';
 requires 'LWP::Simple';

--- a/doc/conf/ledgersmb.conf.default
+++ b/doc/conf/ledgersmb.conf.default
@@ -24,8 +24,19 @@ language =
 #  (default: yyyy-mm-dd; unset means detected from the browser)
 date_format = yyyy-mm-dd
 
-# todo
+# Specifies the logging level to be used
+# This setting is ignored when the 'log_config' setting is supplied and
+# indicates an existing file.
+#
+# Available values are OFF, FATAL, ERROR, WARN, INFO, DEBUG, TRACE
 log_level = ERROR
+
+# Set the name of the extended logging configuration file
+# This file uses the log4j/Log::Log4perl syntax described at
+#  https://metacpan.org/pod/Log::Log4perl#Configuration-files
+#
+# Examples in doc/conf/ledgersmb.log.conf.*
+#log_config = ledgersmb.log.conf
 
 # Maximum POST size to prevent DoS (4MB default)
 max_post_size = 4194304
@@ -115,7 +126,3 @@ sslmode = prefer
 #template_xls = disabled
 #template_xlsx = disabled
 #template_ods = disabled
-
-[log4perl_config_modules_loglevel]
-LedgerSMB = INFO
-LedgerSMB.DBObject = INFO

--- a/doc/conf/ledgersmb.conf.travis-ci
+++ b/doc/conf/ledgersmb.conf.travis-ci
@@ -10,7 +10,8 @@ cache_templates = 1
 # Set language for login and admin pages
 language = 
 
-log_level = ERROR
+log_level = OFF
+# log_config =
 
 # Maximum POST size to prevent DoS (4MB default)
 max_post_size = 4194304
@@ -57,6 +58,3 @@ host = localhost
 db_namespace = public
 # sslmode can be require, allow, prefer, or disable.  Defaults to prefer.
 sslmode = prefer
-
-[log4perl_config_modules_loglevel]
-LedgerSMB=OFF

--- a/doc/conf/ledgersmb.conf.unbuilt-dojo
+++ b/doc/conf/ledgersmb.conf.unbuilt-dojo
@@ -24,8 +24,19 @@ language =
 #  (default: yyyy-mm-dd; unset means detected from the browser)
 date_format = yyyy-mm-dd
 
-# todo
+# Specifies the logging level to be used
+# This setting is ignored when the 'log_config' setting is supplied and
+# indicates an existing file.
+#
+# Available values are OFF, FATAL, ERROR, WARN, INFO, DEBUG, TRACE
 log_level = ERROR
+
+# Set the name of the extended logging configuration file
+# This file uses the log4j/Log::Log4perl syntax described at
+#  https://metacpan.org/pod/Log::Log4perl#Configuration-files
+#
+# Examples in doc/conf/ledgersmb.log.conf.*
+#log_config = ledgersmb.log.conf
 
 # Maximum POST size to prevent DoS (4MB default)
 max_post_size = 4194304
@@ -115,7 +126,3 @@ dojo_built = 0
 #template_xls = disabled
 #template_xlsx = disabled
 #template_ods = disabled
-
-[log4perl_config_modules_loglevel]
-LedgerSMB = INFO
-LedgerSMB.DBObject = INFO

--- a/doc/conf/ledgersmb.log.conf.pre-1.9
+++ b/doc/conf/ledgersmb.log.conf.pre-1.9
@@ -1,0 +1,37 @@
+log4perl.rootlogger = ERROR, Basic, Debug, DebugPanel
+log4perl.logger.LedgerSMB = INFO
+log4perl.logger.LedgerSMB.DBObject = INFO
+
+log4perl.appender.Screen = Log::Log4perl::Appender::Screen
+log4perl.appender.Screen.layout = PatternLayout
+log4perl.appender.Screen.layout.ConversionPattern = Req:%Z %p - %m%n
+
+# Filter for debug level
+log4perl.filter.MatchDebug = Log::Log4perl::Filter::LevelMatch
+log4perl.filter.MatchDebug.LevelToMatch = INFO
+log4perl.filter.MatchDebug.AcceptOnMatch = false
+
+# Filter for everything but debug,trace level
+log4perl.filter.MatchRest = Log::Log4perl::Filter::LevelMatch
+log4perl.filter.MatchRest.LevelToMatch = INFO
+log4perl.filter.MatchRest.AcceptOnMatch = true
+
+# layout for DEBUG,TRACE messages
+log4perl.appender.Debug = Log::Log4perl::Appender::Screen
+log4perl.appender.Debug.layout = PatternLayout
+log4perl.appender.Debug.layout.ConversionPattern = Req:%Z %d - %p - %l -- %m%n
+log4perl.appender.Debug.Filter = MatchDebug
+
+# layout for non-DEBUG messages
+log4perl.appender.Basic = Log::Log4perl::Appender::Screen
+log4perl.appender.Basic.layout = PatternLayout
+log4perl.appender.Basic.layout.ConversionPattern = Req:%Z %d - %p - %M -- %m%n
+log4perl.appender.Basic.Filter = MatchRest
+
+log4perl.appender.DebugPanel              = Log::Log4perl::Appender::TestBuffer
+log4perl.appender.DebugPanel.name         = psgi_debug_panel
+log4perl.appender.DebugPanel.mode         = append
+log4perl.appender.DebugPanel.layout       = PatternLayout
+log4perl.appender.DebugPanel.layout.ConversionPattern = %r >> %p >> %m >> %c >> at %F line %L%n
+#log4perl.appender.DebugPanel.Threshold = TRACE
+

--- a/doc/conf/ledgersmb.log.conf.simple
+++ b/doc/conf/ledgersmb.log.conf.simple
@@ -1,0 +1,5 @@
+log4perl.rootlogger = ERROR, Screen
+
+log4perl.appender.Screen = Log::Log4perl::Appender::Screen
+log4perl.appender.Screen.layout = PatternLayout
+

--- a/doc/conf/ledgersmb.log.conf.simple-web
+++ b/doc/conf/ledgersmb.log.conf.simple-web
@@ -1,0 +1,5 @@
+log4perl.rootlogger = ERROR, Screen
+
+log4perl.appender.Screen = Log::Log4perl::Appender::Screen
+log4perl.appender.Screen.layout = PatternLayout
+log4perl.appender.Screen.layout.ConversionPattern = Req:%Z %p - %m%n

--- a/lib/LedgerSMB/Database.pm
+++ b/lib/LedgerSMB/Database.pm
@@ -39,8 +39,7 @@ use DBD::Pg;
 use DBI;
 use File::Spec;
 use File::Temp;
-use Log::Log4perl;
-use PGObject::Util::DBAdmin 'v1.2.1';
+use PGObject::Util::DBAdmin 'v1.4.0';
 
 use Moose;
 use namespace::autoclean;
@@ -50,8 +49,6 @@ use LedgerSMB::Database::Loadorder;
 
 
 our $VERSION = '1.2';
-
-my $logger = Log::Log4perl->get_logger('LedgerSMB::Database');
 
 
 =head1 PROPERTIES
@@ -259,7 +256,7 @@ sub get_info {
         $dbh = $self->new($self->export, (dbname => $authdb))
             ->connect({PrintError=>0});
         return $retval unless $dbh;
-        $logger->debug("DBI->connect dbh=$dbh");
+        $self->logger->debug("DBI->connect dbh=$dbh");
         _set_system_info($dbh, $retval);
 
         # don't assign to App_State::DBH, since we're a fallback connection,
@@ -284,7 +281,7 @@ sub get_info {
         return $retval;
    } else { # Got a db handle... try to find the version and app by a few
             # different means
-       $logger->debug("DBI->connect dbh=$dbh");
+       $self->logger->debug("DBI->connect dbh=$dbh");
 
        $retval->{status} = 'exists';
        _set_system_info($dbh, $retval);
@@ -591,16 +588,16 @@ Returns true when successful, dies on error.
 
 sub create_and_load {
     my ($self, $args) = @_;
-    $logger->info('Creating database');
+    $self->logger->info('Creating database');
     $self->create;
-    $logger->info('Loading schema');
+    $self->logger->info('Loading schema');
     $self->load_base_schema(
         log_stdout     => $args->{log},
         errlog  => $args->{errlog},
         );
-    $logger->info('Applying schema changes');
+    $self->logger->info('Applying schema changes');
     $self->apply_changes();
-    $logger->info('Loading LedgerSMB application database modules');
+    $self->logger->info('Loading LedgerSMB application database modules');
     return $self->load_modules('LOADORDER', {
     log     => $args->{log},
     errlog  => $args->{errlog},

--- a/lib/LedgerSMB/Sysconfig.pm
+++ b/lib/LedgerSMB/Sysconfig.pm
@@ -306,6 +306,11 @@ def 'log_level',
     default => 'ERROR',
     doc => q{};
 
+def 'log_config',
+    section => 'main',
+    default => '',
+    doc     => q{};
+
 def 'cache_templates',
     section => 'main',
     default => 0,
@@ -492,68 +497,6 @@ sub printer {
     return $printer;
 }
 
-
-
-
-
-#some examples of loglevel setting for modules
-#FATAL, ERROR, WARN, INFO, DEBUG, TRACE
-#log4perl.logger.LedgerSMB = DEBUG
-#log4perl.logger.LedgerSMB.DBObject = INFO
-#log4perl.logger.LedgerSMB.DBObject.Employee = FATAL
-#log4perl.logger.LedgerSMB.Handler = ERROR
-#log4perl.logger.LedgerSMB.User = WARN
-sub log4perl_config {
-
-    my $modules_loglevel_overrides='';
-
-    for (sort $cfg->Parameters('log4perl_config_modules_loglevel')){
-        $modules_loglevel_overrides.='log4perl.logger.'.$_.'='.
-            $cfg->val('log4perl_config_modules_loglevel', $_)."\n";
-    }
-    # Log4perl configuration
-    my $log_level = log_level();
-    return qq(
-    log4perl.rootlogger = $log_level, Basic, Debug, DebugPanel
-    )
-    .
-    $modules_loglevel_overrides
-    .
-    q(
-    log4perl.appender.Screen = Log::Log4perl::Appender::Screen
-    log4perl.appender.Screen.layout = PatternLayout
-    log4perl.appender.Screen.layout.ConversionPattern = Req:%Z %p - %m%n
-    # Filter for debug level
-    log4perl.filter.MatchDebug = Log::Log4perl::Filter::LevelMatch
-    log4perl.filter.MatchDebug.LevelToMatch = INFO
-    log4perl.filter.MatchDebug.AcceptOnMatch = false
-
-    # Filter for everything but debug,trace level
-    log4perl.filter.MatchRest = Log::Log4perl::Filter::LevelMatch
-    log4perl.filter.MatchRest.LevelToMatch = INFO
-    log4perl.filter.MatchRest.AcceptOnMatch = true
-
-    # layout for DEBUG,TRACE messages
-    log4perl.appender.Debug = Log::Log4perl::Appender::Screen
-    log4perl.appender.Debug.layout = PatternLayout
-    log4perl.appender.Debug.layout.ConversionPattern = Req:%Z %d - %p - %l -- %m%n
-    log4perl.appender.Debug.Filter = MatchDebug
-
-    # layout for non-DEBUG messages
-    log4perl.appender.Basic = Log::Log4perl::Appender::Screen
-    log4perl.appender.Basic.layout = PatternLayout
-    log4perl.appender.Basic.layout.ConversionPattern = Req:%Z %d - %p - %M -- %m%n
-    log4perl.appender.Basic.Filter = MatchRest
-
-    log4perl.appender.DebugPanel              = Log::Log4perl::Appender::TestBuffer
-    log4perl.appender.DebugPanel.name         = psgi_debug_panel
-    log4perl.appender.DebugPanel.mode         = append
-    log4perl.appender.DebugPanel.layout       = PatternLayout
-    log4perl.appender.DebugPanel.layout.ConversionPattern = %r >> %p >> %m >> %c >> at %F line %L%n
-    #log4perl.appender.DebugPanel.Threshold = TRACE
-
-    );
-}
 
 
 # if you have latex installed set to 1

--- a/utils/devel/ledgersmb-server-development.psgi
+++ b/utils/devel/ledgersmb-server-development.psgi
@@ -68,8 +68,24 @@ sub check_config_option {
 }
 #TODO: Explore https://github.com/elindsey/Devel-hdb
 
-my $log_config = LedgerSMB::Sysconfig::log4perl_config();
-Log::Log4perl->init(\$log_config);
+my $log_config = LedgerSMB::Sysconfig::log_config();
+if ($log_config) {
+    Log::Log4perl->init($log_config);
+}
+else {
+    my %log_levels = (
+        OFF   => $OFF,
+        FATAL => $FATAL,
+        ERROR => $ERROR,
+        WARN  => $WARN,
+        INFO  => $INFO,
+        DEBUG => $DEBUG,
+        TRACE => $TRACE,
+        );
+    my $log_level = LedgerSMB::Sysconfig::log_level();
+    die "Invalid log level: $log_level" unless exists $log_levels{$log_level};
+    Log::Log4perl->easy_init($log_levels{$log_level});
+}
 Log::Any::Adapter->set('Log4perl');
 
 builder {

--- a/utils/devel/ledgersmb-server-development.psgi
+++ b/utils/devel/ledgersmb-server-development.psgi
@@ -22,6 +22,7 @@ use LedgerSMB::Locale;
 use LedgerSMB::PSGI;
 use LedgerSMB::PSGI::Preloads;
 use LedgerSMB::Sysconfig;
+use Log::Any::Adapter;
 use Log::Log4perl;
 use Log::Log4perl::Layout::PatternLayout;
 use LedgerSMB::Middleware::RequestID;
@@ -68,7 +69,8 @@ sub check_config_option {
 #TODO: Explore https://github.com/elindsey/Devel-hdb
 
 my $log_config = LedgerSMB::Sysconfig::log4perl_config();
-Log::Log4perl::init(\$log_config);
+Log::Log4perl->init(\$log_config);
+Log::Any::Adapter->set('Log4perl');
 
 builder {
 

--- a/xt/01.2-deps.t
+++ b/xt/01.2-deps.t
@@ -21,11 +21,15 @@ push @on_disk, 'bin/ledgersmb-server.psgi';
 
 ok_dependencies($file, \@on_disk,
                 phases => 'runtime',
-                ignores => [ 'LedgerSMB', 'PageObject',
-                             'LaTeX::Driver',
-                             'Starman', 'TeX::Encode::charmap',
-                             'Locale::CLDR::Locales',
-                             'MooseX::ClassAttribute'
-                              ] );
+                ignores => [
+                    'LaTeX::Driver',
+                    'LedgerSMB',
+                    'Locale::CLDR::Locales',
+                    'Log::Any::Adapter::Log4perl', # used as plugin
+                    'MooseX::ClassAttribute',
+                    'PageObject',
+                    'Starman',
+                    'TeX::Encode::charmap',
+                ] );
 
 done_testing;


### PR DESCRIPTION
Initialize Log::Any so our dependencies can use it to forward their logs into our Log::Log4perl configuration.