### PR TITLE
Fix #5181: 'Approved' filter in GL not working

### DIFF
--- a/sql/modules/Report.sql
+++ b/sql/modules/Report.sql
@@ -298,7 +298,9 @@ FOR retval IN
                    OR (transdate >= in_from_date AND  in_to_date IS NULL)
                    OR (transdate <= in_to_date AND in_from_date IS NULL)
                    OR (in_to_date IS NULL AND in_from_date IS NULL))
-              AND (in_approved is false OR (g.approved AND ac.approved))
+              AND (in_approved is null
+                   or (in_approved is not distinct from g.approved
+                       AND in_approved is not distinct from ac.approved))
               AND (in_from_amount IS NULL
                    OR abs(ac.amount_bc) >= in_from_amount)
               AND (in_to_amount IS NULL


### PR DESCRIPTION
The new filter does not restrict the result set unless in_approved
is not null; when it isn't, it restricts to either approved *or*
unapproved.
