### PR TITLE
Only check currency use when explicitly instructed

### DIFF
--- a/lib/LedgerSMB/Currency.pm
+++ b/lib/LedgerSMB/Currency.pm
@@ -82,16 +82,17 @@ sub save {
 }
 
 
-=item list(bool $active, string $mod_name)
+=item list(bool $check_in_use)
 
 Returns a list of all currencies.
 
 =cut
 
 sub list {
-    my ($self) = @_;
+    my ($self, $check_in_use) = @_;
     my @classes = $self->call_procedure(
-            funcname => 'currency__list');
+        funcname => 'currency__list',
+        args     => [ $check_in_use ]);
     for my $class (@classes){
         $class = $self->new(%$class);
     }

--- a/lib/LedgerSMB/Scripts/currency.pm
+++ b/lib/LedgerSMB/Scripts/currency.pm
@@ -39,7 +39,7 @@ Displays a list of configured currencies.  No inputs required or used.
 
 sub list_currencies {
     my ($request) = @_;
-    my @currencies = LedgerSMB::Currency->list();
+    my @currencies = LedgerSMB::Currency->list(1); # check if currency is used
     my $default_curr =
         LedgerSMB::Setting->new(%$request)->get('curr');
     my $columns = [

--- a/old/lib/LedgerSMB/Setting.pm
+++ b/old/lib/LedgerSMB/Setting.pm
@@ -182,7 +182,9 @@ sub get_currencies {
 
     $self->{currencies} = [
         map { $_->{curr} }
-        $self->call_procedure(funcname => 'currency__list') ];
+        $self->call_procedure(funcname => 'currency__list',
+                              args     => [ 0 ] # don't check use
+        )];
     return @{$self->{currencies}};
 }
 

--- a/sql/modules/Currency.sql
+++ b/sql/modules/Currency.sql
@@ -78,16 +78,19 @@ CREATE TYPE currency_list AS (
 );
 
 DROP FUNCTION IF EXISTS currency__list();
-CREATE OR REPLACE FUNCTION currency__list()
+CREATE OR REPLACE FUNCTION currency__list(in_check_use boolean)
 RETURNS SETOF currency_list AS
 $$
-  select c.curr, c.description, currency__is_used(c.curr) from currency c
+  select c.curr, c.description,
+         case when in_check_use then currency__is_used(c.curr)
+              else null end as is_used
+    from currency c
     left join (select value as curr from defaults where setting_key = 'curr') d
          on c.curr = d.curr
    order by case when c.curr = d.curr then 1 else 2 end, c.curr;
 $$ language sql;
 
-COMMENT ON FUNCTION currency__list() IS
+COMMENT ON FUNCTION currency__list(boolean) IS
 $$Returns all currencies, default currency first.$$;
 
 


### PR DESCRIPTION
Checking currency use is a lengthy operation that isn't required to
know which currencies have been configured in order to offer e.g. a
selection drop-down.

Fixes #4679.
