### PR TITLE
Fix failure to delete unapproved reconcilation report

### DIFF
--- a/sql/changes/1.8/reconciliation-links-cascade.sql
+++ b/sql/changes/1.8/reconciliation-links-cascade.sql
@@ -1,0 +1,10 @@
+
+
+alter table cr_report_line_links
+   drop constraint cr_report_line_links_report_line_id_fkey,
+   add CONSTRAINT cr_report_line_links_report_line_id_fkey
+        FOREIGN KEY (report_line_id)
+           REFERENCES public.cr_report_line (id) MATCH SIMPLE
+           ON UPDATE NO ACTION
+           ON DELETE CASCADE;
+

--- a/sql/changes/LOADORDER
+++ b/sql/changes/LOADORDER
@@ -134,6 +134,7 @@ mc/delete-migration-validation-data.sql
 1.8/fix-reporting-units-pks.sql
 1.8/fix-issue-1672.sql
 1.8/re-add-ap-aging-menu.sql
+1.8/reconciliation-links-cascade.sql
 # 1.9 changes
 1.9/templates-last-modified-no-tz.sql
 1.9/drop-view-tx_report.sql


### PR DESCRIPTION
In 1.8, the explicit reconciliations were added, adding a new
table to the schema. However, the removal of (unapproved)
recon reports was not expanded to remove the lines in the new
table. This approach is a more general approach: when report
lines are deleted, so are the items in the cross linking table.
