### PR TITLE
Set STDERR and STDOUT to locale indicated by LC_ALL, LANG and friends

### DIFF
--- a/bin/ledgersmb-admin
+++ b/bin/ledgersmb-admin
@@ -2,6 +2,7 @@
 
 use strict;
 use warnings;
+use open ':locale';
 
 use LedgerSMB::Admin;
 


### PR DESCRIPTION
This allows outputting UTF-8 characters correctly as acquired from
e.g. XML configuration documents.
