### PR TITLE
Declare the required settings in the Given block

### DIFF
--- a/xt/66-cucumber/01-basic/preferences.feature
+++ b/xt/66-cucumber/01-basic/preferences.feature
@@ -6,6 +6,9 @@ Feature: Check correct operation of Preferences screen
 
 Background:
   Given a standard test company
+    And these preferences for the admin:
+      | setting  | value |
+      | language | en    |
     And a logged in admin
 
 Scenario: I change user preferences to the <selection> language
@@ -15,58 +18,54 @@ Scenario: I change user preferences to the <selection> language
    And I save the page
    And I select the "Preferences" tab
   Then I expect "<translation>" to be selected for "<language>"
-  When I select "<default>" from the drop down "<language>"
-   And I click "<save>" to save the page
-   And I select the "Preferences" tab
-  Then I expect "English" to be selected for "Language"
 
   Examples:
   Non UTF8 accented characters are confirmed working
-    | selection              | translation            | language     | default         | save          |
-    | American English       | American English       | Language     | English         | Save          |
-    | Brazilian Portuguese   | português - Brasil     | Idioma       | inglês          | Salvar        |
-    | British English        | British English        | Language     | English         | Save          |
-    | Canadian English       | Canadian English       | Language     | English         | Save          |
-    | Canadian French        | français canadien      | Langue       | anglais         | Enregistrer   |
-    | Catalan                | català                 | Idioma       | anglès          | Guardar       |
-    | Danish                 | dansk                  | Sprog        | engelsk         | Gem           |
-    | Dutch                  | Nederlands             | Taal         | Engels          | Opslaan       |
-    | Estonian               | eesti                  | Keel         | inglise         | Salvesta      |
-    | Finnish                | suomi                  | Kieli        | englanti        | Tallenna      |
-    | Flemish                | Nederlands - België    | Taal         | Engels          | Opslaan       |
-    | French                 | français               | Langue       | anglais         | Enregistrer   |
-    | French - Belgium       | français - Belgique    | Langue       | anglais         | Enregistrer   |
-    | German                 | Deutsch                | Sprache      | Englisch        | Speichern     |
-    | Hungarian              | magyar                 | Nyelv        | angol           | Mentés        |
-    | Icelandic              | íslenska               | Túngumál     | enska           | Geyma         |
-    | Indonesian             | Indonesia              | Bahasa       | Inggris         | Simpan        |
-    | Italian                | italiano               | Lingua       | inglese         | Salva         |
-    | Malay - Malaysia       | Melayu - Malaysia      | Bahasa       | Inggeris        | Simpan        |
-    | Mexican Spanish        | español de México      | Lenguaje     | inglés          | Guardar       |
-    | Norwegian Bokmål       | norsk bokmål           | Språk        | engelsk         | Lagre         |
-    | Portuguese             | português              | Língua       | inglês          | Guardar       |
-    | Spanish                | español                | Lenguaje     | inglés          | Guardar       |
-    | Spanish - Argentina    | español - Argentina    | Idioma       | inglés          | Guardar       |
-    | Spanish - Colombia     | español - Colombia     | Idioma       | inglés          | Guardar       |
-    | Spanish - Ecuador      | español - Ecuador      | Lenguaje     | inglés          | Guardar       |
-    | Spanish - Panama       | español - Panamá       | Idioma       | inglés          | Guardar       |
-    | Spanish - Paraguay     | español - Paraguay     | Idioma       | inglés          | Guardar       |
-    | Spanish - Venezuela    | español - Venezuela    | Idioma       | inglés          | Guardar       |
-    | Swedish                | svenska                | Språk        | engelska        | Spara         |
-    | Swiss High German      | Schweizer Hochdeutsch  | Sprache      | Englisch        | Speichern     |
+    | selection            | translation           | language |
+    | American English     | American English      | Language |
+    | Brazilian Portuguese | português - Brasil    | Idioma   |
+    | British English      | British English       | Language |
+    | Canadian English     | Canadian English      | Language |
+    | Canadian French      | français canadien     | Langue   |
+    | Catalan              | català                | Idioma   |
+    | Danish               | dansk                 | Sprog    |
+    | Dutch                | Nederlands            | Taal     |
+    | Estonian             | eesti                 | Keel     |
+    | Finnish              | suomi                 | Kieli    |
+    | Flemish              | Nederlands - België   | Taal     |
+    | French               | français              | Langue   |
+    | French - Belgium     | français - Belgique   | Langue   |
+    | German               | Deutsch               | Sprache  |
+    | Hungarian            | magyar                | Nyelv    |
+    | Icelandic            | íslenska              | Túngumál |
+    | Indonesian           | Indonesia             | Bahasa   |
+    | Italian              | italiano              | Lingua   |
+    | Malay - Malaysia     | Melayu - Malaysia     | Bahasa   |
+    | Mexican Spanish      | español de México     | Lenguaje |
+    | Norwegian Bokmål     | norsk bokmål          | Språk    |
+    | Portuguese           | português             | Língua   |
+    | Spanish              | español               | Lenguaje |
+    | Spanish - Argentina  | español - Argentina   | Idioma   |
+    | Spanish - Colombia   | español - Colombia    | Idioma   |
+    | Spanish - Ecuador    | español - Ecuador     | Lenguaje |
+    | Spanish - Panama     | español - Panamá      | Idioma   |
+    | Spanish - Paraguay   | español - Paraguay    | Idioma   |
+    | Spanish - Venezuela  | español - Venezuela   | Idioma   |
+    | Swedish              | svenska               | Språk    |
+    | Swiss High German    | Schweizer Hochdeutsch | Sprache  |
 
   @wip
   Examples:
   prove has problems displaying UTF8, even though tests works
