### PR TITLE
Fix #5223: incorrect totals shown on FX payments

### DIFF
--- a/lib/LedgerSMB/Scripts/payment.pm
+++ b/lib/LedgerSMB/Scripts/payment.pm
@@ -1171,7 +1171,7 @@ sub payment2 {
         column_headers => \@column_headers,
         rows        =>  \@invoice_data,
         topay_subtotal => LedgerSMB::PGNumber->new(
-             (sum map {LedgerSMB::PGNumber->from_input($_->{topay} // 0)} @invoice_data) // 0
+             (sum map {LedgerSMB::PGNumber->from_input($_->{orig_topay_fx} // 0)} @invoice_data) // 0
         )->to_output(money => 1),
         topay_state   => \@topay_state,
         vendorcustomer => {
@@ -1204,7 +1204,7 @@ sub payment2 {
         )->to_output(money => 1),
         payment_total => LedgerSMB::PGNumber->new(
               (sum map {LedgerSMB::PGNumber->from_input($_->{amount} // 0)} @overpayment)
-            + (sum map {LedgerSMB::PGNumber->from_input($_->{topay}  // 0)} @invoice_data)
+            + (sum map {LedgerSMB::PGNumber->from_input($_->{orig_topay_fx}  // 0)} @invoice_data)
             + LedgerSMB::PGNumber->from_input(0) # never end up with undef
         )->to_output(money => 1),
     };


### PR DESCRIPTION
The payments subtotal as well as the overall total were
showing incorrectly. Tests show they were correctly posted
to the ledger, though.
