### PR TITLE
Optimize cycle checking in account headings

### DIFF
--- a/sql/modules/Account.sql
+++ b/sql/modules/Account.sql
@@ -848,8 +848,8 @@ PERFORM * from (
   SELECT *
     FROM account_heading ah
     JOIN account_headings at ON ah.parent_id = at.id
-   WHERE at.path || '||||' ||  ah.accno NOT IN
-          (select path from account_headings)
+   WHERE NOT EXISTS (SELECT 1 FROM account_headings
+                  WHERE path = at.path || '||||' || ah.accno)
 ) x;
 
 IF found then


### PR DESCRIPTION
Changing from IN to EXISTS moves heading cycle checking
from >300ms to <0.300ms; "only" three orders of magnitude...

(Let this be a reminder to /sparingly/ use IN!)
