### PR TITLE
Wait for new content on page update

### DIFF
--- a/xt/66-cucumber/05-settings/rates.feature
+++ b/xt/66-cucumber/05-settings/rates.feature
@@ -31,7 +31,7 @@ Scenario: Add an exchange rate
    And I select "Default rate" from the drop down "Rate type"
    And I enter "2020-02-01" into "Valid from"
    And I enter "1.2" into "Rate"
-   And I press "Add/Update"
+   And I update the form
   Then I should see the Edit rates screen
    And I expect the report to contain 3 rows
    And I expect the 'Currency' report column to contain 'EUR' for Valid From '2020-02-01'
@@ -47,7 +47,7 @@ Scenario: Update an exchange rate
    And I select "Default rate" from the drop down "Rate type"
    And I enter "2020-01-01" into "Valid from"
    And I enter "1.2" into "Rate"
-   And I press "Add/Update"
+   And I update the form
   Then I should see the Edit rates screen
    And I expect the report to contain 2 rows
    And I expect the 'Currency' report column to contain 'EUR' for Valid From '2020-01-01'

--- a/xt/66-cucumber/05-settings/step_definitions/pageobject_steps.pl
+++ b/xt/66-cucumber/05-settings/step_definitions/pageobject_steps.pl
@@ -44,4 +44,12 @@ When qr/^I enter "(.*)" as the description for a new currency/, sub {
 };
 
 
+When qr/I update the form/, sub {
+    my $page = S->{ext_wsl}->page->body->maindiv;
+    my $content = $page->content;
+
+    $page->find('*button', text => 'Add/Update')->click;
+    $page->wait_for_content(replaces => $content);
+};
+
 1;

--- a/xt/66-cucumber/13-cash/single-payments.feature
+++ b/xt/66-cucumber/13-cash/single-payments.feature
@@ -94,7 +94,7 @@ Scenario: Payment within period of payment terms, posted afterwards
       | Due      |   100.00 |
       | To pay   |   100.00 |
   When I enter "2017-01-11" into "Date"
-   And I press "Update"
+   And I update the form
   Then I expect the open item for invoice INV100 to show:
       | Column   | Expected |
       | Total    |   100.00 |
@@ -107,7 +107,7 @@ Scenario: Payment within period of payment terms, posted afterwards
   # When I edit the open item for invoice INV100 with these values:
   #     | Column         | Value |
   #     | Apply Discount |       |
-  #  And I press "Update"
+  #  And I update the form
   # Then I expect the open item for invoice INV100 to show:
   #     | Column   | Expected |
   #     | Total    |   100.00 |
@@ -132,7 +132,7 @@ Scenario: Exclusion of an invoice from the payment list
       | Column | Value |
       | X      |       |
   When I enter "2017-02-02" into "Date"
-   And I press "Update"
+   And I update the form
   Then I expect the open items table to contain 1 row
    And I expect the open item for invoice INV101 to show:
       | Column   | Expected |

--- a/xt/66-cucumber/13-cash/step_definitions/pageobject_steps.pl
+++ b/xt/66-cucumber/13-cash/step_definitions/pageobject_steps.pl
@@ -45,6 +45,14 @@ Then qr/^I should see these Reconciliation Report headings:$/, sub {
 };
 
 
+When qr/I update the form/, sub {
+    my $page = S->{ext_wsl}->page->body->maindiv;
+    my $content = $page->content;
+
+    $page->find('*button', text => 'Update')->click;
+    $page->wait_for_content(replaces => $content);
+};
+
 When qr/I click on the Batch with Batch Number "(.*)"/, sub {
     my $page = S->{ext_wsl}->page->body->maindiv->content;
     my $batch_number = $1;


### PR DESCRIPTION
This PR continues the effort to make sure that pages are effectively replaced or updated after an update for tests. Actions which only update pages were opening to race problems where the test would proceed before the page was actually updated.