### PR TITLE
Cancel previous runs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,10 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{ github.token }}
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Setup Perl environment
         # You may pin to the exact commit or the version.


### PR DESCRIPTION
GitHub Actions lacks the ability to cancel a previous run of the same PR if one is submitted anew.
This action makes it run like CircleCI, allowing the latest one only to run.