### PR TITLE
Make sure done-parsing attribute is available

### DIFF
--- a/xt/lib/PageObject/App/Main.pm
+++ b/xt/lib/PageObject/App/Main.pm
@@ -55,7 +55,8 @@ sub _wait_for_valid_content {
     $self->session->wait_for(
         sub {
             my $class = $self->get_attribute('class');
-            return scalar( grep { $_ eq 'done-parsing' }
+            return defined($class)
+                && scalar( grep { $_ eq 'done-parsing' }
                            split /\s+/, $class);
         });
 }


### PR DESCRIPTION
Make sure that the class attribute is defined before checking if a page is done parsing