### PR TITLE
Delete rows from `transactions` with its correspondent from ar/ap/gl

### DIFF
--- a/sql/changes/1.6/track-deleted-transactions.sql@1
+++ b/sql/changes/1.6/track-deleted-transactions.sql@1
@@ -1,11 +1,4 @@
 
-delete from voucher v
- where exists (select 1 from transactions t
-                where not exists (select 1 from ap where t.id = ap.id)
-                      and not exists (select 1 from ar where t.id = ar.id)
-                      and not exists (select 1 from gl where t.id = gl.id)
-                      and v.trans_id = t.id);
-
 delete from transactions t
  where not exists (select 1 from ap where t.id = ap.id)
        and not exists (select 1 from ar where t.id = ar.id)


### PR DESCRIPTION
In 1.8 (but possibly before), `transactions` is being checked for
unapproved transactions. When the ar/ap/gl equivalents have been deleted,
but an unapproved record in `transactions` remains, this causes havoc for
this check. Also, since `transactions` is meant to be the canonical list,
it makes sense to clean up those transactions that are no longer.
