### PR TITLE
Limit Class drop-down on Accounts tab to supported eca types

### DIFF
--- a/UI/Contact/divs/credit.html
+++ b/UI/Contact/divs/credit.html
@@ -60,16 +60,15 @@ PROCESS dynatable
         <tr class="eca_row">
         <td>
         [%
-
         PROCESS select element_data = {
                    id = 'eca-entity-class-id'
                  name = 'entity_class'
                  name = "entity_class"
-              options = entity_classes
+              options = eca_classes
        default_values = [ec]
             text_attr = 'class'
            value_attr = 'id'
-                title = text('Class')
+                label = text('Class')
         } %]</td>
 
 

--- a/lib/LedgerSMB/Scripts/contact.pm
+++ b/lib/LedgerSMB/Scripts/contact.pm
@@ -313,6 +313,7 @@ sub _main_screen {
         $request->call_procedure(
             funcname => 'entity__list_classes'
         );
+    my @eca_classes = grep { $_->{id} < 3 } @entity_classes;
 
     my $roles;
     $roles = $user->list_roles if $user;
@@ -335,6 +336,7 @@ sub _main_screen {
               credit_list => \@credit_list,
               pricegroups => \@pricegroups,
            entity_classes => \@entity_classes,
+              eca_classes => \@eca_classes,
                 locations => \@locations,
                  contacts => \@contacts,
              bank_account => \@bank_account,


### PR DESCRIPTION
Selecting anything other than Customer or Vendor results in a database
schema validity violation error.

Fixes #5216.
