### PR TITLE
Hide 'Payment Type' selector when it's empty

### DIFF
--- a/UI/payments/payments_filter.html
+++ b/UI/payments/payments_filter.html
@@ -92,7 +92,7 @@
                 label = pay_label
         } %]
 
-[% IF payment.payment_types %]
+[% IF payment.payment_types && payment.payment_types.size > 0 %]
 
 <div id = "payments-filter-payment_types" class="inputpayment">
 


### PR DESCRIPTION
There's a payment_type table which allows for adding payment types,
however, it's created empty and there is no way to add payment types
in our UI. At the very least, *hide* the selector in the default
case (when it's empty) to un-clutter the UI.

Fixes #5191.
