### PR TITLE
Fix query error when partially invoicing an order

### DIFF
--- a/old/bin/oe.pl
+++ b/old/bin/oe.pl
@@ -1410,6 +1410,9 @@ sub invoice {
     if ( $form->{type} =~ /_order$/ ) {
         $form->{exchangerate} = $exchangerate;
         &create_backorder;
+        $form->{transdate} = '';
+        $form->{duedate} = '';
+        $form->{crdate} = '';
     }
 
     if (   $form->{type} eq 'purchase_order'


### PR DESCRIPTION
When creating an invoice from an order leads to a backorder being
created, that process overwrites date values, including transdate.

Due to the change where 'transdate' is no longer being set as part
of the $form hash initialization (the fix in 1.8 for dates being
off by a day), the overwritten value doesn't get restored to
the current_date() as it used to.

Clearing the overwritten values allows the UI to generate defaults
as per the intention of the 1.8.0 change.