-    | selection              | translation            | language     | default         | save          |
-    | Arabic - Egypt         | اللغة |  العربية - مصر |   الإنجليزية |                  تخزين         |
-    | Bulgarian              | български              | Език         | английски       | Запази        |
-    | Chinese - China        | 中文 - 中国             | 语言         | 英语             | 储存          |
-    | Chinese - Taiwan       | 中文 - 台灣             | 語言         | 英文             | 儲存          |
-    | Czech                  | čeština                | Jazyk        | angličtina      | Uložit        |
-    | Greek                  | Ελληνικά               | Γλώσσα       | Αγγλικά         | Αποθήκευση    |
-    | Lithuanian             | lietuvių               | Kalba        | anglų           | Išsaugoti     |
-    | Polish                 | polski                 | Język        | angielski       | Zapisz        |
-    | Russian                | русский                | Язык         | английский      | Сохранить     |
-    | Turkish                | Türkçe                 | Dil          | İngilizce       | Kaydet        |
-    | Ukrainian              | українська             | Мова         | англійська      | Зберегти      |
+    | selection        | translation | language      |
+    | Arabic - Egypt   | اللغة       | العربية - مصر |
+    | Bulgarian        | български   | Език          |
+    | Chinese - China  | 中文 - 中国 | 语言          |
+    | Chinese - Taiwan | 中文 - 台灣 | 語言          |
+    | Czech            | čeština     | Jazyk         |
+    | Greek            | Ελληνικά    | Γλώσσα        |
+    | Lithuanian       | lietuvių    | Kalba         |
+    | Polish           | polski      | Język         |
+    | Russian          | русский     | Язык          |
+    | Turkish          | Türkçe      | Dil           |
+    | Ukrainian        | українська  | Мова          |

--- a/xt/66-cucumber/01-basic/step_definitions/ledgersmb_steps.pl
+++ b/xt/66-cucumber/01-basic/step_definitions/ledgersmb_steps.pl
@@ -1,0 +1,35 @@
+#!perl
+
+
+use lib 'xt/lib';
+use strict;
+use warnings;
+
+
+use Test::More;
+use Test::BDD::Cucumber::StepFile;
+
+
+
+###############
+#
+# Setup steps
+#
+###############
+
+
+Given qr/these preferences for the (admin|user)(?: "([^"]+)")?:/, sub {
+    my $reference_user = $1;
+    my $user_name = $2 // S->{"the $reference_user"};
+    my $data = C->data;
+
+    my $dbh = S->{ext_lsmb}->admin_dbh;
+    my $query = 'UPDATE user_preference SET ' . join(' ', map { "$_->{setting} = ?" } $data->@*)
+        . ' WHERE id = (select id from users where username = ?)';
+    $dbh->do($query, {}, (map { $_->{value} } $data->@*), $user_name )
+        or die $dbh->errstr;
+};
+
+
+
+1;


### PR DESCRIPTION
Instead of returning to the correct settings at the end as required
for the next test (which makes them inter-dependent), simply state the
required state at the beginning and make tests independent as well as
(due to the fact that this goes outside the webapp) *faster*?
