### PR TITLE
Delete rows from `transactions` with its correspondent from ar/ap/gl

### DIFF
--- a/sql/changes/1.6/track-deleted-transactions.sql
+++ b/sql/changes/1.6/track-deleted-transactions.sql
@@ -1,0 +1,31 @@
+
+delete from voucher v
+ where exists (select 1 from transactions t
+                where not exists (select 1 from ap where t.id = ap.id)
+                      and not exists (select 1 from ar where t.id = ar.id)
+                      and not exists (select 1 from gl where t.id = gl.id)
+                      and v.trans_id = t.id);
+
+delete from transactions t
+ where not exists (select 1 from ap where t.id = ap.id)
+       and not exists (select 1 from ar where t.id = ar.id)
+       and not exists (select 1 from gl where t.id = gl.id);
+
+
+CREATE TRIGGER ap_track_deleted_transaction
+  AFTER DELETE
+  ON ap
+  FOR EACH ROW
+  EXECUTE PROCEDURE track_global_sequence();
+
+CREATE TRIGGER ar_track_deleted_transaction
+  AFTER DELETE
+  ON ar
+  FOR EACH ROW
+  EXECUTE PROCEDURE track_global_sequence();
+
+CREATE TRIGGER gl_track_deleted_transaction
+  AFTER DELETE
+  ON gl
+  FOR EACH ROW
+  EXECUTE PROCEDURE track_global_sequence();

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -77,6 +77,7 @@
 1.6/missing-countries.sql
 1.6/constrain_default_password_duration.sql
 1.6/add-recon-index.sql
+1.6/track-deleted-transactions.sql
 #
 # mc changes
 mc/create-migration-validation-data.sql

--- a/sql/modules/Voucher.sql
+++ b/sql/modules/Voucher.sql
@@ -530,6 +530,9 @@ BEGIN
                                  where pl.payment_id = p.id);
         DELETE FROM acc_trans WHERE trans_id = voucher_row.trans_id;
 
+        -- deletion of the ar/ap/gl row causes removal of the `transactions`
+        -- row, which fails if the voucher isn't deleted...
+        DELETE FROM voucher WHERE id = voucher_row.id;
         DELETE FROM ar WHERE id = voucher_row.trans_id;
         DELETE FROM ap WHERE id = voucher_row.trans_id;
         DELETE FROM gl WHERE id = voucher_row.trans_id;
@@ -552,9 +555,9 @@ BEGIN
                 AND NOT EXISTS (select 1 from payment_links pl
                                  where pl.payment_id = p.id);
         DELETE FROM acc_trans where voucher_id = voucher_row.id;
+        DELETE FROM voucher WHERE id = voucher_row.id;
     END IF;
 
-    DELETE FROM voucher WHERE id = voucher_row.id;
     RETURN 1;
 END;
 $$ LANGUAGE PLPGSQL SECURITY DEFINER;


### PR DESCRIPTION
In 1.8 (but possibly before), `transactions` is being checked for
unapproved transactions. When the ar/ap/gl equivalents have been deleted,
but an unapproved record in `transactions` remains, this causes havoc for
this check. Also, since `transactions` is meant to be the canonical list,
it makes sense to clean up those transactions that are no longer.
