### PR TITLE
Fix #5213: AP Aging doesn't show in the menu

### DIFF
--- a/sql/changes/1.8/re-add-ap-aging-menu.sql
+++ b/sql/changes/1.8/re-add-ap-aging-menu.sql
@@ -1,0 +1,7 @@
+
+
+insert into menu_node (id, label, parent, "position", url)
+values (29, 'AP Aging', 24, 3,
+ 'reports.pl?report_name=aging&entity_class=1&action=start_report&module_name=gl');
+
+

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -132,6 +132,7 @@ mc/delete-migration-validation-data.sql
 1.8/add-gl-batch-import-menu.sql
 1.8/fix-reporting-units-pks.sql
 1.8/fix-issue-1672.sql
+1.8/re-add-ap-aging-menu.sql
 # 1.9 changes
 1.9/templates-last-modified-no-tz.sql
 1.9/drop-view-tx_report.sql

--- a/sql/modules/Roles.sql
+++ b/sql/modules/Roles.sql
@@ -619,7 +619,7 @@ SELECT lsmb__grant_perms('ap_transaction_list', obj, 'SELECT')
   FROM unnest(array['ap'::text, 'acc_trans', 'invoice', 'warehouse_inventory',
                     'tax_extended', 'ac_tax_form', 'invoice_tax_form']) obj;
 SELECT lsmb__grant_menu('ap_transaction_list', node_id, 'allow')
-  FROM unnest(array[25,34]) node_id;
+  FROM unnest(array[25,29,34]) node_id;
 
 SELECT lsmb__create_role('ap_all_vouchers');
 SELECT lsmb__grant_role('ap_all_vouchers', 'ap_transaction_create_voucher');


### PR DESCRIPTION
When cleaning up the Templates menu, one menu entry too many was removed,
eliminating the AP Aging menu item. This commit adds that back.