### PR TITLE
Catch error in a variable

### DIFF
--- a/lib/LedgerSMB/PSGI.pm
+++ b/lib/LedgerSMB/PSGI.pm
@@ -146,9 +146,7 @@ sub psgi_app {
 
         $request->{dbh}->commit if defined $request->{dbh};
     }
-    catch {
-        my $error = $_;
-
+    catch ($error) {
         # Explicitly roll back, because middleware may require the
         # database connection to be in a working state (e.g. DisableBackbutton)
         $request->{dbh}->rollback

--- a/lib/LedgerSMB/Scripts/contact.pm
+++ b/lib/LedgerSMB/Scripts/contact.pm
@@ -901,8 +901,7 @@ sub create_user {
        try {
            $user->create($request->{reset_password});
        }
-       catch {
-           my $err = $_;
+       catch ($err) {
            die $err unless $err =~ /duplicate user/i;
            $request->{dbh}->rollback;
            $return_with_import = 1;


### PR DESCRIPTION
Follow-up to move to Syntax::Keyword::Try, which deals with catching
errors differently than Try::Tiny.
