### PR TITLE
Move import_csv to existing LedgerSMB::Inventory::* API

### DIFF
--- a/lib/LedgerSMB/Scripts/inventory.pm
+++ b/lib/LedgerSMB/Scripts/inventory.pm
@@ -52,8 +52,8 @@ sub enter_adjust {
 =item adjustment_next
 
 This function is triggered on the next button on the adjustment entry screen.
-It retrieves inventory information, calculates adjustment values, and displays the
-screen.
+It retrieves inventory information, calculates adjustment values, and displays
+the screen.
 
 =cut
 
@@ -78,12 +78,13 @@ sub adjustment_next {
 
 =item adjustment_save
 
-This function saves the inventory adjustment report and then creates the required
-invoices.
+This function saves the inventory adjustment report and then creates the
+required invoices.
 
 =cut
 
 sub _lines_from_form {
+    # NOTE! A similar implementation is also in import_csv!
     my ($adjustment, $hashref) = @_;
     my @lines;
     for my $ln (1 .. $hashref->{rowcount}){


### PR DESCRIPTION
In 1.6, we moved away from using invoices for inventory adjustments.
`import_csv` didn't follow suit, apparently. Move to code highly
similar to the code triggered when manually entering adjustments
situated in inventory.pm.
