### PR TITLE
GitHub Actions CI instead of Travis CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,7 +82,7 @@ jobs:
           cp doc/conf/ledgersmb.conf.default ledgersmb.conf
       
       - name: Starting 'starman'
-        run: starman --preload-app --pid starman.pid --workers 2 -Ilib -Iold/lib --port 5762 bin/ledgersmb-server.psgi --access-log /tmp/plackup-access.log > /tmp/plackup-stdout.log 2> /tmp/plackup-stderr.log &
+        run: starman --preload-app --pid starman.pid --workers 2 -Ilib -Iold/lib --port 5762 bin/ledgersmb-server.psgi &
         
       - name: Starting 'nginx'
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.3.4
   
+      - name: Install apt packages
+        run: apt-get install -y texlive-latex-recommended texlive-xetex
+        env:
+          DEBIAN_FRONTEND: noninteractive
+  
       - name: install with cpanm
         run: |
           cpanm --notest App::cpm

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,9 +6,9 @@ name: CI
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches: [ master ]
+    branches: '*'
   pull_request:
-    branches: [ master ]
+    branches: '*'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,9 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     # Service containers to run with `container-job`
+    strategy:
+      matrix:
+        perl: [ "5.24", "5.28", "5.32" ]
     services:
       # Label used to access the service container
       selenium:
@@ -48,7 +51,7 @@ jobs:
         uses: shogo82148/actions-setup-perl@v1.8.3
         with:
           # The Perl version to download (if necessary) and use. Example: 5.30.0
-          perl-version: 5.32 # optional, default is 5
+          perl-version: ${{ matrix.perl }} # optional, default is 5
           # The distribution of Perl binary.
 
       - name: Setup Node.js environment

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     # Service containers to run with `container-job`
     strategy:
+      fail-fast: false
       matrix:
         perl: [ "5.24", "5.28", "5.32" ]
     services:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
         image: wernight/phantomjs:2.1.1
         options: --stop-signal KILL
         ports:
-          - 4422:4422
+          - 8910:8910
         env:
           LANG: en_US.UTF-8
       postgres:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,4 +99,6 @@ jobs:
           PGPASSWORD: test
           LSMB_NEW_DB: lsmbinstalltest
           LSMB_TEST_DB: 1
+          LSMB_BASE_URL: http://127.0.0.1:5000
+          PSGI_BASE_URL: http://127.0.0.1:5762
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
           # Maps tcp port 5432 on service container to the host
           - 5432:5432
         env:
-          POSTGRES_PASSWORD: postgres
+          POSTGRES_PASSWORD: test
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -79,4 +79,9 @@ jobs:
       # Runs a single command using the runners shell
       - name: Run Perl tests
         run: prove --time --recurse t/ xt/
-
+        env:
+          PGHOST: localhost
+          PGPORT: 5432
+          PGUSER: postgres
+          PGPASSWORD: test
+          LSMB_NEW_DB: lsmbinstalltest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
         image: wernight/phantomjs:2.1.1
         options: --stop-signal KILL
         ports:
-          - 8910:4422
+          - 4422:8910
         env:
           LANG: en_US.UTF-8
       postgres:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,7 @@ jobs:
 
       # Runs a single command using the runners shell
       - name: Run Perl tests
-        run: prove --time --recurse t/ xt/
+        run: prove --time --recurse --pgtap-option dbname=lsmbinstalltest --pgtap-option username=postgres t/ xt/
         env:
           PGHOST: localhost
           PGPORT: 5432

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,8 +45,6 @@ jobs:
           # The distribution of Perl binary.
 
       # Runs a single command using the runners shell
-      - name: Run a one-line script
-        run: |
-           perl -V
-           perl -E 'say "Hello, world!"'
+      - name: Run Perl tests
+        run: prove
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,7 +100,7 @@ jobs:
           nginx -c /tmp/nginx.conf &
 
       - name: Starting 'PhantomJS'
-        run: phantomjs --webdriver=4422 > 2>/dev/null >/dev/null &
+        run: phantomjs --webdriver=4422 2>/dev/null >/dev/null &
 
       # Runs a single command using the runners shell
       - name: Run Perl tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,7 +67,7 @@ jobs:
           # A list of files, directories, and wildcard patterns to cache and restore
           path: $PERL5LIB
           # An explicit key for restoring and saving the cache
