### PR TITLE
Replace deprecated TG_RELNAME with TG_TABLE_NAME

### DIFF
--- a/doc/database/ledgersmb.html
+++ b/doc/database/ledgersmb.html
@@ -41861,7 +41861,7 @@ ELSE
    t_row := OLD;
 END IF;
 
-IF TG_RELNAME IN (&#39;ar&#39;, &#39;ap&#39;) THEN
+IF TG_TABLE_NAME IN (&#39;ar&#39;, &#39;ap&#39;) THEN
     t_reference := t_row.invnumber;
 ELSE
     t_reference := t_row.reference;
@@ -41869,7 +41869,7 @@ END IF;
 
 INSERT INTO audittrail (trans_id,tablename,reference, action, person_id,
                         rolname)
-values (t_row.id,TG_RELNAME,t_reference, TG_OP, person__get_my_entity_id(),
+values (t_row.id,TG_TABLE_NAME,t_reference, TG_OP, person__get_my_entity_id(),
         SESSION_USER);
 
 return null; -- AFTER TRIGGER ONLY, SAFE
@@ -48567,7 +48567,7 @@ because these have not been properly refactored yet.
 BEGIN
         IF tg_op = &#39;INSERT&#39; THEN
                 INSERT INTO transactions (id, table_name, transdate, approved)
-                VALUES (new.id, TG_RELNAME, new.transdate, new.approved);
+                VALUES (new.id, TG_TABLE_NAME, new.transdate, new.approved);
         ELSEIF tg_op = &#39;UPDATE&#39; THEN
                 IF new.id = old.id
                    AND new.approved  = old.approved

--- a/doc/database/ledgersmb.xml
+++ b/doc/database/ledgersmb.xml
@@ -47313,7 +47313,7 @@ ELSE
    t_row := OLD;
 END IF;
 
-IF TG_RELNAME IN (&#39;ar&#39;, &#39;ap&#39;) THEN
+IF TG_TABLENAME IN (&#39;ar&#39;, &#39;ap&#39;) THEN
     t_reference := t_row.invnumber;
 ELSE
     t_reference := t_row.reference;
@@ -47321,7 +47321,7 @@ END IF;
 
 INSERT INTO audittrail (trans_id,tablename,reference, action, person_id,
                         rolname)
-values (t_row.id,TG_RELNAME,t_reference, TG_OP, person__get_my_entity_id(),
+values (t_row.id,TG_TABLE_NAME,t_reference, TG_OP, person__get_my_entity_id(),
         SESSION_USER);
 
 return null; -- AFTER TRIGGER ONLY, SAFE
@@ -57781,7 +57781,7 @@ because these have not been properly refactored yet.
 BEGIN
         IF tg_op = &#39;INSERT&#39; THEN
                 INSERT INTO transactions (id, table_name, transdate, approved)
-                VALUES (new.id, TG_RELNAME, new.transdate, new.approved);
+                VALUES (new.id, TG_TABLE_NAME, new.transdate, new.approved);
         ELSEIF tg_op = &#39;UPDATE&#39; THEN
                 IF new.id = old.id
                    AND new.approved  = old.approved

--- a/sql/Pg-database.sql
+++ b/sql/Pg-database.sql
@@ -2398,7 +2398,7 @@ $$
 BEGIN
         IF tg_op = 'INSERT' THEN
                 INSERT INTO transactions (id, table_name, approved)
-                VALUES (new.id, TG_RELNAME, new.approved);
+                VALUES (new.id, TG_TABLE_NAME, new.approved);
         ELSEIF tg_op = 'UPDATE' THEN
                 IF new.id = old.id AND new.approved = old.approved THEN
                         return new;
@@ -2465,14 +2465,14 @@ ELSE
    t_row := OLD;
 END IF;
 
-IF TG_RELNAME IN ('ar', 'ap') THEN
+IF TG_TABLE_NAME IN ('ar', 'ap') THEN
     t_reference := t_row.invnumber;
 ELSE
     t_reference := t_row.reference;
 END IF;
 
 INSERT INTO audittrail (trans_id,tablename,reference, action, person_id)
-values (t_row.id,TG_RELNAME,t_reference, TG_OP, person__get_my_entity_id());
+values (t_row.id,TG_TABLE_NAME,t_reference, TG_OP, person__get_my_entity_id());
 
 return null; -- AFTER TRIGGER ONLY, SAFE
 END;


### PR DESCRIPTION
The TG_RELNAME variable which is used in the test schema has been
deprecated since PostgreSQL 8.2 and replaced with TG_TABLE_NAME.

See PostgreSQL commit [3a9ae3d2068334bbd0e54efaa729e7590994ccc8](https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=3a9ae3d2068334bbd0e54efaa729e7590994ccc8).