-          key: ${{ runner.os }}-cpan-${{ matrix.perl }}-${{ hashFiles('**/cpanfile') }}
+          key: ${{ runner.os }}-cpan-${{ matrix.perl }}-${{ hashFiles('**/{Makefile,Build}.PL') }}
           # An ordered list of keys to use for restoring the cache if no cache hit occurred for key
           restore-keys: ${{ runner.os }}-cpan-${{ matrix.perl }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,8 +49,8 @@ jobs:
   
       - name: install with cpanm
         run: |
-          cpanm --self-upgrade
-          cpanm --resolver=metacpan --with-develop --feature=starman --feature=latex-pdf-ps --feature=openoffice --feature=xls --feature=edi .
+          cpanm --notest App::cpm
+          cpm --resolver=metacpan --notest --with-develop --feature=starman --feature=latex-pdf-ps --feature=openoffice --feature=xls --feature=edi .
 
       # Runs a single command using the runners shell
       - name: Run Perl tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,12 @@ jobs:
           perl-version: 5.32 # optional, default is 5
           # The distribution of Perl binary.
 
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v2.1.2
+        with:
+          # Version Spec of the version to use.  Examples: 12.x, 10.15.1, >=10.15.0
+          node-version: 12.x
+
       - name: Checkout
         uses: actions/checkout@v2.3.4
   
@@ -63,6 +69,9 @@ jobs:
         run: |
           cpanm --notest App::cpm
           cpm install -g -v --resolver=metacpan --notest --with-develop --feature=starman --feature=latex-pdf-ps --feature=openoffice --feature=xls --feature=edi
+
+      - name: Build JS
+        run: make dojo
 
       # Runs a single command using the runners shell
       - name: Run Perl tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,40 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Setup Perl environment
+        # You may pin to the exact commit or the version.
+        # uses: shogo82148/actions-setup-perl@341aa635c06050493b41d71134eea58bfc5f4018
+        uses: shogo82148/actions-setup-perl@v1.8.3
+        with:
+          # The Perl version to download (if necessary) and use. Example: 5.30.0
+          perl-version: 5.32 # optional, default is 5
+          # The distribution of Perl binary.
+
+      # Runs a single command using the runners shell
+      - name: Run a one-line script
+        run: |
+           perl -V
+           perl -E 'say "Hello, world!"'
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/checkout@v2.3.4
   
       - name: Install apt packages
-        run: sudo apt-get install -y texlive-latex-recommended texlive-xetex gettext
+        run: sudo apt-get install -y texlive-latex-recommended texlive-xetex gettext nginx
         env:
           DEBIAN_FRONTEND: noninteractive
   
@@ -77,7 +77,9 @@ jobs:
         run: make dojo
         
       - name: Other preparations
-        run: mkdir screens logs
+        run: |
+          mkdir screens logs
+          cp doc/conf/ledgersmb.conf.default ledgersmb.conf
       
       - name: Starting 'starman'
         run: starman --preload-app --pid starman.pid --workers 2 -Ilib -Iold/lib --port 5762 bin/ledgersmb-server.psgi --access-log /tmp/plackup-access.log > /tmp/plackup-stdout.log 2> /tmp/plackup-stderr.log &

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,9 @@ jobs:
         uses: actions/checkout@v2.3.4
   
       - name: install with cpanm
-        run: cpanm --resolver=metacpan --with-develop --feature=starman --feature=latex-pdf-ps --feature=openoffice --feature=xls --feature=edi .
+        run: |
+          cpanm --self-upgrade
+          cpanm --resolver=metacpan --with-develop --feature=starman --feature=latex-pdf-ps --feature=openoffice --feature=xls --feature=edi .
 
       # Runs a single command using the runners shell
       - name: Run Perl tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@v2.3.4
   
       - name: Install apt packages
-        run: apt-get install -y texlive-latex-recommended texlive-xetex
+        run: sudo apt-get install -y texlive-latex-recommended texlive-xetex
         env:
           DEBIAN_FRONTEND: noninteractive
   

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
       # Label used to access the service container
       selenium:
         image: wernight/phantomjs:2.1.1
-        options: --entrypoint "phantomjs --webdriver=4422" --stop-signal KILL
+        options: --stop-signal KILL
         ports:
           - 4422:4422
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
       - name: install with cpanm
         run: |
           cpanm --notest App::cpm
-          cpm install -v --resolver=metacpan --notest --with-develop --feature=starman --feature=latex-pdf-ps --feature=openoffice --feature=xls --feature=edi
+          cpm install -g -v --resolver=metacpan --notest --with-develop --feature=starman --feature=latex-pdf-ps --feature=openoffice --feature=xls --feature=edi
 
       # Runs a single command using the runners shell
       - name: Run Perl tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
       - name: install with cpanm
         run: |
           cpanm --notest App::cpm
-          cpm --resolver=metacpan --notest --with-develop --feature=starman --feature=latex-pdf-ps --feature=openoffice --feature=xls --feature=edi .
+          cpm install --resolver=metacpan --notest --with-develop --feature=starman --feature=latex-pdf-ps --feature=openoffice --feature=xls --feature=edi
 
       # Runs a single command using the runners shell
       - name: Run Perl tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,5 +78,5 @@ jobs:
 
       # Runs a single command using the runners shell
       - name: Run Perl tests
-        run: prove --recurse t/ xt/
+        run: prove --time --recurse t/ xt/
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,11 +77,19 @@ jobs:
         run: make dojo
         
       - name: Other preparations
-        run: mkdir screens logs    
+        run: mkdir screens logs
+      
+      - name: Starting 'starman'
+        run: starman --preload-app --pid starman.pid --workers 2 -Ilib -Iold/lib --port 5762 bin/ledgersmb-server.psgi --access-log /tmp/plackup-access.log > /tmp/plackup-stdout.log 2> /tmp/plackup-stderr.log &
+        
+      - name: Starting 'nginx'
+        run: |
+          sed -e "s#{ROOT}#$PWD#" doc/conf/webserver/nginx-travis.conf >/tmp/nginx.conf
+          nginx -c /tmp/nginx.conf &
 
       # Runs a single command using the runners shell
       - name: Run Perl tests
-        run: prove --time --recurse --pgtap-option dbname=lsmbinstalltest --pgtap-option username=postgres t/ xt/
+        run: prove --jobs 2 --time --recurse --pgtap-option dbname=lsmbinstalltest --pgtap-option username=postgres --feature-option tags=~@wip t/ xt/
         env:
           PGHOST: localhost
           PGPORT: 5432

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,14 +24,6 @@ jobs:
       matrix:
         perl: [ "5.24", "5.28", "5.32" ]
     services:
-      # Label used to access the service container
-      selenium:
-        image: wernight/phantomjs:2.1.1
-        options: --stop-signal KILL
-        ports:
-          - 4422:8910
-        env:
-          LANG: en_US.UTF-8
       postgres:
         # Docker Hub image
         image: ledgersmb/ledgersmb-dev-postgres
@@ -59,6 +51,24 @@ jobs:
         with:
           # Version Spec of the version to use.  Examples: 12.x, 10.15.1, >=10.15.0
           node-version: 12.x
+
+      - name: Cache node modules
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+ 
+      - name: Cache cpan modules
+        uses: actions/cache@v2.1.3
+        with:
+          # A list of files, directories, and wildcard patterns to cache and restore
+          path: $PERL5LIB
+          # An explicit key for restoring and saving the cache
+          key: ${{ runner.os }}-cpan-${{ hashFiles('**/cpanfile') }}
+          # An ordered list of keys to use for restoring the cache if no cache hit occurred for key
+          restore-keys: ${{ runner.os }}-cpan-
 
       - name: Checkout
         uses: actions/checkout@v2.3.4
@@ -88,6 +98,9 @@ jobs:
         run: |
           sed -e "s#{ROOT}#$PWD#" doc/conf/webserver/nginx-travis.conf >/tmp/nginx.conf
           nginx -c /tmp/nginx.conf &
+
+      - name: Starting 'PhantomJS'
+        run: phantomjs --webdriver=4422 > 2>/dev/null >/dev/null &
 
       # Runs a single command using the runners shell
       - name: Run Perl tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/checkout@v2.3.4
   
       - name: Install apt packages
-        run: sudo apt-get install -y texlive-latex-recommended texlive-xetex
+        run: sudo apt-get install -y texlive-latex-recommended texlive-xetex gettext
         env:
           DEBIAN_FRONTEND: noninteractive
   

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,3 +85,4 @@ jobs:
           PGUSER: postgres
           PGPASSWORD: test
           LSMB_NEW_DB: lsmbinstalltest
+          LSMB_TEST_DB: 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
       - name: install with cpanm
         run: |
           cpanm --notest App::cpm
-          cpm install --resolver=metacpan --notest --with-develop --feature=starman --feature=latex-pdf-ps --feature=openoffice --feature=xls --feature=edi
+          cpm install -v --resolver=metacpan --notest --with-develop --feature=starman --feature=latex-pdf-ps --feature=openoffice --feature=xls --feature=edi
 
       # Runs a single command using the runners shell
       - name: Run Perl tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,9 @@ jobs:
           perl-version: 5.32 # optional, default is 5
           # The distribution of Perl binary.
 
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+  
       # Runs a single command using the runners shell
       - name: Run Perl tests
         run: prove

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,18 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    # Service containers to run with `container-job`
+    services:
+      # Label used to access the service container
+      postgres:
+        # Docker Hub image
+        image: ledgersmb/ledgersmb-dev-postgres
+        # Provide the password for postgres
+        ports:
+          # Maps tcp port 5432 on service container to the host
+          - 5432:5432
+        env:
+          POSTGRES_PASSWORD: postgres
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,9 +66,9 @@ jobs:
           # A list of files, directories, and wildcard patterns to cache and restore
           path: $PERL5LIB
           # An explicit key for restoring and saving the cache
-          key: ${{ runner.os }}-cpan-${{ hashFiles('**/cpanfile') }}
+          key: ${{ runner.os }}-cpan-${{ matrix.perl }}-${{ hashFiles('**/cpanfile') }}
           # An ordered list of keys to use for restoring the cache if no cache hit occurred for key
-          restore-keys: ${{ runner.os }}-cpan-
+          restore-keys: ${{ runner.os }}-cpan-${{ matrix.perl }}
 
       - name: Checkout
         uses: actions/checkout@v2.3.4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,4 +101,5 @@ jobs:
           LSMB_TEST_DB: 1
           LSMB_BASE_URL: http://127.0.0.1:5000
           PSGI_BASE_URL: http://127.0.0.1:5762
+          REMOTE_SERVER_ADDR: 127.0.0.1
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,8 @@ jobs:
         # You may pin to the exact commit or the version.
         # uses: perl-actions/install-with-cpm@7dead49a9920a1f07629c1902f1fe19c56b6ff12
         uses: perl-actions/install-with-cpm@v1.3
+        with:
+          args: --resolver=metacpan --with-develop --feature=starman --feature=latex-pdf-ps --feature=openoffice --feature=xls --feature=edi
 
       # Runs a single command using the runners shell
       - name: Run Perl tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
         image: wernight/phantomjs:2.1.1
         options: --stop-signal KILL
         ports:
-          - 8910:8910
+          - 8910:4422
         env:
           LANG: en_US.UTF-8
       postgres:
@@ -75,6 +75,9 @@ jobs:
 
       - name: Build JS
         run: make dojo
+        
+      - name: Other preparations
+        run: mkdir screens logs    
 
       # Runs a single command using the runners shell
       - name: Run Perl tests
@@ -86,3 +89,4 @@ jobs:
           PGPASSWORD: test
           LSMB_NEW_DB: lsmbinstalltest
           LSMB_TEST_DB: 1
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,12 +47,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.3.4
   
-      - name: install with cpm
-        # You may pin to the exact commit or the version.
-        # uses: perl-actions/install-with-cpm@7dead49a9920a1f07629c1902f1fe19c56b6ff12
-        uses: perl-actions/install-with-cpm@v1.3
-        with:
-          args: --resolver=metacpan --with-develop --feature=starman --feature=latex-pdf-ps --feature=openoffice --feature=xls --feature=edi
+      - name: install with cpanm
+        run: cpanm --resolver=metacpan --with-develop --feature=starman --feature=latex-pdf-ps --feature=openoffice --feature=xls --feature=edi .
 
       # Runs a single command using the runners shell
       - name: Run Perl tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.3.4
   
+      - name: install with cpm
+        # You may pin to the exact commit or the version.
+        # uses: perl-actions/install-with-cpm@7dead49a9920a1f07629c1902f1fe19c56b6ff12
+        uses: perl-actions/install-with-cpm@v1.3
+
       # Runs a single command using the runners shell
       - name: Run Perl tests
         run: prove

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,7 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
   
-      - name: install with cpanm
+      - name: install with cpm
         run: |
           cpanm --notest App::cpm
           cpm install -g -v --resolver=metacpan --notest --with-develop --feature=starman --feature=latex-pdf-ps --feature=openoffice --feature=xls --feature=edi
@@ -78,5 +78,5 @@ jobs:
 
       # Runs a single command using the runners shell
       - name: Run Perl tests
-        run: prove
+        run: prove --recurse t/ xt/
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,13 @@ jobs:
     # Service containers to run with `container-job`
     services:
       # Label used to access the service container
+      selenium:
+        image: wernight/phantomjs:2.1.1
+        options: --entrypoint "phantomjs --webdriver=4422" --stop-signal KILL
+        ports:
+          - 4422:4422
+        env:
+          LANG: en_US.UTF-8
       postgres:
         # Docker Hub image
         image: ledgersmb/ledgersmb-dev-postgres


### PR DESCRIPTION
Many, many thanks to Travis CI for all its support over the past years,
but with its recent pricing strategy changes, we ran out of test credits
within days. Unfortunately, I received no response on the matter of
receiving FOSS credits.

Instead, move to GitHub Actions now.